### PR TITLE
Multiple eve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ export ZARCH
 
 clean: config stop
 	make -C tests DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) clean
-	$(LOCALBIN) clean
+	$(LOCALBIN) clean --current-context=false
 	rm -rf $(LOCALBIN) $(BINDIR)/$(BIN) $(LOCALTESTBIN) $(WORKDIR)
 
 $(WORKDIR):

--- a/cmd/edenClean.go
+++ b/cmd/edenClean.go
@@ -14,6 +14,8 @@ import (
 var (
 	configDir   string
 	configSaved string
+
+	currentContext bool
 )
 
 var cleanCmd = &cobra.Command{
@@ -48,10 +50,17 @@ var cleanCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("cannot obtain executable path: %s", err)
 		}
-		if err := utils.CleanEden(command, eveDist, adamDist, certsDir, filepath.Dir(eveImageFile),
-			eserverImageDist, redisDist, configDir, evePidFile,
-			configSaved); err != nil {
-			log.Fatalf("cannot CleanEden: %s", err)
+		if currentContext {
+			log.Info("Cleanup current context")
+			if err := utils.CleanContext(command, eveDist, certsDir, filepath.Dir(eveImageFile), evePidFile, configSaved); err != nil {
+				log.Fatalf("cannot CleanContext: %s", err)
+			}
+		} else {
+			if err := utils.CleanEden(command, eveDist, adamDist, certsDir, filepath.Dir(eveImageFile),
+				eserverImageDist, redisDist, configDir, evePidFile,
+				configSaved); err != nil {
+				log.Fatalf("cannot CleanEden: %s", err)
+			}
 		}
 		log.Infof("CleanEden done")
 	},
@@ -75,4 +84,5 @@ func cleanInit() {
 
 	cleanCmd.Flags().StringVarP(&certsDir, "certs-dist", "o", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultCertsDist), "directory with certs")
 	cleanCmd.Flags().StringVarP(&configDir, "config-dist", "", configDist, "directory for config")
+	cleanCmd.Flags().BoolVar(&currentContext, "current-context", true, "clean only current context")
 }

--- a/cmd/edenClean.go
+++ b/cmd/edenClean.go
@@ -35,7 +35,11 @@ var cleanCmd = &cobra.Command{
 			eserverImageDist = utils.ResolveAbsPath(viper.GetString("eden.images.dist"))
 			qemuFileToSave = utils.ResolveAbsPath(viper.GetString("eve.qemu-config"))
 			redisDist = utils.ResolveAbsPath(viper.GetString("redis.dist"))
-			configSaved = utils.ResolveAbsPath(defaults.DefaultConfigSaved)
+			context, err := utils.ContextLoad()
+			if err != nil {
+				log.Fatalf("Load context error: %s", err)
+			}
+			configSaved = utils.ResolveAbsPath(fmt.Sprintf("%s-%s", context.Current, defaults.DefaultConfigSaved))
 		}
 		return nil
 	},
@@ -65,7 +69,7 @@ func cleanInit() {
 	cleanCmd.Flags().StringVarP(&evePidFile, "eve-pid", "", filepath.Join(currentPath, defaults.DefaultDist, "eve.pid"), "file with EVE pid")
 	cleanCmd.Flags().StringVarP(&eveDist, "eve-dist", "", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultEVEDist), "directory to save EVE")
 	cleanCmd.Flags().StringVarP(&redisDist, "redis-dist", "", "", "redis dist")
-	cleanCmd.Flags().StringVarP(&qemuFileToSave, "qemu-config", "", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultQemuFileToSave), "file to save qemu config")
+	cleanCmd.Flags().StringVarP(&qemuFileToSave, "qemu-config", "", "", "file to save qemu config")
 	cleanCmd.Flags().StringVarP(&adamDist, "adam-dist", "", "", "adam dist to start (required)")
 	cleanCmd.Flags().StringVarP(&eserverImageDist, "image-dist", "", "", "image dist for eserver")
 

--- a/cmd/edenSetup.go
+++ b/cmd/edenSetup.go
@@ -33,9 +33,15 @@ var (
 )
 
 func configCheck() {
-	sconf := utils.ResolveAbsPath(defaults.DefaultConfigSaved)
 
-	abs, err := filepath.Abs(sconf)
+	context, err := utils.ContextLoad()
+	if err != nil {
+		log.Fatalf("Load context error: %s", err)
+	}
+
+	configSaved = utils.ResolveAbsPath(fmt.Sprintf("%s-%s", context.Current, defaults.DefaultConfigSaved))
+
+	abs, err := filepath.Abs(configSaved)
 	if err != nil {
 		log.Fatalf("fail in reading filepath: %s\n", err.Error())
 		os.Exit(-2)
@@ -65,7 +71,7 @@ func configCheck() {
 			confCur := viper.AllSettings()
 
 			if reflect.DeepEqual(confOld, confCur) {
-				log.Infof("Config file %s is the same as %s\n", configFile, sconf)
+				log.Infof("Config file %s is the same as %s\n", configFile, configSaved)
 			} else {
 				log.Fatalf("The current configuration file %s is different from the saved %s. You can fix this with the commands 'eden config clean' and 'eden config add/set/edit'.\n", configFile, abs)
 				os.Exit(-1)
@@ -234,7 +240,7 @@ func setupInit() {
 		log.Fatal(err)
 	}
 
-	setupCmd.Flags().StringVarP(&certsDir, "certs-dist", "o", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultCertsDist), "directory with certs")
+	setupCmd.Flags().StringVarP(&certsDir, "certs-dist", "o", "", "directory with certs")
 	setupCmd.Flags().StringVarP(&certsDomain, "domain", "d", defaults.DefaultDomain, "FQDN for certificates")
 	setupCmd.Flags().StringVarP(&certsIP, "ip", "i", defaults.DefaultIP, "IP address to use")
 	setupCmd.Flags().StringVarP(&certsEVEIP, "eve-ip", "", defaults.DefaultEVEIP, "IP address to use for EVE")
@@ -248,13 +254,13 @@ func setupInit() {
 	setupCmd.Flags().StringVarP(&qemuConfigPath, "config-part", "", "", "path for config drive")
 	setupCmd.Flags().StringVarP(&qemuDTBPath, "dtb-part", "", "", "path for device tree drive (for arm)")
 	setupCmd.Flags().StringVarP(&eveImageFile, "image-file", "", "", "path for image drive (required)")
-	setupCmd.Flags().StringVarP(&eveDist, "eve-dist", "", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultEVEDist), "directory to save EVE")
+	setupCmd.Flags().StringVarP(&eveDist, "eve-dist", "", "", "directory to save EVE")
 	setupCmd.Flags().StringVarP(&eveRepo, "eve-repo", "", defaults.DefaultEveRepo, "EVE repo")
 	setupCmd.Flags().StringVarP(&eveTag, "eve-tag", "", defaults.DefaultEVETag, "EVE tag")
 	setupCmd.Flags().StringVarP(&eveUefiTag, "eve-uefi-tag", "", defaults.DefaultEVETag, "EVE UEFI tag")
 	setupCmd.Flags().StringVarP(&eveArch, "eve-arch", "", runtime.GOARCH, "EVE arch")
 	setupCmd.Flags().StringToStringVarP(&qemuHostFwd, "eve-hostfwd", "", defaults.DefaultQemuHostFwd, "port forward map")
-	setupCmd.Flags().StringVarP(&qemuFileToSave, "qemu-config", "", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultQemuFileToSave), "file to save qemu config")
+	setupCmd.Flags().StringVarP(&qemuFileToSave, "qemu-config", "", "", "file to save qemu config")
 	setupCmd.Flags().BoolVarP(&download, "download", "", true, "download EVE or build")
 	setupCmd.Flags().StringVarP(&eveHV, "eve-hv", "", defaults.DefaultEVEHV, "hv of rootfs to use")
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -7,7 +7,7 @@
 * redis as a backing store for adam
 * eserver to serve up files to eve
 
-Each of these can have their own config, and each can have multipe instances, running in their own ways.
+Each of these can have their own config, and each can have multiple instances, running in their own ways.
 
 eden maintains a configuration for running, that combines the setup of adam, eve devices, redis and the eserver. Each such
 combination is called a "context" and is given a unique name.
@@ -28,6 +28,12 @@ by adding the file or using `eden config add <context>`.
 
 You also can set the current context by editing `~/.eden/context.yml` or running `eden config set <context>`, and you can
 list all known contexts with `eden config list`.
+
+Every context you add creates the new instance of EVE with dedicated certificates 
+according to generated context file inside `~/.eden/contexts/` directory.
+You can modify settings before running `eden setup`. Only one EVE instance can be run locally (in qemu). You need to stop it before starting another one.
+
+Please see [Test configuring](../tests/README.md#Test configuring) section for details about tests config options with switching context.
 
 ### Example
 

--- a/docs/eve-images.md
+++ b/docs/eve-images.md
@@ -16,14 +16,14 @@ The normal EVE flow for `eden setup` is as follows.
 
 1. If you do not have a context, get the latest tag for the image `lfedge/eve` from the docker hub, e.g. `0.0.51`, and save that tag in your context
 1. Pull the image `lfedge/eve:<tag>`
-1. Generate a config directory with:
+1. Generate a config directory (inside `$PWD/dist/<name>-certs/`, where `<name>` the current context name) with:
    * server certificate for adam
    * `server` file pointing to the local running adam address
    * device certificate
 1. Run the docker image with the config partition mounted to:
    1. Generate a disk image - raw for RPi, qcow2 for everything else - overriding the config partition with the mounted config directory
    1. Extract the disk image from the docker image, e.g. `live.qcow2`
-1. Save the extracted disk image to a local cache, normally `$PWD/dist/images/eve/`
+1. Save the extracted disk image to a local cache, normally `$PWD/dist/<name>-images/eve/` (where `<name>` is the current context name).
 
 You now have a disk image, e.g. `live.qcow2` ready to run, with the appropriate embedded config partition.
 

--- a/docs/eve-models.md
+++ b/docs/eve-models.md
@@ -3,7 +3,7 @@ Eden has different ways of Eve deployment:
 # Qemu deployment
 This is default deployment
 Once you run `eden config add default` eden generates config with this type of deployment. 
-Also it generates qemu.conf in ~/.eden/ with qemu setings 
+Also, it generates <name>-qemu.conf in ~/.eden/ with qemu settings (where `<name>` is your context name).
 
 This installation type requires qemu package installed. Eve runs in qemu on the same machine. 
 This is useful for debugging and getting started, but not that useful in production 

--- a/pkg/utils/commandWrapper.go
+++ b/pkg/utils/commandWrapper.go
@@ -70,7 +70,10 @@ func RunCommandNohup(name string, logFile string, pidFile string, args ...string
 	}
 	if pidFile != "" {
 		if _, err := os.Stat(pidFile); !os.IsNotExist(err) {
-			return fmt.Errorf("pid file already exists")
+			if status, _ := StatusCommandWithPid(pidFile); strings.Contains(status, "running with pid") {
+				// check if process with defined pid running
+				return fmt.Errorf("pid file already exists")
+			}
 		}
 	}
 	if err := cmd.Start(); err != nil {

--- a/pkg/utils/configDiff.go
+++ b/pkg/utils/configDiff.go
@@ -37,7 +37,7 @@ eve:
     devmodel: ZedVirtual-4G
 
     #file to save qemu config
-    qemu-config: {{ .EdenDir }}/qemu.conf
+    qemu-config: {{ .DefaultQemuFileToSave }}
 
     #EVE arch (amd64/arm64)
     arch: {{ .Arch }}
@@ -89,6 +89,9 @@ eden:
         #port for eserver
         port: {{ .DefaultEserverPort }}
 
+    #directory to save certs
+    certs-dist: {{ .DefaultCertsDist }}
+
     #ssh-key to put into EVE
     ssh-key: {{ .DefaultSSHKey }}
 
@@ -111,6 +114,6 @@ redis:
 `
 
 //GenerateConfigFileDiff is a function to generate diff yml for new context
-func GenerateConfigFileDiff(filePath string) error {
-	return generateConfigFileFromTemplate(filePath, defaultEnvDiffConfig)
+func GenerateConfigFileDiff(filePath string, context *Context) error {
+	return generateConfigFileFromTemplate(filePath, defaultEnvDiffConfig, context)
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -110,13 +110,11 @@ This allows you to use not only hardcoded parameters in test scenarios, eden-con
 Specific arguments for testing binary files may be passed by two ways:
 
 * placing them in the local eden-config.tmpl for this test, for ex.:
-https://github.com/lf-edge/eden/blob/master/tests/reboot/eden-config.tmpl
-then you must generate eden-config.yaml for this test:
-```
-utils template eden-config.tmpl>eden-config.yml
-```
+[tests/reboot/eden-config.tmpl](../tests/reboot/eden-config.tmpl)
+then you must generate eden-config.yaml for this test (it is included into `build` target of Makefiles of tests for simplicity):
+`utils template eden-config.tmpl>eden-config.yml`. You must regenerate config of tests if they use templates (or run `make build`) after switching context to properly rendering of templates with data from new context if you choose first variant (with eden-config.tmpl).
 * use of test arguments in test scripts or a selected test from an executable binary test for ex.:
-https://github.com/lf-edge/eden/blob/master/tests/integration/eden.integration.tests.txt
+[tests/integration/eden.integration.tests.txt](../tests/integration/eden.integration.tests.txt)
 
 The second option is more flexible, because we can run the same test several times with different parameters in the same scenario.
 
@@ -125,9 +123,10 @@ The most commonly used `eden-config` parameters for setting up a test are:
 * `eden.escript.test-scenario` -- name of file with a default test scenario. This file should be placed in the test's directory or in the `eden.root` directory.
 * `eden.escript.test-bin`-- name of default test binary. Can be used with the `eden test -run` command to run the selected test from this binary. This file should be placed in the test's directory or in the `eden.root/eden.bin-dist` directory.
 
-## Test sceanrios
 
-Test sceanrios are plain text files with one line per command structure. The most commonly used commands are just test binaries with arguments. In sceanrios you can use inline comments in the Shell (#) and Go (//) styles. Comment blocks from Go templates {{/* */}} can also be used. Example of scenario: [workflow/eden.workflow.tests.txt](workflow/eden.workflow.tests.txt).
+## Test scenarios
+
+Test scenarios are plain text files with one line per command structure. The most commonly used commands are just test binaries with arguments. In sceanrios you can use inline comments in the Shell (#) and Go (//) styles. Comment blocks from Go templates {{/* */}} can also be used. Example of scenario: [workflow/eden.workflow.tests.txt](workflow/eden.workflow.tests.txt).
 
 ## Test scripting
 


### PR DESCRIPTION
Support for running multiple EVE instances in different contexts. 
When creating a new context, you can run the eden setup again and interact with the new eve. 
Currently, only one EVE instance can be run locally (in qemu). You need to stop it before starting another one.