### PR TITLE
multiple directories

### DIFF
--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -56,14 +56,19 @@ var certsCmd = &cobra.Command{
 				log.Fatal(err)
 			}
 		}
-		if _, err := os.Stat(utils.ResolveAbsPath(defaults.DefaultCertsDist)); os.IsNotExist(err) {
-			if err = os.MkdirAll(utils.ResolveAbsPath(defaults.DefaultCertsDist), 0755); err != nil {
+		edenHome, err := utils.DefaultEdenDir()
+		if err != nil {
+			log.Fatal(err)
+		}
+		globalCertsDir := filepath.Join(edenHome, defaults.DefaultCertsDist)
+		if _, err := os.Stat(globalCertsDir); os.IsNotExist(err) {
+			if err = os.MkdirAll(globalCertsDir, 0755); err != nil {
 				log.Fatal(err)
 			}
 		}
 		log.Debug("generating CA")
-		caCertPath := filepath.Join(utils.ResolveAbsPath(defaults.DefaultCertsDist), "root-certificate.pem")
-		caKeyPath := filepath.Join(utils.ResolveAbsPath(defaults.DefaultCertsDist), "root-certificate-key.pem")
+		caCertPath := filepath.Join(globalCertsDir, "root-certificate.pem")
+		caKeyPath := filepath.Join(globalCertsDir, "root-certificate-key.pem")
 		rootCert, rootKey := utils.GenCARoot()
 		if _, err := tls.LoadX509KeyPair(caCertPath, caKeyPath); err == nil { //existing certs looks ok
 			log.Info("Use existing certs")
@@ -79,8 +84,8 @@ var certsCmd = &cobra.Command{
 		if err := utils.WriteToFiles(rootCert, rootKey, caCertPath, caKeyPath); err != nil {
 			log.Fatal(err)
 		}
-		serverCertPath := filepath.Join(utils.ResolveAbsPath(defaults.DefaultCertsDist), "server.pem")
-		serverKeyPath := filepath.Join(utils.ResolveAbsPath(defaults.DefaultCertsDist), "server-key.pem")
+		serverCertPath := filepath.Join(globalCertsDir, "server.pem")
+		serverKeyPath := filepath.Join(globalCertsDir, "server-key.pem")
 		if _, err := tls.LoadX509KeyPair(serverCertPath, serverKeyPath); err != nil {
 			log.Debug("generating Adam cert and key")
 			ips := []net.IP{net.ParseIP(certsIP), net.ParseIP(certsEVEIP), net.ParseIP("127.0.0.1")}

--- a/pkg/eden/eden.go
+++ b/pkg/eden/eden.go
@@ -100,8 +100,13 @@ func StatusRedis() (status string, err error) {
 //StartAdam function run adam in docker with mounted adamPath/run:/adam/run
 //if adamForce is set, it recreates container
 func StartAdam(adamPort int, adamPath string, adamForce bool, adamTag string, adamRemoteRedisURL string, opts ...string) (err error) {
-	serverCertPath := filepath.Join(utils.ResolveAbsPath(defaults.DefaultCertsDist), "server.pem")
-	serverKeyPath := filepath.Join(utils.ResolveAbsPath(defaults.DefaultCertsDist), "server-key.pem")
+	edenHome, err := utils.DefaultEdenDir()
+	if err != nil {
+		return err
+	}
+	globalCertsDir := filepath.Join(edenHome, defaults.DefaultCertsDist)
+	serverCertPath := filepath.Join(globalCertsDir, "server.pem")
+	serverKeyPath := filepath.Join(globalCertsDir, "server-key.pem")
 	cert, err := ioutil.ReadFile(serverCertPath)
 	if err != nil {
 		return fmt.Errorf("cannot load %s: %s", serverCertPath, err)

--- a/pkg/utils/container.go
+++ b/pkg/utils/container.go
@@ -3,9 +3,7 @@ package utils
 import (
 	"archive/tar"
 	"bufio"
-	"crypto/md5"
 	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -54,11 +52,7 @@ func CreateDockerNetwork(name string) error {
 }
 
 func dockerVolumeName(containerName string) string {
-	distPath := ResolveAbsPath(".")
-	hasher := md5.New()
-	_, _ = hasher.Write([]byte(distPath))
-	hashMD5 := hasher.Sum(nil)
-	return fmt.Sprintf("%s_%s", containerName, hex.EncodeToString(hashMD5))
+	return fmt.Sprintf("%s_volume", containerName)
 }
 
 //RemoveGeneratedVolumeOfContainer remove volumes created by eden


### PR DESCRIPTION
Changes to support multiple directories with eden:

- Moving certificates of Adam to `~/.eden/certs`
- Remove logic of generate names for volumes by directory

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>