### PR TITLE
fix eclient to work with nohyper

### DIFF
--- a/tests/eclient/Makefile
+++ b/tests/eclient/Makefile
@@ -17,7 +17,7 @@ OS ?= $(HOSTOS)
 # IMAGE_TAG is the tag for image to build
 IMAGE_TAG ?= itmoeve/eclient
 # IMAGE_VERSION is the version of image to build
-IMAGE_VERSION ?= 0.2
+IMAGE_VERSION ?= 0.3
 # IMAGE_DIR is the directory with image Dockerfile to build
 IMAGE_DIR=$(CURDIR)/image
 

--- a/tests/eclient/image/Dockerfile
+++ b/tests/eclient/image/Dockerfile
@@ -29,6 +29,7 @@ COPY cert/id_rsa* /root/.ssh/
 COPY cert/id_rsa.pub /root/.ssh/authorized_keys
 RUN chown root:root /root/.ssh/
 RUN chmod 600 /root/.ssh/id_rsa*
+COPY entrypoint.sh /entrypoint.sh
 
 EXPOSE 22
-CMD ["/usr/sbin/sshd", "-D"]
+CMD ["/entrypoint.sh"]

--- a/tests/eclient/image/entrypoint.sh
+++ b/tests/eclient/image/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p /run/sshd
+/usr/sbin/sshd -D

--- a/tests/eclient/testdata/eclient.txt
+++ b/tests/eclient/testdata/eclient.txt
@@ -10,7 +10,7 @@
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=2 &
 
-eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:latest -p {{$port}}:22
+eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.3 -p {{$port}}:22
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 

--- a/tests/eclient/testdata/host-only.txt
+++ b/tests/eclient/testdata/host-only.txt
@@ -11,9 +11,9 @@
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=2 &
 
-eden pod deploy -n ping-nw --memory=512MB docker://itmoeve/eclient:latest -p 2223:22
-eden pod deploy -n ping-fw --memory=512MB docker://itmoeve/eclient:latest -p 2224:22 --only-host=true
-eden pod deploy -n pong --memory=512MB docker://itmoeve/eclient:latest
+eden pod deploy -n ping-nw --memory=512MB docker://itmoeve/eclient:0.3 -p 2223:22
+eden pod deploy -n ping-fw --memory=512MB docker://itmoeve/eclient:0.3 -p 2224:22 --only-host=true
+eden pod deploy -n pong --memory=512MB docker://itmoeve/eclient:0.3
 
 test eden.app.test -test.v -timewait 20m RUNNING ping-nw ping-fw pong
 

--- a/tests/eclient/testdata/maridb.txt
+++ b/tests/eclient/testdata/maridb.txt
@@ -13,7 +13,7 @@
 # Starting of reboot detector with a 2 reboot limit
 #! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=2 &
 
-eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:latest -p {{template "port"}}:22
+eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.3 -p {{template "port"}}:22
 
 eden pod deploy -n {{$server}} --memory=512MB docker://mariadb:10.5.6-focal --metadata='MYSQL_ROOT_PASSWORD=adam&eve'
 

--- a/tests/eclient/testdata/networking_light.txt
+++ b/tests/eclient/testdata/networking_light.txt
@@ -12,11 +12,11 @@
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=2 &
 
-eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:latest -p {{template "port"}}:22
+eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.3 -p {{template "port"}}:22
 #eden -t 20m pod logs eclient
 #stdout 'Executing "/usr/sbin/sshd" "-D"'
 
-eden pod deploy -v warning -n eserver --memory=512MB docker://itmoeve/eclient:latest
+eden pod deploy -v warning -n eserver --memory=512MB docker://itmoeve/eclient:0.3
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient eserver
 

--- a/tests/eclient/testdata/ngnix.txt
+++ b/tests/eclient/testdata/ngnix.txt
@@ -13,7 +13,7 @@
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=2 &
 
-eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:latest -p {{template "port"}}:22
+eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.3 -p {{template "port"}}:22
 
 eden pod deploy -n {{$server}} --memory=512MB docker://nginx:latest
 

--- a/tests/eclient/testdata/nw_switch.txt
+++ b/tests/eclient/testdata/nw_switch.txt
@@ -26,9 +26,9 @@ stdout '^n1\s'
 stdout '^n2\s'
 
 message 'Starting applications'
-eden pod deploy -v debug -n ping1 docker://itmoeve/eclient:latest -p 2223:22 --networks=n1 --memory=512MB
-eden pod deploy -v debug -n ping2 docker://itmoeve/eclient:latest -p 2224:22 --networks=n2 --memory=512MB
-eden pod deploy -v debug -n pong docker://itmoeve/eclient:latest --networks=n1 --memory=512MB
+eden pod deploy -v debug -n ping1 docker://itmoeve/eclient:0.3 -p 2223:22 --networks=n1 --memory=512MB
+eden pod deploy -v debug -n ping2 docker://itmoeve/eclient:0.3 -p 2224:22 --networks=n2 --memory=512MB
+eden pod deploy -v debug -n pong docker://itmoeve/eclient:0.3 --networks=n1 --memory=512MB
 
 message 'Waiting of running'
 test eden.app.test -test.v -timewait 20m RUNNING ping1 ping2 pong


### PR DESCRIPTION
Seems, that we need to create directory inside entrypoint. For --no-hyper variant we see now:
`Missing privilege separation directory: /run/sshd`

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>