### PR TITLE
RPi4 WiFi support

### DIFF
--- a/cmd/edenConfig.go
+++ b/cmd/edenConfig.go
@@ -27,6 +27,8 @@ var (
 	contextValueSet string
 	contextKeyGet   string
 	contextAllGet   bool
+	ssid            string
+	password        string
 )
 
 var configCmd = &cobra.Command{
@@ -121,6 +123,9 @@ var configAddCmd = &cobra.Command{
 			viper.Set("eve.serial", "*")
 			viper.Set("eve.remote", eveRemote)
 			viper.Set("eve.remote-addr", "")
+			if ssid != "" {
+				viper.Set("eve.ssid", ssid)
+			}
 			if err = viper.WriteConfig(); err != nil {
 				log.Fatalf("error writing config: %s", err)
 			}
@@ -452,6 +457,7 @@ func configInit() {
 	configAddCmd.Flags().StringVarP(&qemuDTBPath, "dtb-part", "", "", "path for device tree drive (for arm)")
 	configAddCmd.Flags().StringToStringVarP(&qemuHostFwd, "eve-hostfwd", "", defaults.DefaultQemuHostFwd, "port forward map")
 	configAddCmd.Flags().StringVarP(&qemuSocketPath, "qmp", "", "", "use qmp socket with path")
+	configAddCmd.Flags().StringVar(&ssid, "ssid", "", "set ssid of wifi for rpi")
 	configCmd.AddCommand(configResetCmd)
 	configCmd.AddCommand(configEditCmd)
 }

--- a/cmd/edenPod.go
+++ b/cmd/edenPod.go
@@ -42,6 +42,7 @@ var podDeployCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("error reading config: %s", err.Error())
 		}
+		ssid = viper.GetString("eve.ssid")
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/expect/networkInstance.go
+++ b/pkg/expect/networkInstance.go
@@ -4,7 +4,6 @@ import (
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eden/pkg/utils"
 	"github.com/lf-edge/eve/api/go/config"
-	"github.com/lf-edge/eve/api/go/evecommon"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 )
@@ -36,12 +35,9 @@ func (exp *appExpectation) createNetworkInstance() (*config.NetworkInstanceConfi
 		Displayname: "local",
 		InstType:    config.ZNetworkInstType_ZnetInstLocal, //we use local networks for now
 		Activate:    true,
-		Port: &config.Adapter{
-			Name: "eth0",
-			Type: evecommon.PhyIoType_PhyIoNetEth,
-		},
-		Cfg:    &config.NetworkInstanceOpaqueConfig{},
-		IpType: config.AddressType_IPV4,
+		Port:        exp.uplinkAdapter,
+		Cfg:         &config.NetworkInstanceOpaqueConfig{},
+		IpType:      config.AddressType_IPV4,
 		Ip: &config.Ipspec{
 			Subnet:  defaults.DefaultAppSubnet,
 			Gateway: subentIPs[1].String(),

--- a/pkg/expect/vm.go
+++ b/pkg/expect/vm.go
@@ -28,7 +28,7 @@ func (exp *appExpectation) createAppInstanceConfigVM(img *config.Image, netInstI
 		Activate:    true,
 		Displayname: exp.appName,
 		Interfaces: []*config.NetworkAdapter{{
-			Name:      "eth0",
+			Name:      "default",
 			NetworkId: netInstId,
 			Acls:      acls,
 		}},

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -30,6 +30,7 @@ type ConfigVars struct {
 	AdamRedisUrlEden  string
 	AdamRedisUrlAdam  string
 	EveHV             string
+	EveSSID           string
 	EveName           string
 	EveRemote         bool
 	EveRemoteAddr     string
@@ -71,6 +72,7 @@ func InitVars() (*ConfigVars, error) {
 			EveCert:           ResolveAbsPath(viper.GetString("eve.cert")),
 			EveSerial:         viper.GetString("eve.serial"),
 			ZArch:             viper.GetString("eve.arch"),
+			EveSSID:           viper.GetString("eve.ssid"),
 			EveHV:             viper.GetString("eve.hv"),
 			DevModel:          viper.GetString("eve.devmodel"),
 			EveName:           viper.GetString("eve.name"),

--- a/pkg/utils/eden.go
+++ b/pkg/utils/eden.go
@@ -188,13 +188,15 @@ func StatusEVEQemu(pidFile string) (status string, err error) {
 }
 
 //GenerateEveCerts function generates certs for EVE
-func GenerateEveCerts(commandPath string, certsDir string, domain string, ip string, eveIP string, uuid string) (err error) {
+func GenerateEveCerts(commandPath string, certsDir string, domain string, ip string, eveIP string, uuid string, ssid string, password string) (err error) {
 	if _, err := os.Stat(certsDir); os.IsNotExist(err) {
 		if err = os.MkdirAll(certsDir, 0755); err != nil {
 			return err
 		}
 	}
-	commandArgsString := fmt.Sprintf("certs --certs-dist=%s --domain=%s --ip=%s --eve-ip=%s --uuid=%s -v %s", certsDir, domain, ip, eveIP, uuid, log.GetLevel())
+	commandArgsString := fmt.Sprintf(
+		"certs --certs-dist=%s --domain=%s --ip=%s --eve-ip=%s --uuid=%s --ssid=%s --password=%s -v %s",
+		certsDir, domain, ip, eveIP, uuid, ssid, password, log.GetLevel())
 	log.Infof("GenerateEveCerts run: %s %s", commandPath, commandArgsString)
 	return RunCommandWithLogAndWait(commandPath, defaults.DefaultLogLevelToPrint, strings.Fields(commandArgsString)...)
 }
@@ -231,9 +233,11 @@ func CopyCertsToAdamConfig(certsDir string, domain string, ip string, port int, 
 	if err = CopyFileNotExists(filepath.Join(certsDir, "onboard.key.pem"), filepath.Join(adamConfig, "onboard.key.pem")); err != nil {
 		return err
 	}
-	/*if err = CopyFileNotExists(filepath.Join(certsDir, "id_rsa.pub"), filepath.Join(adamConfig, "authorized_keys")); err != nil {
-		return err
-	}*/
+	if _, err = os.Stat(filepath.Join(certsDir, "DevicePortConfig", "override.json")); !os.IsNotExist(err) {
+		if err = CopyFileNotExists(filepath.Join(certsDir, "DevicePortConfig", "override.json"), filepath.Join(adamConfig, "DevicePortConfig", "override.json")); err != nil {
+			return err
+		}
+	}
 	if _, err = os.Stat(filepath.Join(adamConfig, "hosts")); os.IsNotExist(err) {
 		if err = ioutil.WriteFile(filepath.Join(adamConfig, "hosts"), []byte(fmt.Sprintf("%s %s\n", ip, domain)), 0666); err != nil {
 			return err


### PR DESCRIPTION
#149 
This functionality adds the Wifi support to RPI4. 
Additional parameter of SSID is added. Then WiFi is supported instead of eth0 interface. Eth0 is switched off.
Use Wifi config via:
`./eden config add default --devmodel RPi4 --ssid WIFISSID  `

This will be updated in the future to allow all interfaces at once. 