### PR TITLE
rewrite hostfwd config to be the same with cmd

### DIFF
--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -203,12 +203,7 @@ eve:
     tag: {{ .DefaultEVETag }}
 
     #forward of ports in qemu [(HOST:EVE)]
-    hostfwd:
-        {{ .DefaultSSHPort }}: 22
-        5912: 5902
-        5911: 5901
-        8027: 8027
-        8028: 8028
+    hostfwd: {"{{ .DefaultSSHPort }}":"22","5912":"5902","5911":"5901","8027":"8027","8028":"8028"}
 
     #location of eve directory
     dist: {{ .DefaultEVEDist }}

--- a/pkg/utils/configDiff.go
+++ b/pkg/utils/configDiff.go
@@ -67,12 +67,7 @@ eve:
     tag: {{ .DefaultEVETag }}
 
     #forward of ports in qemu [(HOST:EVE)]
-    hostfwd:
-        {{ .DefaultSSHPort }}: 22
-        5912: 5902
-        5911: 5901
-        8027: 8027
-        8028: 8028
+    hostfwd: {"{{ .DefaultSSHPort }}":"22","5912":"5902","5911":"5901","8027":"8027","8028":"8028"}
 
     #is EVE remote or local
     remote: {{ .DefaultEVERemote }}


### PR DESCRIPTION
To overwrite hostfwd we need to run something like:
```
eden config set default --key eve.hostfwd --value '{"2222":"22","5911":"5901","5912":"5902","8027":"8027","8028":"8028","8029":"8029"}'
```
So, we should overwrite default one to be in the same format as cmd.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>