### PR TITLE
Fixes for multiple EVE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,4 @@ tests/*/eden-config.yml
 
 dist
 Config.in
-eden
+./eden

--- a/cmd/adam.go
+++ b/cmd/adam.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/lf-edge/eden/pkg/defaults"
+	"github.com/lf-edge/eden/pkg/eden"
 	"github.com/lf-edge/eden/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -49,7 +50,7 @@ var startAdamCmd = &cobra.Command{
 		if !adamRemoteRedis {
 			adamRemoteRedisURL = ""
 		}
-		if err := utils.StartAdam(adamPort, adamDist, adamForce, adamTag, adamRemoteRedisURL); err != nil {
+		if err := eden.StartAdam(adamPort, adamDist, adamForce, adamTag, adamRemoteRedisURL); err != nil {
 			log.Errorf("cannot start adam: %s", err)
 		} else {
 			log.Infof("Adam is running and accessible on port %d", adamPort)
@@ -73,7 +74,7 @@ var stopAdamCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := utils.StopAdam(adamRm); err != nil {
+		if err := eden.StopAdam(adamRm); err != nil {
 			log.Errorf("cannot stop adam: %s", err)
 		}
 	},
@@ -94,7 +95,7 @@ var statusAdamCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		statusAdam, err := utils.StatusAdam()
+		statusAdam, err := eden.StatusAdam()
 		if err != nil {
 			log.Errorf("cannot obtain status of adam: %s", err)
 		} else {

--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/lf-edge/eden/pkg/controller"
 	"github.com/lf-edge/eden/pkg/defaults"
+	"github.com/lf-edge/eden/pkg/eden"
 	"github.com/lf-edge/eden/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -56,7 +57,7 @@ var certsCmd = &cobra.Command{
 		log.Debug("generating CA")
 		rootCert, rootKey := utils.GenCARoot()
 		log.Debug("start Adam and get root-certificate.pem")
-		rootCertObtained, err := utils.StartAdamAndGetRootCert(certsIP, adamPort, adamDist, adamForce, adamTag, adamRemoteRedisURL, certsDomain, certsEVEIP)
+		rootCertObtained, err := eden.StartAdamAndGetRootCert(certsIP, adamPort, adamDist, adamForce, adamTag, adamRemoteRedisURL, certsDomain, certsEVEIP)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/changers.go
+++ b/cmd/changers.go
@@ -104,9 +104,9 @@ func (ctx *adamChanger) getControllerAndDev() (controller.Cloud, *device.Ctx, er
 	if err != nil {
 		return nil, nil, fmt.Errorf("getController error: %s", err)
 	}
-	devFirst, err := ctrl.GetDeviceFirst()
+	devFirst, err := ctrl.GetDeviceCurrent()
 	if err != nil {
-		return nil, nil, fmt.Errorf("GetDeviceFirst error: %s", err)
+		return nil, nil, fmt.Errorf("GetDeviceCurrent error: %s", err)
 	}
 	return ctrl, devFirst, nil
 }

--- a/cmd/edenClean.go
+++ b/cmd/edenClean.go
@@ -53,7 +53,8 @@ var cleanCmd = &cobra.Command{
 		}
 		if currentContext {
 			log.Info("Cleanup current context")
-			if err := eden.CleanContext(command, eveDist, certsDir, filepath.Dir(eveImageFile), evePidFile, configSaved); err != nil {
+			eveUUID := viper.GetString("eve.uuid")
+			if err := eden.CleanContext(command, eveDist, certsDir, filepath.Dir(eveImageFile), evePidFile, eveUUID, configSaved); err != nil {
 				log.Fatalf("cannot CleanContext: %s", err)
 			}
 		} else {

--- a/cmd/edenClean.go
+++ b/cmd/edenClean.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/lf-edge/eden/pkg/defaults"
+	"github.com/lf-edge/eden/pkg/eden"
 	"github.com/lf-edge/eden/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -52,11 +53,11 @@ var cleanCmd = &cobra.Command{
 		}
 		if currentContext {
 			log.Info("Cleanup current context")
-			if err := utils.CleanContext(command, eveDist, certsDir, filepath.Dir(eveImageFile), evePidFile, configSaved); err != nil {
+			if err := eden.CleanContext(command, eveDist, certsDir, filepath.Dir(eveImageFile), evePidFile, configSaved); err != nil {
 				log.Fatalf("cannot CleanContext: %s", err)
 			}
 		} else {
-			if err := utils.CleanEden(command, eveDist, adamDist, certsDir, filepath.Dir(eveImageFile),
+			if err := eden.CleanEden(command, eveDist, adamDist, certsDir, filepath.Dir(eveImageFile),
 				eserverImageDist, redisDist, configDir, evePidFile,
 				configSaved); err != nil {
 				log.Fatalf("cannot CleanEden: %s", err)

--- a/cmd/edenReconf.go
+++ b/cmd/edenReconf.go
@@ -37,9 +37,9 @@ var reconfCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("CloudPrepare: %s", err)
 		}
-		devFirst, err := ctrl.GetDeviceFirst()
+		devFirst, err := ctrl.GetDeviceCurrent()
 		if err != nil {
-			log.Fatalf("GetDeviceFirst error: %s", err)
+			log.Fatalf("GetDeviceCurrent error: %s", err)
 		}
 		devUUID := devFirst.GetID()
 		if getConfig {

--- a/cmd/edenSetup.go
+++ b/cmd/edenSetup.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"github.com/lf-edge/eden/pkg/eden"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -152,7 +153,7 @@ var setupCmd = &cobra.Command{
 				wifiPSK = strings.ToLower(hex.EncodeToString(pbkdf2.Key(pass, []byte(ssid), 4096, 32, sha1.New)))
 				fmt.Println()
 			}
-			if err := utils.GenerateEveCerts(command, certsDir, certsDomain, certsIP, certsEVEIP, certsUUID, ssid, wifiPSK); err != nil {
+			if err := eden.GenerateEveCerts(command, certsDir, certsDomain, certsIP, certsEVEIP, certsUUID, ssid, wifiPSK); err != nil {
 				log.Errorf("cannot GenerateEveCerts: %s", err)
 			} else {
 				log.Info("GenerateEveCerts done")
@@ -160,7 +161,7 @@ var setupCmd = &cobra.Command{
 		} else {
 			log.Infof("Certs already exists in certs dir: %s", certsDir)
 		}
-		if err := utils.GenerateEVEConfig(certsDir, certsDomain, certsEVEIP, adamPort, apiV1); err != nil {
+		if err := eden.GenerateEVEConfig(certsDir, certsDomain, certsEVEIP, adamPort, apiV1); err != nil {
 			log.Errorf("cannot GenerateEVEConfig: %s", err)
 		} else {
 			log.Info("GenerateEVEConfig done")
@@ -182,14 +183,14 @@ var setupCmd = &cobra.Command{
 		}
 		if !download {
 			if _, err := os.Lstat(eveImageFile); os.IsNotExist(err) {
-				if err := utils.CloneFromGit(eveDist, eveRepo, eveTag); err != nil {
+				if err := eden.CloneFromGit(eveDist, eveRepo, eveTag); err != nil {
 					log.Errorf("cannot clone EVE: %s", err)
 				} else {
 					log.Info("clone EVE done")
 				}
 				builedImage := ""
 				builedAdditional := ""
-				if builedImage, builedAdditional, err = utils.MakeEveInRepo(eveDist, certsDir, eveArch, eveHV, imageFormat, false); err != nil {
+				if builedImage, builedAdditional, err = eden.MakeEveInRepo(eveDist, certsDir, eveArch, eveHV, imageFormat, false); err != nil {
 					log.Errorf("cannot MakeEveInRepo: %s", err)
 				} else {
 					log.Info("MakeEveInRepo done")

--- a/cmd/edenStart.go
+++ b/cmd/edenStart.go
@@ -117,7 +117,7 @@ func startInit() {
 	startCmd.Flags().BoolVarP(&adamForce, "adam-force", "", false, "adam force rebuild")
 	startCmd.Flags().StringVarP(&adamRemoteRedisURL, "adam-redis-url", "", "", "adam remote redis url")
 	startCmd.Flags().BoolVarP(&adamRemoteRedis, "adam-redis", "", true, "use adam remote redis")
-	startCmd.Flags().StringVarP(&adamTag, "registry-tag", "", defaults.DefaultRegistryTag, "tag on registry container to pull")
+	startCmd.Flags().StringVarP(&registryTag, "registry-tag", "", defaults.DefaultRegistryTag, "tag on registry container to pull")
 	startCmd.Flags().IntVarP(&registryPort, "registry-port", "", defaults.DefaultRegistryPort, "registry port to start")
 	startCmd.Flags().StringVarP(&registryDist, "registry-dist", "", "", "registry dist path to store (required)")
 	startCmd.Flags().StringVarP(&redisTag, "redis-tag", "", defaults.DefaultRedisTag, "tag on redis container to pull")

--- a/cmd/edenStart.go
+++ b/cmd/edenStart.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/lf-edge/eden/pkg/eden"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -71,7 +72,7 @@ var startCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("cannot obtain executable path: %s", err)
 		}
-		if err := utils.StartRedis(redisPort, redisDist, redisForce, redisTag); err != nil {
+		if err := eden.StartRedis(redisPort, redisDist, redisForce, redisTag); err != nil {
 			log.Errorf("cannot start redis: %s", err)
 		} else {
 			log.Infof("Redis is running and accessible on port %d", redisPort)
@@ -79,17 +80,17 @@ var startCmd = &cobra.Command{
 		if !adamRemoteRedis {
 			adamRemoteRedisURL = ""
 		}
-		if err := utils.StartAdam(adamPort, adamDist, adamForce, adamTag, adamRemoteRedisURL); err != nil {
+		if err := eden.StartAdam(adamPort, adamDist, adamForce, adamTag, adamRemoteRedisURL); err != nil {
 			log.Errorf("cannot start adam: %s", err)
 		} else {
 			log.Infof("Adam is running and accesible on port %d", adamPort)
 		}
-		if err := utils.StartRegistry(registryPort, registryTag, registryDist); err != nil {
+		if err := eden.StartRegistry(registryPort, registryTag, registryDist); err != nil {
 			log.Errorf("cannot start registry: %s", err)
 		} else {
 			log.Infof("registry is running and accesible on port %d", registryPort)
 		}
-		if err := utils.StartEServer(eserverPort, eserverImageDist, eserverForce, eserverTag); err != nil {
+		if err := eden.StartEServer(eserverPort, eserverImageDist, eserverForce, eserverTag); err != nil {
 			log.Errorf("cannot start eserver: %s", err)
 		} else {
 			log.Infof("Eserver is running and accesible on port %d", eserverPort)
@@ -97,7 +98,7 @@ var startCmd = &cobra.Command{
 		if eveRemote {
 			return
 		}
-		if err := utils.StartEVEQemu(command, qemuARCH, qemuOS, eveImageFile, qemuSMBIOSSerial, qemuAccel, qemuConfigFile, eveLogFile, evePidFile); err != nil {
+		if err := eden.StartEVEQemu(command, qemuARCH, qemuOS, eveImageFile, qemuSMBIOSSerial, qemuAccel, qemuConfigFile, eveLogFile, evePidFile); err != nil {
 			log.Errorf("cannot start eve: %s", err)
 		} else {
 			log.Infof("EVE is starting")

--- a/cmd/edenStatus.go
+++ b/cmd/edenStatus.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/lf-edge/eden/pkg/eden"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,7 +60,7 @@ func eveStatusRemote() {
 }
 
 func eveStatusQEMU() {
-	statusEVE, err := utils.StatusEVEQemu(evePidFile)
+	statusEVE, err := eden.StatusEVEQemu(evePidFile)
 	if err != nil {
 		log.Errorf("%s cannot obtain status of EVE Qemu process: %s", statusWarn(), err)
 	} else {
@@ -102,7 +103,7 @@ var statusCmd = &cobra.Command{
 			}
 		}
 		fmt.Println()
-		statusAdam, err := utils.StatusAdam()
+		statusAdam, err := eden.StatusAdam()
 		if err != nil {
 			log.Errorf("%s cannot obtain status of adam: %s", statusWarn(), err)
 		} else {
@@ -110,7 +111,7 @@ var statusCmd = &cobra.Command{
 			fmt.Printf("\tAdam is expected at https://%s:%d\n", viper.GetString("adam.ip"), viper.GetInt("adam.port"))
 			fmt.Printf("\tFor local Adam you can run 'docker logs %s' to see logs\n", defaults.DefaultAdamContainerName)
 		}
-		statusRegistry, err := utils.StatusRegistry()
+		statusRegistry, err := eden.StatusRegistry()
 		if err != nil {
 			log.Errorf("%s cannot obtain status of registry: %s", statusWarn(), err)
 		} else {
@@ -118,7 +119,7 @@ var statusCmd = &cobra.Command{
 			fmt.Printf("\tRegistry is expected at https://%s:%d\n", viper.GetString("registry.ip"), viper.GetInt("registry.port"))
 			fmt.Printf("\tFor local registry you can run 'docker logs %s' to see logs\n", defaults.DefaultRegistryContainerName)
 		}
-		statusRedis, err := utils.StatusRedis()
+		statusRedis, err := eden.StatusRedis()
 		if err != nil {
 			log.Errorf("%s cannot obtain status of redis: %s", statusWarn(), err)
 		} else {
@@ -126,7 +127,7 @@ var statusCmd = &cobra.Command{
 			fmt.Printf("\tRedis is expected at %s\n", viper.GetString("adam.redis.eden"))
 			fmt.Printf("\tFor local Redis you can run 'docker logs %s' to see logs\n", defaults.DefaultRedisContainerName)
 		}
-		statusEServer, err := utils.StatusEServer()
+		statusEServer, err := eden.StatusEServer()
 		if err != nil {
 			log.Errorf("%s cannot obtain status of EServer process: %s", statusWarn(), err)
 		} else {

--- a/cmd/edenStop.go
+++ b/cmd/edenStop.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/lf-edge/eden/pkg/eden"
 	"os"
 	"path/filepath"
 
@@ -34,22 +35,22 @@ var stopCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := utils.StopAdam(adamRm); err != nil {
+		if err := eden.StopAdam(adamRm); err != nil {
 			log.Infof("cannot stop adam: %s", err)
 		} else {
 			log.Infof("adam stopped")
 		}
-		if err := utils.StopRedis(redisRm); err != nil {
+		if err := eden.StopRedis(redisRm); err != nil {
 			log.Infof("cannot stop redis: %s", err)
 		} else {
 			log.Infof("redis stopped")
 		}
-		if err := utils.StopRegistry(registryRm); err != nil {
+		if err := eden.StopRegistry(registryRm); err != nil {
 			log.Infof("cannot stop registry: %s", err)
 		} else {
 			log.Infof("registry stopped")
 		}
-		if err := utils.StopEServer(eserverRm); err != nil {
+		if err := eden.StopEServer(eserverRm); err != nil {
 			log.Infof("cannot stop eserver: %s", err)
 		} else {
 			log.Infof("eserver stopped")
@@ -57,7 +58,7 @@ var stopCmd = &cobra.Command{
 		if eveRemote {
 			return
 		}
-		if err := utils.StopEVEQemu(evePidFile); err != nil {
+		if err := eden.StopEVEQemu(evePidFile); err != nil {
 			log.Infof("cannot stop EVE: %s", err)
 		} else {
 			log.Infof("EVE stopped")

--- a/cmd/edenUtils.go
+++ b/cmd/edenUtils.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/lf-edge/eden/pkg/utils"
+	"github.com/lf-edge/eden/pkg/eden"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"io/ioutil"
@@ -25,7 +25,7 @@ var sdInfoEveCmd = &cobra.Command{
 	Short: "get info from SD card",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		eveInfo, err := utils.GetInfoFromSDCard(args[0])
+		eveInfo, err := eden.GetInfoFromSDCard(args[0])
 		if err != nil {
 			log.Info("Check is EVE on SD and your access to read SD")
 			log.Fatalf("Problem with access to EVE partitions: %v", err)

--- a/cmd/eserver.go
+++ b/cmd/eserver.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/lf-edge/eden/pkg/defaults"
+	"github.com/lf-edge/eden/pkg/eden"
 	"github.com/lf-edge/eden/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -39,7 +40,7 @@ var startEserverCmd = &cobra.Command{
 		}
 		log.Infof("Executable path: %s", command)
 
-		if err := utils.StartEServer(eserverPort, eserverImageDist, eserverForce, eserverTag); err != nil {
+		if err := eden.StartEServer(eserverPort, eserverImageDist, eserverForce, eserverTag); err != nil {
 			log.Errorf("cannot start eserver: %s", err)
 		} else {
 			log.Infof("Eserver is running and accesible on port %d", eserverPort)
@@ -60,7 +61,7 @@ var stopEserverCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := utils.StopEServer(eserverRm); err != nil {
+		if err := eden.StopEServer(eserverRm); err != nil {
 			log.Errorf("cannot stop eserver: %s", err)
 		}
 	},
@@ -79,7 +80,7 @@ var statusEserverCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		statusEServer, err := utils.StatusEServer()
+		statusEServer, err := eden.StatusEServer()
 		if err != nil {
 			log.Errorf("cannot obtain status of eserver: %s", err)
 		} else {

--- a/cmd/eve.go
+++ b/cmd/eve.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/lf-edge/eden/pkg/eden"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -138,7 +139,7 @@ var stopEveCmd = &cobra.Command{
 			log.Debug("Cannot stop remote EVE")
 			return
 		}
-		if err := utils.StopEVEQemu(evePidFile); err != nil {
+		if err := eden.StopEVEQemu(evePidFile); err != nil {
 			log.Errorf("cannot stop EVE: %s", err)
 		}
 	},
@@ -204,7 +205,7 @@ var statusEveCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		statusAdam, err := utils.StatusAdam()
+		statusAdam, err := eden.StatusAdam()
 		if err == nil && statusAdam != "container doesn't exist" {
 			eveStatusRemote()
 		}

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -39,9 +39,9 @@ Scans the ADAM Info for correspondence with regular expressions requests to json
 		if err != nil {
 			log.Fatalf("CloudPrepare: %s", err)
 		}
-		devFirst, err := ctrl.GetDeviceFirst()
+		devFirst, err := ctrl.GetDeviceCurrent()
 		if err != nil {
-			log.Fatalf("GetDeviceFirst error: %s", err)
+			log.Fatalf("GetDeviceCurrent error: %s", err)
 		}
 		devUUID := devFirst.GetID()
 		follow, err := cmd.Flags().GetBool("follow")

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -50,9 +50,9 @@ Scans the ADAM logs for correspondence with regular expressions requests to json
 		if err != nil {
 			log.Fatalf("CloudPrepare: %s", err)
 		}
-		devFirst, err := ctrl.GetDeviceFirst()
+		devFirst, err := ctrl.GetDeviceCurrent()
 		if err != nil {
-			log.Fatalf("GetDeviceFirst error: %s", err)
+			log.Fatalf("GetDeviceCurrent error: %s", err)
 		}
 		devUUID := devFirst.GetID()
 		follow, err := cmd.Flags().GetBool("follow")

--- a/cmd/metric.go
+++ b/cmd/metric.go
@@ -37,9 +37,9 @@ Scans the ADAM metrics for correspondence with regular expressions requests to j
 		if err != nil {
 			log.Fatalf("CloudPrepare: %s", err)
 		}
-		devFirst, err := ctrl.GetDeviceFirst()
+		devFirst, err := ctrl.GetDeviceCurrent()
 		if err != nil {
-			log.Fatalf("GetDeviceFirst error: %s", err)
+			log.Fatalf("GetDeviceCurrent error: %s", err)
 		}
 		devUUID := devFirst.GetID()
 		follow, err := cmd.Flags().GetBool("follow")

--- a/cmd/redis.go
+++ b/cmd/redis.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/lf-edge/eden/pkg/defaults"
+	"github.com/lf-edge/eden/pkg/eden"
 	"github.com/lf-edge/eden/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -46,7 +47,7 @@ var startRedisCmd = &cobra.Command{
 			log.Fatalf("cannot obtain executable path: %s", err)
 		}
 		log.Infof("Executable path: %s", command)
-		if err := utils.StartRedis(redisPort, redisDist, redisForce, redisTag); err != nil {
+		if err := eden.StartRedis(redisPort, redisDist, redisForce, redisTag); err != nil {
 			log.Errorf("cannot start redis: %s", err)
 		} else {
 			log.Infof("Redis is running and accessible on port %d", redisPort)
@@ -70,7 +71,7 @@ var stopRedisCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := utils.StopRedis(redisRm); err != nil {
+		if err := eden.StopRedis(redisRm); err != nil {
 			log.Errorf("cannot stop redis: %s", err)
 		}
 	},
@@ -91,7 +92,7 @@ var statusRedisCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		statusRedis, err := utils.StatusRedis()
+		statusRedis, err := eden.StatusRedis()
 		if err != nil {
 			log.Errorf("cannot obtain status of redis: %s", err)
 		} else {

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/lf-edge/eden/pkg/eden"
 	"os"
 
 	"github.com/lf-edge/eden/pkg/defaults"
@@ -45,7 +46,7 @@ var startRegistryCmd = &cobra.Command{
 			log.Fatalf("cannot obtain executable path: %s", err)
 		}
 		log.Infof("Executable path: %s", command)
-		if err := utils.StartRegistry(registryPort, registryTag, registryDist); err != nil {
+		if err := eden.StartRegistry(registryPort, registryTag, registryDist); err != nil {
 			log.Errorf("cannot start registry: %s", err)
 		} else {
 			log.Infof("registry is running and accessible on port %d", adamPort)
@@ -62,7 +63,7 @@ var stopRegistryCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := utils.StopRegistry(registryRm); err != nil {
+		if err := eden.StopRegistry(registryRm); err != nil {
 			log.Errorf("cannot stop registry: %s", err)
 		}
 	},
@@ -77,7 +78,7 @@ var statusRegistryCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		statusRegistry, err := utils.StatusRegistry()
+		statusRegistry, err := eden.StatusRegistry()
 		if err != nil {
 			log.Errorf("cannot obtain status of registry: %s", err)
 		} else {

--- a/go.sum
+++ b/go.sum
@@ -351,6 +351,7 @@ github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
@@ -423,6 +424,7 @@ github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/pkg/controller/adam/adam.go
+++ b/pkg/controller/adam/adam.go
@@ -298,6 +298,16 @@ func (adam *Ctx) MetricLastCallback(devUUID uuid.UUID, q map[string]string, hand
 	return emetric.MetricLast(loader, q, handler)
 }
 
+//OnboardRemove remove onboard by onboardUUID
+func (adam *Ctx) OnboardRemove(onboardUUID string) (err error) {
+	return adam.deleteObj(path.Join("/admin/onboard", onboardUUID))
+}
+
+//DeviceRemove remove device by devUUID
+func (adam *Ctx) DeviceRemove(devUUID uuid.UUID) (err error) {
+	return adam.deleteObj(path.Join("/admin/device", devUUID.String()))
+}
+
 //DeviceGetOnboard get device onboardUUID for devUUID
 func (adam *Ctx) DeviceGetOnboard(devUUID uuid.UUID) (onboardUUID uuid.UUID, err error) {
 	var devCert server.DeviceCert
@@ -335,6 +345,11 @@ func (adam *Ctx) DeviceGetByOnboard(eveCert string) (devUUID uuid.UUID, err erro
 	if err != nil {
 		return uuid.Nil, err
 	}
+	return adam.DeviceGetByOnboardUUID(uuidToFound.String())
+}
+
+//DeviceGetByOnboardUUID try to get device by onboard uuid
+func (adam *Ctx) DeviceGetByOnboardUUID(onboardUUID string) (devUUID uuid.UUID, err error) {
 	devIDs, err := adam.DeviceList(types.RegisteredDeviceFilter)
 	if err != nil {
 		return uuid.Nil, err
@@ -344,8 +359,8 @@ func (adam *Ctx) DeviceGetByOnboard(eveCert string) (devUUID uuid.UUID, err erro
 		if err != nil {
 			return uuid.Nil, err
 		}
-		if onboardUUID, err := adam.DeviceGetOnboard(devUUID); err == nil {
-			if onboardUUID.String() == uuidToFound.String() {
+		if id, err := adam.DeviceGetOnboard(devUUID); err == nil {
+			if id.String() == onboardUUID {
 				return devUUID, nil
 			}
 		} else {

--- a/pkg/controller/adam/httpclient.go
+++ b/pkg/controller/adam/httpclient.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"github.com/lf-edge/eden/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"io/ioutil"
@@ -36,6 +37,28 @@ func (adam *Ctx) getHTTPClient() *http.Client {
 		},
 	}
 	return client
+}
+
+func (adam *Ctx) deleteObj(path string) (err error) {
+	u, err := utils.ResolveURL(adam.url, path)
+	if err != nil {
+		log.Printf("error constructing URL: %v", err)
+		return err
+	}
+	client := adam.getHTTPClient()
+	req, err := http.NewRequest("DELETE", u, nil)
+	if err != nil {
+		log.Fatalf("unable to create new http request: %v", err)
+	}
+
+	response, err := utils.RepeatableAttempt(client, req)
+	if err != nil {
+		log.Fatalf("unable to send request: %v", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("status code: %d", response.StatusCode)
+	}
+	return nil
 }
 
 func (adam *Ctx) getObj(path string) (out string, err error) {

--- a/pkg/controller/cloud.go
+++ b/pkg/controller/cloud.go
@@ -56,7 +56,7 @@ type Cloud interface {
 	RemoveVolume(id string) error
 	ListVolume() []*config.Volume
 	GetConfigBytes(dev *device.Ctx, pretty bool) ([]byte, error)
-	GetDeviceFirst() (dev *device.Ctx, err error)
+	GetDeviceCurrent() (dev *device.Ctx, err error)
 	ConfigSync(dev *device.Ctx) (err error)
 	ConfigParse(config *config.EdgeDevConfig) (dev *device.Ctx, err error)
 	GetNetworkConfig(id string) (networkConfig *config.NetworkConfig, err error)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -23,7 +23,10 @@ type Controller interface {
 	MetricLastCallback(devUUID uuid.UUID, q map[string]string, handler emetric.HandlerFunc) (err error)
 	DeviceList(types.DeviceStateFilter) (out []string, err error)
 	DeviceGetByOnboard(eveCert string) (devUUID uuid.UUID, err error)
+	DeviceGetByOnboardUUID(onboardUUID string) (devUUID uuid.UUID, err error)
 	DeviceGetOnboard(devUUID uuid.UUID) (onboardUUID uuid.UUID, err error)
+	OnboardRemove(onboardUUID string) (err error)
+	DeviceRemove(devUUID uuid.UUID) (err error)
 	Register(device *device.Ctx) error
 	GetDir() (dir string)
 	InitWithVars(vars *utils.ConfigVars) error

--- a/pkg/controller/device.go
+++ b/pkg/controller/device.go
@@ -229,12 +229,16 @@ func (cloud *CloudCtx) GetDeviceUUID(devUUID uuid.UUID) (dev *device.Ctx, err er
 	return nil, errors.New("no device found")
 }
 
-//GetDeviceFirst return first device object
-func (cloud *CloudCtx) GetDeviceFirst() (dev *device.Ctx, err error) {
+//GetDeviceCurrent return current device object
+func (cloud *CloudCtx) GetDeviceCurrent() (dev *device.Ctx, err error) {
+	id, err := cloud.DeviceGetByOnboardUUID(cloud.vars.EveUUID)
+	if err != nil {
+		return nil, err
+	}
 	if len(cloud.devices) == 0 {
 		return nil, errors.New("no device found")
 	}
-	return cloud.devices[0], nil
+	return cloud.GetDeviceUUID(id)
 }
 
 func (cloud *CloudCtx) processDev(id uuid.UUID, state device.EdgeNodeState) {
@@ -284,7 +288,7 @@ func (cloud *CloudCtx) GetAllNodes() {
 //GetEdgeNode by name
 func (cloud *CloudCtx) GetEdgeNode(name string) *device.Ctx {
 	if name == "" {
-		node, _ := cloud.GetDeviceFirst()
+		node, _ := cloud.GetDeviceCurrent()
 		if node != nil {
 			return node
 		} else {

--- a/pkg/eden/eden.go
+++ b/pkg/eden/eden.go
@@ -1,10 +1,11 @@
-package utils
+package eden
 
 import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"github.com/lf-edge/eden/pkg/utils"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -34,21 +35,21 @@ func StartRedis(redisPort int, redisPath string, redisForce bool, redisTag strin
 		}
 	}
 	if redisForce {
-		_ = StopContainer(defaults.DefaultRedisContainerName, true)
-		if err := CreateAndRunContainer(defaults.DefaultRedisContainerName, defaults.DefaultRedisContainerRef+":"+redisTag, portMap, volumeMap, redisServerCommand); err != nil {
+		_ = utils.StopContainer(defaults.DefaultRedisContainerName, true)
+		if err := utils.CreateAndRunContainer(defaults.DefaultRedisContainerName, defaults.DefaultRedisContainerRef+":"+redisTag, portMap, volumeMap, redisServerCommand); err != nil {
 			return fmt.Errorf("error in create redis container: %s", err)
 		}
 	} else {
-		state, err := StateContainer(defaults.DefaultRedisContainerName)
+		state, err := utils.StateContainer(defaults.DefaultRedisContainerName)
 		if err != nil {
 			return fmt.Errorf("error in get state of redis container: %s", err)
 		}
 		if state == "" {
-			if err := CreateAndRunContainer(defaults.DefaultRedisContainerName, defaults.DefaultRedisContainerRef+":"+redisTag, portMap, volumeMap, redisServerCommand); err != nil {
+			if err := utils.CreateAndRunContainer(defaults.DefaultRedisContainerName, defaults.DefaultRedisContainerRef+":"+redisTag, portMap, volumeMap, redisServerCommand); err != nil {
 				return fmt.Errorf("error in create redis container: %s", err)
 			}
 		} else if !strings.Contains(state, "running") {
-			if err := StartContainer(defaults.DefaultRedisContainerName); err != nil {
+			if err := utils.StartContainer(defaults.DefaultRedisContainerName); err != nil {
 				return fmt.Errorf("error in restart redis container: %s", err)
 			}
 		}
@@ -58,13 +59,13 @@ func StartRedis(redisPort int, redisPath string, redisForce bool, redisTag strin
 
 //StopRedis function stop redis container
 func StopRedis(redisRm bool) (err error) {
-	state, err := StateContainer(defaults.DefaultRedisContainerName)
+	state, err := utils.StateContainer(defaults.DefaultRedisContainerName)
 	if err != nil {
 		return fmt.Errorf("error in get state of redis container: %s", err)
 	}
 	if !strings.Contains(state, "running") {
 		if redisRm {
-			if err := StopContainer(defaults.DefaultRedisContainerName, true); err != nil {
+			if err := utils.StopContainer(defaults.DefaultRedisContainerName, true); err != nil {
 				return fmt.Errorf("error in rm redis container: %s", err)
 			}
 		}
@@ -72,11 +73,11 @@ func StopRedis(redisRm bool) (err error) {
 		return nil
 	} else {
 		if redisRm {
-			if err := StopContainer(defaults.DefaultRedisContainerName, false); err != nil {
+			if err := utils.StopContainer(defaults.DefaultRedisContainerName, false); err != nil {
 				return fmt.Errorf("error in rm redis container: %s", err)
 			}
 		} else {
-			if err := StopContainer(defaults.DefaultRedisContainerName, true); err != nil {
+			if err := utils.StopContainer(defaults.DefaultRedisContainerName, true); err != nil {
 				return fmt.Errorf("error in rm redis container: %s", err)
 			}
 		}
@@ -86,7 +87,7 @@ func StopRedis(redisRm bool) (err error) {
 
 //StatusRedis function return status of redis
 func StatusRedis() (status string, err error) {
-	state, err := StateContainer(defaults.DefaultRedisContainerName)
+	state, err := utils.StateContainer(defaults.DefaultRedisContainerName)
 	if err != nil {
 		return "", fmt.Errorf("error in get state of redis container: %s", err)
 	}
@@ -109,7 +110,7 @@ func StartAdamAndGetRootCert(adamIP string, adamPort int, adamPath string, adamF
 	if err != nil {
 		log.Fatalf("unable to create new http request: %v", err)
 	}
-	resp, err := RepeatableAttempt(client, req)
+	resp, err := utils.RepeatableAttempt(client, req)
 	if err != nil {
 		fmt.Println(err)
 	} else {
@@ -137,21 +138,21 @@ func StartAdam(adamPort int, adamPath string, adamForce bool, adamTag string, ad
 		adamServerCommand = append(adamServerCommand, el)
 	}
 	if adamForce {
-		_ = StopContainer(defaults.DefaultAdamContainerName, true)
-		if err := CreateAndRunContainer(defaults.DefaultAdamContainerName, defaults.DefaultAdamContainerRef+":"+adamTag, portMap, volumeMap, adamServerCommand); err != nil {
+		_ = utils.StopContainer(defaults.DefaultAdamContainerName, true)
+		if err := utils.CreateAndRunContainer(defaults.DefaultAdamContainerName, defaults.DefaultAdamContainerRef+":"+adamTag, portMap, volumeMap, adamServerCommand); err != nil {
 			return fmt.Errorf("error in create adam container: %s", err)
 		}
 	} else {
-		state, err := StateContainer(defaults.DefaultAdamContainerName)
+		state, err := utils.StateContainer(defaults.DefaultAdamContainerName)
 		if err != nil {
 			return fmt.Errorf("error in get state of adam container: %s", err)
 		}
 		if state == "" {
-			if err := CreateAndRunContainer(defaults.DefaultAdamContainerName, defaults.DefaultAdamContainerRef+":"+adamTag, portMap, volumeMap, adamServerCommand); err != nil {
+			if err := utils.CreateAndRunContainer(defaults.DefaultAdamContainerName, defaults.DefaultAdamContainerRef+":"+adamTag, portMap, volumeMap, adamServerCommand); err != nil {
 				return fmt.Errorf("error in create adam container: %s", err)
 			}
 		} else if !strings.Contains(state, "running") {
-			if err := StartContainer(defaults.DefaultAdamContainerName); err != nil {
+			if err := utils.StartContainer(defaults.DefaultAdamContainerName); err != nil {
 				return fmt.Errorf("error in restart adam container: %s", err)
 			}
 		}
@@ -161,13 +162,13 @@ func StartAdam(adamPort int, adamPath string, adamForce bool, adamTag string, ad
 
 //StopAdam function stop adam container
 func StopAdam(adamRm bool) (err error) {
-	state, err := StateContainer(defaults.DefaultAdamContainerName)
+	state, err := utils.StateContainer(defaults.DefaultAdamContainerName)
 	if err != nil {
 		return fmt.Errorf("error in get state of adam container: %s", err)
 	}
 	if !strings.Contains(state, "running") {
 		if adamRm {
-			if err := StopContainer(defaults.DefaultAdamContainerName, true); err != nil {
+			if err := utils.StopContainer(defaults.DefaultAdamContainerName, true); err != nil {
 				return fmt.Errorf("error in rm adam container: %s", err)
 			}
 		}
@@ -175,11 +176,11 @@ func StopAdam(adamRm bool) (err error) {
 		return nil
 	} else {
 		if adamRm {
-			if err := StopContainer(defaults.DefaultAdamContainerName, false); err != nil {
+			if err := utils.StopContainer(defaults.DefaultAdamContainerName, false); err != nil {
 				return fmt.Errorf("error in rm adam container: %s", err)
 			}
 		} else {
-			if err := StopContainer(defaults.DefaultAdamContainerName, true); err != nil {
+			if err := utils.StopContainer(defaults.DefaultAdamContainerName, true); err != nil {
 				return fmt.Errorf("error in rm adam container: %s", err)
 			}
 		}
@@ -189,7 +190,7 @@ func StopAdam(adamRm bool) (err error) {
 
 //StatusAdam function return status of adam
 func StatusAdam() (status string, err error) {
-	state, err := StateContainer(defaults.DefaultAdamContainerName)
+	state, err := utils.StateContainer(defaults.DefaultAdamContainerName)
 	if err != nil {
 		return "", fmt.Errorf("error in get state of adam container: %s", err)
 	}
@@ -210,16 +211,16 @@ func StartRegistry(port int, tag, registryPath string, opts ...string) (err erro
 		cmd = append(cmd, el)
 	}
 	volumeMap := map[string]string{"/var/lib/registry": registryPath}
-	state, err := StateContainer(containerName)
+	state, err := utils.StateContainer(containerName)
 	if err != nil {
 		return fmt.Errorf("error in get state of %s container: %s", serviceName, err)
 	}
 	if state == "" {
-		if err := CreateAndRunContainer(containerName, ref+":"+tag, portMap, volumeMap, cmd); err != nil {
+		if err := utils.CreateAndRunContainer(containerName, ref+":"+tag, portMap, volumeMap, cmd); err != nil {
 			return fmt.Errorf("error in create %s container: %s", serviceName, err)
 		}
 	} else if !strings.Contains(state, "running") {
-		if err := StartContainer(containerName); err != nil {
+		if err := utils.StartContainer(containerName); err != nil {
 			return fmt.Errorf("error in restart %s container: %s", serviceName, err)
 		}
 	}
@@ -230,13 +231,13 @@ func StartRegistry(port int, tag, registryPath string, opts ...string) (err erro
 func StopRegistry(rm bool) (err error) {
 	containerName := defaults.DefaultRegistryContainerName
 	serviceName := "registry"
-	state, err := StateContainer(containerName)
+	state, err := utils.StateContainer(containerName)
 	if err != nil {
 		return fmt.Errorf("error in get state of %s container: %s", serviceName, err)
 	}
 	if !strings.Contains(state, "running") {
 		if rm {
-			if err := StopContainer(containerName, true); err != nil {
+			if err := utils.StopContainer(containerName, true); err != nil {
 				return fmt.Errorf("error in rm %s container: %s", serviceName, err)
 			}
 		}
@@ -244,11 +245,11 @@ func StopRegistry(rm bool) (err error) {
 		return nil
 	} else {
 		if rm {
-			if err := StopContainer(containerName, false); err != nil {
+			if err := utils.StopContainer(containerName, false); err != nil {
 				return fmt.Errorf("error in rm %s container: %s", serviceName, err)
 			}
 		} else {
-			if err := StopContainer(containerName, true); err != nil {
+			if err := utils.StopContainer(containerName, true); err != nil {
 				return fmt.Errorf("error in rm %s container: %s", serviceName, err)
 			}
 		}
@@ -260,7 +261,7 @@ func StopRegistry(rm bool) (err error) {
 func StatusRegistry() (status string, err error) {
 	containerName := defaults.DefaultRegistryContainerName
 	serviceName := "registry"
-	state, err := StateContainer(containerName)
+	state, err := utils.StateContainer(containerName)
 	if err != nil {
 		return "", fmt.Errorf("error in get state of %s container: %s", serviceName, err)
 	}
@@ -281,21 +282,21 @@ func StartEServer(serverPort int, imageDist string, eserverForce bool, eserverTa
 		log.Fatalf("%s does not exist and can not be created", imageDist)
 	}
 	if eserverForce {
-		_ = StopContainer(defaults.DefaultEServerContainerName, true)
-		if err := CreateAndRunContainer(defaults.DefaultEServerContainerName, defaults.DefaultEServerContainerRef+":"+eserverTag, portMap, volumeMap, eserverServerCommand); err != nil {
+		_ = utils.StopContainer(defaults.DefaultEServerContainerName, true)
+		if err := utils.CreateAndRunContainer(defaults.DefaultEServerContainerName, defaults.DefaultEServerContainerRef+":"+eserverTag, portMap, volumeMap, eserverServerCommand); err != nil {
 			return fmt.Errorf("error in create eserver container: %s", err)
 		}
 	} else {
-		state, err := StateContainer(defaults.DefaultEServerContainerName)
+		state, err := utils.StateContainer(defaults.DefaultEServerContainerName)
 		if err != nil {
 			return fmt.Errorf("error in get state of eserver container: %s", err)
 		}
 		if state == "" {
-			if err := CreateAndRunContainer(defaults.DefaultEServerContainerName, defaults.DefaultEServerContainerRef+":"+eserverTag, portMap, volumeMap, eserverServerCommand); err != nil {
+			if err := utils.CreateAndRunContainer(defaults.DefaultEServerContainerName, defaults.DefaultEServerContainerRef+":"+eserverTag, portMap, volumeMap, eserverServerCommand); err != nil {
 				return fmt.Errorf("error in create eserver container: %s", err)
 			}
 		} else if !strings.Contains(state, "running") {
-			if err := StartContainer(defaults.DefaultEServerContainerName); err != nil {
+			if err := utils.StartContainer(defaults.DefaultEServerContainerName); err != nil {
 				return fmt.Errorf("error in restart eserver container: %s", err)
 			}
 		}
@@ -305,13 +306,13 @@ func StartEServer(serverPort int, imageDist string, eserverForce bool, eserverTa
 
 //StopEServer function stop eserver container
 func StopEServer(eserverRm bool) (err error) {
-	state, err := StateContainer(defaults.DefaultEServerContainerName)
+	state, err := utils.StateContainer(defaults.DefaultEServerContainerName)
 	if err != nil {
 		return fmt.Errorf("error in get state of eserver container: %s", err)
 	}
 	if !strings.Contains(state, "running") {
 		if eserverRm {
-			if err := StopContainer(defaults.DefaultEServerContainerName, true); err != nil {
+			if err := utils.StopContainer(defaults.DefaultEServerContainerName, true); err != nil {
 				return fmt.Errorf("error in rm eserver container: %s", err)
 			}
 		}
@@ -319,11 +320,11 @@ func StopEServer(eserverRm bool) (err error) {
 		return nil
 	} else {
 		if eserverRm {
-			if err := StopContainer(defaults.DefaultEServerContainerName, false); err != nil {
+			if err := utils.StopContainer(defaults.DefaultEServerContainerName, false); err != nil {
 				return fmt.Errorf("error in rm eserver container: %s", err)
 			}
 		} else {
-			if err := StopContainer(defaults.DefaultEServerContainerName, true); err != nil {
+			if err := utils.StopContainer(defaults.DefaultEServerContainerName, true); err != nil {
 				return fmt.Errorf("error in rm eserver container: %s", err)
 			}
 		}
@@ -333,7 +334,7 @@ func StopEServer(eserverRm bool) (err error) {
 
 //StatusEServer function return eserver of adam
 func StatusEServer() (status string, err error) {
-	state, err := StateContainer(defaults.DefaultEServerContainerName)
+	state, err := utils.StateContainer(defaults.DefaultEServerContainerName)
 	if err != nil {
 		return "", fmt.Errorf("error in get eserver of adam container: %s", err)
 	}
@@ -348,17 +349,17 @@ func StartEVEQemu(commandPath string, qemuARCH string, qemuOS string, eveImageFi
 	commandArgsString := fmt.Sprintf("eve start --qemu-config=%s --eve-serial=%s --eve-accel=%t --eve-arch=%s --eve-os=%s --eve-log=%s --eve-pid=%s --image-file=%s -v %s",
 		qemuConfigFilestring, qemuSMBIOSSerial, qemuAccel, qemuARCH, qemuOS, logFile, pidFile, eveImageFile, log.GetLevel())
 	log.Infof("StartEVEQemu run: %s %s", commandPath, commandArgsString)
-	return RunCommandWithLogAndWait(commandPath, defaults.DefaultLogLevelToPrint, strings.Fields(commandArgsString)...)
+	return utils.RunCommandWithLogAndWait(commandPath, defaults.DefaultLogLevelToPrint, strings.Fields(commandArgsString)...)
 }
 
 //StopEVEQemu function stop EVE
 func StopEVEQemu(pidFile string) (err error) {
-	return StopCommandWithPid(pidFile)
+	return utils.StopCommandWithPid(pidFile)
 }
 
 //StatusEVEQemu function get status of EVE
 func StatusEVEQemu(pidFile string) (status string, err error) {
-	return StatusCommandWithPid(pidFile)
+	return utils.StatusCommandWithPid(pidFile)
 }
 
 //GenerateEveCerts function generates certs for EVE
@@ -372,7 +373,7 @@ func GenerateEveCerts(commandPath string, certsDir string, domain string, ip str
 		"utils certs --certs-dist=%s --domain=%s --ip=%s --eve-ip=%s --uuid=%s --ssid=%s --password=%s -v %s",
 		certsDir, domain, ip, eveIP, uuid, ssid, password, log.GetLevel())
 	log.Infof("GenerateEveCerts run: %s %s", commandPath, commandArgsString)
-	return RunCommandWithLogAndWait(commandPath, defaults.DefaultLogLevelToPrint, strings.Fields(commandArgsString)...)
+	return utils.RunCommandWithLogAndWait(commandPath, defaults.DefaultLogLevelToPrint, strings.Fields(commandArgsString)...)
 }
 
 //GenerateEVEConfig function copy certs to EVE config folder
@@ -389,7 +390,7 @@ func GenerateEVEConfig(eveConfig string, domain string, ip string, port int, api
 	}
 	if apiV1 {
 		if _, err = os.Stat(filepath.Join(eveConfig, "Force-API-V1")); os.IsNotExist(err) {
-			if err := TouchFile(filepath.Join(eveConfig, "Force-API-V1")); err != nil {
+			if err := utils.TouchFile(filepath.Join(eveConfig, "Force-API-V1")); err != nil {
 				log.Fatal(err)
 			}
 		}
@@ -412,7 +413,7 @@ func CloneFromGit(dist string, gitRepo string, tag string) (err error) {
 	}
 	commandArgsString := fmt.Sprintf("clone --branch %s --single-branch %s %s", tag, gitRepo, dist)
 	log.Infof("CloneFromGit run: %s %s", "git", commandArgsString)
-	return RunCommandWithLogAndWait("git", defaults.DefaultLogLevelToPrint, strings.Fields(commandArgsString)...)
+	return utils.RunCommandWithLogAndWait("git", defaults.DefaultLogLevelToPrint, strings.Fields(commandArgsString)...)
 }
 
 //MakeEveInRepo build live image of EVE
@@ -429,7 +430,7 @@ func MakeEveInRepo(distEve string, configPath string, arch string, hv string, im
 		commandArgsString := fmt.Sprintf("-C %s ZARCH=%s HV=%s CONF_DIR=%s rootfs",
 			distEve, arch, hv, configPath)
 		log.Infof("MakeEveInRepo run: %s %s", "make", commandArgsString)
-		err = RunCommandWithLogAndWait("make", defaults.DefaultLogLevelToPrint, strings.Fields(commandArgsString)...)
+		err = utils.RunCommandWithLogAndWait("make", defaults.DefaultLogLevelToPrint, strings.Fields(commandArgsString)...)
 		image = filepath.Join(distEve, "dist", arch, "installer", fmt.Sprintf("live.%s", imageFormat))
 	} else {
 		image = filepath.Join(distEve, "dist", arch, fmt.Sprintf("live.%s", imageFormat))
@@ -439,7 +440,7 @@ func MakeEveInRepo(distEve string, configPath string, arch string, hv string, im
 		commandArgsString := fmt.Sprintf("-C %s ZARCH=%s HV=%s CONF_DIR=%s IMG_FORMAT=%s live",
 			distEve, arch, hv, configPath, imageFormat)
 		log.Infof("MakeEveInRepo run: %s %s", "make", commandArgsString)
-		err = RunCommandWithLogAndWait("make", defaults.DefaultLogLevelToPrint, strings.Fields(commandArgsString)...)
+		err = utils.RunCommandWithLogAndWait("make", defaults.DefaultLogLevelToPrint, strings.Fields(commandArgsString)...)
 		switch arch {
 		case "amd64":
 			biosPath1 := filepath.Join(distEve, "dist", arch, "OVMF.fd")
@@ -448,14 +449,14 @@ func MakeEveInRepo(distEve string, configPath string, arch string, hv string, im
 			commandArgsString = fmt.Sprintf("-C %s ZARCH=%s HV=%s %s %s %s",
 				distEve, arch, hv, biosPath1, biosPath2, biosPath3)
 			log.Infof("MakeEveInRepo run: %s %s", "make", commandArgsString)
-			err = RunCommandWithLogAndWait("make", defaults.DefaultLogLevelToPrint, strings.Fields(commandArgsString)...)
+			err = utils.RunCommandWithLogAndWait("make", defaults.DefaultLogLevelToPrint, strings.Fields(commandArgsString)...)
 			additional = strings.Join([]string{biosPath1, biosPath2, biosPath3}, ",")
 		case "arm64":
 			dtbPath := filepath.Join(distEve, "dist", arch, "dtb", "eve.dtb")
 			commandArgsString = fmt.Sprintf("-C %s ZARCH=%s HV=%s %s",
 				distEve, arch, hv, dtbPath)
 			log.Infof("MakeEveInRepo run: %s %s", "make", commandArgsString)
-			err = RunCommandWithLogAndWait("make", defaults.DefaultLogLevelToPrint, strings.Fields(commandArgsString)...)
+			err = utils.RunCommandWithLogAndWait("make", defaults.DefaultLogLevelToPrint, strings.Fields(commandArgsString)...)
 			additional = dtbPath
 		default:
 			return "", "", fmt.Errorf("unsupported arch %s", arch)
@@ -472,17 +473,17 @@ func BuildVM(linuxKitPath string, imageConfig string, distImage string) (err err
 			return err
 		}
 	}
-	imageConfigTmp := filepath.Join(distImageDir, fmt.Sprintf("%s-bios.img", fileNameWithoutExtension(filepath.Base(distImage))))
+	imageConfigTmp := filepath.Join(distImageDir, fmt.Sprintf("%s-bios.img", utils.FileNameWithoutExtension(filepath.Base(distImage))))
 	commandArgsString := fmt.Sprintf("build -format raw-bios -dir %s %s",
 		distImageDir, imageConfig)
 	log.Infof("BuildVM run: %s %s", linuxKitPath, commandArgsString)
-	if err = RunCommandWithLogAndWait(linuxKitPath, defaults.DefaultLogLevelToPrint, strings.Fields(commandArgsString)...); err != nil {
+	if err = utils.RunCommandWithLogAndWait(linuxKitPath, defaults.DefaultLogLevelToPrint, strings.Fields(commandArgsString)...); err != nil {
 		return fmt.Errorf("error in linuxkit: %s", err)
 	}
 	commandArgsString = fmt.Sprintf("convert -c -f raw -O qcow2 %s %s",
 		imageConfigTmp, distImage)
 	log.Infof("BuildVM run: %s %s", "qemu-img", commandArgsString)
-	if err = RunCommandWithLogAndWait("qemu-img", defaults.DefaultLogLevelToPrint, strings.Fields(commandArgsString)...); err != nil {
+	if err = utils.RunCommandWithLogAndWait("qemu-img", defaults.DefaultLogLevelToPrint, strings.Fields(commandArgsString)...); err != nil {
 		return fmt.Errorf("error in qemu-img: %s", err)
 	}
 	return os.Remove(imageConfigTmp)
@@ -492,7 +493,7 @@ func BuildVM(linuxKitPath string, imageConfig string, distImage string) (err err
 func CleanContext(commandPath, eveDist, certsDist, imagesDist, evePID string, configSaved string) (err error) {
 	commandArgsString := fmt.Sprintf("stop --eve-pid=%s --adam-rm=false --redis-rm=false --eserver-rm=false", evePID)
 	log.Infof("CleanContext run: %s %s", commandPath, commandArgsString)
-	_, _, err = RunCommandAndWait(commandPath, strings.Fields(commandArgsString)...)
+	_, _, err = utils.RunCommandAndWait(commandPath, strings.Fields(commandArgsString)...)
 	if err != nil {
 		return fmt.Errorf("error in eden stop: %s", err)
 	}
@@ -523,7 +524,7 @@ func CleanContext(commandPath, eveDist, certsDist, imagesDist, evePID string, co
 func CleanEden(commandPath, eveDist, adamDist, certsDist, imagesDist, eserverDist, redisDist, configDir, evePID string, configSaved string) (err error) {
 	commandArgsString := fmt.Sprintf("stop --eve-pid=%s --adam-rm=true --redis-rm=true --eserver-rm=true", evePID)
 	log.Infof("CleanEden run: %s %s", commandPath, commandArgsString)
-	_, _, err = RunCommandAndWait(commandPath, strings.Fields(commandArgsString)...)
+	_, _, err = utils.RunCommandAndWait(commandPath, strings.Fields(commandArgsString)...)
 	if err != nil {
 		return fmt.Errorf("error in eden stop: %s", err)
 	}
@@ -567,13 +568,13 @@ func CleanEden(commandPath, eveDist, adamDist, certsDist, imagesDist, eserverDis
 			return fmt.Errorf("error in %s delete: %s", configSaved, err)
 		}
 	}
-	if err = RemoveGeneratedVolumeOfContainer(defaults.DefaultEServerContainerName); err != nil {
+	if err = utils.RemoveGeneratedVolumeOfContainer(defaults.DefaultEServerContainerName); err != nil {
 		return fmt.Errorf("RemoveGeneratedVolumeOfContainer for %s: %s", defaults.DefaultEServerContainerName, err)
 	}
-	if err = RemoveGeneratedVolumeOfContainer(defaults.DefaultRedisContainerName); err != nil {
+	if err = utils.RemoveGeneratedVolumeOfContainer(defaults.DefaultRedisContainerName); err != nil {
 		return fmt.Errorf("RemoveGeneratedVolumeOfContainer for %s: %s", defaults.DefaultRedisContainerName, err)
 	}
-	if err = RemoveGeneratedVolumeOfContainer(defaults.DefaultAdamContainerName); err != nil {
+	if err = utils.RemoveGeneratedVolumeOfContainer(defaults.DefaultAdamContainerName); err != nil {
 		return fmt.Errorf("RemoveGeneratedVolumeOfContainer for %s: %s", defaults.DefaultAdamContainerName, err)
 	}
 	return nil
@@ -596,7 +597,7 @@ func (server *EServer) getHTTPClient(timeout time.Duration) *http.Client {
 
 //EServerAddFileUrl send url to download image into eserver
 func (server *EServer) EServerAddFileUrl(url string) (name string) {
-	u, err := ResolveURL(fmt.Sprintf("http://%s:%s", server.EServerIP, server.EserverPort), "admin/add-from-url")
+	u, err := utils.ResolveURL(fmt.Sprintf("http://%s:%s", server.EServerIP, server.EserverPort), "admin/add-from-url")
 	if err != nil {
 		log.Fatalf("error constructing URL: %v", err)
 	}
@@ -613,7 +614,7 @@ func (server *EServer) EServerAddFileUrl(url string) (name string) {
 		log.Fatalf("unable to create new http request: %v", err)
 	}
 
-	response, err := RepeatableAttempt(client, req)
+	response, err := utils.RepeatableAttempt(client, req)
 	if err != nil {
 		log.Fatalf("unable to send request: %v", err)
 	}
@@ -626,7 +627,7 @@ func (server *EServer) EServerAddFileUrl(url string) (name string) {
 
 //EServerCheckStatus checks status of image in eserver
 func (server *EServer) EServerCheckStatus(name string) (fileInfo *api.FileInfo) {
-	u, err := ResolveURL(fmt.Sprintf("http://%s:%s", server.EServerIP, server.EserverPort), fmt.Sprintf("admin/status/%s", name))
+	u, err := utils.ResolveURL(fmt.Sprintf("http://%s:%s", server.EServerIP, server.EserverPort), fmt.Sprintf("admin/status/%s", name))
 	if err != nil {
 		log.Fatalf("error constructing URL: %v", err)
 	}
@@ -636,7 +637,7 @@ func (server *EServer) EServerCheckStatus(name string) (fileInfo *api.FileInfo) 
 		log.Fatalf("unable to create new http request: %v", err)
 	}
 
-	response, err := RepeatableAttempt(client, req)
+	response, err := utils.RepeatableAttempt(client, req)
 	if err != nil {
 		log.Fatalf("unable to send request: %v", err)
 	}
@@ -652,12 +653,12 @@ func (server *EServer) EServerCheckStatus(name string) (fileInfo *api.FileInfo) 
 
 //EServerAddFile send file with image into eserver
 func (server *EServer) EServerAddFile(filepath string) (fileInfo *api.FileInfo) {
-	u, err := ResolveURL(fmt.Sprintf("http://%s:%s", server.EServerIP, server.EserverPort), "admin/add-from-file")
+	u, err := utils.ResolveURL(fmt.Sprintf("http://%s:%s", server.EServerIP, server.EserverPort), "admin/add-from-file")
 	if err != nil {
 		log.Fatalf("error constructing URL: %v", err)
 	}
 	client := server.getHTTPClient(0)
-	response, err := UploadFile(client, u, filepath)
+	response, err := utils.UploadFile(client, u, filepath)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/expect/file.go
+++ b/pkg/expect/file.go
@@ -2,6 +2,7 @@ package expect
 
 import (
 	"github.com/dustin/go-humanize"
+	"github.com/lf-edge/eden/pkg/eden"
 	"github.com/lf-edge/eden/pkg/utils"
 	"github.com/lf-edge/eve/api/go/config"
 	uuid "github.com/satori/go.uuid"
@@ -11,7 +12,7 @@ import (
 
 //createImageFile uploads image into EServer from file and calculates size and sha256 of image
 func (exp *appExpectation) createImageFile(id uuid.UUID, dsId string) *config.Image {
-	server := &utils.EServer{
+	server := &eden.EServer{
 		EServerIP:   exp.ctrl.GetVars().EServerIp,
 		EserverPort: exp.ctrl.GetVars().EServerPort,
 	}

--- a/pkg/expect/http.go
+++ b/pkg/expect/http.go
@@ -2,12 +2,12 @@ package expect
 
 import (
 	"fmt"
+	"github.com/lf-edge/eden/pkg/eden"
 	"path"
 	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/lf-edge/eden/pkg/defaults"
-	"github.com/lf-edge/eden/pkg/utils"
 	"github.com/lf-edge/eve/api/go/config"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
@@ -16,7 +16,7 @@ import (
 //createImageHttp downloads image into EServer directory from http/https endpoint and calculates size and sha256 of image
 func (exp *appExpectation) createImageHttp(id uuid.UUID, dsId string) *config.Image {
 	log.Infof("Starting download of image from %s", exp.appLink)
-	server := &utils.EServer{
+	server := &eden.EServer{
 		EServerIP:   exp.ctrl.GetVars().EServerIp,
 		EserverPort: exp.ctrl.GetVars().EServerPort,
 	}

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -33,6 +33,7 @@ type ConfigVars struct {
 	AdamRedisUrlAdam  string
 	EveHV             string
 	EveSSID           string
+	EveUUID           string
 	EveName           string
 	EveRemote         bool
 	EveRemoteAddr     string
@@ -80,6 +81,7 @@ func InitVars() (*ConfigVars, error) {
 			EveHV:             viper.GetString("eve.hv"),
 			DevModel:          viper.GetString("eve.devmodel"),
 			EveName:           viper.GetString("eve.name"),
+			EveUUID:           viper.GetString("eve.uuid"),
 			EveRemote:         viper.GetBool("eve.remote"),
 			EveRemoteAddr:     viper.GetString("eve.remote-addr"),
 			EveQemuPorts:      viper.GetStringMapString("eve.hostfwd"),

--- a/pkg/utils/configDiff.go
+++ b/pkg/utils/configDiff.go
@@ -34,7 +34,7 @@ eve:
     image-file: {{ .DefaultImageDist }}/eve/live.img
 
     #devmodel
-    devmodel: ZedVirtual-4G
+    devmodel: {{ .DefaultEVEModel }}
 
     #file to save qemu config
     qemu-config: {{ .DefaultQemuFileToSave }}
@@ -44,6 +44,9 @@ eve:
 
     #EVE acceleration (set to false if you have problems with qemu)
     accel: true
+
+    #variant of hypervisor of EVE (kvm/xen)
+    hv: {{ .DefaultEVEHV }}
 
     #uuid of EVE to use in cert
     uuid: {{ .UUID }}
@@ -56,6 +59,9 @@ eve:
 
     #EVE firmware
     firmware: [{{ .DefaultImageDist }}/eve/OVMF_CODE.fd,{{ .DefaultImageDist }}/eve/OVMF_VARS.fd]
+
+    #eve tag
+    tag: {{ .DefaultEVETag }}
 
     #forward of ports in qemu [(HOST:EVE)]
     hostfwd:

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -98,7 +98,7 @@ func TouchFile(src string) (err error) {
 	return nil
 }
 
-func fileNameWithoutExtension(fileName string) string {
+func FileNameWithoutExtension(fileName string) string {
 	return strings.TrimSuffix(fileName, filepath.Ext(fileName))
 }
 

--- a/tests/integration/application_test.go
+++ b/tests/integration/application_test.go
@@ -54,7 +54,7 @@ func TestApplication(t *testing.T) {
 		t.Fatalf("CloudPrepare: %s", err)
 	}
 
-	deviceCtx, err := ctx.GetDeviceFirst()
+	deviceCtx, err := ctx.GetDeviceCurrent()
 	if err != nil {
 		t.Fatal("Fail in get first device: ", err)
 	}

--- a/tests/integration/application_test.go
+++ b/tests/integration/application_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"flag"
 	"fmt"
+	"github.com/lf-edge/eden/pkg/eden"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -381,7 +382,7 @@ func SetupApplication(t *testing.T, format config.Format, ymlPath string) {
 		}
 		vmImageFile := filepath.Join(eserverImageDist, "vm", fmt.Sprintf("%s.qcow2", imageFile))
 		if _, err := os.Stat(vmImageFile); os.IsNotExist(err) {
-			if err = utils.BuildVM(linuxKitSymlinkPath, ymlPath, vmImageFile); err != nil {
+			if err = eden.BuildVM(linuxKitSymlinkPath, ymlPath, vmImageFile); err != nil {
 				t.Fatalf("Cannot build VM image: %s", err)
 			} else {
 				t.Log("VM image build done")

--- a/tests/integration/baseImage_test.go
+++ b/tests/integration/baseImage_test.go
@@ -78,7 +78,7 @@ func TestBaseImage(t *testing.T) {
 			if err != nil {
 				t.Fatal("Fail in prepare base image from local file: ", err)
 			}
-			deviceCtx, err := ctx.GetDeviceFirst()
+			deviceCtx, err := ctx.GetDeviceCurrent()
 			if err != nil {
 				t.Fatal("Fail in get first device: ", err)
 			}

--- a/tests/integration/baseImage_test.go
+++ b/tests/integration/baseImage_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"flag"
 	"fmt"
+	"github.com/lf-edge/eden/pkg/eden"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -156,12 +157,12 @@ func SetupBaseImage(t *testing.T) (fileToUse string) {
 	eveBaseDist := utils.ResolveAbsPath(*eveBaseDistRelative)
 	if !*download {
 		if _, err := os.Stat(eveBaseDist); os.IsNotExist(err) {
-			if err := utils.CloneFromGit(eveBaseDist, eveRepo, *eveBaseTag); err != nil {
+			if err := eden.CloneFromGit(eveBaseDist, eveRepo, *eveBaseTag); err != nil {
 				t.Fatalf("cannot clone BASE EVE: %s", err)
 			} else {
 				t.Log("clone BASE EVE done")
 			}
-			if _, _, err = utils.MakeEveInRepo(eveBaseDist, adamDist, eveArch, eveHV, "raw", true); err != nil {
+			if _, _, err = eden.MakeEveInRepo(eveBaseDist, adamDist, eveArch, eveHV, "raw", true); err != nil {
 				t.Fatalf("cannot MakeEveInRepo base: %s", err)
 			} else {
 				t.Log("MakeEveInRepo base done")

--- a/tests/integration/controller_test.go
+++ b/tests/integration/controller_test.go
@@ -33,7 +33,7 @@ func TestControllerSetConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CloudPrepare: %s", err)
 	}
-	deviceCtx, err := ctx.GetDeviceFirst()
+	deviceCtx, err := ctx.GetDeviceCurrent()
 	if err != nil {
 		t.Fatal("Fail in get first device: ", err)
 	}
@@ -49,7 +49,7 @@ func TestControllerGetConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CloudPrepare: %s", err)
 	}
-	devUUID, err := ctx.GetDeviceFirst()
+	devUUID, err := ctx.GetDeviceCurrent()
 	if err != nil {
 		t.Fatal("Fail in get first device: ", err)
 	}
@@ -66,7 +66,7 @@ func TestControllerLogs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CloudPrepare: %s", err)
 	}
-	devUUID, err := ctx.GetDeviceFirst()
+	devUUID, err := ctx.GetDeviceCurrent()
 	if err != nil {
 		t.Fatal("Fail in get first device: ", err)
 	}
@@ -83,7 +83,7 @@ func TestControllerInfo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CloudPrepare: %s", err)
 	}
-	devUUID, err := ctx.GetDeviceFirst()
+	devUUID, err := ctx.GetDeviceCurrent()
 	if err != nil {
 		t.Fatal("Fail in get first device: ", err)
 	}

--- a/tests/integration/networkInstance_test.go
+++ b/tests/integration/networkInstance_test.go
@@ -18,7 +18,7 @@ func TestNetworkInstance(t *testing.T) {
 		t.Fatalf("CloudPrepare: %s", err)
 	}
 
-	deviceCtx, err := ctx.GetDeviceFirst()
+	deviceCtx, err := ctx.GetDeviceCurrent()
 	if err != nil {
 		t.Fatal("Fail in get first device: ", err)
 	}


### PR DESCRIPTION
A lot of fixes for #251:

- To avoid circular dependencies, I move eden.go into separate package.
- In #240 I changed `eden clean` to work only for current context. In this PR, I implement deleting of device and onboard certs from Adam during clean and removing of state and devUUID files from ~/.eden.
- I modify GetFirstDevice into GetCurrentDevice to work with device defined in current context.