### PR TITLE
tests for different context

### DIFF
--- a/cmd/edenStatus.go
+++ b/cmd/edenStatus.go
@@ -165,6 +165,8 @@ var statusCmd = &cobra.Command{
 			if el == currentContext || allConfigs {
 				fmt.Printf("--- context: %s ---\n", el)
 				context.SetContext(el)
+				configName = el
+				evePidFile = utils.ResolveAbsPath(fmt.Sprintf("%s-eve.pid", el))
 				_, err := utils.LoadConfigFileContext(context.GetCurrentConfig())
 				if err != nil {
 					log.Fatalf("error reading config: %s", err.Error())
@@ -196,9 +198,9 @@ var statusCmd = &cobra.Command{
 					eveRequestsAdam()
 				}
 				fmt.Println("------")
-				context.SetContext(currentContext)
 			}
 		}
+		context.SetContext(currentContext)
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,10 @@ var configName string
 var configFile string
 
 var rootCmd = &cobra.Command{Use: "eden", PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+	configNameEnv := os.Getenv(defaults.DefaultConfigEnv)
+	if configNameEnv != "" {
+		configName = configNameEnv
+	}
 	configFile = utils.GetConfig(configName)
 	if verbosity == "debug" {
 		fmt.Println("configName: ", configName)

--- a/pkg/controller/device.go
+++ b/pkg/controller/device.go
@@ -15,7 +15,6 @@ import (
 	"github.com/lf-edge/eve/api/go/config"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -29,25 +28,14 @@ func (cloud *CloudCtx) StateUpdate(dev *device.Ctx) (err error) {
 	if err != nil {
 		return err
 	}
-	edenConfig, err := utils.DefaultConfigPath()
-	if err != nil {
-		return err
-	}
-	loaded, err := utils.LoadConfigFile(edenConfig)
-	if err != nil {
-		return err
-	}
-	if loaded {
-		return utils.GenerateStateFile(edenDir, utils.StateObject{
-			EveConfig:  string(devConfig),
-			EveDir:     viper.GetString("eve.dist"),
-			AdamDir:    cloud.GetDir(),
-			EveUUID:    viper.GetString("eve.uuid"),
-			DeviceUUID: dev.GetID().String(),
-			QEMUConfig: viper.GetString("eve.qemu-config"),
-		})
-	}
-	return fmt.Errorf("cannot load config %s", edenConfig)
+	return utils.GenerateStateFile(edenDir, utils.StateObject{
+		EveConfig:  string(devConfig),
+		EveDir:     cloud.GetVars().EveDist,
+		AdamDir:    cloud.GetDir(),
+		EveUUID:    cloud.GetVars().EveUUID,
+		DeviceUUID: dev.GetID().String(),
+		QEMUConfig: cloud.GetVars().EveQemuConfig,
+	})
 }
 
 type idCheckable interface {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -28,6 +28,8 @@ const (
 	DefaultConfigSaved      = "config_saved.yml" //file to save config during 'eden setup'
 
 	DefaultContext = "default" //default context name
+
+	DefaultConfigEnv = "EDEN_CONFIG" //default env for set config
 )
 
 //domains, ips, ports
@@ -200,5 +202,7 @@ var (
 		"eden.test-scenario": "scenario",
 
 		"gcp.key": "key",
+
+		"config": "config",
 	}
 )

--- a/pkg/projects/testContext.go
+++ b/pkg/projects/testContext.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lf-edge/eden/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -44,7 +45,13 @@ type TestContext struct {
 
 //NewTestContext creates new TestContext
 func NewTestContext() *TestContext {
-	viperLoaded, err := utils.LoadConfigFile("")
+	var err error
+	viperLoaded := false
+	if edenConfigEnv := os.Getenv(defaults.DefaultConfigEnv); edenConfigEnv != "" {
+		viperLoaded, err = utils.LoadConfigFile(utils.GetConfig(edenConfigEnv))
+	} else {
+		viperLoaded, err = utils.LoadConfigFile("")
+	}
 	if err != nil {
 		log.Fatalf("LoadConfigFile %s", err)
 	}

--- a/pkg/tests/functions.go
+++ b/pkg/tests/functions.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"github.com/spf13/viper"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -63,6 +64,7 @@ func RunTest(testApp string, args []string, testArgs string, testTimeout string,
 		tst := exec.Command(path, resultArgs...)
 		tst.Stdout = os.Stdout
 		tst.Stderr = os.Stderr
+		tst.Env = append(os.Environ(), fmt.Sprintf("%s=%s", defaults.DefaultConfigEnv, viper.Get("eve.name")))
 		err = tst.Run()
 		close(done)
 

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -37,6 +37,8 @@ type ConfigVars struct {
 	EveRemote         bool
 	EveRemoteAddr     string
 	EveQemuPorts      map[string]string
+	EveQemuConfig     string
+	EveDist           string
 	SSHKey            string
 	EveCert           string
 	EveDeviceCert     string
@@ -68,18 +70,31 @@ func InitVars() (*ConfigVars, error) {
 		}
 	}
 	if loaded {
+		edenHome, err := DefaultEdenDir()
+		if err != nil {
+			log.Fatal(err)
+		}
+		globalCertsDir := filepath.Join(edenHome, defaults.DefaultCertsDist)
+		if _, err := os.Stat(globalCertsDir); os.IsNotExist(err) {
+			if err = os.MkdirAll(globalCertsDir, 0755); err != nil {
+				log.Fatal(err)
+			}
+		}
+		caCertPath := filepath.Join(globalCertsDir, "root-certificate.pem")
 		var vars = &ConfigVars{
 			AdamIP:            viper.GetString("adam.ip"),
 			AdamPort:          viper.GetString("adam.port"),
 			AdamDomain:        viper.GetString("adam.domain"),
 			AdamDir:           ResolveAbsPath(viper.GetString("adam.dist")),
-			AdamCA:            ResolveAbsPath(viper.GetString("adam.ca")),
+			AdamCA:            caCertPath,
 			AdamRedisURLEden:  viper.GetString("adam.redis.eden"),
 			AdamRedisURLAdam:  viper.GetString("adam.redis.adam"),
 			SSHKey:            ResolveAbsPath(viper.GetString("eden.ssh-key")),
 			EveCert:           ResolveAbsPath(viper.GetString("eve.cert")),
 			EveDeviceCert:     ResolveAbsPath(viper.GetString("eve.device-cert")),
 			EveSerial:         viper.GetString("eve.serial"),
+			EveDist:           viper.GetString("eve.dist"),
+			EveQemuConfig:     viper.GetString("eve.qemu-config"),
 			ZArch:             viper.GetString("eve.arch"),
 			EveSSID:           viper.GetString("eve.ssid"),
 			EveHV:             viper.GetString("eve.hv"),

--- a/pkg/utils/context.go
+++ b/pkg/utils/context.go
@@ -81,6 +81,15 @@ func ContextLoad() (*Context, error) {
 	if err != nil {
 		return nil, fmt.Errorf("context Load DefaultEdenDir error: %s", err)
 	}
+	edenConfigEnv := os.Getenv(defaults.DefaultConfigEnv)
+	if edenConfigEnv != "" {
+		ctx, err := ContextInit()
+		if err != nil {
+			return nil, fmt.Errorf("ContextInit error: %s", err)
+		}
+		ctx.Current = edenConfigEnv
+		return ctx, nil
+	}
 	contextFile := filepath.Join(edenDir, defaults.DefaultContextFile)
 	if _, err := os.Stat(contextFile); os.IsNotExist(err) {
 		return ContextInit()

--- a/tests/escript/go-internal/testscript/testscript.go
+++ b/tests/escript/go-internal/testscript/testscript.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eden/tests/escript/go-internal/imports"
 	"github.com/lf-edge/eden/tests/escript/go-internal/internal/os/execpath"
 	"github.com/lf-edge/eden/tests/escript/go-internal/par"
@@ -305,6 +306,9 @@ func (ts *TestScript) setup() string {
 		Values:  make(map[interface{}]interface{}),
 		Cd:      ts.workdir,
 		ts:      ts,
+	}
+	if configEnv := os.Getenv(defaults.DefaultConfigEnv); configEnv != "" {
+		env.Vars = append(env.Vars, fmt.Sprintf("%s=%s", defaults.DefaultConfigEnv, configEnv))
 	}
 	// MacOS envs set
 	if runtime.GOOS == "darwin" {


### PR DESCRIPTION
The ability to run tests for another config:
```
make build-tests
./eden config add default
./eden config add t1
./eden --config=t1 test tests/workflow/ -v debug
```

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>