### PR TITLE
Templates support

### DIFF
--- a/cmd/edenTemplate.go
+++ b/cmd/edenTemplate.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/lf-edge/eden/pkg/utils"
+)
+
+var templateCmd = &cobra.Command{
+	Use:   "template <file>",
+	Short: "Render template",
+	Long: ``,
+	Args: cobra.ExactArgs(1),
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		tmpl, err := ioutil.ReadFile(args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
+		
+		out, err := utils.RenderTemplate(configFile, string(tmpl))
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(out)
+	},
+}
+
+func templateInit() {
+}

--- a/cmd/edenUtils.go
+++ b/cmd/edenUtils.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var utilsCmd = &cobra.Command{
+	Use:   "utils",
+	Short: "Eden utilities",
+	Long: `Additional utilities for EDEN.`,
+}
+
+func utilsInit() {
+	utilsCmd.AddCommand(templateCmd)	
+}

--- a/cmd/root.go.orig
+++ b/cmd/root.go.orig
@@ -76,8 +76,6 @@ func init() {
 	reconfInit()
 	rootCmd.AddCommand(testCmd)
 	testInit()
-	rootCmd.AddCommand(utilsCmd)
-	utilsInit()
 	rootCmd.AddCommand(controllerCmd)
 	controllerInit()
 	rootCmd.AddCommand(podCmd)

--- a/pkg/utils/configDiff.go
+++ b/pkg/utils/configDiff.go
@@ -81,10 +81,10 @@ eden:
     ssh-key: {{ .DefaultSSHKey }}
 
     #test binary
-    test-bin: {{ .DefaultTestProg }}
+    test-bin: "{{ .DefaultTestProg }}"
 
     #test scenario
-    test-scenario: {{ .DefaultTestScenario }}
+    test-scenario: "{{ .DefaultTestScenario }}"
 
 redis:
     #port for access redis

--- a/pkg/utils/templates.go
+++ b/pkg/utils/templates.go
@@ -1,0 +1,54 @@
+package utils
+
+import (
+	"bytes"
+	"text/template"
+	
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+var funcs = template.FuncMap{
+	// Eden config parameter
+	"EdenConfig": func(key string) string {
+		val := viper.GetString(key)
+		return val
+	},
+	// Resolve path from Eden config parameter relative
+	// to the Eden root directory  
+	"EdenConfigPath":  func(path string) string {
+		res := ResolveAbsPath(viper.GetString(path))
+		return res
+	},
+	// Resolve path relative to the Eden root directory  
+	"EdenPath":  func(path string) string {
+		res := ResolveAbsPath(path)
+		return res
+	},
+}
+
+// RenderTemplate render Go template with Eden-related fuctions
+func RenderTemplate(configFile string, tmpl string) (string, error) {
+	var err error
+	var buf bytes.Buffer
+	
+	viperLoaded, err := LoadConfigFile(configFile)
+	if err != nil {
+		log.Fatalf("error reading config: %s", err.Error())
+		return "", err
+	}
+	if viperLoaded {
+		t, err := template.New("Eden").Funcs(funcs).Parse(string(tmpl))
+		if err != nil {
+			return "", err
+		}
+
+		err = t.Execute(&buf, nil)
+		if err != nil {
+			return "", err
+		}
+		return buf.String(), err
+	} else {
+		return tmpl, err
+	}
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,7 +8,10 @@ OS ?= $(HOSTOS)
 WORKDIR ?= $(CURDIR)/../../dist
 ECONFIG ?= `$(LOCALBIN) config get`
 
-test: integration_test
+test: units_test integration_test
+
+units_test:
+	make -C units test
 
 integration_test:
 	make -C integration DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) ECONFIG=$(ECONFIG) test

--- a/tests/units/Makefile
+++ b/tests/units/Makefile
@@ -1,0 +1,22 @@
+.DEFAULT_GOAL := help
+
+test: test_go test_sceanrio
+
+test_go:
+	go test templates_test.go -v
+
+test_sceanrio:
+	./template_test_scenario.sh
+
+help:
+	@echo "EDEN is the harness for testing EVE and ADAM"
+	@echo
+	@echo "This Makefile automates commons tasks of EDEN testing"
+	@echo
+	@echo "Commonly used maintenance and development targets:"
+	@echo "   test          run tests"
+	@echo
+	@echo "You need install requirements for EVE (look at https://github.com/lf-edge/eve#install-dependencies)."
+	@echo "Also, you need to install 'uuidgen' utility."
+	@echo "You need access to docker socket and installed qemu packages."
+

--- a/tests/units/template_test.tmpl
+++ b/tests/units/template_test.tmpl
@@ -1,0 +1,3 @@
+eden.root = {{EdenConfig "eden.root"}}
+eden.images.dist = {{EdenConfig "eden.images.dist"}} -> {{EdenConfigPath "eden.images.dist"}}
+{{$i := EdenConfig "eden.images.dist"}}eden.images.dist = {{$i}} -> {{EdenPath $i }}

--- a/tests/units/template_test_scenario.sh
+++ b/tests/units/template_test_scenario.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+DIR=`mktemp -d --suffix=.eden_template_test`
+
+#echo Test dir: $DIR
+cp template_test_scenario.tmpl $DIR
+cp /bin/echo $DIR
+
+../../eden test $DIR -s template_test_scenario.tmpl > $DIR/out1
+
+ROOT=`../../eden config get --key eden.root`
+DIST=`../../eden config get --key eden.images.dist`
+echo eden.root = $ROOT > $DIR/out2
+echo eden.images.dist = $DIST '->' $ROOT/$DIST >> $DIR/out2
+echo eden.images.dist = $DIST '->' $ROOT/$DIST >> $DIR/out2
+
+if diff $DIR/out1 $DIR/out2
+then
+	echo --- PASS: TestTemplateSceanrio
+	echo PASS
+else
+	echo --- FAIL: TestTemplateSceanrio
+	echo FAIL
+fi
+rm -rf $DIR

--- a/tests/units/template_test_scenario.tmpl
+++ b/tests/units/template_test_scenario.tmpl
@@ -1,0 +1,4 @@
+echo eden.root = {{EdenConfig "eden.root"}}
+echo eden.images.dist = {{EdenConfig "eden.images.dist"}} -> {{EdenConfigPath "eden.images.dist"}}
+echo {{$i := EdenConfig "eden.images.dist"}}eden.images.dist = {{$i}} -> {{EdenPath $i }}
+

--- a/tests/units/templates_test.go
+++ b/tests/units/templates_test.go
@@ -1,0 +1,75 @@
+package templates
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+        "testing"
+	"github.com/spf13/viper"
+	"github.com/lf-edge/eden/pkg/utils"
+)
+
+
+func getConfig(t *testing.T) string {
+	context, err := utils.ContextLoad()
+	if err != nil {
+		t.Fatalf("Load context error: %s", err)
+	}
+	configFile := context.GetCurrentConfig()
+	if configFile == "" {
+		configFile, err = utils.DefaultConfigPath()
+		if err != nil {
+			t.Fatalf("fail in DefaultConfigPath: %s", err)
+		}
+	}
+	return configFile
+}
+
+func TestTemplateString(t *testing.T) {
+	configFile := getConfig(t)
+	viperLoaded, err := utils.LoadConfigFile(configFile)
+	if err != nil {
+		t.Fatalf("error reading config: %s", err.Error())
+	}
+	if viperLoaded {
+		tests := map[string]string {
+			"{{EdenConfig \"eden.root\"}}": viper.GetString("eden.root"),
+			"{{EdenConfigPath \"eden.images.dist\"}}": utils.ResolveAbsPath(viper.GetString("eden.images.dist")),
+			"{{$i := EdenConfig \"eden.images.dist\"}}{{EdenPath $i}}": utils.ResolveAbsPath(viper.GetString("eden.images.dist")),
+		}
+
+		for tmpl, res := range tests {
+			out, err := utils.RenderTemplate(configFile, tmpl)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if out != res {
+				t.Fatalf("Template rendering error: '%s' != '%s'\n", out, res)
+			}
+		}
+	}
+}
+
+func TestTemplateFile(t *testing.T) {
+	configFile := getConfig(t)
+
+	tmpl, err := ioutil.ReadFile("template_test.tmpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := utils.RenderTemplate(configFile, string(tmpl))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out = fmt.Sprintln(out)
+	
+	res,  err := exec.Command("../../eden", "utils", "template", "template_test.tmpl").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	if out != string(res) {
+		t.Fatalf("Template rendering error. We got:\n'%s'\nMust be:\n'%s'\n", out, res)
+	}
+}


### PR DESCRIPTION
Added support of Go Templates with possibility of usnig Eden's env. settings. Implemented `RenderTemplate` utils function, `eden utils template` command and templates support for test scenarios. Added unit tests.

Functions which may be used in templates now:
* `{{EdenConfig "<config_parameter>"}}` -- get value of Eden config parameter;
* `{{EdenPath "<dir_of_file>"}}` -- resolve path relative to the Eden root directory;
* `{{EdenConfigPath "<config_parameter>"}}` -- combination of EdenConfig and EdenPath.