### PR TITLE
Application ports redirection

### DIFF
--- a/cmd/edenPod.go
+++ b/cmd/edenPod.go
@@ -15,6 +15,8 @@ import (
 
 var podName = ""
 
+var portPublish []string
+
 var podCmd = &cobra.Command{
 	Use: "pod",
 }
@@ -40,7 +42,8 @@ var podDeployCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("getControllerAndDev: %s", err)
 		}
-		expectation := expect.AppExpectationFromUrl(ctrl, appLink, podName)
+		qemuPorts := viper.GetStringMapString("eve.hostfwd")
+		expectation := expect.AppExpectationFromUrl(ctrl, appLink, podName, portPublish, qemuPorts)
 		appInstanceConfig := expectation.Application()
 		devModel, err := ctrl.GetDevModelByName(viper.GetString("eve.devmodel"))
 		if err != nil {
@@ -278,6 +281,7 @@ var podDeleteCmd = &cobra.Command{
 
 func podInit() {
 	podCmd.AddCommand(podDeployCmd)
+	podDeployCmd.Flags().StringSliceVarP(&portPublish, "publish", "p", nil, "Ports to publish in format EXTERNAL_PORT:INTERNAL_PORT")
 	podDeployCmd.Flags().StringVarP(&podName, "name", "n", "", "name for pod")
 	podCmd.AddCommand(podPsCmd)
 	podCmd.AddCommand(podStopCmd)

--- a/pkg/expect/expectation.go
+++ b/pkg/expect/expectation.go
@@ -7,6 +7,8 @@ import (
 	"github.com/lf-edge/eden/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"math/rand"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -21,11 +23,55 @@ type appExpectation struct {
 	appUrl     string
 	appVersion string
 	appName    string
+	ports      map[int]int
 }
 
 //AppExpectationFromUrl init appExpectation with defined appLink
-func AppExpectationFromUrl(ctrl controller.Cloud, appLink string, podName string) (expectation *appExpectation) {
-	expectation = &appExpectation{ctrl: ctrl}
+func AppExpectationFromUrl(ctrl controller.Cloud, appLink string, podName string, portPublish []string, qemuPorts map[string]string) (expectation *appExpectation) {
+	expectation = &appExpectation{ctrl: ctrl, ports: make(map[int]int)}
+	if portPublish != nil && len(portPublish) > 0 {
+	exit:
+		for _, el := range portPublish {
+			splitted := strings.Split(el, ":")
+			if len(splitted) != 2 {
+				log.Fatalf("Cannot use %s in format EXTERNAL_PORT:INTERNAL_PORT", el)
+			}
+			extPort, err := strconv.Atoi(splitted[0])
+			if err != nil {
+				log.Fatalf("Cannot use %s in format EXTERNAL_PORT:INTERNAL_PORT: %s", el, err)
+			}
+			if extPort == 22 {
+				log.Fatalf("Port 22 already in use")
+			}
+			intPort, err := strconv.Atoi(splitted[1])
+			if err != nil {
+				log.Fatalf("Cannot use %s in format EXTERNAL_PORT:INTERNAL_PORT: %s", el, err)
+			}
+			for _, qv := range qemuPorts {
+				if qv == strconv.Itoa(extPort) {
+					expectation.ports[extPort] = intPort
+					break exit
+				}
+			}
+			log.Fatalf("Cannot use external port %d. Not in Qemu %s", extPort, qemuPorts)
+		}
+	}
+	//check used ports
+	if len(expectation.ports) > 0 {
+		for _, app := range ctrl.ListApplicationInstanceConfig() {
+			for _, iface := range app.Interfaces {
+				for _, acl := range iface.Acls {
+					for _, match := range acl.Matches {
+						for ip := range expectation.ports {
+							if match.Type == "lport" && match.Value == strconv.Itoa(ip) {
+								log.Fatalf("Port %d already in use", ip)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 	rand.Seed(time.Now().UnixNano())
 	expectation.appName = namesgenerator.GetRandomName(0)
 	if podName != "" {


### PR DESCRIPTION
To 'eden pod deploy' added `-p` | `--publish <EXTERNAL_PORT>:<INTERNAL_PORT>` for apps ports redirection.