### PR TITLE
Tests sets support

### DIFF
--- a/tests/integration/tests_set.go
+++ b/tests/integration/tests_set.go
@@ -1,0 +1,65 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+type EdenTestArgs map[string]string
+type EdenTestFunc func(t *testing.T, name string, args EdenTestArgs) string
+
+// EdenTest is a description of async test in tests set
+type EdenTest struct {
+	Name   string
+	Test   EdenTestFunc
+	Args   EdenTestArgs
+	Result string // Regexp pattern
+}
+
+type EdenTestSets map[string][]EdenTest
+
+// ETests is the main object for tests sets 
+var ETests EdenTestSets = EdenTestSets{}
+
+func runSubTest(t *testing.T, name string, test EdenTestFunc, args EdenTestArgs, result string, cntx context.Context, cancel context.CancelFunc) {
+	for {
+		select {
+		case <-cntx.Done():
+			return
+		default:
+			res := test(t, name, args)
+			matched, err := regexp.Match(result, []byte(res))
+			if err != nil {
+				t.Errorf("%s segexp '%s' for '%s' matching error: %s", name, res, result, err)
+			}
+			if !matched {
+				t.Errorf("%s got '%v'; want '%v'", name, res, result)
+			}
+			cancel()
+			return
+		}
+	}
+}
+
+// runTestSets start Go routines for every test in tests set ETests map
+// by a subtest name
+func runTestSets(t *testing.T) {
+        ctx, cancel := context.WithCancel(context.Background())
+        defer cancel() // cancel when we are finished tasks
+
+	name := strings.Split(t.Name(),"/")[1]
+	for _, tc := range ETests[name] {
+		fmt.Printf("Running %s.%s\n", t.Name(), tc.Name)
+		go runSubTest(t, tc.Name, tc.Test, tc.Args, tc.Result, ctx, cancel)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+

--- a/tests/integration/testset_test.go
+++ b/tests/integration/testset_test.go
@@ -29,8 +29,8 @@ func setupTestCase(t *testing.T) func(t *testing.T) {
 			Name: "FalseHook",
 			Test: BoolHook,
 			Args: EdenTestArgs{"val":"false"},
-			//Result: "false",
-			Result: "true",
+			Result: "false",
+			//Result: "true",
 		},/*
 		EdenTest{
 			Name: "TrueHook",

--- a/tests/integration/testset_test.go
+++ b/tests/integration/testset_test.go
@@ -1,0 +1,145 @@
+package integration
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/lf-edge/eve/api/go/info"
+	"github.com/lf-edge/eden/pkg/controller"
+	"github.com/lf-edge/eden/pkg/controller/einfo"
+)
+
+var lastRebootTime *timestamp.Timestamp
+var lastRebootReason string
+var rebooted bool
+
+func setupTestCase(t *testing.T) func(t *testing.T) {
+	t.Log("Setup test case", t.Name())
+	ETests["BoolTest"] = []EdenTest{
+		EdenTest{
+			Name: "WaitHook",
+			Test: WaitHook,
+			Args: EdenTestArgs{"secs":"5"},
+			Result: "5",
+		},
+		EdenTest{
+			Name: "FalseHook",
+			Test: BoolHook,
+			Args: EdenTestArgs{"val":"false"},
+			//Result: "false",
+			Result: "true",
+		},/*
+		EdenTest{
+			Name: "TrueHook",
+			Test: BoolHook,
+			Args: EdenTestArgs{"val":"true"},
+			Result: "true",
+		},*/
+	}
+	
+	ETests["RebootTest"] = []EdenTest{
+		EdenTest{
+			Name: "CheckRebootInfo",
+			Test: CheckRebootInfo,
+			Args: EdenTestArgs{},
+			Result: "reboot",
+		},
+		EdenTest{
+			Name: "WaitHook",
+			Test: WaitHook,
+			Args: EdenTestArgs{"secs":"1000"},
+			Result: "1000",
+		},
+	}
+	
+	return func(t *testing.T) {
+		t.Log("Teardown test case", t.Name())
+	}
+}
+
+func checkRebootTime(im *info.ZInfoMsg, ds []*einfo.ZInfoMsgInterface, infoType einfo.ZInfoType) bool {
+	lrbt := im.GetDinfo().LastRebootTime
+	lrbr := im.GetDinfo().LastRebootReason
+
+	if lastRebootTime == nil {
+		lastRebootTime = lrbt
+		lastRebootReason = lrbr
+		rebooted = true
+	} else {
+		fmt.Printf("lastRebootTime: %s\n",lastRebootTime)
+		fmt.Printf("lrbt: %s\n",lrbt)
+		if proto.Equal(lastRebootTime, lrbt) {
+			rebooted = false
+		} else {
+			lastRebootTime = lrbt
+			lastRebootReason = lrbr
+			rebooted = true
+		}
+	}
+	fmt.Printf("rebooted: %v\n",rebooted)
+	return rebooted
+}
+
+func CheckRebootInfo(t *testing.T, name string, args EdenTestArgs) string {
+	fmt.Println("CheckRebootInfo")
+	ctx, err := controller.CloudPrepare()
+	if err != nil {
+		t.Fatalf("Fail in CloudPrepare: %s", err)
+		return "fail"
+	}
+	devUUID, err := ctx.GetDeviceFirst()
+	if err != nil {
+		t.Fatal("Fail in get first device: ", err)
+		return "fail"
+	}
+	err = ctx.InfoChecker(devUUID.GetID(), map[string]string{"devId": devUUID.GetID().String(), "lastRebootTime":".*"}, einfo.ZInfoDinfo, checkRebootTime, einfo.InfoAny, 300)
+	if err != nil {
+		t.Fatal("Fail in waiting for info: ", err)
+		return "fail"
+	}
+	t.Logf("Previous reboot at %s with reason '%s'\n", lastRebootTime, lastRebootReason)
+	for {
+		err = ctx.InfoChecker(devUUID.GetID(), map[string]string{"devId": devUUID.GetID().String(), "lastRebootTime":".*"}, einfo.ZInfoDinfo, checkRebootTime, einfo.InfoNew, 3000)
+		if err != nil {
+			t.Fatal("Fail in waiting for info: ", err)
+			return "fail"
+		}
+		if rebooted {
+			t.Logf("Rebooted again at %s with reason '%s'\n", lastRebootTime, lastRebootReason)
+			return "reboot"
+		} else {
+			t.Logf("Not rebooted, lastRebootTime: %s\n", lastRebootTime)
+			return "fail"
+		}
+	}
+}
+
+func BoolHook(t *testing.T, name string, args EdenTestArgs) string {
+	fmt.Println("BoolHook", t.Name(), args["val"])
+	return args["val"]
+}
+
+func WaitHook(t *testing.T, name string, args EdenTestArgs) string {
+	s := args["secs"]
+	if secs, err:=strconv.Atoi(s); err != nil {
+		t.Fatalf("Can't convert '%s' to seconds\n", s)
+		return "fail"
+	} else {
+		fmt.Println("WaitHook", secs, "sec.")
+		time.Sleep(time.Duration(secs)*time.Second)
+		fmt.Println("WaitHook finished")
+	}
+	return s
+}
+
+func TestSets(t *testing.T) {
+	teardownTestCase := setupTestCase(t)
+	defer teardownTestCase(t)
+
+	for name, _ := range ETests {
+		t.Run(name, runTestSets)
+	}
+}


### PR DESCRIPTION
Some solution for issue #45
All tests in this tests set are executing by a separate goroutine, and all of them are completed after finishing of any test in this test set. The cumulative result of this test for the complete test set is just a result of this first finished test. Generally, you just need to create test functions and describe your test set (name, function, arguments and regular expression for the return value) in the ETests map. A simple example that you can see on `tests/integration/testset_test.go`

You can start them by eden from our test binary:
`./eden test -r TestSets/BoolTest -v debug`
or by traditional Go test procedure:
`go test tests/integration/testset_test.go tests/integration/tests_set.go tests/integration/common.go -run=TestSets/BoolTest -v`

The RebootTest test in this example will finish work after rebooting the EVE or timeout exceeding:
`./eden test -r TestSets/RebootTest -v debug`