### PR TITLE
New network tests

### DIFF
--- a/tests/eclient/Makefile
+++ b/tests/eclient/Makefile
@@ -17,7 +17,7 @@ OS ?= $(HOSTOS)
 # IMAGE_TAG is the tag for image to build
 IMAGE_TAG ?= itmoeve/eclient
 # IMAGE_VERSION is the version of image to build
-IMAGE_VERSION ?= 0.1
+IMAGE_VERSION ?= 0.2
 # IMAGE_DIR is the directory with image Dockerfile to build
 IMAGE_DIR=$(CURDIR)/image
 

--- a/tests/eclient/eden+eclient.sh
+++ b/tests/eclient/eden+eclient.sh
@@ -7,22 +7,11 @@ EDEN=./eden
 if $EDEN config get --key eve.hostfwd | grep -v 2223
 then
   echo Adding 2223 port for eclient\'s SSH to EDEN config
-  PORTS=$($EDEN config get --key eve.hostfwd | sed 's/map\[\(.*\)\]/\1/; s/^/2223:2223 /')
+  PORTS=$($EDEN config get default --key eve.hostfwd | sed 's/map\[\(.*\)\]/{"\1 2223:2223"}/;s/ /","/g;s/:/":"/g')
   $EDEN config set default --key eve.hostfwd --value "$PORTS"
+  $EDEN config get default --key eve.hostfwd
+  echo $EDEN stop
+  $EDEN stop
+  echo $EDEN start
+  $EDEN start
 fi
-
-grep 'hostfwd = "tcp::2223-:2223"' ~/.eden/default-qemu.conf && exit
-
-echo Adding 2223 port for eclient\'s SSH to EDEN QEMU config
-ed ~/.eden/default-qemu.conf <<END
-/hostfwd = "tcp::2222-:22"
-a
-  hostfwd = "tcp::2223-:2223"
-.
-wq
-END
-
-echo $EDEN stop
-$EDEN stop
-echo $EDEN start
-$EDEN start

--- a/tests/eclient/eden.eclient.tests.txt
+++ b/tests/eclient/eden.eclient.tests.txt
@@ -1,2 +1,4 @@
 ./eden+eclient.sh
-eden.escript.test -test.run TestEdenScripts/eclient
+#eden.escript.test -test.run TestEdenScripts/eclient
+eden.escript.test -test.run TestEdenScripts/networking_light -test.timeout 40m
+eden.escript.test -test.run TestEdenScripts/ngnix -test.timeout 40m

--- a/tests/eclient/image/Dockerfile
+++ b/tests/eclient/image/Dockerfile
@@ -24,8 +24,11 @@ RUN sed -i 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid
 ENV NOTVISIBLE="in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
 
+RUN mkdir -p /root/.ssh/
+COPY cert/id_rsa* /root/.ssh/
 COPY cert/id_rsa.pub /root/.ssh/authorized_keys
-RUN chown root:root /root/.ssh/authorized_keys
+RUN chown root:root /root/.ssh/
+RUN chmod 600 /root/.ssh/id_rsa*
 
 EXPOSE 22
 CMD ["/usr/sbin/sshd", "-D"]

--- a/tests/eclient/testdata/networking_light.txt
+++ b/tests/eclient/testdata/networking_light.txt
@@ -1,0 +1,88 @@
+{{$test_opts := "-test.v -timewait 1200"}}
+{{$test_msg := "This is a test"}}
+{{define "port"}}2223{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa root@localhost -p {{template "port"}}{{end}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+
+# Starting of reboot detector with a 2 reboot limit
+! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=2 &
+
+eden pod deploy -v debug -n eclient docker://itmoeve/eclient:latest -p {{template "port"}}:22
+#eden -t 20m pod logs eclient
+#stdout 'Executing "/usr/sbin/sshd" "-D"'
+
+eden pod deploy -v debug -n eserver docker://itmoeve/eclient:latest
+
+test eden.app.test -test.v -timewait 20m RUNNING eclient eserver
+
+#exec -t 20m bash wait_ssh.sh
+exec -t 5m bash wait_ssh.sh
+
+eden pod ps
+cp stdout pod_ps
+exec bash eserver_ip.sh
+
+exec sleep 10
+exec -t 1m bash setup_srv.sh
+exec sleep 10
+exec -t 1m bash run_srv.sh &
+exec sleep 10
+exec -t 1m bash run_clent.sh
+exec sleep 10
+exec -t 1m bash get_result.sh
+stdout '{{$test_msg}}'
+
+eden pod delete eclient
+eden pod delete eserver
+
+test eden.app.test -test.v -timewait 10m - eclient eserver
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- wait_ssh.sh --
+
+for i in `seq 10`
+do
+  sleep 5
+  # Test SSH-access to container
+  echo {{template "ssh"}} grep -q Ubuntu /etc/issue && break
+  {{template "ssh"}} grep -q Ubuntu /etc/issue && break
+done
+
+-- eserver_ip.sh --
+echo export ESERVER_IP=$(grep '^eserver\s' pod_ps | cut -f 4) > env
+
+-- setup_srv.sh --
+. ./env
+
+echo {{template "ssh"}} "echo ssh -o StrictHostKeyChecking=no root@$ESERVER_IP nc -l 1234 > /tmp/server"
+{{template "ssh"}} "echo ssh -o StrictHostKeyChecking=no root@$ESERVER_IP nc -l 1234 > /tmp/server"
+
+-- run_srv.sh --
+. ./env
+
+echo {{template "ssh"}} 'sh /tmp/server > /tmp/out'
+{{template "ssh"}} 'sh /tmp/server > /tmp/out'
+
+-- run_clent.sh --
+. ./env
+
+echo {{template "ssh"}} "echo {{$test_msg}} | nc -N $ESERVER_IP 1234"
+{{template "ssh"}} "echo {{$test_msg}} | nc -N $ESERVER_IP 1234"
+
+-- get_result.sh --
+. ./env
+
+echo {{template "ssh"}} 'cat /tmp/out'
+{{template "ssh"}} 'cat /tmp/out'

--- a/tests/eclient/testdata/ngnix.txt
+++ b/tests/eclient/testdata/ngnix.txt
@@ -1,0 +1,62 @@
+{{$test_opts := "-test.v -timewait 1200"}}
+{{$server := "ngnix"}}
+{{$test_msg := "Welcome to nginx!"}}
+{{define "port"}}2223{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa root@localhost -p {{template "port"}}{{end}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+
+# Starting of reboot detector with a 2 reboot limit
+! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=2 &
+
+eden pod deploy -v debug -n eclient docker://itmoeve/eclient:latest -p {{template "port"}}:22
+
+eden pod deploy -v debug -n {{$server}} docker://nginx:latest
+
+test eden.app.test -test.v -timewait 20m RUNNING eclient {{$server}}
+
+exec -t 20m bash wait_ssh.sh
+
+eden pod ps
+cp stdout pod_ps
+exec bash server_ip.sh {{$server}}
+
+exec sleep 10
+exec -t 1m bash run_clent.sh
+stdout '{{$test_msg}}'
+
+eden pod delete eclient
+eden pod delete {{$server}}
+
+test eden.app.test -test.v -timewait 10m - eclient {{$server}}
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- wait_ssh.sh --
+
+for i in `seq 10`
+do
+  sleep 5
+  # Test SSH-access to container
+  echo {{template "ssh"}} grep -q Ubuntu /etc/issue && break
+  {{template "ssh"}} grep -q Ubuntu /etc/issue && break
+done
+
+-- server_ip.sh --
+echo export ESERVER_IP=$(grep "^$1\s" pod_ps | cut -f 4) > env
+
+-- run_clent.sh --
+. ./env
+
+echo {{template "ssh"}} "curl $ESERVER_IP"
+{{template "ssh"}} "curl $ESERVER_IP"


### PR DESCRIPTION
Created universal `eclient` container with SSH access. Old network test split into two tests: simple `nc`-based client/server communication and `nginx` tests.

Signed-off-by: Oleg Sadov <oleg.sadov@gmail.com>