### PR TITLE
pattern fix

### DIFF
--- a/tests/lim/testdata/log_test.txt
+++ b/tests/lim/testdata/log_test.txt
@@ -5,7 +5,7 @@ exec -t 5m bash ssh.sh &
 
 # Trying to find messages about ssh in log
 {{$test1}} -out content 'content:.*Disconnected.*'
-stdout 'Disconnected from user root'
+stdout 'Disconnected from'
 
 # Test's config. file
 -- eden-config.yml --


### PR DESCRIPTION
Seems, that on gcp we have another line in log: `Disconnected from 222.187.222.53 port 49207 [preauth]`

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>