### PR TITLE
args for escript

### DIFF
--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"text/template"
 )
 
@@ -285,6 +286,8 @@ redis:
     dist: "{{ .DefaultRedisDist }}"
 `
 
+var configMutex = sync.RWMutex{}
+
 //DefaultEdenDir returns path to default directory
 func DefaultEdenDir() (string, error) {
 	usr, err := user.Current()
@@ -314,6 +317,8 @@ func CurrentDirConfigPath() (string, error) {
 
 //LoadConfigFile load config from file with viper
 func LoadConfigFile(config string) (loaded bool, err error) {
+	configMutex.Lock()
+	defer configMutex.Unlock()
 	if config == "" {
 		config, err = DefaultConfigPath()
 		if err != nil {

--- a/tests/escript/Makefile
+++ b/tests/escript/Makefile
@@ -37,7 +37,7 @@ $(BINDIR):
 	mkdir -p $@
 
 test_escript:
-	go test escript_test.go common.go -v -count=1 -timeout 3000s
+	go test escript_test.go -v -count=1 -timeout 3000s
 
 test:
 	$(LOCALBIN) test $(CURDIR) -v $(DEBUG)

--- a/tests/escript/README.md
+++ b/tests/escript/README.md
@@ -102,6 +102,12 @@ Params.Condition.
 
 The predefined commands are:
 
+* arg name env
+
+    Set environment variable (env) with value from argument (name) passed into script    
+    You can define arguments in top tests file: `eden.escript.test -test.run TestEdenScripts/arg -args="test1=123,test2=456"`    
+    You can override provided args by run: `./eden test tests/escript/ -v debug -a="test1=789"`
+
 * cd dir
 
     Change to the given directory for future commands.

--- a/tests/escript/eden.escript.tests.txt
+++ b/tests/escript/eden.escript.tests.txt
@@ -1,3 +1,4 @@
+eden.escript.test -test.run TestEdenScripts/arg -args="test1=123,test2=456"
 eden.escript.test -test.run TestEdenScripts/template
 eden.escript.test -test.run TestEdenScripts/message
 eden.escript.test -test.run TestEdenScripts/nested_scripts

--- a/tests/escript/escript_test.go
+++ b/tests/escript/escript_test.go
@@ -5,18 +5,34 @@ import (
 	"github.com/lf-edge/eden/tests/escript/go-internal/testscript"
 	log "github.com/sirupsen/logrus"
 	"os"
+	"strings"
 	"testing"
 )
 
 var testData = flag.String("testdata", "testdata", "Test script directory")
+var args = flag.String("args", "", "Flags to pass into test")
 
 func TestEdenScripts(t *testing.T) {
 	if _, err := os.Stat(*testData); os.IsNotExist(err) {
 		log.Fatalf("can't find %s directory: %s\n", *testData, err)
 	}
 
+	flagsParsed := make(map[string]string)
+
+	flags := strings.Split(strings.Trim(*args, "\""), ",")
+
+	for _, el := range flags {
+		fl := strings.TrimPrefix(el, "-")
+		fl = strings.TrimPrefix(fl, "-")
+		split := strings.SplitN(fl, "=", 2)
+		if len(split) == 2 {
+			flagsParsed[strings.TrimSpace(split[0])] = strings.TrimSpace(split[1])
+		}
+	}
+
 	log.Info("testData directory: ", *testData)
 	testscript.Run(t, testscript.Params{
-		Dir: *testData,
+		Dir:   *testData,
+		Flags: flagsParsed,
 	})
 }

--- a/tests/escript/go-internal/testscript/cmd.go
+++ b/tests/escript/go-internal/testscript/cmd.go
@@ -27,6 +27,7 @@ import (
 // NOTE: If you make changes here, update doc.go.
 //
 var scriptCmds = map[string]func(*TestScript, bool, []string){
+	"arg":     (*TestScript).cmdArg,
 	"cd":      (*TestScript).cmdCd,
 	"chmod":   (*TestScript).cmdChmod,
 	"cmp":     (*TestScript).cmdCmp,
@@ -358,6 +359,21 @@ func (ts *TestScript) cmdEnv(neg bool, args []string) {
 			continue
 		}
 		ts.Setenv(env[:i], env[i+1:])
+	}
+}
+
+// cmdArg process args and set value into environment variable.
+func (ts *TestScript) cmdArg(neg bool, args []string) {
+	if neg {
+		ts.Fatalf("unsupported: ! env")
+	}
+	if len(args) != 2 {
+		ts.Fatalf("usage: arg argument env_variable")
+	}
+	if val, ok := ts.params.Flags[args[0]]; !ok {
+		ts.Logf("argument %s not found in passed argument", args[0])
+	} else {
+		ts.Setenv(args[1], val)
 	}
 }
 

--- a/tests/escript/go-internal/testscript/testscript.go
+++ b/tests/escript/go-internal/testscript/testscript.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -31,6 +32,7 @@ import (
 )
 
 var execCache par.Cache
+var envMapMutex = sync.RWMutex{}
 
 // If -testwork is specified, the test prints the name of the temp directory
 // and does not remove it when done, so that a programmer can
@@ -152,6 +154,8 @@ type Params struct {
 	// a manual change will be needed if it is not unquoted in the
 	// script.
 	UpdateScripts bool
+
+	Flags map[string]string
 }
 
 // RunDir runs the tests in the given directory. All files in dir with a ".txt"

--- a/tests/escript/testdata/arg.txt
+++ b/tests/escript/testdata/arg.txt
@@ -1,0 +1,12 @@
+arg test1 test1
+arg test2 test2
+
+exec bash env_process.sh
+stdout 123
+stdout 456
+
+-- env_process.sh --
+#!/bin/sh
+
+echo "test1:$test1"
+echo "test2:$test2"

--- a/tests/escript/testdata/template.txt
+++ b/tests/escript/testdata/template.txt
@@ -12,12 +12,12 @@ cmp stdout out
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 
 ROOT=`$EDEN config get --key eden.root`
-DIST=`$EDEN config get --key eden.images.dist`
+DIST=`$EDEN config get --key adam.ca`
 echo eden.root = $ROOT > out
-echo eden.images.dist = $DIST '->' $ROOT/$DIST >> out
-echo eden.images.dist = $DIST '->' $ROOT/$DIST >> out
+echo adam.ca = $DIST '->' $ROOT/$DIST >> out
+echo adam.ca = $DIST '->' $ROOT/$DIST >> out
 
 -- template.text --
 eden.root = {{EdenConfig "eden.root"}}
-eden.images.dist = {{EdenConfig "eden.images.dist"}} -> {{EdenConfigPath "eden.images.dist"}}
-{{$i := EdenConfig "eden.images.dist"}}eden.images.dist = {{$i}} -> {{EdenPath $i }}
+adam.ca = {{EdenConfig "adam.ca"}} -> {{EdenConfigPath "adam.ca"}}
+{{$i := EdenConfig "adam.ca"}}adam.ca = {{$i}} -> {{EdenPath $i }}


### PR DESCRIPTION
`arg name env`
Set environment variable (env) with value from argument (name) passed into script    
You can define arguments in top tests file: `eden.escript.test -test.run TestEdenScripts/arg -args="test1=123,test2=456"`    
You can override provided args by run: `./eden test tests/escript/ -v debug -a="test1=789"`

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>