### PR TITLE
fixes of einfo and emetric

### DIFF
--- a/pkg/projects/state.go
+++ b/pkg/projects/state.go
@@ -1,14 +1,12 @@
 package projects
 
 import (
-	"errors"
-	"fmt"
 	"github.com/lf-edge/eden/pkg/controller/einfo"
 	"github.com/lf-edge/eden/pkg/controller/emetric"
 	"github.com/lf-edge/eden/pkg/device"
+	"github.com/lf-edge/eden/pkg/utils"
 	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/api/go/metrics"
-	"github.com/mcuadros/go-lookup"
 	"reflect"
 )
 
@@ -202,19 +200,7 @@ func (state *state) GetDm() *metrics.DeviceMetric {
 //Vm []*metrics.ZMetricVolume
 //Dm *metrics.DeviceMetric
 func (state *state) LookUp(path string) (value reflect.Value, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			switch x := r.(type) {
-			case string:
-				err = errors.New(x)
-			case error:
-				err = x
-			default:
-				err = errors.New(fmt.Sprint(r))
-			}
-		}
-	}()
-	value, err = lookup.LookupString(state.deviceInfo, path)
+	value, err = utils.LookUp(state.deviceInfo, path)
 	return
 }
 

--- a/pkg/utils/lookup.go
+++ b/pkg/utils/lookup.go
@@ -1,0 +1,137 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"github.com/mcuadros/go-lookup"
+	log "github.com/sirupsen/logrus"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+type checkPart = func(reflect.Value)
+
+func parseIndex(s string) (string, int, error) {
+	start := strings.Index(s, lookup.IndexOpenChar)
+	end := strings.Index(s, lookup.IndexCloseChar)
+
+	if start == -1 && end == -1 {
+		return s, -1, nil
+	}
+
+	if (start != -1 && end == -1) || (start == -1 && end != -1) {
+		return "", -1, lookup.ErrMalformedIndex
+	}
+
+	index, err := strconv.Atoi(s[start+1 : end])
+	if err != nil {
+		return "", -1, lookup.ErrMalformedIndex
+	}
+
+	return s[:start], index, nil
+}
+
+//LookupWithCallback travels through inpValue by inpPath and apply callback
+// you can pass [] without index for iterate over loops
+func LookupWithCallback(inpValue interface{}, inpPath string, callback checkPart) {
+	defer func() {
+		var err error
+		if r := recover(); r != nil {
+			switch x := r.(type) {
+			case string:
+				err = errors.New(x)
+			case error:
+				err = x
+			default:
+				err = errors.New(fmt.Sprint(r))
+			}
+		}
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+	if inpPath == "" {
+		return
+	}
+	inpPath = strings.TrimLeft(inpPath, ".")
+	newStrings := strings.Split(inpPath, "[]")
+	if len(newStrings) > 1 {
+		firstPart := newStrings[0]
+		secondPart := strings.TrimPrefix(inpPath, fmt.Sprint(firstPart, "[]"))
+		if secondPart == "" {
+			secondPart = "."
+		}
+		var firstPartValue reflect.Value
+		firstPartValue, err := LookUp(inpValue, firstPart)
+		if err != nil {
+			log.Fatal(err)
+		}
+		switch firstPartValue.Kind() {
+		case reflect.Slice:
+			for i := 0; i < firstPartValue.Len(); i++ {
+				if firstPartValue.Index(i).CanInterface() {
+					LookupWithCallback(firstPartValue.Index(i).Interface(), secondPart, callback)
+				} else {
+					log.Debug("cannot interface ", firstPartValue.Index(i))
+				}
+			}
+		case reflect.Struct:
+			for i := 0; i < firstPartValue.NumField(); i++ {
+				if firstPartValue.Field(i).CanInterface() {
+					LookupWithCallback(firstPartValue.Field(i).Interface(), secondPart, callback)
+				} else {
+					log.Debug("cannot interface ", firstPartValue.Field(i))
+				}
+			}
+		default:
+			log.Debug("default: ", reflect.TypeOf(firstPartValue).Kind())
+		}
+	} else {
+		if inpPath == "" {
+			callback(reflect.ValueOf(inpValue))
+		} else {
+			if strings.HasSuffix(inpPath, lookup.IndexCloseChar) {
+				lastOpen := strings.LastIndex(inpPath, lookup.IndexOpenChar)
+				firstPart := inpPath[:lastOpen]
+				_, ind, err := parseIndex(inpPath[lastOpen-1:])
+				if err != nil {
+					log.Fatal(err)
+				}
+				value, err := LookUp(inpValue, firstPart)
+				if err != nil {
+					log.Fatal(err)
+				}
+				callback(value.Index(ind))
+			} else {
+				value, err := LookUp(inpValue, inpPath)
+				if err == nil && value.IsValid() {
+					callback(value)
+				}
+			}
+		}
+		return
+	}
+	return
+}
+
+//LookUp try to resolve values from interface by path
+func LookUp(i interface{}, path string) (value reflect.Value, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			switch x := r.(type) {
+			case string:
+				err = errors.New(x)
+			case error:
+				err = x
+			default:
+				err = errors.New(fmt.Sprint(r))
+			}
+		}
+	}()
+	value, err = lookup.LookupString(i, path)
+	if err != nil {
+		return
+	}
+	return value, nil
+}

--- a/tests/units/Makefile
+++ b/tests/units/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-test: test_go test_sceanrio
+test: test_go test_scenario test_lookup
 
 setup:
 build:
@@ -9,8 +9,11 @@ clean:
 test_go:
 	go test templates_test.go -v
 
-test_sceanrio:
+test_scenario:
 	./template_test_scenario.sh
+
+test_lookup:
+	go test lookup_test.go -v
 
 help:
 	@echo "EDEN is the harness for testing EVE and ADAM"

--- a/tests/units/lookup_test.go
+++ b/tests/units/lookup_test.go
@@ -1,0 +1,197 @@
+package templates
+
+import (
+	"github.com/lf-edge/eden/pkg/utils"
+	"github.com/lf-edge/eve/api/go/info"
+	"reflect"
+	"testing"
+)
+
+// These tests verify the functionality of EDEN utils.LookupWithCallback
+// by passing different paths for lookup we expect different objects passed into callback
+
+var (
+	devId       = "test"
+	macAddress1 = "00:00:00:01"
+	macAddress2 = "00:00:00:02"
+	ipAddress1  = "192.168.0.1/24"
+	ipAddress2  = "192.168.0.2/24"
+	ipAddress3  = "192.168.0.3/24"
+	ipAddress4  = "192.168.0.4/24"
+	nii         = &info.ZInfoMsg_Niinfo{Niinfo: &info.ZInfoNetworkInstance{
+		IpAssignments: []*info.ZmetIPAssignmentEntry{{
+			MacAddress: macAddress1,
+			IpAddress:  []string{ipAddress1, ipAddress2},
+		}, {
+			MacAddress: macAddress2,
+			IpAddress:  []string{ipAddress3, ipAddress4},
+		}},
+	}}
+	infoTest = &info.ZInfoMsg{
+		Ztype:       info.ZInfoTypes_ZiNetworkInstance,
+		DevId:       devId,
+		InfoContent: nii,
+		AtTimeStamp: nil,
+	}
+)
+
+func checkInSlice(el string, sl []string) bool {
+	for _, val := range sl {
+		if el == val {
+			return true
+		}
+	}
+	return false
+}
+
+//TestLookupEmpty try to use empty lookup string
+func TestLookupEmpty(t *testing.T) {
+	q := ""
+	var callback = func(inp reflect.Value) {
+		t.Error("not expected callback")
+	}
+	utils.LookupWithCallback(infoTest, q, callback)
+}
+
+//TestLookupWrong try to use lookup with wrong string
+//  expected not to fire callback
+func TestLookupWrong(t *testing.T) {
+	q := "wrong"
+	var callback = func(inp reflect.Value) {
+		t.Error("not expected callback")
+	}
+	utils.LookupWithCallback(infoTest, q, callback)
+}
+
+//TestLookupBase try to use lookup with first element
+//  expected to receive value of DevId
+func TestLookupBase(t *testing.T) {
+	q := "DevId"
+	var callback = func(inp reflect.Value) {
+		t.Log(inp)
+		if inp.String() != devId {
+			t.Errorf("expected: %s, received: %s", devId, inp.String())
+		}
+	}
+	utils.LookupWithCallback(infoTest, q, callback)
+}
+
+//TestLookupIndex try to use lookup with one indexed element [0]
+//  expected to fire callback one time with MacAddress1
+func TestLookupIndex(t *testing.T) {
+	q := "InfoContent.Niinfo.IpAssignments[0].MacAddress"
+	var received []string
+	var callback = func(inp reflect.Value) {
+		t.Log(inp)
+		if inp.String() != macAddress1 {
+			t.Errorf("expected: %s, received: %s", macAddress1, inp.String())
+		}
+		received = append(received, inp.String())
+	}
+	utils.LookupWithCallback(infoTest, q, callback)
+	if len(received) != 1 {
+		t.Errorf("expected %d values, received %d", 1, len(received))
+	}
+	if !checkInSlice(macAddress1, received) {
+		t.Errorf("not %s in %s", macAddress1, received)
+	}
+}
+
+//TestLookupIndexes try to use lookup with two indexed elements
+//  expected to fire callback one time with IpAddress4
+func TestLookupIndexes(t *testing.T) {
+	q := "InfoContent.Niinfo.IpAssignments[1].IpAddress[1]"
+	var received []string
+	var callback = func(inp reflect.Value) {
+		t.Log(inp)
+		switch inp.String() {
+		case ipAddress4:
+			received = append(received, inp.String())
+		default:
+			t.Errorf("not expected value %s", inp.String())
+		}
+	}
+	utils.LookupWithCallback(infoTest, q, callback)
+	if len(received) != 1 {
+		t.Errorf("expected %d values, received %d", 2, len(received))
+	}
+	if !checkInSlice(ipAddress4, received) {
+		t.Errorf("not %s in %s", ipAddress4, received)
+	}
+}
+
+//TestLookupBracket try to use lookup with empty brackets to iterate through elements
+//  expected to fire callback two times with MacAddress1 and MacAddress2
+func TestLookupBracket(t *testing.T) {
+	q := "InfoContent.Niinfo.IpAssignments[].MacAddress"
+	var received []string
+	var callback = func(inp reflect.Value) {
+		t.Log(inp)
+		switch inp.String() {
+		case macAddress1:
+			received = append(received, inp.String())
+		case macAddress2:
+			received = append(received, inp.String())
+		default:
+			t.Errorf("not expected value %s", inp.String())
+		}
+	}
+	utils.LookupWithCallback(infoTest, q, callback)
+	if len(received) != 2 {
+		t.Errorf("expected %d values, received %d", 2, len(received))
+	}
+	if !checkInSlice(macAddress1, received) {
+		t.Errorf("not %s in %s", macAddress1, received)
+	}
+	if !checkInSlice(macAddress2, received) {
+		t.Errorf("not %s in %s", macAddress2, received)
+	}
+}
+
+//TestLookupBrackets try to use lookup with empty brackets to iterate through elements and with defined index
+//  expected to fire callback two times with IpAddress1 and IpAddress3
+func TestLookupBrackets(t *testing.T) {
+	q := "InfoContent.Niinfo.IpAssignments[].IpAddress[0]"
+	var received []string
+	var callback = func(inp reflect.Value) {
+		t.Log(inp)
+		received = append(received, inp.String())
+	}
+	utils.LookupWithCallback(infoTest, q, callback)
+	if len(received) != 2 {
+		t.Errorf("expected %d values, received %d", 2, len(received))
+	}
+	if !checkInSlice(ipAddress1, received) {
+		t.Errorf("not %s in %s", ipAddress1, received)
+	}
+	if !checkInSlice(ipAddress3, received) {
+		t.Errorf("not %s in %s", ipAddress3, received)
+	}
+}
+
+//TestLookupBracketsEnds try to use lookup with multiple empty brackets to iterate through elements
+//  expected to fire callback four times with all IpAddresses
+func TestLookupBracketsEnds(t *testing.T) {
+	q := "InfoContent.Niinfo.IpAssignments[].IpAddress[]"
+	var received []string
+	var callback = func(inp reflect.Value) {
+		t.Log(inp)
+		received = append(received, inp.String())
+	}
+	utils.LookupWithCallback(infoTest, q, callback)
+	if len(received) != 4 {
+		t.Errorf("expected %d values, received %d", 4, len(received))
+	}
+	if !checkInSlice(ipAddress1, received) {
+		t.Errorf("not %s in %s", ipAddress1, received)
+	}
+	if !checkInSlice(ipAddress2, received) {
+		t.Errorf("not %s in %s", ipAddress2, received)
+	}
+	if !checkInSlice(ipAddress3, received) {
+		t.Errorf("not %s in %s", ipAddress3, received)
+	}
+	if !checkInSlice(ipAddress4, received) {
+		t.Errorf("not %s in %s", ipAddress4, received)
+	}
+}

--- a/tests/units/template_test_scenario.sh
+++ b/tests/units/template_test_scenario.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-DIR=`mktemp -d --suffix=.eden_template_test`
+DIR=$(mktemp -d 2>/dev/null || mktemp -d -t '.eden_template_test')
 
 #echo Test dir: $DIR
 cp template_test_scenario.tmpl $DIR


### PR DESCRIPTION
Functionality of regexps/lookups for info and metrics was broken some time before. This is a fix that includes the working functionality and tests for that functionality. 
Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>