### PR TITLE
fixes for remote test

### DIFF
--- a/.yetus/excludes.txt
+++ b/.yetus/excludes.txt
@@ -1,3 +1,3 @@
-^.+go.mod
-^.+go.sum
+^.*go.mod
+^.*go.sum
 tests/eclient/testdata/maridb\.txt

--- a/cmd/eve.go
+++ b/cmd/eve.go
@@ -319,7 +319,7 @@ var sshEveCmd = &cobra.Command{
 			if err = ctrl.ConfigSync(dev); err != nil {
 				log.Fatal(err)
 			}
-			if eveRemoteAddr == "" { //obtain IP of EVE from info
+			if eveRemote || eveRemoteAddr == "" { //obtain IP of EVE from info
 				if !cmd.Flags().Changed("eve-ssh-port") {
 					eveSSHPort = 22
 				}

--- a/docs/usb-pt.md
+++ b/docs/usb-pt.md
@@ -32,7 +32,7 @@ To assign a device to a guest VM, the `--adapters` option
 is used during the deployment stage, e.g.:
 
 ```console
-./eden pod deploy -p 8027:22 https://cloud-images.ubuntu.com/xenial/20200904/xenial-server-cloudimg-i386-disk1.img \
+./eden pod deploy -p 8027:22 https://cloud-images.ubuntu.com/releases/groovy/release-20201022.1/ubuntu-20.10-server-cloudimg-amd64.img \
      -v debug --metadata='#cloud-config\npassword: passw0rd\nlock_passwd: False\nchpasswd: { expire: False }\nssh_pwauth: True\n'\
      --adapters USB3:4
 ```

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/lf-edge/adam v0.0.0-20200910222414-5a4c90bf19c2
 	github.com/lf-edge/eden/eserver v0.0.0-00010101000000-000000000000
 	github.com/lf-edge/edge-containers v0.0.0-20200921124327-cb84b924624b
-	github.com/lf-edge/eve/api/go v0.0.0-20201019011810-f8c60fefb83f
+	github.com/lf-edge/eve/api/go v0.0.0-20201103051211-75e6051e2dd0
 	github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40 // indirect
 	github.com/mcuadros/go-lookup v0.0.0-20200513230334-5988786b5617
 	github.com/nerd2/gexto v0.0.0-20190529073929-39468ec063f6

--- a/go.sum
+++ b/go.sum
@@ -338,8 +338,8 @@ github.com/lf-edge/edge-containers v0.0.0-20200921124327-cb84b924624b h1:LVkTzSR
 github.com/lf-edge/edge-containers v0.0.0-20200921124327-cb84b924624b/go.mod h1:WH308e8oM3sEithOMtr3KtwHG8Paj4157NxdNPNDPnM=
 github.com/lf-edge/eve/api/go v0.0.0-20200805060635-507771c7f963 h1:CA+l2dG+902gaFsfAKZOXFvydoa3T//q8OgkeT5k1Lg=
 github.com/lf-edge/eve/api/go v0.0.0-20200805060635-507771c7f963/go.mod h1:DuAv0PyTTzmd3n25iHJ/Hx2SrbON4hf3I0oXfnUH4d8=
-github.com/lf-edge/eve/api/go v0.0.0-20201019011810-f8c60fefb83f h1:4/SP1MXR3CNImxJD4XNxTVdf7ctgx906lW42CXPLu1c=
-github.com/lf-edge/eve/api/go v0.0.0-20201019011810-f8c60fefb83f/go.mod h1:DuAv0PyTTzmd3n25iHJ/Hx2SrbON4hf3I0oXfnUH4d8=
+github.com/lf-edge/eve/api/go v0.0.0-20201103051211-75e6051e2dd0 h1:qsE5ofDzrh7qwz2KhITLpKcX/rcb2AtQnK6sLV169ds=
+github.com/lf-edge/eve/api/go v0.0.0-20201103051211-75e6051e2dd0/go.mod h1:DuAv0PyTTzmd3n25iHJ/Hx2SrbON4hf3I0oXfnUH4d8=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40 h1:EnfXoSqDfSNJv0VBNqY/88RNnhSGYkrHaO0mmFGbVsc=
 github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40/go.mod h1:vy1vK6wD6j7xX6O6hXe621WabdtNkou2h7uRtTfRMyg=

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -45,7 +45,7 @@ const (
 	DefaultRegistryPort = 5000
 
 	//tags, versions, repos
-	DefaultEVETag               = "5.14.0" //DefaultEVETag tag for EVE image
+	DefaultEVETag               = "5.15.0" //DefaultEVETag tag for EVE image
 	DefaultAdamTag              = "0.0.63"
 	DefaultRedisTag             = "6"
 	DefaultRegistryTag          = "2.7"

--- a/pkg/expect/baseOSImage.go
+++ b/pkg/expect/baseOSImage.go
@@ -50,7 +50,6 @@ func (exp *AppExpectation) createBaseOSConfig(img *config.Image) (*config.BaseOS
 		}},
 		Activate:      true,
 		BaseOSVersion: exp.getBaseOSVersion(),
-		BaseOSDetails: nil,
 	}
 	switch exp.appType {
 	case dockerApp:

--- a/pkg/expect/contentTree.go
+++ b/pkg/expect/contentTree.go
@@ -8,12 +8,6 @@ import (
 
 //imageToContentTree converts image with displayName into ContentTree representation
 func (exp *AppExpectation) imageToContentTree(image *config.Image, displayName string) *config.ContentTree {
-	for _, el := range exp.ctrl.ListContentTree() {
-		if el.URL == image.Name && el.Sha256 == image.Sha256 && el.DsId == image.DsId {
-			//we already have it in controller
-			return el
-		}
-	}
 	id, err := uuid.NewV4()
 	if err != nil {
 		log.Fatal(err)

--- a/tests/eclient/eden+ports.sh
+++ b/tests/eclient/eden+ports.sh
@@ -30,8 +30,9 @@ then
   echo $EDEN config set default --key eve.hostfwd --value \'"$NEW"\'
   $EDEN config set default --key eve.hostfwd --value "$NEW"
   $EDEN config get default --key eve.hostfwd
-  echo $EDEN stop
-  $EDEN stop
-  echo $EDEN start
-  $EDEN start
+  echo $EDEN eve stop
+  $EDEN eve stop
+  sleep 5
+  echo $EDEN eve start
+  $EDEN eve start
 fi

--- a/tests/eclient/eden-ports.sh
+++ b/tests/eclient/eden-ports.sh
@@ -30,8 +30,9 @@ then
   echo $EDEN config set default --key eve.hostfwd --value \'"$NEW"\'
   $EDEN config set default --key eve.hostfwd --value "$NEW"
   $EDEN config get default --key eve.hostfwd
-  echo $EDEN stop
-  $EDEN stop
-  echo $EDEN start
-  $EDEN start
+  echo $EDEN eve stop
+  $EDEN eve stop
+  sleep 5
+  echo $EDEN eve start
+  $EDEN eve start
 fi

--- a/tests/eclient/testdata/eclient.txt
+++ b/tests/eclient/testdata/eclient.txt
@@ -8,7 +8,7 @@
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=2 &
 
-eden pod deploy -v debug -n eclient docker://itmoeve/eclient:latest -p {{$port}}:22
+eden pod deploy -v debug -n eclient --memory=512MB docker://itmoeve/eclient:latest -p {{$port}}:22
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 
@@ -33,10 +33,12 @@ test:
         model: {{EdenConfig "eve.devmodel"}}
 
 -- ssh.sh --
-for i in `seq 10`
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for i in `seq 20`
 do
-sleep 5
+sleep 20
 # Test SSH-access to container
-echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa -p {{$port}} root@localhost grep Ubuntu /etc/issue
-ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa -p {{$port}} root@localhost grep Ubuntu /etc/issue && break
+echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue
+ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue && break
 done

--- a/tests/eclient/testdata/host-only.txt
+++ b/tests/eclient/testdata/host-only.txt
@@ -1,6 +1,6 @@
 {{$test_opts := "-test.v -timewait 1200"}}
 {{$test_msg := "This is a test"}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa root@localhost{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa root@{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
@@ -9,13 +9,13 @@
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=2 &
 
-eden pod deploy -v debug -n ping-nw docker://itmoeve/eclient:latest -p 2223:22
-eden pod deploy -v debug -n ping-fw docker://itmoeve/eclient:latest -p 2224:22 --only-host=true
-eden pod deploy -v debug -n pong docker://itmoeve/eclient:latest
+eden pod deploy -v debug -n ping-nw --memory=512MB docker://itmoeve/eclient:latest -p 2223:22
+eden pod deploy -v debug -n ping-fw --memory=512MB docker://itmoeve/eclient:latest -p 2224:22 --only-host=true
+eden pod deploy -v debug -n pong --memory=512MB docker://itmoeve/eclient:latest
 
 test eden.app.test -test.v -timewait 20m RUNNING ping-nw ping-fw pong
 
-exec -t 5m bash wait_ssh.sh 2223 2224
+exec -t 20m bash wait_ssh.sh 2223 2224
 
 eden pod ps
 cp stdout pod_ps
@@ -45,14 +45,16 @@ test:
 
 -- wait_ssh.sh --
 
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
 for p in $*
 do
-  for i in `seq 10`
+  for i in `seq 20`
   do
-    sleep 5
+    sleep 20
     # Test SSH-access to container
-    echo {{template "ssh"}} -p $p grep -q Ubuntu /etc/issue && break
-    {{template "ssh"}} grep -p $p -q Ubuntu /etc/issue && break
+    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
+    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
   done
 done
 
@@ -62,6 +64,9 @@ cat env
 -- ping.sh --
 . ./env
 
-echo {{template "ssh"}} -p $1 ping -c 5 "$PONG_IP"
-{{template "ssh"}} -p $1 ping -c 5 "$PONG_IP"
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+echo {{template "ssh"}}$HOST -p $1 ping -c 5 "$PONG_IP"
+{{template "ssh"}}$HOST -p $1 ping -c 5 "$PONG_IP"
 

--- a/tests/eclient/testdata/maridb.txt
+++ b/tests/eclient/testdata/maridb.txt
@@ -2,7 +2,7 @@
 {{$server := "mariadb"}}
 {{$test_msg := "MariaDB [(none)]> "}}
 {{define "port"}}2223{{end}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa root@localhost -p {{template "port"}}{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
@@ -11,13 +11,13 @@
 # Starting of reboot detector with a 2 reboot limit
 #! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=2 &
 
-eden pod deploy -v debug -n eclient docker://itmoeve/eclient:latest -p {{template "port"}}:22
+eden pod deploy -v debug -n eclient --memory=512MB docker://itmoeve/eclient:latest -p {{template "port"}}:22
 
-eden pod deploy -v debug -n {{$server}} docker://mariadb:10.5.6-focal --metadata='MYSQL_ROOT_PASSWORD=adam&eve'
+eden pod deploy -v debug -n {{$server}} --memory=512MB docker://mariadb:10.5.6-focal --metadata='MYSQL_ROOT_PASSWORD=adam&eve'
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient {{$server}}
 
-exec -t 10m bash wait_ssh.sh
+exec -t 20m bash wait_ssh.sh
 
 eden pod ps
 cp stdout pod_ps
@@ -44,22 +44,25 @@ test:
         model: {{EdenConfig "eve.devmodel"}}
 
 -- wait_ssh.sh --
-
-for i in `seq 10`
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for i in `seq 20`
 do
-  sleep 10
+  sleep 20
   # Test SSH-access to container
-  echo {{template "ssh"}} grep -q Ubuntu /etc/issue && break
-  {{template "ssh"}} grep -q Ubuntu /etc/issue && break
+  echo {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue
+  {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue && break
 done
 
 -- server_ip.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 echo export ESERVER_IP=$(grep "^$1\s" pod_ps | cut -f 4) > env
+echo export HOST=$($EDEN eve ip) >> env
 
 -- wait_db.sh --
 . ./env
 
-until {{template "ssh"}} "echo 'SHOW DATABASES;' | mysql --user=root --password='adam&eve' --host=$ESERVER_IP"
+until {{template "ssh"}}$HOST "echo 'SHOW DATABASES;' | mysql --user=root --password='adam&eve' --host=$ESERVER_IP"
 do
    sleep 10
 done
@@ -67,14 +70,14 @@ done
 -- run_clent.sh --
 . ./env
 
-echo {{template "ssh"}} 'cat > /tmp/maridb.sql' < maridb.in
-{{template "ssh"}} 'cat > /tmp/maridb.sql' < maridb.in
+echo {{template "ssh"}}$HOST 'cat > /tmp/maridb.sql' < maridb.in
+{{template "ssh"}}$HOST 'cat > /tmp/maridb.sql' < maridb.in
 sleep 10
-echo {{template "ssh"}} "mysql --user=root --password='adam&eve' --host=$ESERVER_IP < /tmp/maridb.sql > /tmp/maridb.out"
-{{template "ssh"}} "mysql --user=root --password='adam&eve' --host=$ESERVER_IP < /tmp/maridb.sql > /tmp/maridb.out"
+echo {{template "ssh"}}$HOST "mysql --user=root --password='adam&eve' --host=$ESERVER_IP < /tmp/maridb.sql > /tmp/maridb.out"
+{{template "ssh"}}$HOST "mysql --user=root --password='adam&eve' --host=$ESERVER_IP < /tmp/maridb.sql > /tmp/maridb.out"
 sleep 10
-echo {{template "ssh"}} 'cat /tmp/maridb.out'
-{{template "ssh"}} 'cat /tmp/maridb.out' > out
+echo {{template "ssh"}}$HOST 'cat /tmp/maridb.out'
+{{template "ssh"}}$HOST 'cat /tmp/maridb.out' > out
 
 -- maridb.in --
 CREATE DATABASE bookstore;

--- a/tests/eclient/testdata/networking_light.txt
+++ b/tests/eclient/testdata/networking_light.txt
@@ -1,7 +1,7 @@
 {{$test_opts := "-test.v -timewait 1200"}}
 {{$test_msg := "This is a test"}}
 {{define "port"}}2223{{end}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa root@localhost -p {{template "port"}}{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
@@ -10,16 +10,16 @@
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=2 &
 
-eden pod deploy -v debug -n eclient docker://itmoeve/eclient:latest -p {{template "port"}}:22
+eden pod deploy -v debug -n eclient --memory=512MB docker://itmoeve/eclient:latest -p {{template "port"}}:22
 #eden -t 20m pod logs eclient
 #stdout 'Executing "/usr/sbin/sshd" "-D"'
 
-eden pod deploy -v debug -n eserver docker://itmoeve/eclient:latest
+eden pod deploy -v debug -n eserver --memory=512MB docker://itmoeve/eclient:latest
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient eserver
 
 #exec -t 20m bash wait_ssh.sh
-exec -t 5m bash wait_ssh.sh
+exec -t 20m bash wait_ssh.sh
 
 eden pod ps
 cp stdout pod_ps
@@ -30,7 +30,7 @@ exec -t 1m bash setup_srv.sh
 exec sleep 10
 exec -t 1m bash run_srv.sh &
 exec sleep 10
-exec -t 1m bash run_clent.sh
+exec -t 1m bash run_client.sh
 exec sleep 10
 exec -t 1m bash get_result.sh
 stdout '{{$test_msg}}'
@@ -52,37 +52,41 @@ test:
 
 -- wait_ssh.sh --
 
-for i in `seq 10`
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for i in `seq 20`
 do
-  sleep 5
+  sleep 20
   # Test SSH-access to container
-  echo {{template "ssh"}} grep -q Ubuntu /etc/issue && break
-  {{template "ssh"}} grep -q Ubuntu /etc/issue && break
+  echo {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue
+  {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue && break
 done
 
 -- eserver_ip.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 echo export ESERVER_IP=$(grep '^eserver\s' pod_ps | cut -f 4) > env
+echo export HOST=$($EDEN eve ip) >> env
 
 -- setup_srv.sh --
 . ./env
 
-echo {{template "ssh"}} "echo ssh -o StrictHostKeyChecking=no root@$ESERVER_IP nc -l 1234 > /tmp/server"
-{{template "ssh"}} "echo ssh -o StrictHostKeyChecking=no root@$ESERVER_IP nc -l 1234 > /tmp/server"
+echo {{template "ssh"}}$HOST "echo ssh -o StrictHostKeyChecking=no root@$ESERVER_IP nc -l 1234 > /tmp/server"
+{{template "ssh"}}$HOST "echo ssh -o StrictHostKeyChecking=no root@$ESERVER_IP nc -l 1234 > /tmp/server"
 
 -- run_srv.sh --
 . ./env
 
-echo {{template "ssh"}} 'sh /tmp/server > /tmp/out'
-{{template "ssh"}} 'sh /tmp/server > /tmp/out'
+echo {{template "ssh"}}$HOST 'sh /tmp/server > /tmp/out'
+{{template "ssh"}}$HOST 'sh /tmp/server > /tmp/out'
 
--- run_clent.sh --
+-- run_client.sh --
 . ./env
 
-echo {{template "ssh"}} "echo {{$test_msg}} | nc -N $ESERVER_IP 1234"
-{{template "ssh"}} "echo {{$test_msg}} | nc -N $ESERVER_IP 1234"
+echo {{template "ssh"}}$HOST "echo {{$test_msg}} | nc -N $ESERVER_IP 1234"
+{{template "ssh"}}$HOST "echo {{$test_msg}} | nc -N $ESERVER_IP 1234"
 
 -- get_result.sh --
 . ./env
 
-echo {{template "ssh"}} 'cat /tmp/out'
-{{template "ssh"}} 'cat /tmp/out'
+echo {{template "ssh"}}$HOST 'cat /tmp/out'
+{{template "ssh"}}$HOST 'cat /tmp/out'

--- a/tests/eclient/testdata/ngnix.txt
+++ b/tests/eclient/testdata/ngnix.txt
@@ -2,7 +2,7 @@
 {{$server := "ngnix"}}
 {{$test_msg := "Welcome to nginx!"}}
 {{define "port"}}2223{{end}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa root@localhost -p {{template "port"}}{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
@@ -11,9 +11,9 @@
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=2 &
 
-eden pod deploy -v debug -n eclient docker://itmoeve/eclient:latest -p {{template "port"}}:22
+eden pod deploy -v debug -n eclient --memory=512MB docker://itmoeve/eclient:latest -p {{template "port"}}:22
 
-eden pod deploy -v debug -n {{$server}} docker://nginx:latest
+eden pod deploy -v debug -n {{$server}} --memory=512MB docker://nginx:latest
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient {{$server}}
 
@@ -24,7 +24,7 @@ cp stdout pod_ps
 exec bash server_ip.sh {{$server}}
 
 exec sleep 10
-exec -t 1m bash run_clent.sh
+exec -t 1m bash run_client.sh
 stdout '{{$test_msg}}'
 
 eden pod delete eclient
@@ -43,20 +43,24 @@ test:
         model: {{EdenConfig "eve.devmodel"}}
 
 -- wait_ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
 
-for i in `seq 10`
+for i in `seq 20`
 do
-  sleep 5
+  sleep 20
   # Test SSH-access to container
-  echo {{template "ssh"}} grep -q Ubuntu /etc/issue && break
-  {{template "ssh"}} grep -q Ubuntu /etc/issue && break
+  echo {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue
+  {{template "ssh"}}$HOST grep -q Ubuntu /etc/issue && break
 done
 
 -- server_ip.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 echo export ESERVER_IP=$(grep "^$1\s" pod_ps | cut -f 4) > env
+echo export HOST=$($EDEN eve ip) >> env
 
--- run_clent.sh --
+-- run_client.sh --
 . ./env
 
-echo {{template "ssh"}} "curl $ESERVER_IP"
-{{template "ssh"}} "curl $ESERVER_IP"
+echo {{template "ssh"}}$HOST "curl $ESERVER_IP"
+until {{template "ssh"}}$HOST "curl $ESERVER_IP" | grep Welcome; do sleep 3; done

--- a/tests/vnc/vnc_test.go
+++ b/tests/vnc/vnc_test.go
@@ -22,7 +22,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// This test deploys the VM with image https://cloud-images.ubuntu.com/releases/focal/release-20200921.1/ubuntu-20.04-server-cloudimg-ARCH.img
+// This test deploys the VM with image https://cloud-images.ubuntu.com/releases/groovy/release-20201022.1/ubuntu-20.10-server-cloudimg-ARCH.img
 // with ARCH from config and vncDisplay into EVE
 // waits for the RUNNING state and checks access to VNC and SSH console
 // and removes app from EVE
@@ -36,7 +36,7 @@ var (
 	cpus         = flag.Uint("cpus", 1, "Cpu number for app")
 	memory       = flag.String("memory", "1G", "Memory for app")
 	metadata     = flag.String("metadata", "#cloud-config\npassword: passw0rd\nchpasswd: { expire: False }\nssh_pwauth: True\n", "Metadata to pass into VM")
-	appLink      = flag.String("applink", "https://cloud-images.ubuntu.com/releases/focal/release-20200921.1/ubuntu-20.04-server-cloudimg-%s.img", "Link to qcow2 image. You can pass %s for automatically set of arch (amd64/arm64)")
+	appLink      = flag.String("applink", "https://cloud-images.ubuntu.com/releases/groovy/release-20201022.1/ubuntu-20.10-server-cloudimg-%s.img", "Link to qcow2 image. You can pass %s for automatically set of arch (amd64/arm64)")
 	tc           *projects.TestContext
 	externalIP   string
 	externalPort int

--- a/tests/workflow/testdata/ssh.txt
+++ b/tests/workflow/testdata/ssh.txt
@@ -44,5 +44,5 @@ if [ $? -ne 0 ]; then
    PORT=22
 fi
 CERT=`echo {{EdenConfig "eden.root"}}/{{EdenConfig "eden.ssh-key"}} | sed 's/\.pub$//'`
-HOST=`$EDEN eve status|grep 'EVE Request IP'|grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}'`
+HOST=$($EDEN eve ip)
 until ssh -o ConnectTimeout=5 -oStrictHostKeyChecking=no -i $CERT -p $PORT root@$HOST cat /config/uuid; do sleep 10; done


### PR DESCRIPTION
We need to obtain host info from `eden eve status` to work in the distributed test system.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>