### PR TITLE
sync EVE version and fix onboard

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -43,7 +43,7 @@ const (
 	DefaultRegistryPort = 5000
 
 	//tags, versions, repos
-	DefaultEVETag               = "0.0.0-snapshot-master-8b5a29ce" //DefaultEVETag tag for EVE image
+	DefaultEVETag               = "0.0.0-snapshot-master-09f8c9ae" //DefaultEVETag tag for EVE image
 	DefaultAdamTag              = "0.0.63"
 	DefaultRedisTag             = "6"
 	DefaultRegistryTag          = "2.7"

--- a/tests/workflow/testdata/eden_onboard.txt
+++ b/tests/workflow/testdata/eden_onboard.txt
@@ -4,11 +4,6 @@
 eden eve onboard
 stdout 'onboarded'
 
-# Waiting of onboard reboot.
-test eden.reboot.test -test.v -timewait 1800 -reboot=0 -count=1 &
-wait
-stdout 'Number of reboots: 1'
-
 -- eden-config.yml --
 test:
     controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}


### PR DESCRIPTION
After https://github.com/lf-edge/eve/commit/3bf3c0d2193d714dfcc397ed9f718f7b532bf5c2 we must remove check for reboot from onboard test.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>