### PR TITLE
A test for eve image update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+#rendered eden-config.yml in tests
+tests/*/eden-config.yml
+
 dist
 Config.in
 eden

--- a/cmd/edenConfig.go
+++ b/cmd/edenConfig.go
@@ -119,6 +119,7 @@ var configAddCmd = &cobra.Command{
 			eveRemote = true
 			viper.Set("eve.hostfwd", map[string]string{})
 			viper.Set("eve.devmodel", defaults.DefaultRPIModel)
+			viper.Set("eve.hv", fmt.Sprintf("rpi-%s", defaults.DefaultEVEHV))
 			viper.Set("eve.arch", "arm64")
 			viper.Set("eve.serial", "*")
 			viper.Set("eve.remote", eveRemote)

--- a/pkg/utils/dowloaders.go
+++ b/pkg/utils/dowloaders.go
@@ -103,7 +103,10 @@ func genEVERootFSImage(image, outputDir string, size int) (fileName string, err 
 		return "", err
 	}
 	u = strings.TrimFunc(u, func(r rune) bool {
-		return !unicode.IsGraphic(r)
+		if unicode.IsDigit(r) || unicode.IsLetter(r) || r == '.' || r == '-' {
+			return false
+		}
+		return true
 	})
 	log.Debugf("rootfs version: %s", u)
 	fileName = filepath.Join(outputDir, fmt.Sprintf("rootfs-%s.squashfs", u))

--- a/tests/escript/eden.escript.tests.txt
+++ b/tests/escript/eden.escript.tests.txt
@@ -9,4 +9,5 @@ eden.escript.test -test.run TestEdenScripts/reboot_test
 eden.escript.test -test.run TestEdenScripts/deploy_docker_eden -test.timeout 10m
 eden.escript.test -test.run TestEdenScripts/deploy_docker_test
 eden.escript.test -test.run TestEdenScripts/deploy_vm
+eden.escript.test -test.run TestEdenScripts/update_eve_image -testdata ../update_eve_image/testdata/ -test.timeout 10m
 eden.escript.test -test.run TestEdenScripts/eden_stop

--- a/tests/escript/go-internal/testscript/cmd.go
+++ b/tests/escript/go-internal/testscript/cmd.go
@@ -411,6 +411,7 @@ func (ts *TestScript) cmdMsg(neg bool, args []string) {
 	}
 	if len(args) == 1 {
 		ts.Logf("message: %s\n", args[0])
+		fmt.Printf("message: %s\n", args[0])
 	} else {
 		ts.Fatalf("usage: message [msg]")
 	}

--- a/tests/update_eve_image/Makefile
+++ b/tests/update_eve_image/Makefile
@@ -1,0 +1,63 @@
+DEBUG ?= "debug"
+
+# HOSTARCH is the host architecture
+# ARCH is the target architecture
+# we need to keep track of them separately
+HOSTARCH ?= $(shell uname -m)
+HOSTOS ?= $(shell uname -s | tr A-Z a-z)
+
+# canonicalized names for host architecture
+override HOSTARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(HOSTARCH)))
+
+# unless otherwise set, I am building for my own architecture, i.e. not cross-compiling
+# and for my OS
+ARCH ?= $(HOSTARCH)
+OS ?= $(HOSTOS)
+
+# canonicalized names for target architecture
+override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
+
+WORKDIR ?= $(CURDIR)/../../dist
+BINDIR := $(WORKDIR)/bin
+BIN := eden
+LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
+TESTNAME := eden.escript
+TESTBIN := $(TESTNAME).test
+TESTSCN := eden.update_eve_image.tests.txt
+LOCALTESTBIN := $(TESTBIN)-$(OS)-$(ARCH)
+
+.DEFAULT_GOAL := help
+
+clean: 
+	rm -rf $(WORKDIR)/$(TESTSCN) 
+
+$(WORKDIR):
+	mkdir -p $@
+$(BINDIR):
+	mkdir -p $@
+
+test:
+	$(LOCALBIN) test $(CURDIR) -v $(DEBUG)
+
+build: setup
+
+
+setup:
+	cp $(TESTSCN) $(WORKDIR) 
+	$(LOCALBIN) utils template eden-config.tmpl > eden-config.yml
+
+help:
+	@echo "EDEN is the harness for testing EVE and ADAM"
+	@echo
+	@echo "This Makefile automates commons tasks of EDEN testing"
+	@echo
+	@echo "Commonly used maintenance and development targets:"
+	@echo "   build         build test-binary (OS and ARCH options supported, for ex. OS=linux ARCH=arm64)"
+	@echo "   setup         setup of test environment"
+	@echo "   test          run tests"
+	@echo "   clean         cleanup of test harness"
+	@echo
+	@echo "You need install requirements for EVE (look at https://github.com/lf-edge/eve#install-dependencies)."
+	@echo "Also, you need to install 'uuidgen' utility."
+	@echo "You need access to docker socket and installed qemu packages."
+

--- a/tests/update_eve_image/eden-config.tmpl
+++ b/tests/update_eve_image/eden-config.tmpl
@@ -1,0 +1,14 @@
+eden:
+    #test binary
+    test-bin: "eden.update_eve_image.test"
+
+    #test scenario
+    test-scenario: "eden.update_eve_image.tests.txt"
+
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/update_eve_image/eden.update_eve_image.tests.txt
+++ b/tests/update_eve_image/eden.update_eve_image.tests.txt
@@ -1,0 +1,1 @@
+eden.escript.test -test.run TestEdenScripts/update_eve_image -test.timeout 10m

--- a/tests/update_eve_image/testdata/update_eve_image.txt
+++ b/tests/update_eve_image/testdata/update_eve_image.txt
@@ -1,0 +1,55 @@
+# Default EVE version to update
+{{$eve_ver := "5.7.0"}}
+
+# Obtain EVE version from environment variable EVE_VERSION
+{{$env := EdenGetEnv "EVE_VERSION"}}
+
+# If environment variable EVE_VERSION set, use it instead of default
+{{if $env}}{{$eve_ver = $env}}{{end}}
+
+# Obtain eve.hv from config
+{{$eve_hv := EdenConfig "eve.hv"}}
+
+# Obtain eve.arch from config
+{{$eve_arch := EdenConfig "eve.arch"}}
+
+# Combine variables into $short_version
+{{$short_version := printf "%s-%s-%s" $eve_ver $eve_hv $eve_arch}}
+
+# Use eden.lim.test for access Infos with timewait 900 seconds
+{{$test := "test eden.lim.test -test.v -timewait 900 -test.run TestInfo"}}
+
+
+# Download EVE rootfs into downloader-dist
+message 'EVE image download'
+eden utils download eve-rootfs --eve-tag={{$eve_ver}} --eve-hv={{EdenConfig "eve.hv"}} --downloader-dist={{EdenConfigPath "eden.images.dist"}} -v debug
+
+# Check stdout of previous command. Expected to get full path to squashfs
+stdout '{{EdenConfigPath "eden.images.dist"}}/rootfs-{{ $short_version }}.squashfs'
+
+
+# Send command to update eveimage
+message 'EVE update request'
+eden controller edge-node eveimage-update file://{{EdenConfigPath "eden.images.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam://
+
+# Check stderr, it must be empty
+! stderr .
+
+
+# Run monitoring of Info messages to obtain info with PartitionState inprogress or active and previously defined ShortVersion
+message 'Waiting for EVE update...'
+{{$test}} -out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:inprogress|active InfoContent.dinfo.SwList[0].ShortVersion:{{ $short_version }}'
+
+# Check stdout of previous command. Expected to get previously defined ShortVersion
+stdout '{{ $short_version }}'
+
+
+# Test's config file
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}


### PR DESCRIPTION
This test does the eve image update. If not specified explicitly the image to update to  is 5.7.0

Run it: 
`./eden test tests/update_eve_image -v debug`

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>