### PR TITLE
fix for volume type

### DIFF
--- a/pkg/expect/docker.go
+++ b/pkg/expect/docker.go
@@ -168,6 +168,7 @@ func (exp *AppExpectation) prepareImage() *config.Image {
 		appLink = fmt.Sprintf("file://%s", utils.ResolveAbsPath(appLink))
 	}
 	tempExp := AppExpectationFromURL(exp.ctrl, exp.device, appLink, "")
+	tempExp.imageFormat = string(exp.volumesType)
 	return tempExp.Image()
 }
 


### PR DESCRIPTION
Seems, that we forgot to set type of image for volume type (`--volume-type=raw`) from pod deploy.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>