### PR TITLE
Tracking state of the application

### DIFF
--- a/tests/app/Makefile
+++ b/tests/app/Makefile
@@ -1,0 +1,71 @@
+DEBUG ?= "debug"
+
+# HOSTARCH is the host architecture
+# ARCH is the target architecture
+# we need to keep track of them separately
+HOSTARCH ?= $(shell uname -m)
+HOSTOS ?= $(shell uname -s | tr A-Z a-z)
+
+# canonicalized names for host architecture
+override HOSTARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(HOSTARCH)))
+
+# unless otherwise set, I am building for my own architecture, i.e. not cross-compiling
+# and for my OS
+ARCH ?= $(HOSTARCH)
+OS ?= $(HOSTOS)
+
+# canonicalized names for target architecture
+override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
+
+WORKDIR ?= $(CURDIR)/../../dist
+BINDIR := $(WORKDIR)/bin
+BIN := eden
+LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
+TESTNAME := eden.app
+TESTBIN := $(TESTNAME).test
+TESTSCN := $(TESTNAME).tests.txt
+LOCALTESTBIN := $(TESTBIN)-$(OS)-$(ARCH)
+
+.DEFAULT_GOAL := help
+
+clean: 
+	rm -rf $(LOCALTESTBIN) $(BINDIR)/$(TESTBIN) $(WORKDIR)/$(TESTSCN) $(CURDIR)/$(TESTBIN) $(BINDIR)/$(TESTBIN)
+
+$(WORKDIR):
+	mkdir -p $@
+$(BINDIR):
+	mkdir -p $@
+
+test_docker:
+	go test docker_test.go -v -count=1 -timeout 3000s
+
+test:
+	$(LOCALBIN) test $(CURDIR) -v $(DEBUG)
+
+build: setup
+
+testbin: $(TESTBIN)
+$(LOCALTESTBIN): $(BINDIR) *.go
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
+$(TESTBIN): $(LOCALTESTBIN)
+	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN); fi
+
+setup: testbin
+	cp $(TESTSCN) $(WORKDIR) 
+	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(CURDIR)/$(TESTBIN) $(BINDIR)/; fi
+	$(LOCALBIN) utils template eden-config.tmpl>eden-config.yml
+
+help:
+	@echo "EDEN is the harness for testing EVE and ADAM"
+	@echo
+	@echo "This Makefile automates commons tasks of EDEN testing"
+	@echo
+	@echo "Commonly used maintenance and development targets:"
+	@echo "   build         build test-binary (OS and ARCH options supported, for ex. OS=linux ARCH=arm64)"
+	@echo "   setup         setup of test environment"
+	@echo "   test          run tests"
+	@echo "   clean         cleanup of test harness"
+	@echo
+	@echo "You need install requirements for EVE (look at https://github.com/lf-edge/eve#install-dependencies)."
+	@echo "You need access to docker socket and installed qemu packages."
+

--- a/tests/app/app_test.go
+++ b/tests/app/app_test.go
@@ -1,0 +1,94 @@
+package lim
+
+import (
+	"flag"
+	"fmt"
+	"github.com/lf-edge/eden/pkg/projects"
+	"github.com/lf-edge/eve/api/go/info"
+	"os"
+	"testing"
+	"time"
+)
+
+// This test wait for the app's state with a timewait.
+var (
+	timewait    = flag.Duration("timewait", time.Minute, "Timewait for items waiting")
+	tc          *projects.TestContext
+	externalIP  string
+	portPublish []string
+	//appName     string
+)
+
+// TestMain is used to provide setup and teardown for the rest of the
+// tests. As part of setup we make sure that context has a slice of
+// EVE instances that we can operate on. For any action, if the instance
+// is not specified explicitly it is assumed to be the first one in the slice
+func TestMain(m *testing.M) {
+	fmt.Println("Docker app's state test")
+
+	tc = projects.NewTestContext()
+
+	projectName := fmt.Sprintf("%s_%s", "TestAppState", time.Now())
+
+	tc.InitProject(projectName)
+
+	tc.AddEdgeNodesFromDescription()
+
+	tc.StartTrackingState(false)
+
+	res := m.Run()
+
+	os.Exit(res)
+}
+
+//checkApp wait for info of ZInfoApp type with state
+func checkApp(appName string, state string) projects.ProcInfoFunc {
+	return func(msg *info.ZInfoMsg) error {
+		if state == "" {
+			if msg.Ztype == info.ZInfoTypes_ZiDevice {
+				for _, app := range msg.GetDinfo().AppInstances {
+					if app.Name == appName {
+						return nil
+					}
+				}
+				return fmt.Errorf("no app with %s found", appName)
+			}
+		} else {
+			if msg.Ztype == info.ZInfoTypes_ZiApp {
+				if msg.GetAinfo().AppName == appName {
+					astate := msg.GetAinfo().State.String()
+					if state == astate {
+						return fmt.Errorf("app %s in state %s", appName, state)
+					}
+
+				}
+			}
+		}
+		return nil
+	}
+}
+
+//TestAppSatus wait for application reaching the selected state
+//with a timewait
+func TestAppSatus(t *testing.T) {
+	edgeNode := tc.GetEdgeNode(tc.WithTest(t))
+
+	args := flag.Args()
+	if len(args) == 0 {
+		t.Fatalf("Usage: %s [options] name [state]\n", os.Args[0])
+	} else {
+		secs := int(timewait.Seconds())
+		var state string
+		if len(args) > 1 {
+			state = args[1]
+		} else {
+			state = ""
+		}
+		fmt.Printf("appName: '%s' state: '%s' secs: %d\n",
+			args[0], state, secs)
+
+		tc.AddProcInfo(edgeNode, checkApp(args[0], state))
+
+		tc.WaitForProc(secs)
+	}
+}

--- a/tests/app/eden-config.tmpl
+++ b/tests/app/eden-config.tmpl
@@ -1,0 +1,14 @@
+eden:
+    #test binary
+    test-bin: "eden.app.test"
+
+    #test scenario
+    test-scenario: "eden.app.tests.txt"
+
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/app/eden-config.tmpl
+++ b/tests/app/eden-config.tmpl
@@ -1,6 +1,6 @@
 eden:
     #test binary
-    test-bin: "eden.app.test"
+    test-bin: "eden.escript.test"
 
     #test scenario
     test-scenario: "eden.app.tests.txt"

--- a/tests/app/eden.app.tests.txt
+++ b/tests/app/eden.app.tests.txt
@@ -1,1 +1,1 @@
-eden.app.test
+eden.escript.test -test.run TestEdenScripts/2dockers_test

--- a/tests/app/eden.app.tests.txt
+++ b/tests/app/eden.app.tests.txt
@@ -1,0 +1,1 @@
+eden.app.test

--- a/tests/app/testdata/2dockers_test.txt
+++ b/tests/app/testdata/2dockers_test.txt
@@ -1,0 +1,60 @@
+[!exec:curl] stop
+[!exec:sleep] stop
+
+eden -t 1s pod ps
+
+# Starting of reboot detector with a 3 reboots limit
+! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=1 &
+
+# Run t1 docker
+eden -t 1m pod deploy -p 8027:80 docker://nginx -v debug -n t1
+stdout 'deploy pod t1 with docker://nginx request sent'
+# Wait for run
+test eden.app.test -test.v -timewait 10m t1 RUNNING
+
+# Run t1 docker
+eden -t 1m pod deploy -p 8028:80 docker://nginx -v debug -n t2
+stdout 'deploy pod t2 with docker://nginx request sent'
+# Wait for run
+test eden.app.test -test.v -timewait 10m t2 RUNNING
+
+# Dockers detecting
+eden -t 1m pod ps
+stdout 't1	nginx:latest	.*:80	127.0.0.1:8027	IN_CONFIG	RUNNING'
+stdout 't2	nginx:latest	.*:80	127.0.0.1:8028	IN_CONFIG	RUNNING'
+
+# Wait 5 min
+exec sleep 5m
+
+# Ngnix detecting
+exec -t 1m curl localhost:8027
+stdout 'Welcome to nginx'
+exec -t 1m curl localhost:8028
+stdout 'Welcome to nginx'
+
+# Stop by docker's actor
+eden -t 1m pod delete t1
+stdout 'app t1 delete done'
+eden -t 1m pod delete t2
+stdout 'app t2 delete done'
+
+# Wait for delete
+test eden.app.test -test.v -timewait 10m t1 
+stdout 'no app with t1 found'
+test eden.app.test -test.v -timewait 10m t2 
+stdout 'no app with t2 found'
+
+# Dockers detecting
+eden -t 1m pod ps
+! stdout '^t[12]'
+
+# Test's config. file
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -10,8 +10,9 @@ eden.escript.test -test.run TestEdenScripts/log_test -testdata ../lim/testdata/
 /bin/echo Eden SSH test (5/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/ssh
 /bin/echo Eden 2 dockers test (6/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/2dockers_test -testdata ../docker/testdata/
+eden.escript.test -test.run TestEdenScripts/2dockers_test -testdata ../app/testdata/
 {{/*
+eden.escript.test -test.run TestEdenScripts/2dockers_test -testdata ../docker/testdata/
 eden.escript.test -test.run TestEdenScripts/deploy_docker_eden -test.timeout 10m
 eden.escript.test -test.run TestEdenScripts/deploy_docker_test
 eden.escript.test -test.run TestEdenScripts/deploy_docker_eden


### PR DESCRIPTION
We add this application test state to support this functionality in further tests and test that we can correctly use messages to know the actual state. Alternative is use `eden pod ps `