### PR TITLE
Test arguments refactoring

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -29,7 +29,8 @@ const (
 
 	DefaultContext = "default" //default context name
 
-	DefaultConfigEnv = "EDEN_CONFIG" //default env for set config
+	DefaultConfigEnv   = "EDEN_CONFIG"    //default env for set config
+	DefaultTestArgsEnv = "EDEN_TEST_ARGS" //default env for test arguments
 )
 
 //domains, ips, ports

--- a/tests/app/app_test.go
+++ b/tests/app/app_test.go
@@ -9,13 +9,14 @@ import (
 
 	"github.com/lf-edge/eden/pkg/eve"
 	"github.com/lf-edge/eden/pkg/projects"
+	"github.com/lf-edge/eden/pkg/tests"
 	"github.com/lf-edge/eden/pkg/utils"
 	"github.com/lf-edge/eve/api/go/info"
 )
 
 // This test wait for the app's state with a timewait.
 var (
-	timewait = flag.Duration("timewait", time.Minute, "Timewait for items waiting")
+	timewait = flag.Duration("timewait", 10*time.Minute, "Timewait for items waiting")
 	tc       *projects.TestContext
 	states   map[string][]string
 	eveState *eve.State
@@ -27,6 +28,8 @@ var (
 // is not specified explicitly it is assumed to be the first one in the slice
 func TestMain(m *testing.M) {
 	fmt.Println("Docker app's state test")
+
+	tests.TestArgsParse()
 
 	tc = projects.NewTestContext()
 

--- a/tests/app/testdata/2dockers_test.txt
+++ b/tests/app/testdata/2dockers_test.txt
@@ -6,7 +6,7 @@
 eden -t 5s pod ps
 
 # Starting of reboot detector with a 3 reboots limit
-! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
 
 # Run t1 docker
 eden -t 1m pod deploy -p 8027:80 docker://nginx -n t1

--- a/tests/docker/docker_test.go
+++ b/tests/docker/docker_test.go
@@ -24,7 +24,7 @@ import (
 // and removes app from EVE
 // you can replace defaults with flags
 var (
-	timewait     = flag.Int("timewait", 600, "Timewait for items waiting in seconds")
+	timewait     = flag.Duration("timewait", 10*time.Minute, "Timewait for items waiting")
 	name         = flag.String("name", "", "Name of app, random if empty")
 	externalPort = flag.Int("externalPort", 8028, "Port for access app from outside of EVE. Not publish if equals with 0.")
 	internalPort = flag.Int("internalPort", 80, "Port for access app inside EVE")
@@ -201,7 +201,7 @@ func TestDockerStart(t *testing.T) {
 
 	}
 
-	tc.WaitForProc(*timewait)
+	tc.WaitForProc(int(timewait.Seconds()))
 }
 
 //TestDockerDelete gets EdgeNode and deletes previously deployed app, defined in appName
@@ -238,5 +238,5 @@ func TestDockerDelete(t *testing.T) {
 		}
 	}
 
-	tc.WaitForProc(*timewait)
+	tc.WaitForProc(int(timewait.Seconds()))
 }

--- a/tests/docker/testdata/10dockers_test.txt
+++ b/tests/docker/testdata/10dockers_test.txt
@@ -1,4 +1,4 @@
-{{$test_opts := "-test.v -timewait 2400"}}
+{{$test_opts := "-test.v -timewait 40m"}}
 
 [!exec:curl] stop
 

--- a/tests/docker/testdata/2dockers_test.txt
+++ b/tests/docker/testdata/2dockers_test.txt
@@ -1,4 +1,4 @@
-{{$test_opts := "-test.v -timewait 1200"}}
+{{$test_opts := "-test.v -timewait 20m"}}
 
 [!exec:curl] stop
 [!exec:cut] stop

--- a/tests/eclient/eden+ports.sh
+++ b/tests/eclient/eden+ports.sh
@@ -7,6 +7,7 @@ then
 fi
 
 EDEN=eden
+which $EDEN || EDEN=../../eden
 CFG=$($EDEN config get)
 
 OLD=$($EDEN config get "$CFG" --key eve.hostfwd)

--- a/tests/eclient/eden-ports.sh
+++ b/tests/eclient/eden-ports.sh
@@ -7,6 +7,7 @@ then
 fi
 
 EDEN=eden
+which $EDEN || EDEN=../../eden
 CFG=$($EDEN config get)
 
 OLD=$($EDEN config get "$CFG" --key eve.hostfwd)

--- a/tests/eclient/testdata/eclient.txt
+++ b/tests/eclient/testdata/eclient.txt
@@ -1,6 +1,5 @@
 # Simple test of `eclient` image functionality
 
-{{$test_opts := "-test.v -timewait 1200"}}
 {{$port := "2223"}}
 
 [!exec:bash] stop
@@ -8,7 +7,7 @@
 [!exec:ssh] stop
 
 # Starting of reboot detector with a 2 reboot limit
-! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=2 &
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
 
 eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.3 -p {{$port}}:22
 

--- a/tests/eclient/testdata/host-only.txt
+++ b/tests/eclient/testdata/host-only.txt
@@ -1,6 +1,5 @@
 # Test host-only ACL application isolation
 
-{{$test_opts := "-test.v -timewait 1200"}}
 {{$test_msg := "This is a test"}}
 {{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa root@{{end}}
 
@@ -9,7 +8,7 @@
 [!exec:ssh] stop
 
 # Starting of reboot detector with a 2 reboot limit
-! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=2 &
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
 
 eden pod deploy -n ping-nw --memory=512MB docker://itmoeve/eclient:0.3 -p 2223:22
 eden pod deploy -n ping-fw --memory=512MB docker://itmoeve/eclient:0.3 -p 2224:22 --only-host=true

--- a/tests/eclient/testdata/maridb.txt
+++ b/tests/eclient/testdata/maridb.txt
@@ -1,6 +1,5 @@
 # Simple test of standard `mariadb` image
 
-{{$test_opts := "-test.v -timewait 1200"}}
 {{$server := "mariadb"}}
 {{$test_msg := "MariaDB [(none)]> "}}
 {{define "port"}}2223{{end}}
@@ -11,7 +10,7 @@
 [!exec:ssh] stop
 
 # Starting of reboot detector with a 2 reboot limit
-#! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=2 &
+#! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
 
 eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.3 -p {{template "port"}}:22
 

--- a/tests/eclient/testdata/networking_light.txt
+++ b/tests/eclient/testdata/networking_light.txt
@@ -1,6 +1,5 @@
 # Test for internal TCP clien/server interconnection
 
-{{$test_opts := "-test.v -timewait 1200"}}
 {{$test_msg := "This is a test"}}
 {{define "port"}}2223{{end}}
 {{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
@@ -10,7 +9,7 @@
 [!exec:ssh] stop
 
 # Starting of reboot detector with a 2 reboot limit
-! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=2 &
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
 
 eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.3 -p {{template "port"}}:22
 #eden -t 20m pod logs eclient

--- a/tests/eclient/testdata/ngnix.txt
+++ b/tests/eclient/testdata/ngnix.txt
@@ -1,6 +1,5 @@
 # Simple test of standard `nginx` image
 
-{{$test_opts := "-test.v -timewait 1200"}}
 {{$server := "ngnix"}}
 {{$test_msg := "Welcome to nginx!"}}
 {{define "port"}}2223{{end}}
@@ -11,7 +10,7 @@
 [!exec:ssh] stop
 
 # Starting of reboot detector with a 2 reboot limit
-! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=2 &
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
 
 eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.3 -p {{template "port"}}:22
 

--- a/tests/eclient/testdata/nw_switch.txt
+++ b/tests/eclient/testdata/nw_switch.txt
@@ -1,6 +1,5 @@
 # Test for apllications network connectivity switching
 
-{{$test_opts := "-test.v -timewait 1200"}}
 {{$test_msg := "This is a test"}}
 {{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa root@{{end}}
 
@@ -9,7 +8,7 @@
 [!exec:ssh] stop
 
 # Starting of reboot detector with 2 reboots limit
-! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=2 &
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
 
 message 'Resetting of EVE'
 eden eve reset

--- a/tests/eclient/testdata/port_switch.txt
+++ b/tests/eclient/testdata/port_switch.txt
@@ -4,7 +4,7 @@
 [!exec:sleep] stop
 
 # Starting of reboot detector with 2 reboots limit
-! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=2 &
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
 
 eden pod deploy -p 8027:80 docker://nginx -v debug -n nginx --memory=512MB
 

--- a/tests/escript/escript_test.go
+++ b/tests/escript/escript_test.go
@@ -2,12 +2,13 @@ package escript
 
 import (
 	"flag"
-	"github.com/lf-edge/eden/pkg/tests"
-	"github.com/lf-edge/eden/tests/escript/go-internal/testscript"
 	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/lf-edge/eden/pkg/tests"
+	"github.com/lf-edge/eden/tests/escript/go-internal/testscript"
 )
 
 var testData = flag.String("testdata", "testdata", "Test script directory")
@@ -40,7 +41,8 @@ func TestEdenScripts(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	flag.Parse()
+	tests.TestArgsParse()
+
 	result := m.Run()
 	if result != 0 {
 		tests.RunScenario(*failScenario, "", "", "", "", "")

--- a/tests/lim/testdata/info_test.txt
+++ b/tests/lim/testdata/info_test.txt
@@ -1,4 +1,4 @@
-{{$test1 := "test eden.lim.test -test.v -timewait 600 -test.run TestInfo"}}
+{{$test1 := "test eden.lim.test -test.v -timewait 10m -test.run TestInfo"}}
 {{$test2 := "test eden.lim.test -test.v -test.run TestInfo"}}
 
 #eden config add default

--- a/tests/lim/testdata/log_test.txt
+++ b/tests/lim/testdata/log_test.txt
@@ -1,4 +1,4 @@
-{{$test1 := "test eden.lim.test -test.v -timewait 600 -test.run TestLog"}}
+{{$test1 := "test eden.lim.test -test.v -timewait 10m -test.run TestLog"}}
 
 # ssh into EVE to force log creation
 exec -t 5m bash ssh.sh &

--- a/tests/lim/testdata/metric_test.txt
+++ b/tests/lim/testdata/metric_test.txt
@@ -1,4 +1,4 @@
-{{$test1 := "test eden.lim.test -test.v -timewait 600 -test.run TestMetric"}}
+{{$test1 := "test eden.lim.test -test.v -timewait 10m -test.run TestMetric"}}
 {{$test2 := "test eden.lim.test -test.v -test.run TestMetric"}}
 
 #eden config add default

--- a/tests/registry/testdata/registry_test.txt
+++ b/tests/registry/testdata/registry_test.txt
@@ -6,7 +6,7 @@
 eden -t 5s pod ps
 
 # Starting of reboot detector with a 3 reboots limit
-! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
 
 # Upload image to registry
 eden -t 5m registry load nginx

--- a/tests/update_eve_image/testdata/update_eve_image.txt
+++ b/tests/update_eve_image/testdata/update_eve_image.txt
@@ -16,8 +16,8 @@
 # Combine variables into $short_version
 {{$short_version := printf "%s-%s-%s" $eve_ver $eve_hv $eve_arch}}
 
-# Use eden.lim.test for access Infos with timewait 1200 seconds
-{{$test := "test eden.lim.test -test.v -timewait 1200 -test.run TestInfo"}}
+# Use eden.lim.test for access Infos with timewait 20m
+{{$test := "test eden.lim.test -test.v -timewait 20m -test.run TestInfo"}}
 
 
 # Download EVE rootfs into eve-dist

--- a/tests/vnc/vnc_test.go
+++ b/tests/vnc/vnc_test.go
@@ -28,8 +28,9 @@ import (
 // and removes app from EVE
 
 var (
-	timewait     = flag.Int("timewait", 900, "Timewait for items waiting in seconds")
-	expand       = flag.Int("expand", 400, "Expand timewait on success of step in seconds")
+	timewait = flag.Duration("timewait", 15*time.Minute, "Timewait for items waiting")
+
+	expand       = flag.Duration("expand", 7*time.Minute, "Expand timewait on success of step")
 	name         = flag.String("name", "", "Name of app, random if empty")
 	vncDisplay   = flag.Int("vncDisplay", 1, "VNC display number")
 	vncPassword  = flag.String("vncPassword", "12345678", "Password for VNC")
@@ -238,9 +239,9 @@ func TestVNCVMStart(t *testing.T) {
 
 	}
 
-	tc.ExpandOnSuccess(*expand)
+	tc.ExpandOnSuccess(int(expand.Seconds()))
 
-	tc.WaitForProc(*timewait)
+	tc.WaitForProc(int(timewait.Seconds()))
 }
 
 //TestVNCVMDelete gets EdgeNode and deletes previously deployed app, defined in appName or in name flag
@@ -278,5 +279,5 @@ func TestVNCVMDelete(t *testing.T) {
 		}
 	}
 
-	tc.WaitForProc(*timewait)
+	tc.WaitForProc(int(timewait.Seconds()))
 }

--- a/tests/workflow/testdata/deploy_docker_eden.txt
+++ b/tests/workflow/testdata/deploy_docker_eden.txt
@@ -3,7 +3,7 @@
 [!exec:grep] stop
 
 # Fail if reboot
-! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
 
 eden pod deploy -p 8028:80 docker://nginx
 stdout 'deploy pod .* with docker://nginx request sent'

--- a/tests/workflow/testdata/deploy_docker_test.txt
+++ b/tests/workflow/testdata/deploy_docker_test.txt
@@ -1,4 +1,4 @@
-{{$test_opts := "-test.v -timewait 600"}}
+{{$test_opts := "-test.v -timewait 10m"}}
 
 # Starting of reboot detector with a 1 reboots limit
 ! test eden.reboot.test {{$test_opts}} -reboot=0 -count=1 &

--- a/tests/workflow/testdata/deploy_vm.txt
+++ b/tests/workflow/testdata/deploy_vm.txt
@@ -3,7 +3,7 @@
 exec uname
 ! stdout Darwin
 
-{{$test_opts := "-test.v -timewait 600"}}
+{{$test_opts := "-test.v -timewait 10m"}}
 
 # Starting of reboot detector with a 1 reboots limit
 ! test eden.reboot.test {{$test_opts}} -reboot=0 -count=1 &

--- a/tests/workflow/testdata/reboot_eden.txt
+++ b/tests/workflow/testdata/reboot_eden.txt
@@ -1,4 +1,4 @@
-test eden.reboot.test -timewait 600 -reboot=0 -test.v &
+test eden.reboot.test -timewait 10m -reboot=0 -test.v &
 
 eden controller edge-node -m adam:// reboot -v debug
 stdout 'Reboot request has been sent'

--- a/tests/workflow/testdata/reboot_test.txt
+++ b/tests/workflow/testdata/reboot_test.txt
@@ -1,4 +1,4 @@
-test eden.reboot.test -test.v -timewait 600
+test eden.reboot.test -test.v -timewait 10m
 stdout 'Number of reboots:'
 
 -- eden-config.yml --


### PR DESCRIPTION
Passing standard Go-test parameters, via EDEN_TEST_ARGS env. var. Test params unification.

Signed-off-by: Oleg Sadov <oleg.sadov@gmail.com>