### PR TITLE
Eden eve reset command and onboard fix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,17 @@ Eden is controlled by a single command named (in a secret code) `eden`. It has m
 Run `eden help` to see sub-commands.
 
 To build `eden`:
+```
+make bin
+```
+
+To build `eden` and tests inside eden 
+It's better to call `eden config add` first, so the build command can build tests for the desired architecture
 
 ```
 make build
 ```
+
 
 You can build it for different computer architectures and operating systems by passing `OS` and `ARCH` options.
 The default, however, is for the architecture and OS on which you are building it.
@@ -191,4 +198,11 @@ The current sub-commands are:
    * `eve` -- sub-commands for interact with EVE.
    * `controller` -- sub-commands to update EVE.
    * `pod` -- work with applications running on EVE (containers and VMs)
+
+## Eden EVE commands
+
+`eden eve onboard` - onboard EVE that is the current config
+`eden eve reset` - put EVE to the initial state (reset to config) removing all changes made by commands or tests
+
+
 


### PR DESCRIPTION
We introduce `eden eve reset` command that allows to reset the config to the initial one (global) that is set up by `eden config add` and modified manually. This is useful if something bad happens and config is broken, but connection between EVE and ADAM is still available e.g. Raspberry lost WiFi or ssh or just you want to restore the environment.

Also there is a fix for `eden eve onboard` when eve is onboarded after the timeout of` eden eve onboard` command
#135 