### PR TITLE
json output format option

### DIFF
--- a/cmd/edenPod.go
+++ b/cmd/edenPod.go
@@ -525,7 +525,7 @@ var podLogsCmd = &cobra.Command{
 						//logsQ for filtering logs by app
 						logsQ := make(map[string]string)
 						logsQ["msg"] = app.Uuidandversion.Uuid
-						if err = ctrl.LogChecker(dev.GetID(), logsQ, elog.HandleAll, logType, 0); err != nil {
+						if err = ctrl.LogChecker(dev.GetID(), logsQ, elog.HandleFactory(logFormat, false), logType, 0); err != nil {
 							log.Fatalf("LogChecker: %s", err)
 						}
 					case "info":

--- a/tests/integration/application_test.go
+++ b/tests/integration/application_test.go
@@ -3,6 +3,14 @@ package integration
 import (
 	"flag"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/lf-edge/eden/pkg/controller"
 	"github.com/lf-edge/eden/pkg/controller/einfo"
 	"github.com/lf-edge/eden/pkg/controller/elog"
@@ -12,13 +20,6 @@ import (
 	"github.com/lf-edge/eve/api/go/info"
 	"github.com/spf13/viper"
 	"gotest.tools/assert"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
-	"strings"
-	"testing"
-	"time"
 )
 
 var (
@@ -207,7 +208,7 @@ func TestApplication(t *testing.T) {
 				if !checkLogs {
 					t.Skip("no LOGS flag set - skipped")
 				}
-				err = ctx.LogChecker(devUUID, map[string]string{"devId": devUUID.String(), "msg": fmt.Sprintf(".*AppID:\"%s\".*downloadProgress:100.*", tt.appDefinition.appID)}, elog.HandleFirst, elog.LogAny, 1200)
+				err = ctx.LogChecker(devUUID, map[string]string{"devId": devUUID.String(), "msg": fmt.Sprintf(".*AppID:\"%s\".*downloadProgress:100.*", tt.appDefinition.appID)}, elog.HandleFactory(elog.LogLines, true), elog.LogAny, 1200)
 				if err != nil {
 					t.Fatal("Fail in waiting for app downloaded status: ", err)
 				}
@@ -216,7 +217,7 @@ func TestApplication(t *testing.T) {
 				if !checkLogs {
 					t.Skip("no LOGS flag set - skipped")
 				}
-				err = ctx.LogChecker(devUUID, map[string]string{"devId": devUUID.String(), "msg": fmt.Sprintf(".*AppID:\"%s\".*state:INSTALLED.*", tt.appDefinition.appID)}, elog.HandleFirst, elog.LogAny, 1200)
+				err = ctx.LogChecker(devUUID, map[string]string{"devId": devUUID.String(), "msg": fmt.Sprintf(".*AppID:\"%s\".*state:INSTALLED.*", tt.appDefinition.appID)}, elog.HandleFactory(elog.LogLines, true), elog.LogAny, 1200)
 				if err != nil {
 					t.Fatal("Fail in waiting for app installed status: ", err)
 				}

--- a/tests/integration/baseImage_test.go
+++ b/tests/integration/baseImage_test.go
@@ -3,13 +3,6 @@ package integration
 import (
 	"flag"
 	"fmt"
-	"github.com/lf-edge/eden/pkg/controller"
-	"github.com/lf-edge/eden/pkg/controller/einfo"
-	"github.com/lf-edge/eden/pkg/controller/elog"
-	"github.com/lf-edge/eden/pkg/defaults"
-	"github.com/lf-edge/eden/pkg/utils"
-	"github.com/lf-edge/eve/api/go/config"
-	"github.com/spf13/viper"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,6 +10,14 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/lf-edge/eden/pkg/controller"
+	"github.com/lf-edge/eden/pkg/controller/einfo"
+	"github.com/lf-edge/eden/pkg/controller/elog"
+	"github.com/lf-edge/eden/pkg/defaults"
+	"github.com/lf-edge/eden/pkg/utils"
+	"github.com/lf-edge/eve/api/go/config"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -102,7 +103,7 @@ func TestBaseImage(t *testing.T) {
 				if !checkLogs {
 					t.Skip("no LOGS flag set - skipped")
 				}
-				err = ctx.LogChecker(devUUID, map[string]string{"devId": devUUID.String(), "eveVersion": baseOSVersion}, elog.HandleFirst, elog.LogAny, 1200)
+				err = ctx.LogChecker(devUUID, map[string]string{"devId": devUUID.String(), "eveVersion": baseOSVersion}, elog.HandleFactory(elog.LogLines, true), elog.LogAny, 1200)
 				if err != nil {
 					t.Fatal("Fail in waiting for base image logs: ", err)
 				}

--- a/tests/integration/controller_test.go
+++ b/tests/integration/controller_test.go
@@ -1,11 +1,12 @@
 package integration
 
 import (
+	"testing"
+
 	"github.com/lf-edge/eden/pkg/controller"
 	"github.com/lf-edge/eden/pkg/controller/einfo"
 	"github.com/lf-edge/eden/pkg/controller/elog"
 	"github.com/lf-edge/eden/pkg/device"
-	"testing"
 )
 
 //TestAdamOnBoard test onboarding into controller
@@ -70,7 +71,7 @@ func TestControllerLogs(t *testing.T) {
 		t.Fatal("Fail in get first device: ", err)
 	}
 	t.Log(devUUID.GetID())
-	err = ctx.LogChecker(devUUID.GetID(), map[string]string{"devId": devUUID.GetID().String()}, elog.HandleFirst, elog.LogAny, 600)
+	err = ctx.LogChecker(devUUID.GetID(), map[string]string{"devId": devUUID.GetID().String()}, elog.HandleFactory(elog.LogLines, true), elog.LogAny, 600)
 	if err != nil {
 		t.Fatal("Fail in waiting for logs: ", err)
 	}

--- a/tests/integration/networkInstance_test.go
+++ b/tests/integration/networkInstance_test.go
@@ -2,12 +2,13 @@ package integration
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/lf-edge/eden/pkg/controller"
 	"github.com/lf-edge/eden/pkg/controller/einfo"
 	"github.com/lf-edge/eden/pkg/controller/elog"
 	"github.com/lf-edge/eden/pkg/defaults"
-	"testing"
-	"time"
 )
 
 //TestNetworkInstance test network instances creation in EVE
@@ -59,7 +60,7 @@ func TestNetworkInstance(t *testing.T) {
 				if !checkLogs {
 					t.Skip("no LOGS flag set - skipped")
 				}
-				err = ctx.LogChecker(devUUID, map[string]string{"devId": devUUID.String(), "msg": fmt.Sprintf(".*handleNetworkInstanceModify\\(%s\\) done.*", tt.networkInstance.networkInstanceID), "level": "info"}, elog.HandleFirst, elog.LogAny, 600)
+				err = ctx.LogChecker(devUUID, map[string]string{"devId": devUUID.String(), "msg": fmt.Sprintf(".*handleNetworkInstanceModify\\(%s\\) done.*", tt.networkInstance.networkInstanceID), "level": "info"}, elog.HandleFactory(elog.LogLines, true), elog.LogAny, 600)
 				if err != nil {
 					t.Fatal("Fail in waiting for handleNetworkInstanceModify done from zedagent: ", err)
 				}

--- a/tests/lim/lim_test.go
+++ b/tests/lim/lim_test.go
@@ -3,6 +3,11 @@ package lim
 import (
 	"flag"
 	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/lf-edge/eden/pkg/controller/einfo"
 	"github.com/lf-edge/eden/pkg/controller/elog"
 	"github.com/lf-edge/eden/pkg/controller/emetric"
@@ -11,10 +16,6 @@ import (
 	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/api/go/metrics"
 	log "github.com/sirupsen/logrus"
-	"os"
-	"strings"
-	"testing"
-	"time"
 )
 
 var (
@@ -158,9 +159,9 @@ func TestLog(t *testing.T) {
 			}
 			t.Logf("LOG %d(%d) from %s:\n", items+1, *number, name)
 			if len(*out) == 0 {
-				elog.LogPrn(log)
+				elog.LogPrn(log, elog.LogLines)
 			} else {
-				elog.LogItemPrint(log,
+				elog.LogItemPrint(log, elog.LogLines,
 					strings.Split(*out, ":")).Print()
 			}
 


### PR DESCRIPTION
Closes #214 

Default format (now named "lines") remains the same, but if you give it `--format json`, it gives your in json output (which you then can run through `jq` and have _lots_ of fun!)