### PR TITLE
Log/Info/Metric monitors

### DIFF
--- a/tests/escript/eden.escript.tests.txt
+++ b/tests/escript/eden.escript.tests.txt
@@ -1,6 +1,9 @@
 eden.escript.test -test.run TestEdenScripts/template
 eden.escript.test -test.run TestEdenScripts/eden_start  
 eden.escript.test -test.run TestEdenScripts/eden_onboard
+eden.escript.test -test.run TestEdenScripts/log_test -testdata ../lim/testdata/
+eden.escript.test -test.run TestEdenScripts/info_test -testdata ../lim/testdata/
+eden.escript.test -test.run TestEdenScripts/metric_test -testdata ../lim/testdata/
 eden.escript.test -test.run TestEdenScripts/reboot_eden -test.timeout 10m
 eden.escript.test -test.run TestEdenScripts/reboot_test
 eden.escript.test -test.run TestEdenScripts/deploy_docker_eden -test.timeout 10m

--- a/tests/lim/eden.lim.tests.txt
+++ b/tests/lim/eden.lim.tests.txt
@@ -1,1 +1,3 @@
-eden.lim.test
+eden.escript.test -test.run TestEdenScripts/log_test
+eden.escript.test -test.run TestEdenScripts/info_test
+eden.escript.test -test.run TestEdenScripts/metric_test

--- a/tests/lim/testdata/info_test.txt
+++ b/tests/lim/testdata/info_test.txt
@@ -1,0 +1,25 @@
+{{$test := "test eden.lim.test -test.v -timewait 120 -test.run TestInfo"}}
+
+#eden config add default
+#eden setup
+#eden start
+#eden eve onboard
+
+# Trying to find eth0 or eth1 in dinfo.network.devName.
+{{$test}} -out InfoContent.dinfo.network.devName 'InfoContent.dinfo.network.devName:.*eth[01].*'
+stdout 'eth[01]'
+
+# Checking dinfo.network.devName for interfaces other than eth0 or eth1.
+! {{$test}} -out InfoContent.dinfo.network.devName 'InfoContent.dinfo.network.devName:.*eth[^01].*'
+! stdout 'eth[^01]'
+
+# Test's config. file
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+

--- a/tests/lim/testdata/log_test.txt
+++ b/tests/lim/testdata/log_test.txt
@@ -1,0 +1,24 @@
+{{$test := "test eden.lim.test -test.v -timewait 120 -test.run TestLog"}}
+
+#eden config add default
+#eden setup
+#eden start
+#eden eve onboard
+
+# Trying to find eth0 or eth1 in msg.
+{{$test}} -out msg 'msg:.*eth[01].*'
+stdout 'eth[01]'
+
+# Checking msg for interfaces other than eth0 or eth1.
+! {{$test}} -out msg msg:'.*eth[^01].*'
+
+# Test's config. file
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+

--- a/tests/lim/testdata/metric_test.txt
+++ b/tests/lim/testdata/metric_test.txt
@@ -1,0 +1,24 @@
+{{$test := "test eden.lim.test -test.v -timewait 120 -test.run TestMetric"}}
+
+#eden config add default
+#eden setup
+#eden start
+#eden eve onboard
+
+# Trying to find eth0 or eth1 in dm.network.iName.
+{{$test}} -out MetricContent.dm.network.iName 'MetricContent.dm.network.iName:.*eth[01].*'
+stdout 'eth[01]'
+
+# Checking dm.network.iName for interfaces other than eth0 or eth1.
+! {{$test}} -out MetricContent.dm.network.iName 'MetricContent.dm.network.iName:.*eth[^01].*'
+
+# Test's config. file
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+


### PR DESCRIPTION
Log/Info/Metric tests refactored as test detector. We may choose now:

'-timewait' -- timewait for items waiting in seconds
'-number' -- the number of items (0=unlimited) you need to get
'-out' -- paramters for out separated by ':'
regexp queries for Log/Info/Metric items selecting
Added Log/Info/Metric test escripts.

Usage example: 
```
# Trying to find eth0 or eth1 in dm.network.iName.
{{$test}} -out MetricContent.dm.network.iName 'MetricContent.dm.network.iName:.*eth[01].*'
stdout 'eth[01]'
```