### PR TITLE
docker on file/http transports, qcow2 on docker transport

### DIFF
--- a/cmd/edenPod.go
+++ b/cmd/edenPod.go
@@ -2,6 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"net"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
 	"github.com/dustin/go-humanize"
 	"github.com/lf-edge/eden/pkg/controller/einfo"
 	"github.com/lf-edge/eden/pkg/controller/elog"
@@ -15,12 +22,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"net"
-	"os"
-	"sort"
-	"strconv"
-	"strings"
-	"text/tabwriter"
 )
 
 var (
@@ -34,6 +35,7 @@ var (
 	appCpus     uint32
 	appMemory   string
 	diskSize    string
+	imageFormat string
 
 	outputTail   uint
 	outputFields []string
@@ -91,6 +93,7 @@ var podDeployCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 		opts = append(opts, expect.WithResources(appCpus, uint32(appMemoryParsed/1000)))
+		opts = append(opts, expect.WithImageFormat(imageFormat))
 		expectation := expect.AppExpectationFromUrl(ctrl, dev, appLink, podName, opts...)
 		appInstanceConfig := expectation.Application()
 		dev.SetApplicationInstanceConfig(append(dev.GetApplicationInstances(), appInstanceConfig.Uuidandversion.Uuid))
@@ -589,6 +592,7 @@ func podInit() {
 	podDeployCmd.Flags().StringVar(&appMemory, "memory", humanize.Bytes(defaults.DefaultAppMem*1024), "memory for app")
 	podDeployCmd.Flags().StringVar(&diskSize, "disk-size", humanize.Bytes(0), "disk size (empty or 0 - same as in image)")
 	podDeployCmd.Flags().StringSliceVar(&podNetworks, "networks", nil, "Networks to connect to app (ports will be mapped to first network)")
+	podDeployCmd.Flags().StringVar(&imageFormat, "format", "", "format for image, one of 'container','qcow2'; if not provided, defaults to container image for docker and oci transports, qcow2 for file and http/s transports")
 	podCmd.AddCommand(podPsCmd)
 	podCmd.AddCommand(podStopCmd)
 	podCmd.AddCommand(podStartCmd)

--- a/pkg/expect/docker.go
+++ b/pkg/expect/docker.go
@@ -29,7 +29,7 @@ func (exp *appExpectation) createImageDocker(id uuid.UUID, dsId string) *config.
 			Version: "1",
 		},
 		Name:    fmt.Sprintf("%s:%s", ref.Context().RepositoryStr(), exp.appVersion),
-		Iformat: config.Format_CONTAINER,
+		Iformat: exp.imageFormatEnum(),
 		DsId:    dsId,
 		Siginfo: &config.SignatureInfo{},
 	}

--- a/pkg/expect/expectation.go
+++ b/pkg/expect/expectation.go
@@ -28,15 +28,16 @@ var (
 
 //appExpectation is description of app, expected to run on EVE
 type appExpectation struct {
-	ctrl       controller.Cloud
-	appType    appType
-	appUrl     string
-	appVersion string
-	appName    string
-	appLink    string
-	cpu        uint32
-	mem        uint32
-	metadata   string
+	ctrl        controller.Cloud
+	appType     appType
+	appUrl      string
+	appVersion  string
+	appName     string
+	appLink     string
+	imageFormat string
+	cpu         uint32
+	mem         uint32
+	metadata    string
 
 	vncDisplay  uint32
 	vncPassword string

--- a/pkg/expect/file.go
+++ b/pkg/expect/file.go
@@ -35,7 +35,7 @@ func (exp *appExpectation) createImageFile(id uuid.UUID, dsId string) *config.Im
 			Version: "1",
 		},
 		Name:      filePath,
-		Iformat:   config.Format_QCOW2,
+		Iformat:   exp.imageFormatEnum(),
 		DsId:      dsId,
 		Siginfo:   &config.SignatureInfo{},
 		SizeBytes: fileSize,

--- a/pkg/expect/http.go
+++ b/pkg/expect/http.go
@@ -2,14 +2,15 @@ package expect
 
 import (
 	"fmt"
+	"path"
+	"time"
+
 	"github.com/dustin/go-humanize"
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eden/pkg/utils"
 	"github.com/lf-edge/eve/api/go/config"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
-	"path"
-	"time"
 )
 
 //createImageHttp downloads image into EServer directory from http/https endpoint and calculates size and sha256 of image
@@ -49,7 +50,7 @@ func (exp *appExpectation) createImageHttp(id uuid.UUID, dsId string) *config.Im
 			Version: "1",
 		},
 		Name:      filePath,
-		Iformat:   config.Format_QCOW2,
+		Iformat:   exp.imageFormatEnum(),
 		DsId:      dsId,
 		Siginfo:   &config.SignatureInfo{},
 		SizeBytes: fileSize,

--- a/pkg/expect/image.go
+++ b/pkg/expect/image.go
@@ -2,6 +2,7 @@ package expect
 
 import (
 	"fmt"
+
 	"github.com/lf-edge/eve/api/go/config"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
@@ -37,6 +38,28 @@ func (exp *appExpectation) createImage(dsId string) (*config.Image, error) {
 	default:
 		return nil, fmt.Errorf("not supported appType")
 	}
+}
+
+// imageFormatEnum return the correct enum for the image format
+func (exp *appExpectation) imageFormatEnum() config.Format {
+	var defaultFormat, actual config.Format
+	switch exp.appType {
+	case dockerApp:
+		defaultFormat = config.Format_CONTAINER
+	case httpApp, httpsApp, fileApp:
+		defaultFormat = config.Format_QCOW2
+	default:
+		defaultFormat = config.Format_QCOW2
+	}
+	switch exp.imageFormat {
+	case "container", "oci":
+		actual = config.Format_CONTAINER
+	case "qcow2":
+		actual = config.Format_QCOW2
+	default:
+		actual = defaultFormat
+	}
+	return actual
 }
 
 //Image expects image in controller

--- a/pkg/expect/options.go
+++ b/pkg/expect/options.go
@@ -1,9 +1,10 @@
 package expect
 
 import (
+	"strings"
+
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eve/api/go/config"
-	"strings"
 )
 
 //ExpectationOption is type to use for creation of appExpectation
@@ -85,5 +86,12 @@ func WithResources(cpus uint32, memory uint32) ExpectationOption {
 func WithVirtualizationMode(virtualizationMode config.VmMode) ExpectationOption {
 	return func(expectation *appExpectation) {
 		expectation.virtualizationMode = virtualizationMode
+	}
+}
+
+// WithImageFormat sets app format
+func WithImageFormat(format string) ExpectationOption {
+	return func(expectation *appExpectation) {
+		expectation.imageFormat = format
 	}
 }


### PR DESCRIPTION
We have assumed until now that everything that comes from a docker registry is a docker image, and everything that comes from a file/http is a qcow2, but that isn't necessarily true.

This adds the option to store qcow2 on OCI registries, and OCI images on http/file.

Of course, eve does not yet support it, so using the option will cause appinstance errors. But we are building it.

The point of this PR is to create the option, so we can get eve working with it.