### PR TITLE
Checking for config changes during the 'eden setup'.

### DIFF
--- a/cmd/edenClean.go
+++ b/cmd/edenClean.go
@@ -11,7 +11,10 @@ import (
 	"path/filepath"
 )
 
-var configDir string
+var (
+	configDir   string
+	configSaved string
+)
 
 var cleanCmd = &cobra.Command{
 	Use:   "clean",
@@ -31,6 +34,7 @@ var cleanCmd = &cobra.Command{
 			eserverImageDist = utils.ResolveAbsPath(viper.GetString("eden.images.dist"))
 			qemuFileToSave = utils.ResolveAbsPath(viper.GetString("eve.qemu-config"))
 			redisDist = utils.ResolveAbsPath(viper.GetString("redis.dist"))
+			configSaved = utils.ResolveAbsPath(defaults.DefaultConfigSaved)
 		}
 		return nil
 	},
@@ -39,8 +43,9 @@ var cleanCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("cannot obtain executable path: %s", err)
 		}
-		if err := utils.CleanEden(command, eveDist, adamDist, certsDir, eserverImageDist, redisDist,
-			configDir, evePidFile); err != nil {
+		if err := utils.CleanEden(command, eveDist, adamDist, certsDir,
+			eserverImageDist, redisDist, configDir, evePidFile,
+			configSaved); err != nil {
 			log.Fatalf("cannot CleanEden: %s", err)
 		}
 		log.Infof("CleanEden done")

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -22,6 +22,7 @@ const (
 	DefaultQemuFileToSave   = "qemu.conf"        //qemu config file inside DefaultEdenHomeDir
 	DefaultSSHKey           = "certs/id_rsa.pub" //file for save ssh key
 	DefaultConfigHidden     = ".eden-config.yml" //file to save config get --all
+	DefaultConfigSaved      = "config_saved.yml" //file to save config during 'eden setup'
 
 	DefaultContext = "default" //default context name
 

--- a/pkg/utils/eden.go
+++ b/pkg/utils/eden.go
@@ -442,7 +442,7 @@ func PrepareQEMUConfig(commandPath string, qemuConfigFile string, firmwareFile [
 }
 
 //CleanEden teardown Eden and cleanup
-func CleanEden(commandPath, eveDist, adamDist, certsDist, imagesDist, redisDist, configDir, evePID string) (err error) {
+func CleanEden(commandPath, eveDist, adamDist, certsDist, imagesDist, redisDist, configDir, evePID string, configSaved string) (err error) {
 	commandArgsString := fmt.Sprintf("stop --eve-pid=%s --adam-rm=true",
 		evePID)
 	log.Infof("CleanEden run: %s %s", commandPath, commandArgsString)
@@ -478,6 +478,11 @@ func CleanEden(commandPath, eveDist, adamDist, certsDist, imagesDist, redisDist,
 	if _, err = os.Stat(configDir); !os.IsNotExist(err) {
 		if err = os.RemoveAll(configDir); err != nil {
 			return fmt.Errorf("error in %s delete: %s", configDir, err)
+		}
+	}
+	if _, err = os.Stat(configSaved); !os.IsNotExist(err) {
+		if err = os.RemoveAll(configSaved); err != nil {
+			return fmt.Errorf("error in %s delete: %s", configSaved, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Checking for config changes during the 'eden setup'. Fix for lf-edge#83.
Now we save the config during setup and check if something old is still there for `eden setup` and inform a user. 

All good: 
`INFO[0000] Config file /home/user/.eden/contexts/default.yml is the same as /home/user/work/EVE/github/itmo-eve/eden/dist/config_saved.yml 
`
or something is still there:
`FATA[0000] The current configuration file /home/user/.eden/contexts/rpi4.yml is different from the saved /home/user/work/EVE/github/itmo-eve/eden/dist/config_saved.yml. You can fix this with the commands 'eden config clean' and 'eden config add/set/edit'. `




Signed-off-by: Oleg Sadov <oleg.sadov@gmail.com>