### PR TITLE
Log/Info/Metric tests

### DIFF
--- a/cmd/edenTest.go
+++ b/cmd/edenTest.go
@@ -1,12 +1,12 @@
 package cmd
 
 import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eden/pkg/utils"
@@ -72,7 +72,7 @@ func runTest(testApp string, args []string, testArgs string) {
 	}
 }
 
-func runScenario() {
+func runScenario(testArgs string) {
 	// is it path to file?
 	_, err := os.Stat(testScenario)
 	if os.IsNotExist(err) {
@@ -102,9 +102,9 @@ func runScenario() {
 	}
 	strs := strings.Split(out, "\n")
 	var targs []string
-	for _, str := range strs  {
+	for _, str := range strs {
 		targs = strings.Split(str, " ")
-		runTest(targs[0], targs[1:], "")
+		runTest(targs[0], targs[1:], testArgs)
 	}
 }
 
@@ -146,7 +146,6 @@ test [test_dir] -r <regexp> [-t <timewait>] [-v <level>]
 			testScenario = vars.TestScenario
 		}
 
-
 		if testScenario == "" && testProg == "" && testRun == "" {
 			log.Fatal("Please set the --scenario option or environment variable eden.test-scenario in the EDEN configuration.")
 			return err
@@ -163,10 +162,10 @@ test [test_dir] -r <regexp> [-t <timewait>] [-v <level>]
 			runTest(testProg, []string{"-test.run", testRun}, testArgs)
 			return
 		case testScenario != "":
-			runScenario()
+			runScenario(testArgs)
 			return
 		default:
-			runScenario()
+			runScenario(testArgs)
 			return
 		}
 

--- a/pkg/projects/testContext.go
+++ b/pkg/projects/testContext.go
@@ -225,20 +225,18 @@ func (tc *TestContext) StartTrackingState(onlyNewElements bool) {
 		curState := InitState(dev)
 		tc.states[dev] = curState
 		if !onlyNewElements {
-			err := tc.GetController().InfoLastCallback(dev.GetID(), map[string]string{}, einfo.ZAll, curState.getProcessorInfo())
-			if err != nil {
-				log.Errorf("InfoChecker for dev %s error %s", dev.GetID(), err)
+			if err := tc.GetController().InfoLastCallback(dev.GetID(), map[string]string{}, einfo.ZAll, curState.getProcessorInfo()); err != nil {
+				log.Errorf("InfoLastCallback for dev %s error %s", dev.GetID(), err)
+			}
+			if err := tc.GetController().MetricLastCallback(dev.GetID(), map[string]string{}, curState.getProcessorMetric()); err != nil {
+				log.Errorf("MetricLastCallback for dev %s error %s", dev.GetID(), err)
 			}
 		}
 		if _, exists := tc.procBus.proc[dev]; !exists {
-			go func() {
-				err := tc.GetController().InfoChecker(dev.GetID(), map[string]string{}, einfo.ZAll, tc.procBus.getMainProcessorInfo(dev), einfo.InfoNew, 0)
-				if err != nil {
-					log.Errorf("InfoChecker for dev %s error %s", dev.GetID(), err)
-				}
-			}()
+			tc.procBus.initCheckers(dev)
 		}
 		tc.procBus.proc[dev] = append(tc.procBus.proc[dev], &absFunc{proc: curState.GetInfoProcessingFunction(), disabled: false})
+		tc.procBus.proc[dev] = append(tc.procBus.proc[dev], &absFunc{proc: curState.GetMetricProcessingFunction(), disabled: false})
 	}
 }
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -16,11 +16,11 @@ OS ?= $(HOSTOS)
 
 WORKDIR ?= $(CURDIR)/../dist
 
-test: units_test integration_test
+test: units_test integration_test lim_test
 
-build: integration_build reboot_build
-setup: integration_setup reboot_setup
-clean: integration_clean reboot_clean
+build: integration_build reboot_build lim_build
+setup: integration_setup reboot_setup lim_setup
+clean: integration_clean reboot_clean lim_clean
 
 units_test:
 	make -C units test
@@ -31,11 +31,17 @@ integration_test: integration_build integration_setup
 reboot_test: reboot_build reboot_setup
 	make -C reboot DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) test
 
+lim_test: reboot_build reboot_setup
+	make -C lim DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) test
+
 integration_build:
 	make -C integration DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) build
 
 reboot_build:
 	make -C reboot DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) build
+
+lim_build:
+	make -C lim DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) build
 
 integration_setup:
 	make -C integration DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) setup
@@ -43,8 +49,14 @@ integration_setup:
 reboot_setup:
 	make -C reboot DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) setup
 
+lim_setup:
+	make -C lim DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) setup
+
 integration_clean:
 	make -C integration DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) clean
 
 reboot_clean:
 	make -C reboot DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) clean
+
+lim_clean:
+	make -C lim DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) clean

--- a/tests/lim/Makefile
+++ b/tests/lim/Makefile
@@ -1,0 +1,72 @@
+DEBUG ?= "debug"
+
+# HOSTARCH is the host architecture
+# ARCH is the target architecture
+# we need to keep track of them separately
+HOSTARCH ?= $(shell uname -m)
+HOSTOS ?= $(shell uname -s | tr A-Z a-z)
+
+# canonicalized names for host architecture
+override HOSTARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(HOSTARCH)))
+
+# unless otherwise set, I am building for my own architecture, i.e. not cross-compiling
+# and for my OS
+ARCH ?= $(HOSTARCH)
+OS ?= $(HOSTOS)
+
+# canonicalized names for target architecture
+override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
+
+WORKDIR ?= $(CURDIR)/../../dist
+BINDIR := $(WORKDIR)/bin
+BIN := eden
+LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
+TESTNAME := eden.lim
+TESTBIN := $(TESTNAME).test
+TESTSCN := $(TESTNAME).tests.txt
+LOCALTESTBIN := $(TESTBIN)-$(OS)-$(ARCH)
+
+.DEFAULT_GOAL := help
+
+clean: 
+	rm -rf $(LOCALTESTBIN) $(BINDIR)/$(TESTBIN) $(WORKDIR)/$(TESTSCN) $(CURDIR)/$(TESTBIN) $(BINDIR)/$(TESTBIN)
+
+$(WORKDIR):
+	mkdir -p $@
+$(BINDIR):
+	mkdir -p $@
+
+test_lim:
+	go test lim_test.go common.go -v -count=1 -timeout 3000s
+
+test:
+	$(LOCALBIN) test $(CURDIR) -v $(DEBUG)
+
+build: setup
+
+testbin: $(TESTBIN)
+$(LOCALTESTBIN): $(BINDIR) *.go
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
+$(TESTBIN): $(LOCALTESTBIN)
+	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN); fi
+
+setup: testbin
+	cp $(TESTSCN) $(WORKDIR) 
+	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(CURDIR)/$(TESTBIN) $(BINDIR)/; fi
+	$(LOCALBIN) utils template eden-config.tmpl>eden-config.yml
+
+help:
+	@echo "EDEN is the harness for testing EVE and ADAM"
+	@echo
+	@echo "This Makefile automates commons tasks of EDEN testing"
+	@echo
+	@echo "Commonly used maintenance and development targets:"
+	@echo "   build         build test-binary (OS and ARCH options supported, for ex. OS=linux ARCH=arm64)"
+	@echo "   setup         setup of test environment"
+	@echo "   test          run tests"
+	@echo "   clean         cleanup of test harness"
+	@echo
+	@echo "You need install requirements for EVE (look at https://github.com/lf-edge/eve#install-dependencies)."
+	@echo "Also, you need to install 'uuidgen' utility."
+	@echo "You need access to docker socket and installed qemu packages."
+

--- a/tests/lim/eden-config.tmpl
+++ b/tests/lim/eden-config.tmpl
@@ -1,9 +1,9 @@
 eden:
     #test binary
-    test-bin: "eden.reboot.test"
+    test-bin: "eden.lim.test"
 
     #test scenario
-    test-scenario: "eden.reboot.tests.txt"
+    test-scenario: "eden.lim.tests.txt"
 
 test:
     controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}

--- a/tests/lim/eden.lim.tests.txt
+++ b/tests/lim/eden.lim.tests.txt
@@ -1,0 +1,1 @@
+eden.lim.test

--- a/tests/lim/lim_test.go
+++ b/tests/lim/lim_test.go
@@ -1,0 +1,182 @@
+package lim
+
+import (
+	"flag"
+	"fmt"
+	"github.com/lf-edge/eden/pkg/controller/elog"
+	"github.com/lf-edge/eden/pkg/device"
+	"github.com/lf-edge/eden/pkg/projects"
+	"github.com/lf-edge/eve/api/go/info"
+	"github.com/lf-edge/eve/api/go/metrics"
+	log "github.com/sirupsen/logrus"
+	"os"
+	"testing"
+	"time"
+)
+
+// This context holds all the configuration items in the same
+// way that Eden context works: the commands line options override
+// YAML settings. In addition to that, context is polymorphic in
+// a sense that it abstracts away a particular controller (currently
+// Adam and Zedcloud are supported)
+/*
+tc *TestContext // TestContext is at least {
+                //    controller *Controller
+                //    project *Project
+                //    nodes []EdgeNode
+                //    ...
+                // }
+*/
+
+var (
+	number   = flag.Int("number", 1, "The number of items (0=unlimited) you need to get")
+	timewait = flag.Int("timewait", 60, "Timewait for items waiting in seconds")
+	tc       *projects.TestContext
+)
+
+// TestMain is used to provide setup and teardown for the rest of the
+// tests. As part of setup we make sure that context has a slice of
+// EVE instances that we can operate on. For any action, if the instance
+// is not specified explicitly it is assumed to be the first one in the slice
+func TestMain(m *testing.M) {
+	fmt.Println("Log/Info/Metric Test")
+
+	tc = projects.NewTestContext()
+
+	projectName := fmt.Sprintf("%s_%s", "TestLogInfoMetric", time.Now())
+
+	// Registering our own project namespace with controller for easy cleanup
+	tc.InitProject(projectName)
+
+	// Create representation of EVE instances (based on the names
+	// or UUIDs that were passed in) in the context. This is the first place
+	// where we're using zcli-like API:
+	for _, node := range tc.GetNodeDescriptions() {
+		edgeNode := tc.GetController().GetEdgeNode(node.Name)
+		if edgeNode == nil {
+			// Couldn't find existing edgeNode record in the controller.
+			// Need to create it from scratch now:
+			// this is modeled after: zcli edge-node create <name>
+			// --project=<project> --model=<model> [--title=<title>]
+			// ([--edge-node-certificate=<certificate>] |
+			// [--onboarding-certificate=<certificate>] |
+			// [(--onboarding-key=<key> --serial=<serial-number>)])
+			// [--network=<network>...]
+			//
+			// XXX: not sure if struct (giving us optional fields) would be better
+			edgeNode = tc.NewEdgeNode(tc.WithNodeDescription(node), tc.WithCurrentProject())
+		} else {
+			// make sure to move EdgeNode to the project we created, again
+			// this is modeled after zcli edge-node update <name> [--title=<title>]
+			// [--lisp-mode=experimental|default] [--project=<project>]
+			// [--clear-onboarding-certs] [--config=<key:value>...] [--network=<network>...]
+			edgeNode.SetProject(projectName)
+		}
+
+		tc.ConfigSync(edgeNode)
+
+		// finally we need to make sure that the edgeNode is in a state that we need
+		// it to be, before the test can run -- this could be multiple checks on its
+		// status, but for example:
+		if edgeNode.GetState() == device.NotOnboarded {
+			log.Fatal("Node is not onboarded now")
+		}
+
+		// this is a good node -- lets add it to the test context
+		tc.AddNode(edgeNode)
+	}
+
+	tc.StartTrackingState(false)
+
+	// we now have a situation where TestContext has enough EVE nodes known
+	// for the rest of the tests to run. So run them:
+	res := m.Run()
+
+	// Finally, we need to cleanup whatever objects may be in in the project we created
+	// and then we can exit
+	os.Exit(res)
+}
+
+func TestLog(t *testing.T) {
+	var logs int
+
+	edgeNode := tc.GetEdgeNode(tc.WithTest(t))
+
+	tc.ConfigSync(edgeNode)
+
+	t.Logf("Wait for log of %s number=%d timewait=%d\n", edgeNode.GetName(), *number, *timewait)
+
+	tc.AddProcLog(edgeNode, func(log *elog.LogItem) error {
+		return func(t *testing.T, edgeNode *device.Ctx, log *elog.LogItem) error {
+			t.Logf("LOG from %s: %s", edgeNode.GetName(), log)
+			if *number == 0 {
+				return nil
+			} else {
+				logs += 1
+				if logs >= *number {
+					return fmt.Errorf("Recieved %d logs from %s", logs, edgeNode.GetName())
+				} else {
+					return nil
+				}
+			}
+		}(t, edgeNode, log)
+	})
+
+	tc.WaitForProc(*timewait)
+}
+
+func TestInfo(t *testing.T) {
+	var infos int
+
+	edgeNode := tc.GetEdgeNode(tc.WithTest(t))
+
+	tc.ConfigSync(edgeNode)
+
+	t.Logf("Wait for info of %s number=%d timewait=%d\n", edgeNode.GetName(), *number, *timewait)
+
+	tc.AddProcInfo(edgeNode, func(einfo *info.ZInfoMsg) error {
+		return func(t *testing.T, edgeNode *device.Ctx, einfo *info.ZInfoMsg) error {
+			t.Logf("INFO from %s: %s", edgeNode.GetName(), einfo)
+			if *number == 0 {
+				return nil
+			} else {
+				infos += 1
+				if infos >= *number {
+					return fmt.Errorf("Recieved %d infos from %s", infos, edgeNode.GetName())
+				} else {
+					return nil
+				}
+			}
+		}(t, edgeNode, einfo)
+	})
+
+	tc.WaitForProc(*timewait)
+}
+
+func TestMetrics(t *testing.T) {
+	var metrs int
+
+	edgeNode := tc.GetEdgeNode(tc.WithTest(t))
+
+	tc.ConfigSync(edgeNode)
+
+	t.Logf("Wait for metric of %s number=%d timewait=%d\n", edgeNode.GetName(), *number, *timewait)
+
+	tc.AddProcMetric(edgeNode, func(metric *metrics.ZMetricMsg) error {
+		return func(t *testing.T, edgeNode *device.Ctx, metric *metrics.ZMetricMsg) error {
+			t.Logf("METRIC from %s: %s", edgeNode.GetName(), metric)
+			if *number == 0 {
+				return nil
+			} else {
+				metrs += 1
+				if metrs >= *number {
+					return fmt.Errorf("Recieved %d metrics from %s", metrs, edgeNode.GetName())
+				} else {
+					return nil
+				}
+			}
+		}(t, edgeNode, metric)
+	})
+
+	tc.WaitForProc(*timewait)
+}


### PR DESCRIPTION
Related to https://github.com/lf-edge/eden/issues/104.

Added Logs/Metrics support for Process/State machinery. Improved 'eden test` functionality for passing parameters to scenario tests. Log/Info/Metric tests are implemented, which can be performed, for example, with the following command:
```
./eden test tests / lim / -v debug -a '-timewait 600 -number 3'
```
In this case, we will run TestLog, TestInfo and TestMetrics with the expectation of 3 events (by this parameter we check the deactivation of the Process function after a non-zero return, by default we expect 1 event) and 10 minutes. timeout (test for asynchronous processes, default 1 min.)