### PR TITLE
Added gotestsum for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ test: build
 $(EMPTY_DRIVE):
 	qemu-img create -f qcow2 $(EMPTY_DRIVE) 1G
 
-build-tests: build testbin
+build-tests: build testbin gotestsum
 install: build
 	CGO_ENABLED=0 go install .
 
@@ -73,6 +73,9 @@ $(BIN): $(LOCALBIN)
 
 testbin: config
 	make -C tests DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) build
+
+gotestsum:
+	go get gotest.tools/gotestsum
 
 config: build
 	$(LOCALBIN) config add default -v $(DEBUG) $(CONFIG)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -17,7 +17,9 @@ OS ?= $(HOSTOS)
 
 WORKDIR ?= $(CURDIR)/../dist
 
-test: $(TESTS:=_test)
+#test: $(TESTS:=_test)
+test:
+	gotestsum --jsonfile $(WORKDIR)/results.json --junitfile $(WORKDIR)/results.xml --raw-command -- go tool test2json -t ../eden test workflow -v debug
 
 build: $(TESTS:=_build)
 setup: $(TESTS:=_setup)
@@ -26,7 +28,7 @@ clean: $(TESTS:=_clean)
 .PHONY: test build setup clean all
 
 %_test: % %_build %_setup
-	make -C $$(dirname $<) DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) test
+	#make -C $$(dirname $<) DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) test
 
 %_build: %
 	make -C $$(dirname $<) DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) build


### PR DESCRIPTION
Added `gotestsum` setup to `make build-tests`. A test `workflow` with `gotestsum`, for example, can be started with the command:
```
EDEN_TEST=large make test
```
The results are placed in `dist/results.json` and `dist/results.xml` files.

Single test execution example:
```
gotestsum --junitfile /tmp/escript.message.test.xml --jsonfile /tmp/escript.message.test.json --raw-command -- go tool test2json -t ./eden test tests/escript -p eden.escript.test -r TestEdenScripts/message -v debug
```

Signed-off-by: Oleg Sadov <oleg.sadov@gmail.com>