### PR TITLE
provide option to override uefi tag

### DIFF
--- a/cmd/downloader.go
+++ b/cmd/downloader.go
@@ -2,19 +2,21 @@ package cmd
 
 import (
 	"fmt"
+	"path/filepath"
+	"runtime"
+
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eden/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"path/filepath"
-	"runtime"
 )
 
 var (
-	eveArch   string
-	eveTag    string
-	outputDir string
+	eveArch    string
+	eveTag     string
+	eveUefiTag string
+	outputDir  string
 )
 
 var downloaderCmd = &cobra.Command{
@@ -32,6 +34,7 @@ var downloadEVECmd = &cobra.Command{
 		}
 		if viperLoaded {
 			eveTag = viper.GetString("eve.tag")
+			eveUefiTag = viper.GetString("eve.uefi-tag")
 			eveArch = viper.GetString("eve.arch")
 			eveHV = viper.GetString("eve.hv")
 			adamDist = utils.ResolveAbsPath(viper.GetString("adam.dist"))
@@ -45,7 +48,7 @@ var downloadEVECmd = &cobra.Command{
 		if devModel == defaults.DefaultRPIModel {
 			format = "raw"
 		}
-		if err := utils.DownloadEveLive(adamDist, eveImageFile, eveArch, eveHV, eveTag, format); err != nil {
+		if err := utils.DownloadEveLive(adamDist, eveImageFile, eveArch, eveHV, eveTag, eveUefiTag, format); err != nil {
 			log.Fatal(err)
 		} else {
 			if devModel == defaults.DefaultRPIModel {
@@ -86,7 +89,8 @@ var downloadEVERootFSCmd = &cobra.Command{
 
 func downloaderInit() {
 	downloaderCmd.AddCommand(downloadEVECmd)
-	downloadEVECmd.Flags().StringVarP(&eveTag, "eve-tag", "", defaults.DefaultEVETag, "tag to download")
+	downloadEVECmd.Flags().StringVarP(&eveTag, "eve-tag", "", defaults.DefaultEVETag, "tag to download eve")
+	downloadEVECmd.Flags().StringVarP(&eveUefiTag, "eve-uefi-tag", "", defaults.DefaultEVETag, "tag to download eve UEFI")
 	downloadEVECmd.Flags().StringVarP(&eveArch, "eve-arch", "", runtime.GOARCH, "arch of EVE")
 	downloadEVECmd.Flags().StringVarP(&eveHV, "eve-hv", "", defaults.DefaultEVEHV, "HV of EVE (kvm or xen)")
 	downloadEVECmd.Flags().StringVarP(&eveImageFile, "image-file", "i", "", "path for image drive")

--- a/cmd/edenSetup.go
+++ b/cmd/edenSetup.go
@@ -4,6 +4,12 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eden/pkg/utils"
 	log "github.com/sirupsen/logrus"
@@ -11,11 +17,6 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/crypto/pbkdf2"
 	"golang.org/x/crypto/ssh/terminal"
-	"os"
-	"path/filepath"
-	"reflect"
-	"runtime"
-	"strings"
 )
 
 var (
@@ -115,6 +116,7 @@ var setupCmd = &cobra.Command{
 			eveDist = utils.ResolveAbsPath(viper.GetString("eve.dist"))
 			eveRepo = viper.GetString("eve.repo")
 			eveTag = viper.GetString("eve.tag")
+			eveUefiTag = viper.GetString("eve.uefi-tag")
 			eveHV = viper.GetString("eve.hv")
 			eveArch = viper.GetString("eve.arch")
 			qemuHostFwd = viper.GetStringMapString("eve.hostfwd")
@@ -202,7 +204,7 @@ var setupCmd = &cobra.Command{
 			}
 		} else {
 			if _, err := os.Lstat(eveImageFile); os.IsNotExist(err) {
-				if err := utils.DownloadEveLive(certsDir, eveImageFile, eveArch, eveHV, eveTag, imageFormat); err != nil {
+				if err := utils.DownloadEveLive(certsDir, eveImageFile, eveArch, eveHV, eveTag, eveUefiTag, imageFormat); err != nil {
 					log.Errorf("cannot download EVE: %s", err)
 				} else {
 					log.Infof("download EVE done: %s", eveImageFile)
@@ -240,6 +242,7 @@ func setupInit() {
 	setupCmd.Flags().StringVarP(&eveDist, "eve-dist", "", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultEVEDist), "directory to save EVE")
 	setupCmd.Flags().StringVarP(&eveRepo, "eve-repo", "", defaults.DefaultEveRepo, "EVE repo")
 	setupCmd.Flags().StringVarP(&eveTag, "eve-tag", "", defaults.DefaultEVETag, "EVE tag")
+	setupCmd.Flags().StringVarP(&eveUefiTag, "eve-uefi-tag", "", defaults.DefaultEVETag, "EVE UEFI tag")
 	setupCmd.Flags().StringVarP(&eveArch, "eve-arch", "", runtime.GOARCH, "EVE arch")
 	setupCmd.Flags().StringToStringVarP(&qemuHostFwd, "eve-hostfwd", "", defaults.DefaultQemuHostFwd, "port forward map")
 	setupCmd.Flags().StringVarP(&qemuFileToSave, "qemu-config", "", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultQemuFileToSave), "file to save qemu config")

--- a/docs/eve-images.md
+++ b/docs/eve-images.md
@@ -43,7 +43,6 @@ To generate the docker container with your image:
 1. Work in the `github.com/lf-edge/eve` directory
 1. Configure your code as desired
 1. Run `make eve`, optionally setting the desired hypervisor, e.g. `make eve HV=kvm` (recommended with eden)
-1. Run `make eve-uefi`.
 
 When done, you will be provided with output telling you the docker image name and tag, e.g.
 
@@ -52,15 +51,6 @@ Successfully built a46458b4ce1a
 Successfully tagged lfedge/eve:0.0.0-testbranch-b6a6d6fd-kvm-amd64
 Tagging lfedge/eve:0.0.0-testbranch-b6a6d6fd-kvm-amd64 as lfedge/eve:0.0.0-testbranch-b6a6d6fd-kvm
 ```
-
-And for `eve-uefi`:
-
-```
-Tagging lfedge/eve-uefi:0.0.0-testbranch-b6a6d6fd-kvm-amd64 as lfedge/eve-uefi:0.0.0-testbranch-b6a6d6fd-kvm
-```
-
-You need to run both `make eve` and `make eve-uefi` because eden uses the `--eve-tag` to look for both
-the eve image and the eve-uefi image.
 
 Now, run eden setup, but tell eden to use the provided image:
 
@@ -82,6 +72,36 @@ eden setup
 ```
 
 eden now will use the above container image to generate and configure the live disk image.
+
+#### Changing UEFI
+
+eden uses separate tags for `eve` and `eve-uefi`. This means that you can set the tag
+just for `eve`, while it will continue to use the default for `eve-uefi`. This helps with
+a development cycle where you are changing `eve`, but do not want to make changes to or rebuild
+`eve-uefi`.
+
+On the other hand, you can make changes to `eve-uefi`, in addition to or independent of `eve`.
+
+To run eden setup to use just a specific `eve-uefi` image, or both `eve` and `eve-uefi`:
+
+```sh
+eden setup --eve-uefi-tag <uefi-tag>
+eden setup --eve-tag <tag> --eve-uefi-tag <uefi-tag>
+```
+
+Continuing the above example:
+
+```sh
+eden setup --eve-uefi-tag eve-uefi-special
+eden setup --eve-tag 0.0.0-testbranch-b6a6d6fd-kvm --eve-uefi-tag eve-uefi-special
+```
+
+Or you can save it, by setting it in the file:
+
+```console
+eden config set default --key eve.uefi-tag --value eve-uefi-special
+eden setup
+```
 
 ### Live Image
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -139,6 +139,7 @@ var (
 		"eve.firmware":     "eve-firmware",
 		"eve.repo":         "eve-repo",
 		"eve.tag":          "eve-tag",
+		"eve.uefi-tag":     "eve-uefi-tag",
 		"eve.hostfwd":      "eve-hostfwd",
 		"eve.dist":         "eve-dist",
 		"eve.base-dist":    "eve-base-dist",

--- a/pkg/utils/dowloaders.go
+++ b/pkg/utils/dowloaders.go
@@ -2,17 +2,18 @@ package utils
 
 import (
 	"fmt"
-	"github.com/lf-edge/eden/pkg/defaults"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"path/filepath"
 	"strings"
 	"unicode"
+
+	"github.com/lf-edge/eden/pkg/defaults"
+	log "github.com/sirupsen/logrus"
 )
 
 //DownloadEveLive pulls EVE live image from docker
-func DownloadEveLive(configPath string, outputFile string, eveArch string, eveHV string, eveTag string, format string) (err error) {
-	efiImage := fmt.Sprintf("lfedge/eve-uefi:%s-%s", eveTag, eveArch) //download OVMF
+func DownloadEveLive(configPath string, outputFile string, eveArch string, eveHV string, eveTag, eveUefiTag string, format string) (err error) {
+	efiImage := fmt.Sprintf("lfedge/eve-uefi:%s-%s", eveUefiTag, eveArch) //download OVMF
 	image := fmt.Sprintf("lfedge/eve:%s-%s-%s", eveTag, eveHV, eveArch)
 	log.Debugf("Try ImagePull with (%s)", image)
 	if err := PullImage(image); err != nil {


### PR DESCRIPTION
Fixes #223 

When working with developing eve, you need to change and rebuild it frequently. You do _not_ want to have to rebuild UEFI all of the time. This lets you override just the eve tag, while keeping the uefi tag the same.