### PR TITLE
Allowing for explicit rpi-XXX HV settings

### DIFF
--- a/cmd/edenSetup.go
+++ b/cmd/edenSetup.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 var (
@@ -97,10 +98,13 @@ var setupCmd = &cobra.Command{
 		var imageFormat string
 		switch devModel {
 		case defaults.DefaultRPIModel:
-			if eveHV == "kvm" {
-				eveHV = fmt.Sprintf("rpi-%s", eveHV)
-			} else {
-				eveHV = "rpi"
+			// don't second guess explicit rpi- setting
+			if !strings.HasPrefix(eveHV, "rpi-") {
+				if eveHV == "kvm" {
+					eveHV = fmt.Sprintf("rpi-%s", eveHV)
+				} else {
+					eveHV = "rpi"
+				}
 			}
 			imageFormat = "raw"
 		case defaults.DefaultEVEModel:


### PR DESCRIPTION
This is to make sure that we don't second guess users when they put an explicit hv=rpi-XXX label in Eden config

@sadov @giggsoff can you please review?