### PR TITLE
Upload timeouts expand; latest tag of eserver

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -50,7 +50,7 @@ const (
 	DefaultEveRepo           = "https://github.com/lf-edge/eve.git"
 	DefaultRegistry          = "docker.io"
 
-	DefaultEServerTag          = "0.0.3"
+	DefaultEServerTag          = "latest"
 	DefaultEServerContainerRef = "lfedge/eden-http-server"
 
 	//DefaultRepeatCount is repeat count for requests

--- a/pkg/utils/eden.go
+++ b/pkg/utils/eden.go
@@ -493,7 +493,7 @@ func (server *EServer) getHTTPClient(timeout time.Duration) *http.Client {
 	return &http.Client{
 		Timeout: timeout,
 		Transport: &http.Transport{
-			ResponseHeaderTimeout: defaults.DefaultRepeatTimeout,
+			ResponseHeaderTimeout: defaults.DefaultRepeatTimeout * defaults.DefaultRepeatCount,
 		},
 	}
 }
@@ -534,7 +534,7 @@ func (server *EServer) EServerCheckStatus(name string) (fileInfo *api.FileInfo) 
 	if err != nil {
 		log.Fatalf("error constructing URL: %v", err)
 	}
-	client := server.getHTTPClient(defaults.DefaultRepeatTimeout)
+	client := server.getHTTPClient(defaults.DefaultRepeatTimeout * defaults.DefaultRepeatCount)
 	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
 		log.Fatalf("unable to create new http request: %v", err)


### PR DESCRIPTION
Expanding of ResponseHeaderTimeout for waiting of SHA256 calculation inside eserver. Errors representation fixes.

`DefaultEServerTag` set to `latest` to support of autobuilding images in #162 

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>