### PR TITLE
Eden reset escript

### DIFF
--- a/cmd/edenTest.go
+++ b/cmd/edenTest.go
@@ -1,14 +1,10 @@
 package cmd
 
 import (
-	"fmt"
-	"io/ioutil"
 	"os"
-	"os/exec"
-	"strings"
-	"time"
 
 	"github.com/lf-edge/eden/pkg/defaults"
+	"github.com/lf-edge/eden/pkg/tests"
 	"github.com/lf-edge/eden/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -22,161 +18,9 @@ var (
 	testList     string
 	testProg     string
 	testScenario string
+	failScenario string
 	curDir       string
 )
-
-func printDebug() {
-	fmt.Println("POD LIST")
-	if err := podsList(log.InfoLevel); err != nil {
-		log.Warn(err)
-	}
-	fmt.Println()
-	fmt.Println("NET LIST")
-	if err := netList(log.InfoLevel); err != nil {
-		log.Warn(err)
-	}
-	fmt.Println()
-}
-
-func runTest(testApp string, args []string, testArgs string) {
-	if testApp != "" {
-		log.Debug("testApp: ", testApp)
-		vars, err := utils.InitVars()
-		if err != nil {
-			log.Fatalf("error reading config: %s\n", err)
-			return
-		}
-		_, err = exec.LookPath(testApp)
-		if err != nil {
-			testApp = utils.ResolveAbsPath(vars.EdenBinDir + "/" + testApp)
-		}
-
-		_, err = os.Stat(testApp)
-		if os.IsNotExist(err) {
-			log.Fatalf("Test binary file %s does not exist\n", testApp)
-			return
-		}
-		if err != nil {
-			log.Fatalf("Error reading test binary %s: %s", testApp, err)
-			return
-		}
-
-		path, err := exec.LookPath(testApp)
-		if err != nil {
-			log.Fatalf("Cannot find executable %s\n", testApp)
-			return
-		}
-
-		log.Debug("testProg: ", path)
-		if testTimeout != "" {
-			args = append(args, "-test.timeout", testTimeout)
-		}
-		if verbosity != "info" {
-			args = append(args, "-test.v")
-		}
-		done := make(chan bool, 1)
-		go func() {
-			ticker := time.NewTicker(defaults.DefaultRepeatTimeout * defaults.DefaultRepeatCount)
-			for {
-				select {
-				case tickTime := <-ticker.C:
-					//we need to log periodically to avoid stopping of ci/cd system
-					log.Infof("Test is running: %s", tickTime.Format(time.RFC3339))
-					printDebug()
-				case <-done:
-					ticker.Stop()
-					return
-				}
-			}
-		}()
-		resultArgs := append(args, strings.Fields(testArgs)...)
-		log.Debugf("Test: %s %s", path, strings.Join(resultArgs, " "))
-		tst := exec.Command(path, resultArgs...)
-		tst.Stdout = os.Stdout
-		tst.Stderr = os.Stderr
-		err = tst.Run()
-		close(done)
-		if err != nil {
-			printDebug()
-			os.Exit(1)
-		}
-	}
-}
-
-func runScenario(testArgs string) {
-	// is it path to file?
-	_, err := os.Stat(testScenario)
-	if os.IsNotExist(err) {
-		testScenario = utils.ResolveAbsPath(testScenario)
-		_, err = os.Stat(testScenario)
-		if os.IsNotExist(err) {
-			log.Fatalf("Scenario file %s is not exist\n", testScenario)
-			return
-		}
-		if err != nil {
-			log.Fatalf("Scenario file %s error reading: %s\n", testScenario, err)
-			return
-		}
-	}
-
-	log.Debug("testScenario:", testScenario)
-
-	tmpl, err := ioutil.ReadFile(testScenario)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	out, err := utils.RenderTemplate(configFile, string(tmpl))
-	if err != nil {
-		log.Fatal(err)
-	}
-	strs := strings.Split(out, "\n")
-	var targs []string
-	for _, str := range strs {
-		// Handle line comments
-		str = strings.Split(str, "#")[0]
-		str = strings.Split(str, "//")[0]
-		targs = strings.Split(str, " ")
-		for i, part := range targs {
-			// Handle defined args
-			flagsParsed := make(map[string]string)
-			// parse provided testArgs
-			flags := strings.Split(strings.Trim(testArgs, "\""), ",")
-			for _, el := range flags {
-				fl := strings.TrimPrefix(el, "-")
-				fl = strings.TrimPrefix(fl, "-")
-				split := strings.SplitN(fl, "=", 2)
-				if len(split) == 2 {
-					flagsParsed[strings.TrimSpace(split[0])] = strings.TrimSpace(split[1])
-				}
-			}
-			// parse args from scenario
-			splitStr := strings.SplitN(part, "args=\"", 2)
-			if len(splitStr) == 2 {
-				flags := strings.Split(strings.SplitN(splitStr[1], "\"", 2)[0], ",")
-				for _, el := range flags {
-					fl := strings.TrimPrefix(el, "-")
-					fl = strings.TrimPrefix(fl, "-")
-					split := strings.SplitN(fl, "=", 2)
-					if len(split) == 2 {
-						if _, ok := flagsParsed[strings.TrimSpace(split[0])]; !ok { // do not overwrite flags from args
-							flagsParsed[strings.TrimSpace(split[0])] = strings.TrimSpace(split[1])
-						}
-					}
-				}
-
-				// merge result map into args
-				var resultArgs []string
-				for k, v := range flagsParsed {
-					resultArgs = append(resultArgs, fmt.Sprintf("%s=%s", k, v))
-				}
-				targs[i] = fmt.Sprintf("-args=\"%s\"", strings.Join(resultArgs, ","))
-				log.Info(targs[i])
-			}
-		}
-		runTest(targs[0], targs[1:], testArgs)
-	}
-}
 
 var testCmd = &cobra.Command{
 	Use:   "test [test_dir]",
@@ -235,19 +79,16 @@ test <test_dir> -r <regexp> [-t <timewait>] [-v <level>]
 		}()
 		switch {
 		case testList != "":
-			runTest(testProg, []string{"-test.list", testList}, "")
+			tests.RunTest(testProg, []string{"-test.list", testList}, "", testTimeout, failScenario, configFile, verbosity)
 			return
 		case testOpts:
-			runTest(testProg, []string{"-h"}, "")
+			tests.RunTest(testProg, []string{"-h"}, "", testTimeout, failScenario, configFile, verbosity)
 			return
 		case testRun != "":
-			runTest(testProg, []string{"-test.run", testRun}, testArgs)
-			return
-		case testScenario != "":
-			runScenario(testArgs)
+			tests.RunTest(testProg, []string{"-test.run", testRun}, testArgs, testTimeout, failScenario, configFile, verbosity)
 			return
 		default:
-			runScenario(testArgs)
+			tests.RunScenario(testScenario, testArgs, testTimeout, failScenario, configFile, verbosity)
 			return
 		}
 	},
@@ -260,5 +101,6 @@ func testInit() {
 	testCmd.Flags().StringVarP(&testArgs, "args", "a", "", "Arguments for test binary")
 	testCmd.Flags().StringVarP(&testList, "list", "l", "", "list tests matching the regular expression")
 	testCmd.Flags().StringVarP(&testScenario, "scenario", "s", "", "scenario for tests bunch running")
+	testCmd.Flags().StringVarP(&failScenario, "fail_scenario", "f", "failScenario.txt", "scenario for test failing")
 	testCmd.Flags().BoolVarP(&testOpts, "opts", "o", false, "Options description for test binary which may be used in test scenarious and '-a|--args' option")
 }

--- a/pkg/tests/functions.go
+++ b/pkg/tests/functions.go
@@ -1,0 +1,162 @@
+package tests
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/lf-edge/eden/pkg/defaults"
+	"github.com/lf-edge/eden/pkg/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+//RunTest -- single test runner.
+func RunTest(testApp string, args []string, testArgs string, testTimeout string, failScenario string, configFile string, verbosity string) {
+	if testApp != "" {
+		log.Debug("testApp: ", testApp)
+		vars, err := utils.InitVars()
+		if err != nil {
+			log.Fatalf("error reading config: %s\n", err)
+			return
+		}
+		_, err = exec.LookPath(testApp)
+		if err != nil {
+			testApp = utils.ResolveAbsPath(vars.EdenBinDir + "/" + testApp)
+		}
+
+		_, err = os.Stat(testApp)
+		if os.IsNotExist(err) {
+			log.Fatalf("Test binary file %s does not exist\n", testApp)
+			return
+		}
+		if err != nil {
+			log.Fatalf("Error reading test binary %s: %s", testApp, err)
+			return
+		}
+
+		path, err := exec.LookPath(testApp)
+		if err != nil {
+			log.Fatalf("Cannot find executable %s\n", testApp)
+			return
+		}
+
+		log.Debug("testProg: ", path)
+		if testTimeout != "" {
+			args = append(args, "-test.timeout", testTimeout)
+		}
+		if verbosity != "info" {
+			args = append(args, "-test.v")
+		}
+		done := make(chan bool, 1)
+		go func() {
+			ticker := time.NewTicker(defaults.DefaultRepeatTimeout * defaults.DefaultRepeatCount)
+			for {
+				select {
+				case tickTime := <-ticker.C:
+					//we need to log periodically to avoid stopping of ci/cd system
+					log.Infof("Test is running: %s",
+						tickTime.Format(time.RFC3339))
+				case <-done:
+					ticker.Stop()
+					return
+				}
+			}
+		}()
+		resultArgs := append(args, strings.Fields(testArgs)...)
+		log.Debugf("Test: %s %s", path, strings.Join(resultArgs, " "))
+		tst := exec.Command(path, resultArgs...)
+		tst.Stdout = os.Stdout
+		tst.Stderr = os.Stderr
+		err = tst.Run()
+		close(done)
+		if err != nil && failScenario != "" {
+			log.Debug("failScenario: ", failScenario)
+			RunScenario("", "", testTimeout, "",
+				configFile, "")
+			os.Exit(1)
+		}
+	}
+}
+
+//RunScenario -- run a scenario with a test suite
+func RunScenario(testScenario string, testArgs string, testTimeout string, failScenario string, configFile string, verbosity string) {
+	if testScenario == "" {
+		return
+	}
+	// is it path to file?
+	_, err := os.Stat(testScenario)
+	if os.IsNotExist(err) {
+		testScenario = utils.ResolveAbsPath(testScenario)
+		_, err = os.Stat(testScenario)
+		if os.IsNotExist(err) {
+			log.Fatalf("Scenario file '%s' is not exist\n", testScenario)
+			return
+		}
+		if err != nil {
+			log.Fatalf("Scenario file '%s' error reading: %s\n", testScenario, err)
+			return
+		}
+	}
+
+	log.Debug("testScenario:", testScenario)
+
+	tmpl, err := ioutil.ReadFile(testScenario)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	out, err := utils.RenderTemplate(configFile, string(tmpl))
+	if err != nil {
+		log.Fatal(err)
+	}
+	strs := strings.Split(out, "\n")
+	var targs []string
+	for _, str := range strs {
+		// Handle line comments
+		str = strings.Split(str, "#")[0]
+		str = strings.Split(str, "//")[0]
+		targs = strings.Split(str, " ")
+		for i, part := range targs {
+			// Handle defined args
+			flagsParsed := make(map[string]string)
+			// parse provided testArgs
+			flags := strings.Split(strings.Trim(testArgs, "\""), ",")
+			for _, el := range flags {
+				fl := strings.TrimPrefix(el, "-")
+				fl = strings.TrimPrefix(fl, "-")
+				split := strings.SplitN(fl, "=", 2)
+				if len(split) == 2 {
+					flagsParsed[strings.TrimSpace(split[0])] = strings.TrimSpace(split[1])
+				}
+			}
+			// parse args from scenario
+			splitStr := strings.SplitN(part, "args=\"", 2)
+			if len(splitStr) == 2 {
+				flags := strings.Split(strings.SplitN(splitStr[1], "\"", 2)[0], ",")
+				for _, el := range flags {
+					fl := strings.TrimPrefix(el, "-")
+					fl = strings.TrimPrefix(fl, "-")
+					split := strings.SplitN(fl, "=", 2)
+					if len(split) == 2 {
+						if _, ok := flagsParsed[strings.TrimSpace(split[0])]; !ok { // do not overwrite flags from args
+							flagsParsed[strings.TrimSpace(split[0])] = strings.TrimSpace(split[1])
+						}
+					}
+				}
+
+				// merge result map into args
+				var resultArgs []string
+				for k, v := range flagsParsed {
+					resultArgs = append(resultArgs, fmt.Sprintf("%s=%s", k, v))
+				}
+				targs[i] = fmt.Sprintf("-args=\"%s\"", strings.Join(resultArgs, ","))
+				log.Info(targs[i])
+			}
+		}
+		RunTest(targs[0], targs[1:], testArgs, testTimeout,
+			failScenario, configFile, verbosity)
+	}
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -192,6 +192,12 @@ Scenarios to run after a fail:
 * for eden test: `-f, --fail_scenario string` (default dist/failScenario.txt)
 * for eden.escript.test: `-fail_scenario string`
 
+For automatic reset after the test's FAIL in default dist/failScenario.txt you need to set EDEN_FAIL_RESET env. var.:
+
+```console
+EDEN_FAIL_RESET=y ./eden test tests/escript/ -p eden.escript.test -r TestEdenScripts/fail_test
+```
+
 ## Test scripting
 
 Escript test binary `eden.escript.test` provides support for defining

--- a/tests/README.md
+++ b/tests/README.md
@@ -45,14 +45,15 @@ Usage:
   eden test [test_dir] [flags]
 
 Flags:
-  -a, --args string       Arguments for test binary
-  -h, --help              help for test
-  -l, --list string       list tests matching the regular expression
-  -o, --opts              Options description for test binary which may be used in test scenarious and '-a|--args' option
-  -p, --prog string       program binary to run tests
-  -r, --run string        run only those tests matching the regular expression
-  -s, --scenario string   scenario for tests bunch running
-  -t, --timeout string    panic if test exceded the timeout
+  -a, --args string            Arguments for test binary
+  -f, --fail_scenario string   scenario for test failing (default "failScenario.txt")
+  -h, --help                   help for test
+  -l, --list string            list tests matching the regular expression
+  -o, --opts                   Options description for test binary which may be used in test scenarious and '-a|--args' option
+  -p, --prog string            program binary to run tests
+  -r, --run string             run only those tests matching the regular expression
+  -s, --scenario string        scenario for tests bunch running
+  -t, --timeout string         panic if test exceded the timeout
 
 Global Flags:
       --config-file string   path to config file (default "~/.eden/contexts/default.yml")
@@ -185,6 +186,11 @@ The most commonly used commands are just test binaries with arguments.
 In scenarios, you can use inline comments in the Shell (#) and Go (//) styles.
 Comment blocks from Go templates {{/*comment*/}} can also be used.
 Example of scenario: [workflow/eden.workflow.tests.txt](workflow/eden.workflow.tests.txt).
+
+Scenarios to run after a fail:
+
+* for eden test: `-f, --fail_scenario string` (default dist/failScenario.txt)
+* for eden.escript.test: `-fail_scenario string`
 
 ## Test scripting
 

--- a/tests/escript/Makefile
+++ b/tests/escript/Makefile
@@ -51,7 +51,7 @@ $(TESTBIN): $(LOCALTESTBIN)
 	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN); fi
 
 setup: testbin
-	cp $(TESTSCN) $(WORKDIR)
+	cp custom.fail.scenario.txt failScenario.txt $(TESTSCN) $(WORKDIR)
 	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(CURDIR)/$(TESTBIN) $(BINDIR)/; fi
 	$(LOCALBIN) utils template eden-config.tmpl>eden-config.yml
 

--- a/tests/escript/custom.fail.scenario.txt
+++ b/tests/escript/custom.fail.scenario.txt
@@ -1,0 +1,1 @@
+/bin/echo Custom test fail scenario

--- a/tests/escript/eden.escript.tests.txt
+++ b/tests/escript/eden.escript.tests.txt
@@ -4,3 +4,4 @@ eden.escript.test -test.run TestEdenScripts/message
 eden.escript.test -test.run TestEdenScripts/nested_scripts
 eden.escript.test -test.run TestEdenScripts/time
 eden.escript.test -test.run TestEdenScripts/source
+eden.escript.test -test.run TestEdenScripts/fail_scenario

--- a/tests/escript/escript_test.go
+++ b/tests/escript/escript_test.go
@@ -2,6 +2,7 @@ package escript
 
 import (
 	"flag"
+	"github.com/lf-edge/eden/pkg/tests"
 	"github.com/lf-edge/eden/tests/escript/go-internal/testscript"
 	log "github.com/sirupsen/logrus"
 	"os"
@@ -10,6 +11,7 @@ import (
 )
 
 var testData = flag.String("testdata", "testdata", "Test script directory")
+var failScenario = flag.String("fail_scenario", "failScenario.txt", "Scenario that runs after a test fails")
 var args = flag.String("args", "", "Flags to pass into test")
 
 func TestEdenScripts(t *testing.T) {
@@ -35,4 +37,13 @@ func TestEdenScripts(t *testing.T) {
 		Dir:   *testData,
 		Flags: flagsParsed,
 	})
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	result := m.Run()
+	if result != 0 {
+		tests.RunScenario(*failScenario, "", "", "", "", "")
+	}
+	os.Exit(result)
 }

--- a/tests/escript/failScenario.txt
+++ b/tests/escript/failScenario.txt
@@ -1,0 +1,8 @@
+/bin/echo Default test fail scenario
+
+/bin/echo eden status
+eden status
+/bin/echo eden pod ps
+eden pod ps
+/bin/echo eden network ls
+eden network ls

--- a/tests/escript/failScenario.txt
+++ b/tests/escript/failScenario.txt
@@ -1,3 +1,5 @@
+{{$reset := EdenGetEnv "EDEN_FAIL_RESET"}}
+
 /bin/echo Default test fail scenario
 
 /bin/echo eden status
@@ -6,3 +8,8 @@ eden status
 eden pod ps
 /bin/echo eden network ls
 eden network ls
+
+{{ if (ne $reset "") }}
+/bin/echo EDEN's reset
+eden.escript.test -test.run TestEdenScripts/eden_reset -testdata {{EdenConfig "eden.root"}}/../tests/workflow/testdata/
+{{end}}

--- a/tests/escript/testdata/fail_scenario.txt
+++ b/tests/escript/testdata/fail_scenario.txt
@@ -1,0 +1,5 @@
+! test eden.escript.test -test.run TestEdenScripts/fail_test -test.v -testdata {{EdenConfig "eden.root"}}/../tests/escript/testdata/
+stdout 'Default test fail scenario'
+
+! test eden.escript.test -test.run TestEdenScripts/fail_test -test.v -testdata {{EdenConfig "eden.root"}}/../tests/escript/testdata/ -fail_scenario custom.fail.scenario.txt
+stdout 'Custom test fail scenario'

--- a/tests/escript/testdata/fail_test.txt
+++ b/tests/escript/testdata/fail_test.txt
@@ -1,0 +1,3 @@
+[!exec:false] stop
+
+exec false

--- a/tests/workflow/testdata/eden_reset.txt
+++ b/tests/workflow/testdata/eden_reset.txt
@@ -1,0 +1,46 @@
+[!exec:bash] stop
+[!exec:wc] stop
+
+eden eve reset
+stdout 'reset done'
+
+exec bash chk_pods.sh
+stdout '^1$'
+
+exec bash chk_nets.sh
+stdout '^1$'
+
+-- chk_pods.sh --
+#!/bin/bash
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+for i in `seq 10`
+do
+    echo Step $i pod ps
+    test `$EDEN pod ps | wc -l` -gt 1 || break
+    sleep 10
+done
+
+$EDEN pod ps | wc -l
+
+-- chk_nets.sh --
+#!/bin/bash
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+for i in `seq 10`
+do
+    echo Step $i network ls
+    test `$EDEN network ls | wc -l` -gt 1 || break
+    sleep 10
+done
+
+$EDEN network ls | wc -l
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}


### PR DESCRIPTION
Added eden_reset escript for reset of EDEN's state. Based on #363.

Running:
```
./eden test tests/workflow -p eden.escript.test -r TestEdenScripts/eden_reset -v debug
```
For automatic running after the test's FAIL you need to set EDEN_FAIL_RESET env. var.:
```
EDEN_FAIL_RESET=y ./eden test tests/escript/ -p eden.escript.test -r TestEdenScripts/fail_test
```
