### PR TITLE
debug-container and perf test

### DIFF
--- a/.yetus-excludes
+++ b/.yetus-excludes
@@ -2,3 +2,4 @@
 .*go.sum
 tests/escript/go-internal/internal/syscall/windows/.*
 tests/eclient/testdata/maridb\.txt
+tests/debug-container/image/abuild/.*

--- a/.yetus/blanks-tabs.txt
+++ b/.yetus/blanks-tabs.txt
@@ -2,3 +2,4 @@
 .*\.go
 .*\.md
 tests/eclient/testdata/maridb\.txt
+tests/debug-container/image/abuild/.*

--- a/.yetus/excludes.txt
+++ b/.yetus/excludes.txt
@@ -1,3 +1,4 @@
 ^.*go.mod
 ^.*go.sum
 tests/eclient/testdata/maridb\.txt
+tests/debug-container/image/abuild/.*

--- a/tests/debug-container/Makefile
+++ b/tests/debug-container/Makefile
@@ -1,0 +1,63 @@
+DEBUG ?= "debug"
+
+# HOSTARCH is the host architecture
+# ARCH is the target architecture
+# we need to keep track of them separately
+HOSTARCH ?= $(shell uname -m)
+HOSTOS ?= $(shell uname -s | tr A-Z a-z)
+
+# canonicalized names for host architecture
+override HOSTARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(HOSTARCH)))
+
+# unless otherwise set, I am building for my own architecture, i.e. not cross-compiling
+# and for my OS
+ARCH ?= $(HOSTARCH)
+OS ?= $(HOSTOS)
+
+# canonicalized names for target architecture
+override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
+
+WORKDIR ?= $(CURDIR)/../../dist
+BINDIR := $(WORKDIR)/bin
+BIN := eden
+LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
+TESTNAME := eden.debug-container
+TESTBIN := $(TESTNAME).test
+TESTSCN := $(TESTNAME).tests.txt
+LOCALTESTBIN := $(TESTBIN)-$(OS)-$(ARCH)
+LINKDIR := ../../tests/debug-container
+
+.DEFAULT_GOAL := help
+
+clean:
+	rm -rf $(LOCALTESTBIN) $(BINDIR)/$(TESTBIN) $(WORKDIR)/$(TESTSCN) $(CURDIR)/$(TESTBIN) $(BINDIR)/$(TESTBIN)
+
+$(WORKDIR):
+	mkdir -p $@
+$(BINDIR):
+	mkdir -p $@
+
+test:
+	$(LOCALBIN) test $(CURDIR) -v $(DEBUG)
+
+build: setup
+
+setup:
+	cp $(TESTSCN) $(WORKDIR)
+	$(LOCALBIN) utils template eden-config.tmpl>eden-config.yml
+
+.PHONY: test build setup clean all testbin
+
+help:
+	@echo "EDEN is the harness for testing EVE and ADAM"
+	@echo
+	@echo "This Makefile automates commons tasks of EDEN testing"
+	@echo
+	@echo "Commonly used maintenance and development targets:"
+	@echo "   build         build test-binary (OS and ARCH options supported, for ex. OS=linux ARCH=arm64)"
+	@echo "   setup         setup of test environment"
+	@echo "   test          run tests"
+	@echo "   clean         cleanup of test harness"
+	@echo
+	@echo "You need install requirements for EVE (look at https://github.com/lf-edge/eve#install-dependencies)."
+	@echo "You need access to docker socket and installed qemu packages."

--- a/tests/debug-container/eden-config.tmpl
+++ b/tests/debug-container/eden-config.tmpl
@@ -1,0 +1,14 @@
+eden:
+    #test binary
+    test-bin: "eden.debug-container.test"
+
+    #test scenario
+    test-scenario: "eden.debug-container.tests.txt"
+
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/debug-container/eden.debug-container.tests.txt
+++ b/tests/debug-container/eden.debug-container.tests.txt
@@ -1,0 +1,1 @@
+eden.escript.test -test.run TestEdenScripts/perf_test

--- a/tests/debug-container/testdata/perf_test.txt
+++ b/tests/debug-container/testdata/perf_test.txt
@@ -1,0 +1,40 @@
+# perf test for 10 seconds on EVE
+# output of test is located inside {{EdenConfig "eden.root"}}/perf.data
+
+{{$test_opts := "-test.v -timewait 120"}}
+
+[!exec:ssh] stop
+[!exec:bash] stop
+[!exec:rm] stop
+
+# Set kernel parameters
+eden eve ssh 'echo -1 >/proc/sys/kernel/perf_event_paranoid'
+eden eve ssh 'echo 0 >/proc/sys/kernel/kptr_restrict'
+
+# Run perf for 10 seconds
+eden eve ssh 'perf record -F 99 -a -g -o /persist/perf.data sleep 10'
+
+# Obtain perf results
+exec -t 1m bash get.sh
+
+! stdout 'file is empty'
+
+exists {{EdenConfig "eden.root"}}/perf.data
+
+message 'Please see output in {{EdenConfig "eden.root"}}/perf.data'
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- get.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+rm -rf {{EdenConfig "eden.root"}}/perf.data
+$EDEN eve ssh 'cat /persist/perf.data' >{{EdenConfig "eden.root"}}/perf.data
+[ -s {{EdenConfig "eden.root"}}/perf.data ] || echo "file is empty"


### PR DESCRIPTION
Integration of debug-container from https://github.com/lf-edge/eve/pull/1688 into Eden test.
`perf_test` modifies kernel params via `eden eve ssh`, runs debug-container and sends command via ssh to container to run `perf` inside for 10 seconds. Then it loads `perf.data` into `dist/perf.data`.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>