### PR TITLE
phoronix expand timeout

### DIFF
--- a/tests/phoronix/eden.phoronix.tests.txt
+++ b/tests/phoronix/eden.phoronix.tests.txt
@@ -1,2 +1,1 @@
-eden.escript.test -test.run TestEdenScripts/test_phoronix -test.timeout 90m -args="benchmark=pts/coremark-1.0.0"
-eden.escript.test -test.run TestEdenScripts/test_phoronix -test.timeout 90m -args="benchmark=fio-basic"
+eden.escript.test -test.run TestEdenScripts/test_phoronix -args="benchmark=fio-basic"

--- a/tests/phoronix/testdata/test_phoronix.txt
+++ b/tests/phoronix/testdata/test_phoronix.txt
@@ -12,10 +12,10 @@ arg benchmark benchmark
 # read the environment variables
 source .env
 
-# deploy the third application by nested escript
+# deploy the application by nested escript
 test eden.escript.test -test.run TestEdenScripts/deploy_app -test.v  -testdata {{EdenConfig "eden.root"}}/../tests/phoronix/testdata/
 
-exec -t 80m bash wait_app.sh
+exec -t 180m bash wait_app.sh
 exec cat result
 # expect in stdout
 stdout 'Average'


### PR DESCRIPTION
Expand timeout of phoronix.

Move to fio test by default. To test coremark please run `./eden test tests/phoronix/ -v debug -a="benchmark=pts/coremark-1.0.0"`

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>