### PR TITLE
tests fixes and timeouts expanding

### DIFF
--- a/pkg/controller/loaders/redisLoader.go
+++ b/pkg/controller/loaders/redisLoader.go
@@ -146,7 +146,7 @@ func (loader *redisLoader) process(process ProcessFunction, typeToProcess infoOr
 		counter, _ := strconv.Atoi(splitted[1])
 		start = fmt.Sprintf("%s-%v", splitted[0], counter+1)
 		for {
-			rr, err := loader.client.XRangeN(OrderStream, start, "+", 10).Result()
+			rr, err := loader.client.XRangeN(OrderStream, start, "+", 100).Result()
 			if err != nil {
 				return false, false, fmt.Errorf("XRange error: %s", err)
 			}
@@ -171,6 +171,7 @@ func (loader *redisLoader) process(process ProcessFunction, typeToProcess infoOr
 			splitted := strings.Split(loader.lastID, "-")
 			counter, _ := strconv.Atoi(splitted[1])
 			start = fmt.Sprintf("%s-%v", splitted[0], counter+1)
+			time.Sleep(time.Second) //sleep for second to reduce the load of redis
 		}
 	}
 }

--- a/pkg/projects/state.go
+++ b/pkg/projects/state.go
@@ -80,14 +80,14 @@ func (state *state) processInfo(infoMsg *info.ZInfoMsg) error {
 	case info.ZInfoTypes_ZiBlobList:
 		bInfoList := infoMsg.GetBinfo()
 	blobsLoop:
-		for ind, blob := range state.deviceInfo.Binfo {
-			for _, newBlob := range bInfoList.Blob {
+		for _, newBlob := range bInfoList.Blob {
+			for ind, blob := range state.deviceInfo.Binfo {
 				if blob.Sha256 == newBlob.Sha256 {
 					state.deviceInfo.Binfo[ind] = newBlob
 					continue blobsLoop
 				}
 			}
-			state.deviceInfo.Binfo = append(state.deviceInfo.Binfo, blob)
+			state.deviceInfo.Binfo = append(state.deviceInfo.Binfo, newBlob)
 		}
 	}
 	return nil

--- a/tests/docker/testdata/2dockers_test.txt
+++ b/tests/docker/testdata/2dockers_test.txt
@@ -1,11 +1,11 @@
-{{$test_opts := "-test.v -timewait 600"}}
+{{$test_opts := "-test.v -timewait 1200"}}
 
 [!exec:curl] stop
 
 eden -t 1s pod ps
 
-# Starting of reboot detector with a 3 reboots limit
-! test eden.reboot.test {{$test_opts}} -reboot=0 -count=1 &
+# Starting of reboot detector with a 2 reboots limit
+! test eden.reboot.test {{$test_opts}} -reboot=0 -count=2 &
 
 # Run by docker's actor
 test eden.docker.test {{$test_opts}} -test.run TestDockerStart -name t1 -externalPort 8027

--- a/tests/lim/lim_test.go
+++ b/tests/lim/lim_test.go
@@ -37,7 +37,7 @@ var (
 	*/
 	tc *projects.TestContext
 
-	query map[string]string = map[string]string{}
+	query = map[string]string{}
 	found bool
 	items int
 )
@@ -142,8 +142,6 @@ func TestLog(t *testing.T) {
 
 	edgeNode := tc.GetEdgeNode(tc.WithTest(t))
 
-	tc.ConfigSync(edgeNode)
-
 	t.Logf("Wait for log of %s number=%d timewait=%d\n", edgeNode.GetName(),
 		*number, *timewait)
 
@@ -185,8 +183,6 @@ func TestInfo(t *testing.T) {
 
 	edgeNode := tc.GetEdgeNode(tc.WithTest(t))
 
-	tc.ConfigSync(edgeNode)
-
 	t.Logf("Wait for info of %s number=%d timewait=%d\n",
 		edgeNode.GetName(), *number, *timewait)
 
@@ -227,8 +223,6 @@ func TestMetrics(t *testing.T) {
 	}
 
 	edgeNode := tc.GetEdgeNode(tc.WithTest(t))
-
-	tc.ConfigSync(edgeNode)
 
 	t.Logf("Wait for metric of %s number=%d timewait=%d\n",
 		edgeNode.GetName(), *number, *timewait)

--- a/tests/lim/testdata/info_test.txt
+++ b/tests/lim/testdata/info_test.txt
@@ -1,4 +1,5 @@
-{{$test := "test eden.lim.test -test.v -timewait 120 -test.run TestInfo"}}
+{{$test1 := "test eden.lim.test -test.v -timewait 600 -test.run TestInfo"}}
+{{$test2 := "test eden.lim.test -test.v -test.run TestInfo"}}
 
 #eden config add default
 #eden setup
@@ -6,11 +7,11 @@
 #eden eve onboard
 
 # Trying to find eth0 or eth1 in dinfo.network.devName.
-{{$test}} -out InfoContent.dinfo.network.devName 'InfoContent.dinfo.network.devName:.*eth[01].*'
+{{$test1}} -out InfoContent.dinfo.network.devName 'InfoContent.dinfo.network.devName:.*eth[01].*'
 stdout 'eth[01]'
 
 # Checking dinfo.network.devName for interfaces other than eth0 or eth1.
-! {{$test}} -out InfoContent.dinfo.network.devName 'InfoContent.dinfo.network.devName:.*eth[^01].*'
+! {{$test2}} -out InfoContent.dinfo.network.devName 'InfoContent.dinfo.network.devName:.*eth[^01].*'
 ! stdout 'eth[^01]'
 
 # Test's config. file

--- a/tests/lim/testdata/log_test.txt
+++ b/tests/lim/testdata/log_test.txt
@@ -1,4 +1,5 @@
-{{$test := "test eden.lim.test -test.v -timewait 600 -test.run TestLog"}}
+{{$test1 := "test eden.lim.test -test.v -timewait 600 -test.run TestLog"}}
+{{$test2 := "test eden.lim.test -test.v -test.run TestLog"}}
 
 #eden config add default
 #eden setup
@@ -6,11 +7,11 @@
 #eden eve onboard
 
 # Trying to find eth0 or eth1 in msg.
-{{$test}} -out msg 'msg:.*eth[01].*'
+{{$test1}} -out msg 'msg:.*eth[01].*'
 stdout 'eth[01]'
 
 # Checking msg for interfaces other than eth0 or eth1.
-! {{$test}} -out msg msg:'.*eth[^01].*'
+! {{$test2}} -out msg msg:'.*eth[^01].*'
 
 # Test's config. file
 -- eden-config.yml --

--- a/tests/lim/testdata/metric_test.txt
+++ b/tests/lim/testdata/metric_test.txt
@@ -1,4 +1,5 @@
-{{$test := "test eden.lim.test -test.v -timewait 120 -test.run TestMetric"}}
+{{$test1 := "test eden.lim.test -test.v -timewait 600 -test.run TestMetric"}}
+{{$test2 := "test eden.lim.test -test.v -test.run TestMetric"}}
 
 #eden config add default
 #eden setup
@@ -6,11 +7,11 @@
 #eden eve onboard
 
 # Trying to find eth0 or eth1 in dm.network.iName.
-{{$test}} -out MetricContent.dm.network.iName 'MetricContent.dm.network.iName:.*eth[01].*'
+{{$test1}} -out MetricContent.dm.network.iName 'MetricContent.dm.network.iName:.*eth[01].*'
 stdout 'eth[01]'
 
 # Checking dm.network.iName for interfaces other than eth0 or eth1.
-! {{$test}} -out MetricContent.dm.network.iName 'MetricContent.dm.network.iName:.*eth[^01].*'
+! {{$test2}} -out MetricContent.dm.network.iName 'MetricContent.dm.network.iName:.*eth[^01].*'
 
 # Test's config. file
 -- eden-config.yml --

--- a/tests/reboot/reboot_test.go
+++ b/tests/reboot/reboot_test.go
@@ -138,9 +138,10 @@ func TestReboot(t *testing.T) {
 		// this is expected to be a synchronous call for now
 		if *reboot {
 			edgeNode.Reboot()
-		}
 
-		tc.ConfigSync(edgeNode)
+			//sync config only if reboot needed
+			tc.ConfigSync(edgeNode)
+		}
 
 		t.Logf("Wait for reboot of %s", edgeNode.GetName())
 

--- a/tests/update_eve_image/testdata/update_eve_image.txt
+++ b/tests/update_eve_image/testdata/update_eve_image.txt
@@ -1,5 +1,5 @@
 # Default EVE version to update
-{{$eve_ver := "5.7.0"}}
+{{$eve_ver := "5.7.1"}}
 
 # Obtain EVE version from environment variable EVE_VERSION
 {{$env := EdenGetEnv "EVE_VERSION"}}
@@ -20,17 +20,17 @@
 {{$test := "test eden.lim.test -test.v -timewait 900 -test.run TestInfo"}}
 
 
-# Download EVE rootfs into downloader-dist
+# Download EVE rootfs into eve-dist
 message 'EVE image download'
-eden -t 10m utils download eve-rootfs --eve-tag={{$eve_ver}} --eve-hv={{EdenConfig "eve.hv"}} --downloader-dist={{EdenConfigPath "eden.images.dist"}} -v debug
+eden -t 10m utils download eve-rootfs --eve-tag={{$eve_ver}} --eve-hv={{EdenConfig "eve.hv"}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
 
 # Check stdout of previous command. Expected to get full path to squashfs
-stdout '{{EdenConfigPath "eden.images.dist"}}/rootfs-{{ $short_version }}.squashfs'
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs'
 
 
 # Send command to update eveimage
 message 'EVE update request'
-eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eden.images.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam://
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam://
 
 # Check stderr, it must be empty
 ! stderr .

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -9,18 +9,18 @@ eden.escript.test -test.run TestEdenScripts/eden_onboard
 eden.escript.test -test.run TestEdenScripts/log_test -testdata ../lim/testdata/
 /bin/echo Eden SSH test (5/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/ssh
-/bin/echo Eden 2 dockers test (6/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/2dockers_test -testdata ../docker/testdata/
 {{/*
 eden.escript.test -test.run TestEdenScripts/deploy_docker_eden -test.timeout 10m
 eden.escript.test -test.run TestEdenScripts/deploy_docker_test
 eden.escript.test -test.run TestEdenScripts/deploy_docker_eden
 eden.escript.test -test.run TestEdenScripts/reboot_eden -test.timeout 10m
 */}}
-/bin/echo Eden Info test (7/{{$tests}})
+/bin/echo Eden Info test (6/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/info_test -testdata ../lim/testdata/
-/bin/echo Eden Metric test (8/{{$tests}})
+/bin/echo Eden Metric test (7/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/metric_test -testdata ../lim/testdata/
+/bin/echo Eden 2 dockers test (8/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/2dockers_test -testdata ../docker/testdata/
 /bin/echo Eden Reboot test (9/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/reboot_test
 #eden.escript.test -test.run TestEdenScripts/update_eve_image -testdata ../update_eve_image/testdata/ -test.timeout 10m

--- a/tests/workflow/testdata/eden_onboard.txt
+++ b/tests/workflow/testdata/eden_onboard.txt
@@ -1,13 +1,11 @@
 # eden start
 
-# Waiting of onboard reboot.
-test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=1 &
-
 # Onboarding.
 eden eve onboard
 stdout 'onboarded'
 
-# Waiting for reboot detection.
+# Waiting of onboard reboot.
+test eden.reboot.test -test.v -timewait 1800 -reboot=0 -count=1 &
 wait
 stdout 'Number of reboots: 1'
 


### PR DESCRIPTION
1) Fix multiple timeouts for Workflow to make it reasonable & runnable
2) Fix CPU and memory consumption for reboot test & docker test. 

In addition we limit number of processed messages of each type per second to 100. 

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>