### PR TITLE
Catalina QEMU 5.1 update

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -88,7 +88,7 @@ const (
 	DefaultInfoRedisPrefix       = "INFO_EVE_"
 	DefaultMetricsRedisPrefix    = "METRICS_EVE_"
 
-	DefaultQemuAccelDarwin = "-machine q35,accel=hvf -cpu host,kvmclock=off "
+	DefaultQemuAccelDarwin = "-machine q35,accel=hvf -cpu kvm64,kvmclock=off "
 	DefaultQemuAccelLinux  = "-machine q35,accel=kvm,dump-guest-core=off -cpu host,invtsc=on,kvmclock=off -machine kernel-irqchip=split -device intel-iommu,intremap=on,caching-mode=on,aw-bits=48 "
 
 	DefaultAppSubnet = "10.1.0.0/24"


### PR DESCRIPTION
This is required to run kernel 5.x series on Mac OS Catalina with hvf acceleration (the -cpu host fails in tsc_read inside of the Linux kernel)