### PR TITLE
eden-http-server move for faster builds

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -60,7 +60,7 @@ const (
 	DefaultRegistry             = "docker.io"
 
 	DefaultEServerTag          = "1.2"
-	DefaultEServerContainerRef = "lfedge/eden-http-server"
+	DefaultEServerContainerRef = "itmoeve/eden-http-server"
 
 	//DefaultRepeatCount is repeat count for requests
 	DefaultRepeatCount = 20


### PR DESCRIPTION
We spend about 4 minutes to create a service image (eden-http-server). This way we can save time by using the prebuilded image.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>