### PR TITLE
fix ports permissions and make symlink

### DIFF
--- a/pkg/tests/functions.go
+++ b/pkg/tests/functions.go
@@ -39,7 +39,7 @@ func RunTest(testApp string, args []string, testArgs string, testTimeout string,
 
 		path, err := exec.LookPath(testApp)
 		if err != nil {
-			log.Fatalf("Cannot find executable %s\n", testApp)
+			log.Fatalf("Cannot find executable %s", testApp)
 			return
 		}
 

--- a/tests/eclient/Makefile
+++ b/tests/eclient/Makefile
@@ -32,6 +32,7 @@ TESTNAME := eden.eclient
 TESTBIN := $(TESTNAME).test
 TESTSCN := $(TESTNAME).tests.txt
 LOCALTESTBIN := $(TESTBIN)-$(OS)-$(ARCH)
+LINKDIR := ../../tests/eclient
 
 .DEFAULT_GOAL := help
 
@@ -51,7 +52,8 @@ build: setup
 setup:
 	$(LOCALBIN) utils template eden+ports.sh.tmpl > eden+ports.sh
 	$(LOCALBIN) utils template eden-ports.sh.tmpl > eden-ports.sh
-	cp eden+ports.sh eden-ports.sh $(BINDIR)/
+	chmod a+x eden+ports.sh eden-ports.sh
+	ln -sf $(LINKDIR)/eden+ports.sh $(LINKDIR)/eden-ports.sh $(BINDIR)/
 	cp $(TESTSCN) $(WORKDIR)
 	$(LOCALBIN) utils template eden-config.tmpl>eden-config.yml
 	chmod 700 image/cert/


### PR DESCRIPTION
Seems, that we need to set correct permissions for `eden+ports.sh` and `eden-ports.sh`.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>