### PR TITLE
Scripts for activate Shell's EDEN environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,9 @@ build: $(BIN) $(EMPTY_DRIVE) eserver
 endif
 $(LOCALBIN): $(BINDIR) cmd/*.go pkg/*/*.go pkg/*/*/*.go
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o $@ .
+	mkdir -p dist/scripts/shell
+	cp shell-scripts/* dist/scripts/shell/
+
 $(BIN): $(LOCALBIN)
 	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(BIN)-$(OS)-$(ARCH) $(BINDIR)/$@; fi
 	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(LOCALBIN) $@; fi
@@ -80,7 +83,7 @@ gotestsum:
 config: build
 	$(LOCALBIN) config add default -v $(DEBUG) $(CONFIG)
 
-setup: config
+setup: config build-tests
 	make -C tests DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) setup
 	$(LOCALBIN) setup -v $(DEBUG)
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ You need to use Parallels. ([Parallels Manual](./docs/parallels.md))
 git clone https://github.com/lf-edge/eden.git
 cd eden
 make clean
-make build
-eden config add default
-eden setup
+make build-tests
+./eden config add default
+./eden setup
+source ~/.eden/activate.sh
 eden start
 eden eve onboard
 eden status
-make build-tests
-eden test ./tests/docker
+eden test tests/workflow
 ```
 
 Note: Don't forget to call clean if you want to try the  installation again.
@@ -61,6 +61,23 @@ To find out what is running and where:
 ```console
 eden status
 ```
+
+## Eden's shell settings
+
+For more ease of use of Eden, you can use the automatically generated setup files for your shell:
+
+* for BASH -- `source ~/.eden/activate.sh`
+* for TCSH -- `source ~/.eden/activate.csh`
+
+These settings add the Eden's binaries directory to the PATH environment variable and add the "EDEN\_<current\_config>\_" label to the command prompt.
+
+In setup files defined some functions (BASH) and aliases (TCSH) for work with configs:
+
+* eden+config <config\_name> -- add new config for Eden
+* eden-config <config\_name> -- remove config from Eden and switch to 'default'
+* eden_config <config\_name> -- switch Eden to config and change prompt
+
+To deactivate this settings call `eden_deactivate` function.
 
 ## Eden Config
 

--- a/cmd/edenConfig.go
+++ b/cmd/edenConfig.go
@@ -244,7 +244,7 @@ var configSetCmd = &cobra.Command{
 			if el == args[0] {
 				context.SetContext(el)
 				if contextKeySet != "" {
-					_, err := utils.LoadConfigFile(context.GetCurrentConfig())
+					_, err := utils.LoadConfigFileContext(context.GetCurrentConfig())
 					if err != nil {
 						log.Fatalf("error reading config: %s", err.Error())
 					}

--- a/shell-scripts/activate.csh.tmpl
+++ b/shell-scripts/activate.csh.tmpl
@@ -1,0 +1,48 @@
+# This file must be used with "source bin/activate.csh" *from csh*.
+# You cannot run it directly.
+
+set newline='\
+'
+
+alias eden_deactivate 'test $?_OLD_EDEN_PATH != 0 && setenv PATH "$_OLD_EDEN_PATH:q" && unset _OLD_EDEN_PATH; rehash; test $?_OLD_EDEN_PROMPT != 0 && set prompt="$_OLD_EDEN_PROMPT:q" && unset _OLD_EDEN_PROMPT; unsetenv EDEN_HOME; test "\!:*" != "nondestructive" && unalias eden_deactivate && unalias eden_config && unalias eden+config && unalias eden-config'
+
+alias eden_config 'eden config set \!:1 && set prompt="EDEN-`eden config get`_$_OLD_EDEN_PROMPT:q"'
+
+alias eden+config 'cd `eden config get --key eden.root`/..; eden config add \!:1; cd -'
+alias eden-config 'eden config delete \!:1; eden_config default'
+
+# Unset irrelevant variables.
+eden_deactivate nondestructive
+
+setenv EDEN_HOME "{{EdenConfig "eden.root"}}"
+
+set _OLD_EDEN_PATH="$PATH:q"
+setenv PATH "$EDEN_HOME/{{EdenConfig "eden.bin-dist"}}:$PATH:q"
+
+if ( $?EDEN_DISABLE_PROMPT ) then
+    if ( $EDEN_DISABLE_PROMPT == "" ) then
+        set do_prompt = "1"
+    else
+        set do_prompt = "0"
+    endif
+else
+    set do_prompt = "1"
+endif
+
+if ( $do_prompt == "1" ) then
+    # Could be in a non-interactive environment,
+    # in which case, $prompt is undefined and we wouldn't
+    # care about the prompt anyway.
+    if ( $?prompt ) then
+        set _OLD_EDEN_PROMPT="$prompt:q"
+        if ( "$prompt:q" =~ *"$newline:q"* ) then
+            :
+        else
+            set prompt = "eden-`eden config get`_$prompt:q"
+        endif
+    endif
+endif
+
+unset do_prompt
+
+rehash

--- a/shell-scripts/activate.sh.tmpl
+++ b/shell-scripts/activate.sh.tmpl
@@ -1,0 +1,97 @@
+# This file must be used with "source bin/activate" *from bash*
+# you cannot run it directly
+
+if [ "${BASH_SOURCE-}" = "$0" ]; then
+    echo "You must source this script: \$ source $0" >&2
+    exit 33
+fi
+
+eden_deactivate () {
+    # reset old environment variables
+    # ! [ -z ${VAR+_} ] returns true if VAR is declared at all
+    if ! [ -z "${_OLD_EDEN_PATH:+_}" ] ; then
+        PATH="$_OLD_EDEN_PATH"
+        export PATH
+        unset _OLD_EDEN_PATH
+    fi
+
+    # This should detect bash and zsh, which have a hash command that must
+    # be called to get it to forget past commands.  Without forgetting
+    # past commands the $PATH changes we made may not be respected
+    if [ -n "${BASH-}" ] || [ -n "${ZSH_VERSION-}" ] ; then
+        hash -r 2>/dev/null
+    fi
+
+    if ! [ -z "${_OLD_EDEN_PS1+_}" ] ; then
+        PS1="$_OLD_EDEN_PS1"
+        export PS1
+        unset _OLD_EDEN_PS1
+    fi
+
+    unset EDEN_HOME
+    if [ ! "${1-}" = "nondestructive" ] ; then
+    # Self destruct!
+        unset -f eden_deactivate
+        unset -f eden_config
+        unset -f eden-config
+        unset -f eden+config
+    fi
+}
+
+eden_config () {
+    if [ $# -eq 0 ]
+    then
+        echo Usage: eden_config config
+        return
+    fi
+
+    eden config set $1
+    PS1="EDEN-`eden config get`_${_OLD_EDEN_PS1-}"
+}
+
+eden+config () {
+    if [ $# -eq 0 ]
+    then
+        echo Usage: eden+config config
+        return
+    fi
+
+    cd `eden config get --key eden.root`/..
+    eden config add $1
+    cd -
+}
+
+eden-config () {
+    if [ $# -eq 0 ]
+    then
+        echo Usage: eden-config config
+        return
+    fi
+
+    eden config delete $1
+    eden_config default
+}
+
+# unset irrelevant variables
+eden_deactivate nondestructive
+
+EDEN_HOME={{EdenConfig "eden.root"}}
+EDEN_BIN="$EDEN_HOME/{{EdenConfig "eden.bin-dist"}}"
+export EDEN_HOME
+
+_OLD_EDEN_PATH="$PATH"
+PATH="$EDEN_BIN:$PATH"
+export PATH
+
+if [ -z "${EDEN_HOME_DISABLE_PROMPT-}" ] ; then
+    _OLD_EDEN_PS1="${PS1-}"
+    PS1="EDEN-`eden config get`_${PS1-}"
+    export PS1
+fi
+
+# This should detect bash and zsh, which have a hash command that must
+# be called to get it to forget past commands.  Without forgetting
+# past commands the $PATH changes we made may not be respected
+if [ -n "${BASH-}" ] || [ -n "${ZSH_VERSION-}" ] ; then
+    hash -r 2>/dev/null
+fi

--- a/tests/app/Makefile
+++ b/tests/app/Makefile
@@ -49,11 +49,11 @@ testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
 $(TESTBIN): $(LOCALTESTBIN)
-	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN); fi
+	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then cp $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN); fi
 
 setup: testbin
 	cp $(TESTSCN) $(WORKDIR)
-	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(LINKDIR)/$(TESTBIN) $(BINDIR)/; fi
+	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then cp $(LINKDIR)/$(TESTBIN) $(BINDIR)/; fi
 	$(LOCALBIN) utils template eden-config.tmpl>eden-config.yml
 
 .PHONY: test build setup clean all testbin

--- a/tests/docker/Makefile
+++ b/tests/docker/Makefile
@@ -49,11 +49,11 @@ testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
 $(TESTBIN): $(LOCALTESTBIN)
-	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN); fi
+	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then cp $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN); fi
 
 setup: testbin
 	cp $(TESTSCN) $(WORKDIR)
-	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(LINKDIR)/$(TESTBIN) $(BINDIR)/; fi
+	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then cp $(LINKDIR)/$(TESTBIN) $(BINDIR)/; fi
 	$(LOCALBIN) utils template eden-config.tmpl>eden-config.yml
 
 .PHONY: test build setup clean all testbin

--- a/tests/eclient/Makefile
+++ b/tests/eclient/Makefile
@@ -50,10 +50,7 @@ test:
 build: setup
 
 setup:
-	$(LOCALBIN) utils template eden+ports.sh.tmpl > eden+ports.sh
-	$(LOCALBIN) utils template eden-ports.sh.tmpl > eden-ports.sh
-	chmod a+x eden+ports.sh eden-ports.sh
-	ln -sf $(LINKDIR)/eden+ports.sh $(LINKDIR)/eden-ports.sh $(BINDIR)/
+	cp eden+ports.sh eden-ports.sh $(BINDIR)/
 	cp $(TESTSCN) $(WORKDIR)
 	$(LOCALBIN) utils template eden-config.tmpl>eden-config.yml
 	chmod 700 image/cert/

--- a/tests/eclient/eden+ports.sh
+++ b/tests/eclient/eden+ports.sh
@@ -6,9 +6,10 @@ then
   exit
 fi
 
-EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+EDEN=eden
+CFG=$($EDEN config get)
 
-OLD=$($EDEN config get --key eve.hostfwd)
+OLD=$($EDEN config get "$CFG" --key eve.hostfwd)
 NEW=$OLD
 
 for port in "$@"
@@ -25,9 +26,10 @@ done
 
 if [ "$OLD" != "$NEW" ]
 then
-  echo $EDEN config set default --key eve.hostfwd --value \'"$NEW"\'
-  $EDEN config set default --key eve.hostfwd --value "$NEW"
-  $EDEN config get default --key eve.hostfwd
+  echo $EDEN config set "$CFG" --key eve.hostfwd --value \'"$NEW"\'
+  $EDEN config set "$CFG" --key eve.hostfwd --value "$NEW"
+  echo $EDEN config get "$CFG" --key eve.hostfwd
+  $EDEN config get "$CFG" --key eve.hostfwd
   echo $EDEN eve stop
   $EDEN eve stop
   sleep 5

--- a/tests/eclient/eden-ports.sh
+++ b/tests/eclient/eden-ports.sh
@@ -6,9 +6,10 @@ then
   exit
 fi
 
-EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+EDEN=eden
+CFG=$($EDEN config get)
 
-OLD=$($EDEN config get --key eve.hostfwd)
+OLD=$($EDEN config get "$CFG" --key eve.hostfwd)
 NEW=$OLD
 
 for port in "$@"
@@ -19,15 +20,16 @@ do
   if echo "$OLD" | grep "$port"
   then
     echo Removing "$port" port redirection to EDEN config
-    NEW=$(echo "$NEW" | sed "s/{\(.*\)$port\(.*\)}/{\1,\2}/;s/\(,\)\1/\1/g;s/,*}/}/")
+    NEW=$(echo "$NEW" | sed "s/{\(.*\)$port\(.*\)}/{\1,\2}/; s/\(,\)\1/\1/g; s/[, ]*}/}/; s/{[, ]\+/{/; s/\([^, ]\),[, ]\+\([^, ]\)/\1,\2/")
   fi
 done
 
 if [ "$OLD" != "$NEW" ]
 then
-  echo $EDEN config set default --key eve.hostfwd --value \'"$NEW"\'
-  $EDEN config set default --key eve.hostfwd --value "$NEW"
-  $EDEN config get default --key eve.hostfwd
+  echo $EDEN config set "$CFG" --key eve.hostfwd --value \'"$NEW"\'
+  $EDEN config set "$CFG" --key eve.hostfwd --value "$NEW"
+  echo $EDEN config get "$CFG" --key eve.hostfwd
+  $EDEN config get "$CFG" --key eve.hostfwd
   echo $EDEN eve stop
   $EDEN eve stop
   sleep 5

--- a/tests/eclient/eden.eclient.tests.txt
+++ b/tests/eclient/eden.eclient.tests.txt
@@ -1,4 +1,4 @@
-./eden+ports.sh 2223:2223 2224:2224
+eden+ports.sh 2223:2223 2224:2224
 # Just a simple test of eclient image functionality -- tested in more complex tests
 #eden.escript.test -test.run TestEdenScripts/eclient -test.timeout 15m
 eden.escript.test -test.run TestEdenScripts/host-only -test.timeout 15m
@@ -8,4 +8,4 @@ eden.escript.test -test.run TestEdenScripts/port_switch -test.timeout 20m
 # Just a simple test of nginx image -- tested in port_switch test
 #eden.escript.test -test.run TestEdenScripts/ngnix -test.timeout 20m
 eden.escript.test -test.run TestEdenScripts/maridb -test.timeout 20m
-./eden-ports.sh 2223:2223 2224:2224
+eden-ports.sh 2223:2223 2224:2224

--- a/tests/escript/Makefile
+++ b/tests/escript/Makefile
@@ -49,11 +49,11 @@ testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
 $(TESTBIN): $(LOCALTESTBIN)
-	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN); fi
+	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then cp $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN); fi
 
 setup: testbin
 	cp custom.fail.scenario.txt failScenario.txt $(TESTSCN) $(WORKDIR)
-	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(LINKDIR)/$(TESTBIN) $(BINDIR)/; fi
+	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then cp $(LINKDIR)/$(TESTBIN) $(BINDIR)/; fi
 	$(LOCALBIN) utils template eden-config.tmpl>eden-config.yml
 
 .PHONY: test build setup clean all testbin

--- a/tests/lim/Makefile
+++ b/tests/lim/Makefile
@@ -49,11 +49,11 @@ testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
 $(TESTBIN): $(LOCALTESTBIN)
-	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN); fi
+	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then cp $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN); fi
 
 setup: testbin
 	cp $(TESTSCN) $(WORKDIR)
-	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(LINKDIR)/$(TESTBIN) $(BINDIR)/; fi
+	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then cp $(LINKDIR)/$(TESTBIN) $(BINDIR)/; fi
 	$(LOCALBIN) utils template eden-config.tmpl>eden-config.yml
 
 .PHONY: test build setup clean all testbin

--- a/tests/reboot/Makefile
+++ b/tests/reboot/Makefile
@@ -49,11 +49,11 @@ testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
 $(TESTBIN): $(LOCALTESTBIN)
-	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN); fi
+	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then cp $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN); fi
 
 setup: testbin
 	cp $(TESTSCN) $(WORKDIR)
-	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(LINKDIR)/$(TESTBIN) $(BINDIR)/; fi
+	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then cp $(LINKDIR)/$(TESTBIN) $(BINDIR)/; fi
 	$(LOCALBIN) utils template eden-config.tmpl>eden-config.yml
 
 .PHONY: test build setup clean all testbin

--- a/tests/vnc/Makefile
+++ b/tests/vnc/Makefile
@@ -49,11 +49,11 @@ testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
 $(TESTBIN): $(LOCALTESTBIN)
-	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN); fi
+	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then cp $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN); fi
 
 setup: testbin
 	cp $(TESTSCN) $(WORKDIR)
-	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then ln -sf $(LINKDIR)/$(TESTBIN) $(BINDIR)/; fi
+	@if [ "$(OS)" = "$(HOSTOS)" -a "$(ARCH)" = "$(HOSTARCH)" ]; then cp $(LINKDIR)/$(TESTBIN) $(BINDIR)/; fi
 	$(LOCALBIN) utils template eden-config.tmpl>eden-config.yml
 
 .PHONY: test build setup clean all testbin

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -18,16 +18,15 @@ eden.escript.test -test.run TestEdenScripts/info_test -testdata ../lim/testdata/
 {{end}}
 /bin/echo Eden Metric test (7/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/metric_test -testdata ../lim/testdata/
+eden+ports.sh 2223:2223 2224:2224
 /bin/echo Eden Network test (8/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/test_networking -testdata ../network/testdata/
 /bin/echo Eden 2 dockers test (9/{{$tests}})
 #eden.escript.test -test.run TestEdenScripts/2dockers_test -testdata ../docker/testdata/
 eden.escript.test -test.run TestEdenScripts/2dockers_test -testdata ../app/testdata/
-
 {{ if eq $workflow "large" }}
 /bin/echo Eden VNC (9.5/{{$tests}})
 eden.vnc.test
-./eden+ports.sh 2223:2223 2224:2224
 /bin/echo Eden Host only ACL (11/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/host-only -testdata ../eclient/testdata/
 /bin/echo Eden Network light (12/{{$tests}})


### PR DESCRIPTION
For more ease of use of Eden, you can use the automatically generated setup files for your shell:

* for BASH -- `source ~/.eden/activate.sh`
* for TCSH -- `source ~/.eden/activate.csh`

These settings add the Eden's binaries directory to the PATH environment variable and add the "EDEN\_<current\_config>\_" label to the command prompt.

In setup files defined some functions (BASH) and aliases (TCSH) for work with configs with a workaround for current directory independence:

* `eden+config <config_name>` -- add new config for Eden
* `eden-config <config_name>` -- remove config from Eden and switch to 'default'
* `eden_config <config_name>` -- switch Eden to config and change prompt

To deactivate this settings call `eden_deactivate` function.

Signed-off-by: Oleg Sadov <oleg.sadov@gmail.com>