### PR TITLE
support oci: url, pass through host

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -1,9 +1,10 @@
 package defaults
 
 import (
-	log "github.com/sirupsen/logrus"
 	"strconv"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -75,7 +76,7 @@ const (
 	DefaultTestScenario          = ""
 	DefaultRootFSVersionPattern  = `^(\d+\.*){2,3}.*-(xen|kvm|acrn|rpi|rpi-xen|rpi-kvm)-(amd64|arm64)$`
 	DefaultControllerModePattern = `^(?P<Type>(file|proto|adam|zedcloud)):\/\/(?P<URL>.*)$`
-	DefaultPodLinkPattern        = `^(?P<TYPE>(docker|http[s]{0,1}|file)):\/\/(?P<TAG>[^:]+):*(?P<VERSION>.*)$`
+	DefaultPodLinkPattern        = `^(?P<TYPE>(oci|docker|http[s]{0,1}|file)):\/\/(?P<TAG>[^:]+):*(?P<VERSION>.*)$`
 	DefaultRedisContainerName    = "eden_redis"
 	DefaultAdamContainerName     = "eden_adam"
 	DefaultEServerContainerName  = "eden_eserver"

--- a/pkg/expect/expectation.go
+++ b/pkg/expect/expectation.go
@@ -1,6 +1,11 @@
 package expect
 
 import (
+	"math/rand"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/docker/docker/pkg/namesgenerator"
 	"github.com/lf-edge/eden/pkg/controller"
 	"github.com/lf-edge/eden/pkg/defaults"
@@ -9,10 +14,6 @@ import (
 	"github.com/lf-edge/eve/api/go/config"
 	"github.com/lf-edge/eve/api/go/evecommon"
 	log "github.com/sirupsen/logrus"
-	"math/rand"
-	"strconv"
-	"strings"
-	"time"
 )
 
 //appType is type of app according to provided appLink
@@ -156,7 +157,7 @@ func AppExpectationFromUrl(ctrl controller.Cloud, device *device.Ctx, appLink st
 	//parse provided appLink to obtain params
 	params := utils.GetParams(appLink, defaults.DefaultPodLinkPattern)
 	if len(params) == 0 {
-		log.Fatalf("fail to parse (docker|http(s)|file)://(<TAG>[:<VERSION>] | <URL> | <PATH>) from argument (%s)", appLink)
+		log.Fatalf("fail to parse (oci|docker|http(s)|file)://(<TAG>[:<VERSION>] | <URL> | <PATH>) from argument (%s)", appLink)
 	}
 	expectation.appType = 0
 	expectation.appUrl = ""
@@ -167,7 +168,7 @@ func AppExpectationFromUrl(ctrl controller.Cloud, device *device.Ctx, appLink st
 		log.Fatalf("cannot parse appType (not [docker]): %s", appLink)
 	}
 	switch appType {
-	case "docker":
+	case "docker", "oci":
 		expectation.appType = dockerApp
 	case "http":
 		expectation.appType = httpApp

--- a/tests/docker/testdata/2dockers_test.txt
+++ b/tests/docker/testdata/2dockers_test.txt
@@ -15,8 +15,8 @@ stdout '--- PASS: TestDockerStart'
 
 # Dockers detecting
 eden -t 1m pod ps
-stdout 't1	nginx:latest	.*:80	127.0.0.1:8027	IN_CONFIG	RUNNING'
-stdout 't2	nginx:latest	.*:80	127.0.0.1:8028	IN_CONFIG	RUNNING'
+stdout 't1	library/nginx:latest	.*:80	127.0.0.1:8027	IN_CONFIG	RUNNING'
+stdout 't2	library/nginx:latest	.*:80	127.0.0.1:8028	IN_CONFIG	RUNNING'
 
 # Ngnix detecting
 exec -t 1m curl localhost:8027
@@ -43,4 +43,3 @@ test:
         onboard-cert: {{EdenConfigPath "eve.cert"}}
         serial: "{{EdenConfig "eve.serial"}}"
         model: {{EdenConfig "eve.devmodel"}}
-


### PR DESCRIPTION
Two changes:

* support `oci://` in addition to `docker://` (nothing against docker the company, but this is broader)
* support non-docker hub registries

The latter is the most important. You can do any of the below, and they will work:

* `docker://library/nginx:latest`
* `docker://library/nginx`
* `docker://library/nginx:v1.14`
* `docker://nginx:latest`
* `docker://library/nginx`
* `docker://nginx:v1.14`
* `docker://docker.io/library/nginx:latest`
* `docker://docker.io/library/nginx`
* `docker://docker.io/library/nginx:v1.14`
* `docker://quay.io/coreos/etcd:latest`
* `docker://quay.io/coreos/etcd`

etc