### PR TITLE
First cut at allowing baseOS images to be loaded from OCI containers

### DIFF
--- a/cmd/edenController.go
+++ b/cmd/edenController.go
@@ -87,7 +87,7 @@ func checkIsFileOrURL(pathToCheck string) (isFile bool, pathToRet string, err er
 }
 
 var edgeNodeEVEImageUpdate = &cobra.Command{
-	Use:   "eveimage-update <image file or url (file:// or http(s)://)>",
+	Use:   "eveimage-update <image file or url (oci:// or file:// or http(s)://)>",
 	Short: "update EVE image",
 	Long:  `Update EVE image.`,
 	Args:  cobra.ExactArgs(1),
@@ -131,7 +131,7 @@ var edgeNodeEVEImageUpdate = &cobra.Command{
 }
 
 var edgeNodeEVEImageRemove = &cobra.Command{
-	Use:   "eveimage-remove <image file or url (file:// or http(s)://)>",
+	Use:   "eveimage-remove <image file or url (oci:// or file:// or http(s)://)>",
 	Short: "remove EVE image",
 	Long:  `Remove EVE image.`,
 	Args:  cobra.ExactArgs(1),

--- a/cmd/edenController.go
+++ b/cmd/edenController.go
@@ -81,6 +81,10 @@ func checkIsFileOrURL(pathToCheck string) (isFile bool, pathToRet string, err er
 		return false, pathToCheck, nil
 	case "https":
 		return false, pathToCheck, nil
+	case "oci":
+		return false, pathToCheck, nil
+	case "docker":
+		return false, pathToCheck, nil
 	default:
 		return false, "", fmt.Errorf("%s scheme not supported now", res.Scheme)
 	}
@@ -160,14 +164,26 @@ var edgeNodeEVEImageRemove = &cobra.Command{
 				log.Fatalf("GetFileFollowLinks: %s", err)
 			}
 		} else {
-			if err = os.MkdirAll(filepath.Join(edenDist, "tmp"), 0755); err != nil {
-				log.Fatalf("cannot create dir for download image %s", err)
-			}
 			r, _ := url.Parse(baseOSImage)
-			rootFsPath = filepath.Join(edenDist, "tmp", path.Base(r.Path))
-			defer os.Remove(rootFsPath)
-			if err := utils.DownloadFile(rootFsPath, baseOSImage); err != nil {
-				log.Fatalf("DownloadFile error: %s", err)
+			switch r.Scheme {
+			case "http", "https":
+				if err = os.MkdirAll(filepath.Join(edenDist, "tmp"), 0755); err != nil {
+					log.Fatalf("cannot create dir for download image %s", err)
+				}
+				rootFsPath = filepath.Join(edenDist, "tmp", path.Base(r.Path))
+				defer os.Remove(rootFsPath)
+				if err := utils.DownloadFile(rootFsPath, baseOSImage); err != nil {
+					log.Fatalf("DownloadFile error: %s", err)
+				}
+			case "oci", "docker":
+				bits := strings.Split(r.Path, ":")
+				if len(bits) == 2 {
+					rootFsPath = "rootfs-" + bits[1] + ".dummy"
+				} else {
+					rootFsPath = "latest.dummy"
+				}
+			default:
+				log.Fatalf("unknown URI scheme: %s", r.Scheme)
 			}
 		}
 		changer, err := changerByControllerMode(controllerMode)
@@ -178,10 +194,6 @@ var edgeNodeEVEImageRemove = &cobra.Command{
 		ctrl, dev, err := changer.getControllerAndDev()
 		if err != nil {
 			log.Fatalf("getControllerAndDev error: %s", err)
-		}
-
-		if _, err := os.Lstat(rootFsPath); os.IsNotExist(err) {
-			log.Fatalf("image file problem (%s): %s", args[0], err)
 		}
 
 		if getFromFileName {
@@ -196,25 +208,19 @@ var edgeNodeEVEImageRemove = &cobra.Command{
 
 		log.Infof("Will use rootfs version %s", baseOSVersion)
 
-		sha256sum, err := utils.SHA256SUM(rootFsPath)
-		if err != nil {
-			log.Fatalf("SHA256SUM (%s): %s", rootFsPath, err)
-		}
 		toActivate := true
 		for _, baseOSConfig := range ctrl.ListBaseOSConfig() {
-			if len(baseOSConfig.Drives) == 1 {
-				if baseOSConfig.Drives[0].Image.Sha256 == sha256sum {
-					if ind, found := utils.FindEleInSlice(dev.GetBaseOSConfigs(), baseOSConfig.Uuidandversion.GetUuid()); found {
-						configs := dev.GetBaseOSConfigs()
-						utils.DelEleInSlice(&configs, ind)
-						dev.SetBaseOSConfig(configs)
-						log.Infof("EVE base OS image removed with id %s", baseOSConfig.Uuidandversion.GetUuid())
-					}
-				} else {
-					if toActivate {
-						toActivate = false
-						baseOSConfig.Activate = true //activate another one if exists
-					}
+			if baseOSConfig.BaseOSVersion == baseOSVersion {
+				if ind, found := utils.FindEleInSlice(dev.GetBaseOSConfigs(), baseOSConfig.Uuidandversion.GetUuid()); found {
+					configs := dev.GetBaseOSConfigs()
+					utils.DelEleInSlice(&configs, ind)
+					dev.SetBaseOSConfig(configs)
+					log.Infof("EVE base OS image removed with id %s", baseOSConfig.Uuidandversion.GetUuid())
+				}
+			} else {
+				if toActivate {
+					toActivate = false
+					baseOSConfig.Activate = true //activate another one if exists
 				}
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/lf-edge/adam v0.0.0-20201209042112-7d1fa049e66b
 	github.com/lf-edge/eden/eserver v0.0.0-20201210161141-8551a3b0751b
 	github.com/lf-edge/edge-containers v0.0.0-20201111200732-5491ea93dbe4
-	github.com/lf-edge/eve/api/go v0.0.0-20201210213536-60ef9c6c9746
+	github.com/lf-edge/eve/api/go v0.0.0-20201223041948-f66d1d3f800d
 	github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40 // indirect
 	github.com/mcuadros/go-lookup v0.0.0-20200831155250-80f87a4fa5ee
 	github.com/moby/term v0.0.0-20201110203204-bea5bbe245bf
@@ -66,7 +66,6 @@ require (
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/errgo.v2 v2.1.0
 	gopkg.in/yaml.v2 v2.4.0
-	gotest.tools/gotestsum v0.6.0 // indirect
 	rsc.io/letsencrypt v0.0.3 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -257,7 +257,6 @@ github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5y
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.0.0-20200808040245-162e5629780b/go.mod h1:NAJj0yf/KaRKURN6nyi7A9IZydMivZEm9oQLWNjfKDc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
@@ -379,8 +378,6 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
-github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
@@ -490,8 +487,8 @@ github.com/lf-edge/adam v0.0.0-20201209042112-7d1fa049e66b/go.mod h1:V673Vi9mE0y
 github.com/lf-edge/edge-containers v0.0.0-20201111200732-5491ea93dbe4 h1:o30WvD7AhMtSdutrhypyoq7wCBSbzcODIwKf4fpVNac=
 github.com/lf-edge/edge-containers v0.0.0-20201111200732-5491ea93dbe4/go.mod h1:7Fm7xKAgGGZGT0ulgi1ifBFrNSYikVZrzCY7lDqGDYY=
 github.com/lf-edge/eve/api/go v0.0.0-20201031014148-3a9bcf5d26a7/go.mod h1:DuAv0PyTTzmd3n25iHJ/Hx2SrbON4hf3I0oXfnUH4d8=
-github.com/lf-edge/eve/api/go v0.0.0-20201210213536-60ef9c6c9746 h1:hSWR0yDPohutUIfheABdXQE2DXRVfb98Cn5S37Z7WjQ=
-github.com/lf-edge/eve/api/go v0.0.0-20201210213536-60ef9c6c9746/go.mod h1:DuAv0PyTTzmd3n25iHJ/Hx2SrbON4hf3I0oXfnUH4d8=
+github.com/lf-edge/eve/api/go v0.0.0-20201223041948-f66d1d3f800d h1:BacPq4YVW+GuathmMnZk92Bf8LNwchrQXw5LJvFnNc4=
+github.com/lf-edge/eve/api/go v0.0.0-20201223041948-f66d1d3f800d/go.mod h1:DuAv0PyTTzmd3n25iHJ/Hx2SrbON4hf3I0oXfnUH4d8=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40 h1:EnfXoSqDfSNJv0VBNqY/88RNnhSGYkrHaO0mmFGbVsc=
@@ -506,14 +503,10 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
-github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
-github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
-github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
-github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -933,7 +926,6 @@ golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -981,7 +973,6 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3 h1:kzM6+9dur93BcC2kVlYl34cHU+TYZLanmpSJHVMmL64=
@@ -1217,8 +1208,6 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
-gotest.tools/gotestsum v0.6.0 h1:0zIxynXq9gkAcRpboAi3qOQIkZkCt/stfQzd7ab7Czs=
-gotest.tools/gotestsum v0.6.0/go.mod h1:LEX+ioCVdeWhZc8GYfiBRag360eBhwixWJ62R9eDQtI=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=

--- a/pkg/controller/device.go
+++ b/pkg/controller/device.go
@@ -411,28 +411,31 @@ func (cloud *CloudCtx) GetConfigBytes(dev *device.Ctx, pretty bool) ([]byte, err
 			}
 		}
 
-		volumeConfig, err := cloud.GetVolume(baseOSConfig.VolumeID)
-		if err != nil {
-			return nil, err
-		}
-
-		volumes = append(volumes, volumeConfig)
 		baseOS = append(baseOS, baseOSConfig)
 
-		if contentTreeConfig, err := cloud.GetContentTree(volumeConfig.Origin.DownloadContentTreeID); err == nil {
-			for _, contentTree := range contentTrees {
-				if contentTree.Uuid == contentTreeConfig.Uuid {
-					contentTreeConfig = nil
-					break
-				}
+		if baseOSConfig.VolumeID != "" {
+			volumeConfig, err := cloud.GetVolume(baseOSConfig.VolumeID)
+			if err != nil {
+				return nil, err
 			}
-			if contentTreeConfig != nil {
-				//add required datastores
-				dataStores, err = cloud.checkContentTreeDs(contentTreeConfig, dataStores)
-				if err != nil {
-					return nil, err
+
+			volumes = append(volumes, volumeConfig)
+
+			if contentTreeConfig, err := cloud.GetContentTree(volumeConfig.Origin.DownloadContentTreeID); err == nil {
+				for _, contentTree := range contentTrees {
+					if contentTree.Uuid == contentTreeConfig.Uuid {
+						contentTreeConfig = nil
+						break
+					}
 				}
-				contentTrees = append(contentTrees, contentTreeConfig)
+				if contentTreeConfig != nil {
+					//add required datastores
+					dataStores, err = cloud.checkContentTreeDs(contentTreeConfig, dataStores)
+					if err != nil {
+						return nil, err
+					}
+					contentTrees = append(contentTrees, contentTreeConfig)
+				}
 			}
 		}
 	}

--- a/pkg/controller/device.go
+++ b/pkg/controller/device.go
@@ -403,48 +403,38 @@ func (cloud *CloudCtx) GetConfigBytes(dev *device.Ctx, pretty bool) ([]byte, err
 			return nil, err
 		}
 
-	volumeLoopHack:
 		//check drives from baseOSConfigs
 		for _, drive := range baseOSConfig.Drives {
 			dataStores, err = cloud.checkDriveDs(drive, dataStores)
 			if err != nil {
 				return nil, err
 			}
+		}
 
-			// FIXME: this is a total hack, we need to pull Volumes and contentTrees
-			// from the only breadcrumb that is left in the drive.Image -- name
-			if drive.Image.Iformat == config.Format_CONTAINER {
-				for _, ctID := range dev.GetContentTrees() {
-					ct, _ := cloud.GetContentTree(ctID)
-					if ct.DisplayName == drive.Image.Name {
-						for _, v := range cloud.volumes {
-							if v.Origin.DownloadContentTreeID == ct.Uuid {
-								volumeConfig, err := cloud.GetVolume(v.Uuid)
-								if err != nil {
-									return nil, err
-								}
-								volumes = append(volumes, volumeConfig)
-								if contentTreeConfig, err := cloud.GetContentTree(volumeConfig.Origin.DownloadContentTreeID); err == nil {
-									for _, contentTree := range contentTrees {
-										if contentTree.Uuid == contentTreeConfig.Uuid {
-											//we already define this contentTree in EdgeDevConfig
-											continue volumeLoopHack
-										}
-									}
-									//add required datastores
-									dataStores, err = cloud.checkContentTreeDs(contentTreeConfig, dataStores)
-									if err != nil {
-										return nil, err
-									}
-									contentTrees = append(contentTrees, contentTreeConfig)
-								}
-							}
-						}
-					}
+		volumeConfig, err := cloud.GetVolume(baseOSConfig.VolumeID)
+		if err != nil {
+			return nil, err
+		}
+
+		volumes = append(volumes, volumeConfig)
+		baseOS = append(baseOS, baseOSConfig)
+
+		if contentTreeConfig, err := cloud.GetContentTree(volumeConfig.Origin.DownloadContentTreeID); err == nil {
+			for _, contentTree := range contentTrees {
+				if contentTree.Uuid == contentTreeConfig.Uuid {
+					contentTreeConfig = nil
+					break
 				}
 			}
+			if contentTreeConfig != nil {
+				//add required datastores
+				dataStores, err = cloud.checkContentTreeDs(contentTreeConfig, dataStores)
+				if err != nil {
+					return nil, err
+				}
+				contentTrees = append(contentTrees, contentTreeConfig)
+			}
 		}
-		baseOS = append(baseOS, baseOSConfig)
 	}
 	var applicationInstances []*config.AppInstanceConfig
 	for _, applicationInstanceConfigID := range dev.GetApplicationInstances() {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -48,8 +48,8 @@ const (
 	DefaultRegistryPort = 5000
 
 	//tags, versions, repos
-	DefaultEVETag               = "0.0.0-master-60ef9c6c" //DefaultEVETag tag for EVE image
-	DefaultAdamTag              = "df3aa59442b25ecc9fe0c0032dc84eb0808125a4"
+	DefaultEVETag               = "0.0.0-master-f66d1d3f" //DefaultEVETag tag for EVE image
+	DefaultAdamTag              = "bbb1add4a627bfab64ffa8dae7a170aed5136d50"
 	DefaultRedisTag             = "6"
 	DefaultRegistryTag          = "2.7"
 	DefaultProcTag              = "1.2"

--- a/pkg/expect/baseOSImage.go
+++ b/pkg/expect/baseOSImage.go
@@ -94,6 +94,8 @@ func (exp *AppExpectation) BaseOSImage() (baseOSConfig *config.BaseOSConfig) {
 		volume := exp.driveToVolume(baseOSConfig.Drives[0], 0, contentTree)
 		_ = exp.ctrl.AddVolume(volume)
 		exp.device.SetVolumeConfigs(append(exp.device.GetVolumes(), volume.Uuid))
+
+		baseOSConfig.VolumeID = volume.Uuid
 	}
 
 	return


### PR DESCRIPTION
This is a rather ugly implementation that allows us to start implementing loading baseOS images from OCI containers, so that the following eden command `$ eden controller edge-node eveimage-update oci://docker.io/lfedge/eve:5.17.0-kvm` results in the following config given to EVE:

```
    "base": [
        {
            "uuidandversion": {
                "uuid": "a1cbf8a6-adda-4a24-9e95-18adf93060b6",
                "version": "4"
            },
            "drives": [
                {
                    "image": {
                        "uuidandversion": {
                            "uuid": "a1cbf8a6-adda-4a24-9e95-18adf93060b6",
                            "version": "1"
                        },
                        "name": "lfedge/eve:5.17.0-kvm",
                        "iformat": 8,
                        "dsId": "1a4acbf2-56bd-45ec-a2f4-c94dfc4cae35"
                    }
                }
            ],
            "baseOSVersion": "5.17.0-kvm"
        }
    ],
    "contentInfo": [
        {
            "uuid": "696a2b9a-f43d-4cf4-9bbd-32f1884b4218",
            "dsId": "1a4acbf2-56bd-45ec-a2f4-c94dfc4cae35",
            "URL": "lfedge/eve:5.17.0-kvm",
            "iformat": 8,
            "displayName": "lfedge/eve:5.17.0-kvm"
        }
    ],
    "volumes": [
        {
            "uuid": "f1b57261-82ee-47c1-aa28-645e8dad7712",
            "origin": {
                "type": 2,
                "downloadContentTreeID": "696a2b9a-f43d-4cf4-9bbd-32f1884b4218"
            },
            "displayName": "exciting_tesla_0_m_0"
        }
    ]
```

The config actually results in Image being fetched from Docker registry (great news) and then everything gets lost in the guts of baseOS update functionality and nothing useful happens.

Thus, I'd like to as @deitch to take a look at what's the deal on the EVE implementation side and also @giggsoff to suggest if there's a better approach compared to the totally hacky way I'm doing it now.

This is clearly NOT for merging (yet).

P.S. @eriknordmark -- you may also want to keep an eye on this since baseOS refactoring is expected to come to EVE soon.