### PR TITLE
states list for failed app

### DIFF
--- a/cmd/edenPod.go
+++ b/cmd/edenPod.go
@@ -210,7 +210,7 @@ func getPortMapping(appConfig *config.AppInstanceConfig, qemuPorts map[string]st
 //podPsCmd is a command to list deployed apps
 var podPsCmd = &cobra.Command{
 	Use:   "ps",
-	Short: "List podsList",
+	Short: "List pods",
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		assignCobraToViper(cmd)
 		_, err := utils.LoadConfigFile(configFile)

--- a/tests/app/app_test.go
+++ b/tests/app/app_test.go
@@ -16,7 +16,7 @@ import (
 var (
 	timewait = flag.Duration("timewait", time.Minute, "Timewait for items waiting")
 	tc       *projects.TestContext
-	found    map[string]string
+	states   map[string][]string
 )
 
 // TestMain is used to provide setup and teardown for the rest of the
@@ -41,6 +41,24 @@ func TestMain(m *testing.M) {
 	os.Exit(res)
 }
 
+// checkNewLastState returns true if provided state not equals with last
+func checkNewLastState(appName, state string) bool {
+	appStates, ok := states[appName]
+	if ok {
+		lastState := appStates[len(appStates)-1]
+		if lastState != state {
+			return true
+		}
+	}
+	return false
+}
+
+func checkAndAppendState(appName, state string) {
+	if checkNewLastState(appName, state) {
+		states[appName] = append(states[appName], state)
+	}
+}
+
 //checkApp wait for info of ZInfoApp type with state
 func checkApp(state string, appNames []string) projects.ProcInfoFunc {
 	return func(msg *info.ZInfoMsg) error {
@@ -50,7 +68,7 @@ func checkApp(state string, appNames []string) projects.ProcInfoFunc {
 				foundAny := false
 				for _, app := range msg.GetDinfo().AppInstances {
 					if _, inSlice := utils.FindEleInSlice(appNames, app.Name); inSlice {
-						found[app.Name] = "EXISTS"
+						checkAndAppendState(app.Name, "EXISTS")
 						foundAny = true
 					}
 				}
@@ -68,12 +86,17 @@ func checkApp(state string, appNames []string) projects.ProcInfoFunc {
 			if msg.Ztype == info.ZInfoTypes_ZiApp {
 				app := msg.GetAinfo()
 				if _, inSlice := utils.FindEleInSlice(appNames, app.AppName); inSlice {
-					found[app.AppName] = app.State.String()
+					if len(app.AppErr) > 0 {
+						//if AppErr, show them
+						checkAndAppendState(app.AppName, fmt.Sprintf("%s: %s", app.State.String(), app.AppErr))
+					} else {
+						checkAndAppendState(app.AppName, app.State.String())
+					}
 				}
 			}
-			if len(found) == len(appNames) {
+			if len(states) == len(appNames) {
 				for _, appName := range appNames {
-					if astate, inFoundSlice := found[appName]; inFoundSlice && astate == state {
+					if !checkNewLastState(appName, state) {
 						out += fmt.Sprintf(
 							"app %s state %s\n",
 							appName, state)
@@ -104,17 +127,23 @@ func TestAppStatus(t *testing.T) {
 			args[1:], state, secs)
 
 		apps := args[1:]
-		found = make(map[string]string)
+		states = make(map[string][]string)
 		for _, el := range apps {
-			found[el] = "no info from controller"
+			states[el] = []string{"no info from controller"}
 		}
 
 		tc.AddProcInfo(edgeNode, checkApp(state, apps))
 
 		callback := func() {
 			t.Errorf("ASSERTION FAILED: expected apps %s in %s state", apps, state)
-			for k, v := range found {
-				t.Errorf("\tactual app %s: %s", k, v)
+			for k, v := range states {
+				t.Errorf("\tactual %s: %s", k, v[len(v)-1])
+				if checkNewLastState(k, state) {
+					t.Errorf("\thistory of states for %s:", k)
+					for _, st := range v {
+						t.Errorf("\t\t%s", st)
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
Add info about state transition for app with error.

```
        Docker app's state test
        === RUN   TestAppStatus
        apps: '[t1 t2]' state: 'RUNNING' secs: 600
            app_test.go:138: ASSERTION FAILED: expected apps [t1 t2] in RUNNING state
            app_test.go:140:    actual t1: RUNNING
            app_test.go:140:    actual t2: CREATING_VOLUME: [description:"PrepareContainerRootDir: Could not create snapshot e84c7307-1bbc-495f-8dbf-5d917e6f30d2#0.container. CreateSnapshotForImage: Exception while getting clientImageObj: 603d38b4-1a86-4b68-b4f8-4c91a047308b-library/nginx@sha256:34f3f875e745861ff8a37552ed7eb4b673544d2c56c7cc58f9a9bec5b4b3530e. image \"603d38b4-1a86-4b68-b4f8-4c91a047308b-library/nginx@sha256:34f3f875e745861ff8a37552ed7eb4b673544d2c56c7cc58f9a9bec5b4b3530e\": not found\n\n" timestamp:{seconds:1605190208 nanos:656274699}]
            app_test.go:142:    history of states for t2:
            app_test.go:144:            no info from controller
            app_test.go:144:            RESOLVING_TAG
            app_test.go:144:            DOWNLOAD_STARTED
            app_test.go:144:            LOADING
            app_test.go:144:            LOADING: [description:"Found error in content tree library/nginx:latest attached to volume t2_0_m_0: doUpdateContentTree(603d38b4-1a86-4b68-b4f8-4c91a047308b): IngestWorkResult error, exception while loading blobs into CAS: IngestBlobsAndCreateImage: could not reference 603d38b4-1a86-4b68-b4f8-4c91a047308b-library/nginx@sha256:34f3f875e745861ff8a37552ed7eb4b673544d2c56c7cc58f9a9bec5b4b3530e with rootBlob sha256:34f3f875e745861ff8a37552ed7eb4b673544d2c56c7cc58f9a9bec5b4b3530e: CreateImage: exception while parsing blob sha256:34f3f875e745861ff8a37552ed7eb4b673544d2c56c7cc58f9a9bec5b4b3530e: unable to get blob info for sha256:34f3f875e745861ff8a37552ed7eb4b673544d2c56c7cc58f9a9bec5b4b3530e: GetBlobInfo: Exception while getting size of blob: sha256:34f3f875e745861ff8a37552ed7eb4b673544d2c56c7cc58f9a9bec5b4b3530e. content digest sha256:34f3f875e745861ff8a37552ed7eb4b673544d2c56c7cc58f9a9bec5b4b3530e: not found\n\n" timestamp:{seconds:1605190206 nanos:112560822}]
            app_test.go:144:            CREATING_VOLUME
            app_test.go:144:            CREATING_VOLUME: [description:"PrepareContainerRootDir: Could not create snapshot e84c7307-1bbc-495f-8dbf-5d917e6f30d2#0.container. CreateSnapshotForImage: Exception while getting clientImageObj: 603d38b4-1a86-4b68-b4f8-4c91a047308b-library/nginx@sha256:34f3f875e745861ff8a37552ed7eb4b673544d2c56c7cc58f9a9bec5b4b3530e. image \"603d38b4-1a86-4b68-b4f8-4c91a047308b-library/nginx@sha256:34f3f875e745861ff8a37552ed7eb4b673544d2c56c7cc58f9a9bec5b4b3530e\": not found\n\n" timestamp:{seconds:1605190208 nanos:656274699}]
        --- FAIL: TestAppStatus (600.00s)
        FAIL
        [exit status 1]
        FAIL: ../app/testdata/2dockers_test.txt:20: command failure
        
--- FAIL: TestEdenScripts (0.00s)
    --- FAIL: TestEdenScripts/2dockers_test (609.16s)

```

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>