### PR TITLE
Controller command

### DIFF
--- a/cmd/changers.go
+++ b/cmd/changers.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/lf-edge/eden/pkg/controller"
+	"github.com/lf-edge/eden/pkg/controller/adam"
+	"github.com/lf-edge/eden/pkg/device"
+	"github.com/lf-edge/eve/api/go/config"
+	"github.com/spf13/viper"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+type configChanger interface {
+	getControllerAndDev() (controller.Cloud, *device.Ctx, error)
+	setControllerAndDev(controller.Cloud, *device.Ctx) error
+}
+
+type fileChanger struct {
+	fileConfig string
+}
+
+func (ctx *fileChanger) getControllerAndDev() (controller.Cloud, *device.Ctx, error) {
+	if _, err := os.Lstat(ctx.fileConfig); os.IsNotExist(err) {
+		return nil, nil, err
+	}
+	var ctrl controller.Cloud = &controller.CloudCtx{Controller: &adam.Ctx{}}
+	data, err := ioutil.ReadFile(ctx.fileConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("file reading error: %s", err)
+	}
+	var deviceConfig config.EdgeDevConfig
+	err = json.Unmarshal(data, &deviceConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unmarshal error: %s", err)
+	}
+	dev, err := ctrl.ConfigParse(&deviceConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("configParse error: %s", err)
+	}
+	return ctrl, dev, nil
+}
+
+func (ctx *fileChanger) setControllerAndDev(ctrl controller.Cloud, dev *device.Ctx) error {
+	res, err := ctrl.GetConfigBytes(dev)
+	if err != nil {
+		return fmt.Errorf("GetConfigBytes error: %s", err)
+	}
+	if err = ioutil.WriteFile(ctx.fileConfig, res, 0755); err != nil {
+		return fmt.Errorf("WriteFile error: %s", err)
+	}
+	return nil
+}
+
+type adamChanger struct {
+	adamUrl string
+}
+
+func (ctx *adamChanger) getControllerAndDev() (controller.Cloud, *device.Ctx, error) {
+	ipPort := strings.Split(ctx.adamUrl, ":")
+	ip := ipPort[0]
+	if ip == "" {
+		return nil, nil, fmt.Errorf("cannot get ip/hostname from %s", ctx.adamUrl)
+	}
+	port := "80"
+	if len(ipPort) > 1 {
+		port = ipPort[1]
+	}
+	viper.Set("adam.ip", ip)
+	viper.Set("adam.port", port)
+	ctrl, err := controller.CloudPrepare()
+	if err != nil {
+		return nil, nil, fmt.Errorf("CloudPrepare error: %s", err)
+	}
+	if err := ctrl.OnBoard(); err != nil {
+		return nil, nil, fmt.Errorf("OnBoard: %s", err)
+	}
+	devFirst, err := ctrl.GetDeviceFirst()
+	if err != nil {
+		return nil, nil, fmt.Errorf("GetDeviceFirst error: %s", err)
+	}
+	configString, err := ctrl.ConfigGet(devFirst.GetID())
+	if err != nil {
+		return nil, nil, fmt.Errorf("ConfigGet error: %s", err)
+	}
+	var deviceConfig config.EdgeDevConfig
+	err = json.Unmarshal([]byte(configString), &deviceConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unmarshal error: %s", err)
+	}
+	dev, err := ctrl.ConfigParse(&deviceConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("configParse error: %s", err)
+	}
+	return ctrl, dev, nil
+}
+
+func (ctx *adamChanger) setControllerAndDev(ctrl controller.Cloud, dev *device.Ctx) error {
+	if err := ctrl.ConfigSync(dev); err != nil {
+		return fmt.Errorf("configSync error: %s", err)
+	}
+	return nil
+}

--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -26,6 +26,7 @@ const (
 	defaultTestProg        = "eden.integration.test"
 	defaultTestScript      = "eden.integration.test"
 	rootFSVersionPattern   = `^(\d+\.*){2,3}.*-(xen|kvm|acrn)-(amd64|arm64)$`
+	controllerModePattern  = `^(?P<Type>(file|proto|adam|zedcloud)):\/\/(?P<URL>.+)$`
 )
 
 var (

--- a/cmd/edenController.go
+++ b/cmd/edenController.go
@@ -2,14 +2,21 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/docker/docker/pkg/fileutils"
 	"github.com/lf-edge/eden/pkg/utils"
+	"github.com/lf-edge/eve/api/go/config"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
 
 var controllerMode string
+var baseOSImage string
+var baseOSImageActivate bool
 
 func getParams(line, regEx string) (paramsMap map[string]string) {
 
@@ -56,6 +63,19 @@ var edgeNodeReboot = &cobra.Command{
 	Use:   "reboot",
 	Short: "reboot EVE instance",
 	Long:  `reboot EVE instance.`,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		assingCobraToViper(cmd)
+		if baseOSVersionFlag := cmd.Flags().Lookup("os-version"); baseOSVersionFlag != nil {
+			if err := viper.BindPFlag("eve.base-tag", baseOSVersionFlag); err != nil {
+				log.Fatal(err)
+			}
+		}
+		_, err := utils.LoadConfigFile(configFile)
+		if err != nil {
+			return fmt.Errorf("error reading configFile: %s", err.Error())
+		}
+		return nil
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		modeType, modeURL, err := getControllerMode()
 		if err != nil {
@@ -87,6 +107,162 @@ var edgeNodeReboot = &cobra.Command{
 	},
 }
 
+var edgeNodeEVEImageUpdate = &cobra.Command{
+	Use:   "eveimage-update",
+	Short: "update EVE image",
+	Long:  `Update EVE image.`,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		assingCobraToViper(cmd)
+		if baseOSVersionFlag := cmd.Flags().Lookup("os-version"); baseOSVersionFlag != nil {
+			if err := viper.BindPFlag("eve.base-tag", baseOSVersionFlag); err != nil {
+				log.Fatal(err)
+			}
+		}
+		viperLoaded, err := utils.LoadConfigFile(configFile)
+		if err != nil {
+			return fmt.Errorf("error reading configFile: %s", err.Error())
+		}
+		if viperLoaded {
+			eserverIP = viper.GetString("eden.eserver.ip")
+			eserverPort = viper.GetString("eden.eserver.port")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		rootFsPath, err := utils.GetFileFollowLinks(baseOSImage)
+		if err != nil {
+			log.Fatalf("GetFileFollowLinks: %s", err)
+		}
+		modeType, modeURL, err := getControllerMode()
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Infof("Mode type: %s", modeType)
+		log.Infof("Mode url: %s", modeURL)
+		var changer configChanger
+		switch modeType {
+		case "file":
+			changer = &fileChanger{fileConfig: modeURL}
+		case "adam":
+			changer = &adamChanger{adamUrl: modeURL}
+
+		default:
+			log.Fatalf("Not implemented type: %s", modeType)
+		}
+
+		ctrl, dev, err := changer.getControllerAndDev()
+		if err != nil {
+			log.Fatalf("getControllerAndDev error: %s", err)
+		}
+
+		dataStore := &config.DatastoreConfig{
+			Id:       dataStoreID,
+			DType:    config.DsType_DsHttp,
+			Fqdn:     fmt.Sprintf("http://%s:%s", eserverIP, eserverPort),
+			ApiKey:   "",
+			Password: "",
+			Dpath:    "",
+			Region:   "",
+		}
+		if _, err := os.Lstat(rootFsPath); os.IsNotExist(err) {
+			log.Fatalf("image file problem (%s): %s", args[0], err)
+		}
+
+		if getFromFileName {
+			rootFSName := strings.TrimSuffix(filepath.Base(rootFsPath), filepath.Ext(rootFsPath))
+			rootFSName = strings.TrimPrefix(rootFSName, "rootfs-")
+			re := regexp.MustCompile(rootFSVersionPattern)
+			if !re.MatchString(rootFSName) {
+				log.Fatalf("Filename of rootfs %s does not match pattern %s", rootFSName, rootFSVersionPattern)
+			}
+			baseOSVersion = rootFSName
+		}
+
+		log.Infof("Will use rootfs version %s", baseOSVersion)
+
+		imageFullPath := filepath.Join(eserverImageDist, "baseos", defaultFilename)
+		if _, err := fileutils.CopyFile(rootFsPath, imageFullPath); err != nil {
+			log.Fatalf("CopyFile problem: %s", err)
+		}
+		imageDSPath := fmt.Sprintf("baseos/%s", defaultFilename)
+		fi, err := os.Stat(imageFullPath)
+		if err != nil {
+			log.Fatalf("ImageFile (%s): %s", imageFullPath, err)
+		}
+		size := fi.Size()
+
+		sha256sum := ""
+		sha256sum, err = utils.SHA256SUM(imageFullPath)
+		if err != nil {
+			log.Fatalf("SHA256SUM (%s): %s", imageFullPath, err)
+		}
+		img := &config.Image{
+			Uuidandversion: &config.UUIDandVersion{
+				Uuid:    imageID,
+				Version: "4",
+			},
+			Name:      imageDSPath,
+			Sha256:    sha256sum,
+			Iformat:   config.Format_QCOW2,
+			DsId:      dataStoreID,
+			SizeBytes: size,
+			Siginfo: &config.SignatureInfo{
+				Intercertsurl: "",
+				Signercerturl: "",
+				Signature:     nil,
+			},
+		}
+		if _, err := ctrl.GetDataStore(dataStoreID); err == nil {
+			if err = ctrl.RemoveDataStore(dataStoreID); err != nil {
+				log.Fatalf("RemoveDataStore: %s", err)
+			}
+		}
+		if err = ctrl.AddDataStore(dataStore); err != nil {
+			log.Fatalf("AddDataStore: %s", err)
+		}
+		if _, err := ctrl.GetImage(imageID); err == nil {
+			if err = ctrl.RemoveImage(imageID); err != nil {
+				log.Fatalf("RemoveImage: %s", err)
+			}
+		}
+		if err = ctrl.AddImage(img); err != nil {
+			log.Fatalf("AddImage: %s", err)
+		}
+
+		baseOSConfig := &config.BaseOSConfig{
+			Uuidandversion: &config.UUIDandVersion{
+				Uuid:    baseID,
+				Version: "4",
+			},
+			Drives: []*config.Drive{{
+				Image:        img,
+				Readonly:     false,
+				Preserve:     false,
+				Drvtype:      config.DriveType_Unclassified,
+				Target:       config.Target_TgtUnknown,
+				Maxsizebytes: img.SizeBytes,
+			}},
+			Activate:      baseOSImageActivate,
+			BaseOSVersion: baseOSVersion,
+			BaseOSDetails: nil,
+		}
+		if _, err := ctrl.GetBaseOSConfig(baseID); err == nil {
+			if err = ctrl.RemoveBaseOsConfig(baseID); err != nil {
+				log.Fatalf("RemoveBaseOsConfig: %s", err)
+			}
+		}
+
+		if err = ctrl.AddBaseOsConfig(baseOSConfig); err != nil {
+			log.Fatalf("AddBaseOsConfig: %s", err)
+		}
+		dev.SetBaseOSConfig([]string{baseID})
+		if err = changer.setControllerAndDev(ctrl, dev); err != nil {
+			log.Fatalf("setControllerAndDev error: %s", err)
+		}
+		log.Info("EVE update request has been sent")
+	},
+}
+
 func controllerInit() {
 	configPath, err := utils.DefaultConfigPath()
 	if err != nil {
@@ -94,10 +270,19 @@ func controllerInit() {
 	}
 	controllerCmd.AddCommand(edgeNode)
 	edgeNode.AddCommand(edgeNodeReboot)
+	edgeNode.AddCommand(edgeNodeEVEImageUpdate)
 	pf := controllerCmd.PersistentFlags()
 	pf.StringVarP(&controllerMode, "mode", "m", "", "mode to use [file|proto|adam|zedcloud]://<URL>")
 	pf.StringVar(&configFile, "config", configPath, "path to config file")
 	if err = cobra.MarkFlagRequired(pf, "mode"); err != nil {
+		log.Fatal(err)
+	}
+	edgeNodeEVEImageUpdateFlags := edgeNodeEVEImageUpdate.Flags()
+	edgeNodeEVEImageUpdateFlags.StringVarP(&baseOSVersion, "os-version", "", fmt.Sprintf("%s-%s-%s", utils.DefaultBaseOSVersion, eveHV, eveArch), "version of ROOTFS")
+	edgeNodeEVEImageUpdateFlags.BoolVarP(&getFromFileName, "from-filename", "", true, "get version from filename")
+	edgeNodeEVEImageUpdateFlags.BoolVarP(&baseOSImageActivate, "activate", "", true, "activate image")
+	edgeNodeEVEImageUpdateFlags.StringVarP(&baseOSImage, "image", "", "", "image file")
+	if err = cobra.MarkFlagRequired(edgeNodeEVEImageUpdateFlags, "image"); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/edenController.go
+++ b/cmd/edenController.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/lf-edge/eden/pkg/utils"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"regexp"
+	"strings"
+)
+
+var controllerMode string
+
+func getParams(line, regEx string) (paramsMap map[string]string) {
+
+	var compRegEx = regexp.MustCompile(regEx)
+	match := compRegEx.FindStringSubmatch(strings.TrimSpace(line))
+
+	paramsMap = make(map[string]string)
+	for i, name := range compRegEx.SubexpNames() {
+		if i > 0 && i <= len(match) {
+			paramsMap[name] = match[i]
+		}
+	}
+	return
+}
+
+func getControllerMode() (modeType, modeURL string, err error) {
+	params := getParams(controllerMode, controllerModePattern)
+	if len(params) == 0 {
+		return "", "", fmt.Errorf("cannot parse mode (not [file|proto|adam|zedcloud]://<URL>): %s", controllerMode)
+	}
+	ok := false
+	if modeType, ok = params["Type"]; !ok {
+		return "", "", fmt.Errorf("cannot parse modeType (not [file|proto|adam|zedcloud]://<URL>): %s", controllerMode)
+	}
+	if modeURL, ok = params["URL"]; !ok {
+		return "", "", fmt.Errorf("cannot parse modeURL (not [file|proto|adam|zedcloud]://<URL>): %s", controllerMode)
+	}
+	return
+}
+
+var controllerCmd = &cobra.Command{
+	Use:   "controller",
+	Short: "interact with controller",
+	Long:  `Interact with controller.`,
+}
+
+var edgeNode = &cobra.Command{
+	Use:   "edge-node",
+	Short: "manage EVE instance",
+	Long:  `Manage EVE instance.`,
+}
+
+var edgeNodeReboot = &cobra.Command{
+	Use:   "reboot",
+	Short: "reboot EVE instance",
+	Long:  `reboot EVE instance.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		modeType, modeURL, err := getControllerMode()
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Infof("Mode type: %s", modeType)
+		log.Infof("Mode url: %s", modeURL)
+		var changer configChanger
+		switch modeType {
+		case "file":
+			changer = &fileChanger{fileConfig: modeURL}
+		case "adam":
+			changer = &adamChanger{adamUrl: modeURL}
+
+		default:
+			log.Fatalf("Not implemented type: %s", modeType)
+		}
+
+		ctrl, dev, err := changer.getControllerAndDev()
+		if err != nil {
+			log.Fatalf("getControllerAndDev error: %s", err)
+		}
+		rebootCounter, _ := dev.GetRebootCounter()
+		dev.SetRebootCounter(rebootCounter+1, true)
+		if err = changer.setControllerAndDev(ctrl, dev); err != nil {
+			log.Fatalf("setControllerAndDev error: %s", err)
+		}
+		log.Info("Reboot request has been sent")
+	},
+}
+
+func controllerInit() {
+	configPath, err := utils.DefaultConfigPath()
+	if err != nil {
+		log.Fatal(err)
+	}
+	controllerCmd.AddCommand(edgeNode)
+	edgeNode.AddCommand(edgeNodeReboot)
+	pf := controllerCmd.PersistentFlags()
+	pf.StringVarP(&controllerMode, "mode", "m", "", "mode to use [file|proto|adam|zedcloud]://<URL>")
+	pf.StringVar(&configFile, "config", configPath, "path to config file")
+	if err = cobra.MarkFlagRequired(pf, "mode"); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,6 +73,8 @@ func init() {
 	eveUpdateInit()
 	rootCmd.AddCommand(testCmd)
 	testInit()
+	rootCmd.AddCommand(controllerCmd)
+	controllerInit()
 }
 
 // Execute primary function for cobra

--- a/pkg/controller/baseOs.go
+++ b/pkg/controller/baseOs.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"github.com/lf-edge/eden/pkg/utils"
 	"github.com/lf-edge/eve/api/go/config"
 )
 
@@ -24,4 +25,15 @@ func (cloud *CloudCtx) AddBaseOsConfig(baseOSConfig *config.BaseOSConfig) error 
 	}
 	cloud.baseOS = append(cloud.baseOS, baseOSConfig)
 	return nil
+}
+
+//RemoveBaseOsConfig remove BaseOsConfig from cloud
+func (cloud *CloudCtx) RemoveBaseOsConfig(id string) error {
+	for ind, baseOS := range cloud.baseOS {
+		if baseOS.Uuidandversion.Uuid == id {
+			utils.DelEleInSlice(&cloud.baseOS, ind)
+			return nil
+		}
+	}
+	return fmt.Errorf("not found baseOS with ID: %s", id)
 }

--- a/pkg/controller/baseOs.go
+++ b/pkg/controller/baseOs.go
@@ -16,6 +16,11 @@ func (cloud *CloudCtx) GetBaseOSConfig(id string) (baseOSConfig *config.BaseOSCo
 	return nil, fmt.Errorf("not found BaseOSConfig with ID: %s", id)
 }
 
+//ListBaseOSConfig return baseOS configs from cloud
+func (cloud *CloudCtx) ListBaseOSConfig() []*config.BaseOSConfig {
+	return cloud.baseOS
+}
+
 //AddBaseOsConfig add baseOS config to cloud
 func (cloud *CloudCtx) AddBaseOsConfig(baseOSConfig *config.BaseOSConfig) error {
 	for _, baseConfig := range cloud.baseOS {

--- a/pkg/controller/cloud.go
+++ b/pkg/controller/cloud.go
@@ -30,16 +30,20 @@ type Cloud interface {
 	GetDeviceUUID(devUUID uuid.UUID) (dev *device.Ctx, err error)
 	GetBaseOSConfig(id string) (baseOSConfig *config.BaseOSConfig, err error)
 	AddBaseOsConfig(baseOSConfig *config.BaseOSConfig) error
+	RemoveBaseOsConfig(id string) error
 	AddDataStore(dataStoreConfig *config.DatastoreConfig) error
 	GetDataStore(id string) (ds *config.DatastoreConfig, err error)
+	RemoveDataStore(id string) error
 	GetNetworkInstanceConfig(id string) (networkInstanceConfig *config.NetworkInstanceConfig, err error)
 	AddNetworkInstanceConfig(networkInstanceConfig *config.NetworkInstanceConfig) error
 	RemoveNetworkInstanceConfig(id string) error
 	GetImage(id string) (image *config.Image, err error)
 	AddImage(imageConfig *config.Image) error
+	RemoveImage(id string) error
 	GetConfigBytes(dev *device.Ctx) ([]byte, error)
 	GetDeviceFirst() (dev *device.Ctx, err error)
 	ConfigSync(dev *device.Ctx) (err error)
+	ConfigParse(config *config.EdgeDevConfig) (dev *device.Ctx, err error)
 	GetNetworkConfig(id string) (networkConfig *config.NetworkConfig, err error)
 	AddNetworkConfig(networkInstanceConfig *config.NetworkConfig) error
 	RemoveNetworkConfig(id string) error

--- a/pkg/controller/cloud.go
+++ b/pkg/controller/cloud.go
@@ -29,6 +29,7 @@ type Cloud interface {
 	AddDevice(devUUID uuid.UUID) (dev *device.Ctx, err error)
 	GetDeviceUUID(devUUID uuid.UUID) (dev *device.Ctx, err error)
 	GetBaseOSConfig(id string) (baseOSConfig *config.BaseOSConfig, err error)
+	ListBaseOSConfig() []*config.BaseOSConfig
 	AddBaseOsConfig(baseOSConfig *config.BaseOSConfig) error
 	RemoveBaseOsConfig(id string) error
 	AddDataStore(dataStoreConfig *config.DatastoreConfig) error

--- a/pkg/controller/datastore.go
+++ b/pkg/controller/datastore.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"github.com/lf-edge/eden/pkg/utils"
 	"github.com/lf-edge/eve/api/go/config"
 )
 
@@ -24,4 +25,15 @@ func (cloud *CloudCtx) AddDataStore(dataStoreConfig *config.DatastoreConfig) err
 	}
 	cloud.datastores = append(cloud.datastores, dataStoreConfig)
 	return nil
+}
+
+//RemoveDataStore remove DataStore config from cloud
+func (cloud *CloudCtx) RemoveDataStore(id string) error {
+	for ind, datastore := range cloud.datastores {
+		if datastore.Id == id {
+			utils.DelEleInSlice(&cloud.datastores, ind)
+			return nil
+		}
+	}
+	return fmt.Errorf("not found DataStore with ID: %s", id)
 }

--- a/pkg/controller/device.go
+++ b/pkg/controller/device.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lf-edge/eve/api/go/config"
 	uuid "github.com/satori/go.uuid"
 	"github.com/spf13/viper"
+	"strconv"
 )
 
 //StateUpdate refresh state file
@@ -384,6 +385,14 @@ func (cloud *CloudCtx) GetConfigBytes(dev *device.Ctx) ([]byte, error) {
 			Value: dev.GetControllerLogLevel(),
 		})
 	}
+
+	if dev.GetTimerConfigInterval() != 0 {
+		configItems = append(configItems, &config.ConfigItem{
+			Key:   "timer.config.interval",
+			Value: strconv.Itoa(dev.GetTimerConfigInterval()),
+		})
+	}
+
 	rebootCounter, rebootState := dev.GetRebootCounter()
 	rebootCmd := &config.DeviceOpsCmd{Counter: rebootCounter, DesiredState: rebootState}
 	devConfig := &config.EdgeDevConfig{

--- a/pkg/controller/image.go
+++ b/pkg/controller/image.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"github.com/lf-edge/eden/pkg/utils"
 	"github.com/lf-edge/eve/api/go/config"
 )
 
@@ -28,4 +29,15 @@ func (cloud *CloudCtx) AddImage(imageConfig *config.Image) error {
 	}
 	cloud.images = append(cloud.images, imageConfig)
 	return nil
+}
+
+//RemoveImage remove Image config from cloud
+func (cloud *CloudCtx) RemoveImage(id string) error {
+	for ind, image := range cloud.images {
+		if image.Uuidandversion.Uuid == id {
+			utils.DelEleInSlice(&cloud.images, ind)
+			return nil
+		}
+	}
+	return fmt.Errorf("not found Image with ID: %s", id)
 }

--- a/pkg/device/device.go
+++ b/pkg/device/device.go
@@ -15,6 +15,8 @@ type Ctx struct {
 	systemAdapters             []string
 	applicationInstanceConfigs []string
 	sshKeys                    []string
+	rebootCounter              uint32
+	rebootState                bool
 	devModel                   string
 	vncAccess                  bool
 	controllerLogLevel         string
@@ -23,7 +25,9 @@ type Ctx struct {
 //CreateWithBaseConfig generate base config for device with id and associate with cloudCtx
 func CreateWithBaseConfig(id uuid.UUID) *Ctx {
 	return &Ctx{
-		id: id,
+		id:            id,
+		rebootCounter: 1000,
+		rebootState:   false,
 	}
 }
 
@@ -125,4 +129,15 @@ func (cfg *Ctx) SetVncAccess(enabled bool) {
 func (cfg *Ctx) SetApplicationInstanceConfig(configIDs []string) *Ctx {
 	cfg.applicationInstanceConfigs = configIDs
 	return cfg
+}
+
+//SetRebootCounter setter
+func (cfg *Ctx) SetRebootCounter(counter uint32, state bool) {
+	cfg.rebootCounter = counter
+	cfg.rebootState = state
+}
+
+//SetRebootCounter getter
+func (cfg *Ctx) GetRebootCounter() (counter uint32, state bool) {
+	return cfg.rebootCounter, cfg.rebootState
 }

--- a/pkg/device/device.go
+++ b/pkg/device/device.go
@@ -20,14 +20,16 @@ type Ctx struct {
 	devModel                   string
 	vncAccess                  bool
 	controllerLogLevel         string
+	timerConfigInterval        int
 }
 
 //CreateWithBaseConfig generate base config for device with id and associate with cloudCtx
 func CreateWithBaseConfig(id uuid.UUID) *Ctx {
 	return &Ctx{
-		id:            id,
-		rebootCounter: 1000,
-		rebootState:   false,
+		id:                  id,
+		rebootCounter:       1000,
+		rebootState:         false,
+		timerConfigInterval: 5,
 	}
 }
 
@@ -63,6 +65,9 @@ func (cfg *Ctx) GetVncAccess() bool { return cfg.vncAccess }
 
 //GetControllerLogLevel return controllerLogLevel of device
 func (cfg *Ctx) GetControllerLogLevel() string { return cfg.controllerLogLevel }
+
+//GetTimerConfigInterval return timer.config.interval
+func (cfg *Ctx) GetTimerConfigInterval() int { return cfg.timerConfigInterval }
 
 //GetAdaptersForSwitch return adaptersForSwitch of device
 func (cfg *Ctx) GetAdaptersForSwitch() []string {
@@ -123,6 +128,11 @@ func (cfg *Ctx) SetControllerLogLevel(controllerLogLevel string) {
 //SetVncAccess set vncAccess
 func (cfg *Ctx) SetVncAccess(enabled bool) {
 	cfg.vncAccess = enabled
+}
+
+//SetTimerConfigInterval set timer.config.interval
+func (cfg *Ctx) SetTimerConfigInterval(interval int) {
+	cfg.timerConfigInterval = interval
 }
 
 //SetApplicationInstanceConfig set applicationInstanceConfigs by configIDs from cloud


### PR DESCRIPTION
Implemented commands from [issue 51](https://github.com/lf-edge/eden/issues/51) for `file` and `adam` locations. The '&lt;name&gt;' is not implemented -- used single EVE instance from EDEN's config. For 'edge-node update' implemented only `--config=<key:value>` options.

Fixed [issue53](https://github.com/lf-edge/eden/issues/53).