### PR TITLE
GetEdgeNode by onboarding key if exists

### DIFF
--- a/pkg/projects/edgeNodeDescription.go
+++ b/pkg/projects/edgeNodeDescription.go
@@ -10,6 +10,23 @@ type EdgeNodeDescription struct {
 	Model  string
 }
 
+//GetEdgeNode returns EdgeNode for provided EdgeNodeDescription based on onboarding key (if exists) or name
+func (nodeDescription *EdgeNodeDescription) GetEdgeNode(tc *TestContext) *device.Ctx {
+	ctrl := tc.GetController()
+	if nodeDescription.Key != "" {
+		id, err := ctrl.DeviceGetByOnboard(nodeDescription.Key)
+		if err != nil {
+			return nil
+		}
+		dev, err := ctrl.GetDeviceUUID(id)
+		if err != nil {
+			return nil
+		}
+		return dev
+	}
+	return ctrl.GetEdgeNode(nodeDescription.Name)
+}
+
 //EdgeNodeOption is type to use for creation of device.Ctx
 type EdgeNodeOption func(description *device.Ctx)
 

--- a/pkg/projects/testContext.go
+++ b/pkg/projects/testContext.go
@@ -118,7 +118,7 @@ func (tc *TestContext) InitProject(name string) {
 //AddEdgeNodesFromDescription adds EdgeNodes from description in test.eve param
 func (tc *TestContext) AddEdgeNodesFromDescription() {
 	for _, node := range tc.GetNodeDescriptions() {
-		edgeNode := tc.GetController().GetEdgeNode(node.Name)
+		edgeNode := node.GetEdgeNode(tc)
 		if edgeNode == nil {
 			edgeNode = tc.NewEdgeNode(tc.WithNodeDescription(node), tc.WithCurrentProject())
 		} else {

--- a/tests/lim/lim_test.go
+++ b/tests/lim/lim_test.go
@@ -87,7 +87,7 @@ func TestMain(m *testing.M) {
 	// or UUIDs that were passed in) in the context. This is the first place
 	// where we're using zcli-like API:
 	for _, node := range tc.GetNodeDescriptions() {
-		edgeNode := tc.GetController().GetEdgeNode(node.Name)
+		edgeNode := node.GetEdgeNode(tc)
 		if edgeNode == nil {
 			// Couldn't find existing edgeNode record in the controller.
 			// Need to create it from scratch now:

--- a/tests/reboot/reboot_test.go
+++ b/tests/reboot/reboot_test.go
@@ -70,7 +70,7 @@ func TestMain(m *testing.M) {
 	// or UUIDs that were passed in) in the context. This is the first place
 	// where we're using zcli-like API:
 	for _, node := range tc.GetNodeDescriptions() {
-		edgeNode := tc.GetController().GetEdgeNode(node.Name)
+		edgeNode := node.GetEdgeNode(tc)
 		if edgeNode == nil {
 			// Couldn't find existing edgeNode record in the controller.
 			// Need to create it from scratch now:


### PR DESCRIPTION
Seems, that we need to get node inside tests by onboarding key. It helps us to avoid inconsistent states when we have multiple EVE inside controller.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>