### PR TITLE
Raspberry Pi 4 support

### DIFF
--- a/cmd/edenPod.go
+++ b/cmd/edenPod.go
@@ -47,6 +47,9 @@ var podDeployCmd = &cobra.Command{
 		}
 		qemuPorts := viper.GetStringMapString("eve.hostfwd")
 		expectation := expect.AppExpectationFromUrl(ctrl, appLink, podName, portPublish, qemuPorts, podMetadata)
+		if len(qemuPorts) == 0 {
+			qemuPorts = nil
+		}
 		appInstanceConfig := expectation.Application()
 		dev.SetApplicationInstanceConfig(append(dev.GetApplicationInstances(), appInstanceConfig.Uuidandversion.Uuid))
 		if err = changer.setControllerAndDev(ctrl, dev); err != nil {

--- a/cmd/edenStart.go
+++ b/cmd/edenStart.go
@@ -57,6 +57,7 @@ var startCmd = &cobra.Command{
 			qemuConfigFile = utils.ResolveAbsPath(viper.GetString("eve.qemu-config"))
 			evePidFile = utils.ResolveAbsPath(viper.GetString("eve.pid"))
 			eveLogFile = utils.ResolveAbsPath(viper.GetString("eve.log"))
+			devModel = viper.GetString("eve.devmodel")
 		}
 		return nil
 	},
@@ -93,6 +94,9 @@ var startCmd = &cobra.Command{
 			log.Errorf("cannot start eserver: %s", err)
 		} else {
 			log.Infof("Eserver is running and accesible on port %d", eserverPort)
+		}
+		if devModel == defaults.DefaultRPIModel {
+			return
 		}
 		if err := utils.StartEVEQemu(command, qemuARCH, qemuOS, eveImageFile, qemuSMBIOSSerial, qemuAccel, qemuConfigFile, eveLogFile, evePidFile); err != nil {
 			log.Errorf("cannot start eve: %s", err)

--- a/cmd/edenStatus.go
+++ b/cmd/edenStatus.go
@@ -2,14 +2,65 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/lf-edge/eden/pkg/controller/einfo"
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eden/pkg/utils"
+	"github.com/lf-edge/eve/api/go/info"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"net"
 	"os"
 	"path/filepath"
+	"strings"
 )
+
+func eveStatusRPI() {
+	log.Debugf("Will try to obtain info from ADAM")
+	changer := &adamChanger{}
+	ctrl, dev, err := changer.getControllerAndDev()
+	if err != nil {
+		log.Debugf("getControllerAndDev: %s", err)
+		fmt.Println("EVE status: undefined (no onboarded EVE)")
+	} else {
+		var lastDInfo *info.ZInfoMsg
+		var handleInfo = func(im *info.ZInfoMsg, ds []*einfo.ZInfoMsgInterface, infoType einfo.ZInfoType) bool {
+			lastDInfo = im
+			return false
+		}
+		if err = ctrl.InfoLastCallback(dev.GetID(), map[string]string{"devId": dev.GetID().String()}, einfo.ZInfoNetwork, handleInfo); err != nil {
+			log.Fatalf("Fail in get InfoLastCallback: %s", err)
+		}
+		if lastDInfo != nil {
+			var ips []string
+			for _, nw := range lastDInfo.GetDinfo().Network {
+				for _, addr := range nw.IPAddrs {
+					ip, _, err := net.ParseCIDR(addr)
+					if err != nil {
+						log.Fatal(err)
+					}
+					ipv4 := ip.To4()
+					if ipv4 != nil {
+						ips = append(ips, ipv4.String())
+					}
+				}
+			}
+			fmt.Printf("EVE REMOTE IPs: %s\n", strings.Join(ips, "; "))
+		} else {
+			fmt.Printf("EVE REMOTE IPs: %s\n", "waiting for info...")
+		}
+	}
+}
+
+func eveStatusQEMU() {
+	statusEVE, err := utils.StatusEVEQemu(evePidFile)
+	if err != nil {
+		log.Errorf("cannot obtain status of EVE process: %s", err)
+	} else {
+		fmt.Printf("EVE process status: %s\n", statusEVE)
+		fmt.Printf("\tLogs for local EVE at: %s\n", utils.ResolveAbsPath("eve.log"))
+	}
+}
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
@@ -24,6 +75,7 @@ var statusCmd = &cobra.Command{
 		if viperLoaded {
 			eserverPidFile = utils.ResolveAbsPath(viper.GetString("eden.eserver.pid"))
 			evePidFile = utils.ResolveAbsPath(viper.GetString("eve.pid"))
+			devModel = viper.GetString("eve.devmodel")
 		}
 		return nil
 	},
@@ -69,12 +121,10 @@ var statusCmd = &cobra.Command{
 			fmt.Printf("\tEServer is expected at http://%s:%d from EVE\n", viper.GetString("eden.eserver.ip"), viper.GetInt("eden.eserver.port"))
 			fmt.Printf("\tLogs for local EServer at: %s\n", utils.ResolveAbsPath("eserver.log"))
 		}
-		statusEVE, err := utils.StatusEVEQemu(evePidFile)
-		if err != nil {
-			log.Errorf("cannot obtain status of EVE process: %s", err)
+		if devModel == defaults.DefaultRPIModel {
+			eveStatusRPI()
 		} else {
-			fmt.Printf("EVE process status: %s\n", statusEVE)
-			fmt.Printf("\tLogs for local EVE at: %s\n", utils.ResolveAbsPath("eve.log"))
+			eveStatusQEMU()
 		}
 	},
 }

--- a/cmd/edenStop.go
+++ b/cmd/edenStop.go
@@ -28,6 +28,7 @@ var stopCmd = &cobra.Command{
 		if viperLoaded {
 			eserverPidFile = utils.ResolveAbsPath(viper.GetString("eden.eserver.pid"))
 			evePidFile = utils.ResolveAbsPath(viper.GetString("eve.pid"))
+			devModel = viper.GetString("eve.devmodel")
 		}
 		return nil
 	},
@@ -46,6 +47,9 @@ var stopCmd = &cobra.Command{
 			log.Infof("cannot stop eserver: %s", err)
 		} else {
 			log.Infof("eserver stopped")
+		}
+		if devModel == defaults.DefaultRPIModel {
+			return
 		}
 		if err := utils.StopEVEQemu(evePidFile); err != nil {
 			log.Infof("cannot stop EVE: %s", err)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -39,7 +39,7 @@ const (
 
 	//tags, versions, repos
 	DefaultNewBuildProcess   = true
-	DefaultEVETag            = "5.6.1" //DefaultEVETag tag for EVE image
+	DefaultEVETag            = "0.0.0-snapshot-master-a833eaf1" //DefaultEVETag tag for EVE image
 	DefaultAdamTag           = "0.0.44"
 	DefaultRedisTag          = "6"
 	DefaultLinuxKitVersion   = "v0.7"
@@ -67,6 +67,7 @@ const (
 	DefaultBaseID                = "22b8761b-5f89-4e0b-b757-4b87a9fa93ec"
 	NetDHCPID                    = "6822e35f-c1b8-43ca-b344-0bbc0ece8cf1"
 	NetNoDHCPID                  = "6822e35f-c1b8-43ca-b344-0bbc0ece8cf2"
+	NetWiFiID                    = "6822e35f-c1b8-43ca-b344-0bbc0ece8cf3"
 	DefaultTestProg              = ""
 	DefaultTestScenario          = ""
 	DefaultRootFSVersionPattern  = `^(\d+\.*){2,3}.*-(xen|kvm|acrn)-(amd64|arm64)$`
@@ -85,6 +86,8 @@ const (
 	DefaultAppSubnet = "10.1.0.0/24"
 
 	DefaultEVEModel = "ZedVirtual-4G"
+
+	DefaultRPIModel = "RPi4"
 
 	DefaultEVEImageSize = 8192
 
@@ -130,6 +133,7 @@ var (
 		"eve.dtb-part":     "dtb-part",
 		"eve.config-part":  "config-part",
 		"eve.base-version": "os-version",
+		"eve.devmodel":     "devmodel",
 
 		"eden.images.dist":   "image-dist",
 		"eden.images.docker": "docker-yml",

--- a/pkg/expect/expectation.go
+++ b/pkg/expect/expectation.go
@@ -62,13 +62,17 @@ func AppExpectationFromUrl(ctrl controller.Cloud, appLink string, podName string
 			if err != nil {
 				log.Fatalf("Cannot use %s in format EXTERNAL_PORT:INTERNAL_PORT: %s", el, err)
 			}
-			for _, qv := range qemuPorts {
-				if qv == strconv.Itoa(extPort) {
-					expectation.ports[extPort] = intPort
-					break exit
+			if qemuPorts != nil && len(qemuPorts) > 0 { //not empty forwarding rules, need to check for existing
+				for _, qv := range qemuPorts {
+					if qv == strconv.Itoa(extPort) {
+						expectation.ports[extPort] = intPort
+						break exit
+					}
 				}
+				log.Fatalf("Cannot use external port %d. Not in Qemu %s", extPort, qemuPorts)
+			} else {
+				expectation.ports[extPort] = intPort
 			}
-			log.Fatalf("Cannot use external port %d. Not in Qemu %s", extPort, qemuPorts)
 		}
 	}
 	//check used ports

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -102,7 +102,7 @@ adam:
     domain: {{ .DefaultDomain }}
 
     #ip of adam for EVE access
-    eve-ip: {{ .EVEIP }}
+    eve-ip: {{ .IP }}
 
     #ip of adam for EDEN access
     ip: {{ .IP }}
@@ -155,7 +155,7 @@ eve:
     hv: {{ .DefaultEVEHV }}
 
     #serial number in SMBIOS
-    serial: {{ .DefaultEVESerial }}
+    serial: "{{ .DefaultEVESerial }}"
 
     #onboarding certificate of EVE to put into adam
     cert: certs/onboard.cert.pem
@@ -167,7 +167,7 @@ eve:
     log: eve.log
 
     #EVE firmware
-    firmware: [{{ .DefaultEVEDist }}/dist/amd64/OVMF_CODE.fd,{{ .DefaultEVEDist }}/dist/amd64/OVMF_VARS.fd]
+    firmware: [{{ .DefaultImageDist }}/eve/OVMF_CODE.fd,{{ .DefaultImageDist }}/eve/OVMF_VARS.fd]
 
     #eve repo used in clone mode (eden.download = false)
     repo: {{ .DefaultEveRepo }}
@@ -193,10 +193,10 @@ eve:
     uuid: {{ .UUID }}
 
     #live image of EVE
-    image-file: {{ .DefaultEVEDist }}/dist/amd64/live.qcow2
+    image-file: {{ .DefaultImageDist }}/eve/live.img
 
     #dtb directory of EVE
-    dtb-part: 
+    dtb-part: ""
 
     #config part of EVE
     config-part: {{ .DefaultAdamDist }}/run/config

--- a/pkg/utils/configDiff.go
+++ b/pkg/utils/configDiff.go
@@ -12,7 +12,7 @@ adam:
     domain: {{ .DefaultDomain }}
 
     #ip of adam for EVE access
-    eve-ip: {{ .EVEIP }}
+    eve-ip: {{ .IP }}
 
     #ip of adam for EDEN access
     ip: {{ .IP }}
@@ -28,7 +28,7 @@ adam:
 
 eve:
     #live image of EVE
-    image-file: {{ .DefaultEVEDist }}/dist/amd64/live.qcow2
+    image-file: {{ .DefaultImageDist }}/eve/live.img
 
     #devmodel
     devmodel: ZedVirtual-4G
@@ -46,13 +46,13 @@ eve:
     uuid: {{ .UUID }}
 
     #serial number in SMBIOS
-    serial: {{ .DefaultEVESerial }}
+    serial: "{{ .DefaultEVESerial }}"
 
     #onboarding certificate of EVE to put into adam
     cert: certs/onboard.cert.pem
 
     #EVE firmware
-    firmware: {{ .DefaultEVEDist }}/dist/amd64/OVMF.fd
+    firmware: [{{ .DefaultImageDist }}/eve/OVMF_CODE.fd,{{ .DefaultImageDist }}/eve/OVMF_VARS.fd]
 
     #forward of ports in qemu [(HOST:EVE)]
     hostfwd:

--- a/pkg/utils/container.go
+++ b/pkg/utils/container.go
@@ -164,12 +164,16 @@ func PullImage(image string) error {
 }
 
 //GenEVEImage from docker to outputFile only with defined configDir
-func GenEVEImage(image, outputDir, command, format string, configDir string) (fileName string, err error) {
+func GenEVEImage(image, outputDir, command, format string, configDir string, size int) (fileName string, err error) {
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return "", err
 	}
 	volumeMap := map[string]string{"/in": configDir, "/out": outputDir}
-	u, err := RunDockerCommand(image, fmt.Sprintf("-f %s %s %d", format, command, defaults.DefaultEVEImageSize), volumeMap)
+	dockerCommand := fmt.Sprintf("-f %s %s %d", format, command, size)
+	if size == 0 {
+		dockerCommand = fmt.Sprintf("-f %s %s", format, command)
+	}
+	u, err := RunDockerCommand(image, dockerCommand, volumeMap)
 	if err != nil {
 		log.Printf("error GenEVEImage: %v", err)
 		return "", err

--- a/tests/integration/baseImage_test.go
+++ b/tests/integration/baseImage_test.go
@@ -160,7 +160,7 @@ func SetupBaseImage(t *testing.T) (fileToUse string) {
 			} else {
 				t.Log("clone BASE EVE done")
 			}
-			if err := utils.MakeEveInRepo(eveBaseDist, adamDist, eveArch, eveHV, true); err != nil {
+			if _, _, err = utils.MakeEveInRepo(eveBaseDist, adamDist, eveArch, eveHV, "raw", true); err != nil {
 				t.Fatalf("cannot MakeEveInRepo base: %s", err)
 			} else {
 				t.Log("MakeEveInRepo base done")


### PR DESCRIPTION
To EDEN added support for Rpi4.

In Ubuntu you need install the package qemu-user-static.

Initialization procedure:
```
make clean
make bin
./eden config add default --devmodel RPi4
./eden setup
```
Output will contain file for dd onto sd card
```
./eden start
./eden eve onboard
./eden status
```
