### PR TITLE
[WIP] GCP devmodel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ help:
 	@echo "   eserver       build eserver image"
 	@echo
 	@echo "You can use some parameters:"
-	@echo "   CONFIG        additional parameters for 'eden config add default', for ex. make CONFIG='--devmodel RPi4' run"
+	@echo "   CONFIG        additional parameters for 'eden config add default', for ex. \"make CONFIG='--devmodel RPi4' run\" or \"make CONFIG='--devmodel GCP' run\""
 	@echo "   TESTS         list of tests for 'make test' to run, for ex. make TESTS='lim units' test"
 	@echo "   DEBUG         debug level for 'eden' command ('debug' by default)"
 	@echo

--- a/README.md
+++ b/README.md
@@ -110,6 +110,34 @@ Some tests may accept parameters - run Log/Metrics/Info test in debug mode with 
 
 You can find more detailed information about `eden test` in [tests/README.md](tests/README.md) and [tests/escript/README.md](tests/escript/README.md)
 
+## Google Cloud support
+Eden is enough to deploy Eve on Google Cloud. We are going to make it one command, but now the process is: 
+* Make an image 
+* Upload it to GCP and run 
+* start eden (if not started yet) 
+* Onboard eve (use `eden eve onboard`)
+
+Step 1 : Make an image. You need to specify IP of Adam, by defalut Adam is a container inside machine with Eden, so put there an IP that is accessible from gcp
+```
+make CONFIG='--devmodel GCP' build
+./eden config set default --key adam.eve-ip --value <IP of Adam/Eden>  
+./eden setup
+```
+Step 2 : Upload image to gcp and run it. You will need a google service key json. https://cloud.google.com/iam/docs/creating-managing-service-account-keys 
+```
+./eden utils gcp image -k  <PATH TO SERVICE KEY FILE>  upload <PATH TO EVE IMAGE>
+./eden utils gcp vm -k <PATH TO SERVICE KEY FILE> 
+```
+vm is named eden-gcp-test
+`eden utils gcp` supports vm-name image-name and bucket-name  parameters
+
+Step 3 : Start eden and onboard Eve
+```
+./eden start
+./eden eve onboard
+```
+
+
 ## Raspberry Pi 4 support
 
 Eden is the only thing you need to work with Raspberry and deploy containers there:

--- a/cmd/downloader.go
+++ b/cmd/downloader.go
@@ -48,11 +48,17 @@ var downloadEVECmd = &cobra.Command{
 		if devModel == defaults.DefaultRPIModel {
 			format = "raw"
 		}
+		if devModel == defaults.DefaultGCPModel {
+			format = "gcp"
+		}
 		if err := utils.DownloadEveLive(adamDist, eveImageFile, eveArch, eveHV, eveTag, eveUefiTag, format); err != nil {
 			log.Fatal(err)
 		} else {
-			if devModel == defaults.DefaultRPIModel {
+			switch devModel {
+			case defaults.DefaultRPIModel:
 				log.Infof("Write file %s to sd (it is in raw format)", eveImageFile)
+			case defaults.DefaultGCPModel:
+				log.Infof("Upload %s to gcp and run", eveImageFile)
 			}
 			fmt.Println(eveImageFile)
 		}

--- a/cmd/edenConfig.go
+++ b/cmd/edenConfig.go
@@ -43,7 +43,7 @@ var configAddCmd = &cobra.Command{
 	Long:  `Generate config context for eden.`,
 	Args:  cobra.ExactValidArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if devModel != defaults.DefaultRPIModel && devModel != defaults.DefaultEVEModel {
+		if devModel != defaults.DefaultRPIModel && devModel != defaults.DefaultEVEModel && devModel != defaults.DefaultGCPModel {
 			log.Fatal("unsupported model")
 		}
 		var err error
@@ -127,6 +127,17 @@ var configAddCmd = &cobra.Command{
 			if ssid != "" {
 				viper.Set("eve.ssid", ssid)
 			}
+			if err = viper.WriteConfig(); err != nil {
+				log.Fatalf("error writing config: %s", err)
+			}
+		}
+		if devModel == defaults.DefaultGCPModel { //modify default settings according to GCP params
+			eveRemote = true
+			viper.Set("eve.hostfwd", map[string]string{})
+			viper.Set("eve.devmodel", defaults.DefaultGCPModel)
+			viper.Set("eve.serial", "*")
+			viper.Set("eve.remote", eveRemote)
+			viper.Set("eve.remote-addr", "")
 			if err = viper.WriteConfig(); err != nil {
 				log.Fatalf("error writing config: %s", err)
 			}

--- a/cmd/edenPod.go
+++ b/cmd/edenPod.go
@@ -295,7 +295,7 @@ var podPsCmd = &cobra.Command{
 					if !seen {
 						appStateObj.eveState = "UNKNOWN" //UNKNOWN if not found in recent AppInstances
 					}
-					if devModel == defaults.DefaultRPIModel {
+					if devModel == defaults.DefaultRPIModel || devModel == defaults.DefaultGCPModel {
 						for _, nw := range im.GetDinfo().Network {
 							for _, addr := range nw.IPAddrs {
 								ip, _, err := net.ParseCIDR(addr)

--- a/cmd/edenPod.go
+++ b/cmd/edenPod.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"net"
 	"os"
 	"sort"
 	"strconv"
@@ -298,13 +297,13 @@ var podPsCmd = &cobra.Command{
 					if devModel == defaults.DefaultRPIModel || devModel == defaults.DefaultGCPModel {
 						for _, nw := range im.GetDinfo().Network {
 							for _, addr := range nw.IPAddrs {
-								ip, _, err := net.ParseCIDR(addr)
-								if err != nil {
-									log.Fatal(err)
-								}
-								ipv4 := ip.To4()
-								if ipv4 != nil {
-									appStateObj.extIp = ipv4.String()
+								//ip, _, err := net.ParseCIDR(addr)
+								//	if err != nil {
+								//		log.Fatal(err)
+								//	}
+								//ipv4 := ip.To4()
+								if addr != "" {
+									appStateObj.extIp = addr //ipv4.String()
 								}
 							}
 						}

--- a/cmd/edenSetup.go
+++ b/cmd/edenSetup.go
@@ -165,6 +165,8 @@ var setupCmd = &cobra.Command{
 				eveHV = fmt.Sprintf("rpi-%s", eveHV)
 			}
 			imageFormat = "raw"
+		case defaults.DefaultGCPModel:
+			imageFormat = "gcp"
 		case defaults.DefaultEVEModel:
 			imageFormat = "qcow2"
 		default:
@@ -195,8 +197,12 @@ var setupCmd = &cobra.Command{
 						}
 					}
 				}
-				if devModel == defaults.DefaultRPIModel {
+
+				switch devModel {
+				case defaults.DefaultRPIModel:
 					log.Infof("Write file %s to sd (it is in raw format)", eveImageFile)
+				case defaults.DefaultGCPModel:
+					log.Infof("Upload %s to gcp and run", eveImageFile)
 				}
 			} else {
 				log.Infof("EVE already exists in dir: %s", eveDist)
@@ -208,8 +214,11 @@ var setupCmd = &cobra.Command{
 					log.Errorf("cannot download EVE: %s", err)
 				} else {
 					log.Infof("download EVE done: %s", eveImageFile)
-					if devModel == defaults.DefaultRPIModel {
+					switch devModel {
+					case defaults.DefaultRPIModel:
 						log.Infof("Write file %s to sd (it is in raw format)", eveImageFile)
+					case defaults.DefaultGCPModel:
+						log.Infof("Upload %s to gcp and run", eveImageFile)
 					}
 				}
 			} else {

--- a/cmd/eve.go
+++ b/cmd/eve.go
@@ -2,6 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
 	"github.com/lf-edge/eden/pkg/controller/einfo"
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eden/pkg/device"
@@ -10,12 +16,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"io/ioutil"
-	"net"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
 )
 
 var (
@@ -295,13 +295,13 @@ var sshEveCmd = &cobra.Command{
 					}
 					for _, nw := range lastDInfo.GetDinfo().Network {
 						for _, addr := range nw.IPAddrs {
-							ip, _, err := net.ParseCIDR(addr)
-							if err != nil {
-								log.Fatal(err)
-							}
-							ipv4 := ip.To4()
-							if ipv4 != nil {
-								eveHost = ipv4.String()
+							//ip, _, err := net.ParseCIDR(addr)
+							//if err != nil {
+							//	log.Fatal(err)
+							//}
+							//ipv4 := ip.To4()
+							if addr != "" {
+								eveHost = addr //ipv4.String()
 							}
 						}
 					}

--- a/docs/eve-models.md
+++ b/docs/eve-models.md
@@ -1,0 +1,28 @@
+Eden has different ways of Eve deployment: 
+
+# Qemu deployment
+This is default deployment
+Once you run `eden config add default` eden generates config with this type of deployment. 
+Also it generates qemu.conf in ~/.eden/ with qemu setings 
+
+This installation type requires qemu package installed. Eve runs in qemu on the same machine. 
+This is useful for debugging and getting started, but not that useful in production 
+
+Note that KVM requires that the virtual machine host's processor has virtualization support
+
+# GCP deployment
+This deployment type is activated  by flag `--devmodel GCP`
+like `make CONFIG='--devmodel GCP' run`
+The line above prepares the image for GCP. Use `eden utils gcp` to upload it to Google cloud
+
+# Raspberry 4  deployment
+This deployment type is activated  by flag `--devmodel RPi`
+like `make CONFIG='--devmodel RPi' run
+The line above makes an image for Raspberry. Use simple SD card burner to burn the image and put the card into Raspberry and power it up.
+
+Each deployment requires to run 
+```
+eden setup
+eden start
+eden eve onboard
+```

--- a/pkg/controller/devModel.go
+++ b/pkg/controller/devModel.go
@@ -128,6 +128,9 @@ const DevModelTypeQemu DevModelType = defaults.DefaultEVEModel
 //DevModelTypeRaspberry is model type for Raspberry
 const DevModelTypeRaspberry DevModelType = defaults.DefaultRPIModel
 
+//DevModelTypeGCP is model type for GCP
+const DevModelTypeGCP DevModelType = defaults.DefaultGCPModel
+
 //CreateDevModel create manual DevModel with provided params
 func (cloud *CloudCtx) CreateDevModel(PhysicalIOs []*config.PhysicalIO, Networks []*config.NetworkConfig, Adapters []*config.SystemAdapter, AdapterForSwitches []string, modelType DevModelType) *DevModel {
 	devModel := &DevModel{adapterForSwitches: AdapterForSwitches, physicalIOs: PhysicalIOs, networks: Networks, adapters: Adapters, devModelType: modelType}
@@ -148,7 +151,7 @@ func (cloud *CloudCtx) GetDevModel(devModelType DevModelType) (*DevModel, error)
 	switch devModelType {
 	case DevModelTypeEmpty:
 		return cloud.CreateDevModel(nil, nil, nil, nil, DevModelTypeEmpty), nil
-	case DevModelTypeQemu:
+	case DevModelTypeQemu, DevModelTypeGCP:
 		return cloud.CreateDevModel(
 				[]*config.PhysicalIO{{
 					Ptype:        evecommon.PhyIoType_PhyIoNetEth,

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -41,7 +41,7 @@ const (
 	DefaultAdamPort    = 3333
 
 	//tags, versions, repos
-	DefaultEVETag            = "5.9.0" //DefaultEVETag tag for EVE image
+	DefaultEVETag            = "0.0.0-snapshot-master-2684e660" //DefaultEVETag tag for EVE image
 	DefaultAdamTag           = "0.0.53"
 	DefaultRedisTag          = "6"
 	DefaultLinuxKitVersion   = "v0.7"
@@ -93,7 +93,10 @@ const (
 	DefaultEVEModel = "ZedVirtual-4G"
 
 	DefaultRPIModel = "RPi4"
-	DefaultEVEName  = "node1"
+
+	DefaultGCPModel = "GCP"
+
+	DefaultEVEName = "node1"
 
 	DefaultEVERemote = false
 

--- a/pkg/utils/dowloaders.go
+++ b/pkg/utils/dowloaders.go
@@ -26,7 +26,6 @@ func DownloadEveLive(configPath string, outputFile string, eveArch string, eveHV
 	}
 	size := 0
 	if format == "qcow2" {
-		format = "qcow2"
 		size = defaults.DefaultEVEImageSize
 		if err := PullImage(efiImage); err != nil {
 			log.Infof("cannot pull %s", efiImage)
@@ -39,6 +38,9 @@ func DownloadEveLive(configPath string, outputFile string, eveArch string, eveHV
 		if err := SaveImage(efiImage, filepath.Dir(outputFile), ""); err != nil {
 			return fmt.Errorf("SaveImage: %s", err)
 		}
+	}
+	if format == "gcp" {
+		size = defaults.DefaultEVEImageSize
 	}
 	if fileName, err := genEVELiveImage(image, filepath.Dir(outputFile), format, configPath, size); err != nil {
 		return fmt.Errorf("genEVEImage: %s", err)
@@ -62,6 +64,9 @@ func genEVELiveImage(image, outputDir string, format string, configDir string, s
 	fileName = filepath.Join(outputDir, "live.raw")
 	if format == "qcow2" {
 		fileName = fileName + "." + format
+	}
+	if format == "gcp" {
+		fileName = fileName + ".img.tar.gz"
 	}
 	dockerCommand := fmt.Sprintf("-f %s live %d", format, size)
 	if size == 0 {

--- a/pkg/utils/eden.go
+++ b/pkg/utils/eden.go
@@ -361,6 +361,9 @@ func MakeEveInRepo(distEve string, configPath string, arch string, hv string, im
 		image = filepath.Join(distEve, "dist", arch, "installer", fmt.Sprintf("live.%s", imageFormat))
 	} else {
 		image = filepath.Join(distEve, "dist", arch, fmt.Sprintf("live.%s", imageFormat))
+		if imageFormat == "gcp" {
+			image = filepath.Join(distEve, "dist", arch, "live.img.tar.gz")
+		}
 		commandArgsString := fmt.Sprintf("-C %s ZARCH=%s HV=%s CONF_DIR=%s IMG_FORMAT=%s live",
 			distEve, arch, hv, configPath, imageFormat)
 		log.Infof("MakeEveInRepo run: %s %s", "make", commandArgsString)

--- a/tests/vnc/vnc_test.go
+++ b/tests/vnc/vnc_test.go
@@ -62,7 +62,7 @@ func TestMain(m *testing.M) {
 //for qemu it is forwarded
 //for rpi it is direct
 func getVNCPort(edgeNode *device.Ctx, vncDisplay int) int {
-	if edgeNode.GetDevModel() == defaults.DefaultRPIModel {
+	if edgeNode.GetDevModel() == defaults.DefaultRPIModel || edgeNode.GetDevModel() == defaults.DefaultGCPModel {
 		return 5900 + vncDisplay
 	} else {
 		return 5910 + vncDisplay //forwarded by qemu ports


### PR DESCRIPTION
 Creates gcp image to deploy to google cloud 
 GCP target in make: 
`make CONFIG='--devmodel GCP' build
`then 

`./eden config set default --key adam.eve-ip --value EXTERNAL_IP
`
And setup port forward on your router:

EXTERNAL_IP:8888/TCP<->INTERNAL_IP:8888/TCP
EXTERNAL_IP:3333/TCP<->INTERNAL_IP:3333/TCP

 GCP building:
` ./eden setup
`
Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>