### PR TITLE
Placing tests in dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ $(LOCALBIN): $(BINDIR) cmd/*.go pkg/*/*.go pkg/*/*/*.go
 $(BIN): $(LOCALBIN)
 	ln -sf $(BIN)-$(OS)-$(ARCH) $(BINDIR)/$@
 	ln -sf $(LOCALBIN) $@
+	ln -sf bin/$@ $(WORKDIR)/$@
 
 testbin: config
 	make -C tests DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) build
@@ -110,7 +111,10 @@ run: build setup
 stop: build
 	$(LOCALBIN) stop -v $(DEBUG)
 
-.PHONY: processing eserver all clean test build config
+dist: build-tests
+	tar cvzf dist/eden_dist.tgz dist/bin dist/scripts dist/tests dist/*.txt
+
+.PHONY: processing eserver all clean test build build-tests config setup stop testbin gotestsum dist
 
 eserver:
 	@echo "Build eserver image"
@@ -132,6 +136,7 @@ help:
 	@echo "  * ADAM"
 	@echo
 	@echo "Commonly used maintenance and development targets:"
+	@echo "   dist          make distribution archive dist/eden_dist.tgz"
 	@echo "   run           run ADAM and EVE"
 	@echo "   test          run tests"
 	@echo "   config        generate required config files"

--- a/tests/app/Makefile
+++ b/tests/app/Makefile
@@ -18,7 +18,9 @@ OS ?= $(HOSTOS)
 override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
 
 WORKDIR ?= $(CURDIR)/../../dist
+TESTDIR := tests/$(shell basename $(CURDIR))
 BINDIR := $(WORKDIR)/bin
+DATADIR := $(WORKDIR)/$(TESTDIR)/
 BIN := eden
 LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
 TESTNAME := eden.app
@@ -32,9 +34,9 @@ LINKDIR := ../../tests/app
 clean:
 	rm -rf $(LOCALTESTBIN) $(BINDIR)/$(TESTBIN) $(WORKDIR)/$(TESTSCN) $(CURDIR)/$(TESTBIN) $(BINDIR)/$(TESTBIN)
 
-$(WORKDIR):
-	mkdir -p $@
 $(BINDIR):
+	mkdir -p $@
+$(DATADIR):
 	mkdir -p $@
 
 test_docker:
@@ -48,12 +50,14 @@ build: setup
 testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
-$(TESTBIN): $(LOCALTESTBIN)
-	ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN)
 
-setup: testbin
-	cp $(TESTSCN) $(WORKDIR)
-	ln -sf $(LINKDIR)/$(TESTBIN) $(BINDIR)
+$(TESTBIN): $(LOCALTESTBIN)
+	ln -sf $(LOCALTESTBIN) $(TESTBIN)
+
+setup: testbin $(BINDIR) $(DATADIR)
+	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(DATADIR)
+	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
+	ln -sf ../$(TESTDIR)/$(TESTBIN) $(BINDIR)
 
 .PHONY: test build setup clean all testbin
 

--- a/tests/docker/Makefile
+++ b/tests/docker/Makefile
@@ -18,7 +18,9 @@ OS ?= $(HOSTOS)
 override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
 
 WORKDIR ?= $(CURDIR)/../../dist
+TESTDIR := tests/$(shell basename $(CURDIR))
 BINDIR := $(WORKDIR)/bin
+DATADIR := $(WORKDIR)/$(TESTDIR)
 BIN := eden
 LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
 TESTNAME := eden.docker
@@ -32,9 +34,9 @@ LINKDIR := ../../tests/docker
 clean:
 	rm -rf $(LOCALTESTBIN) $(BINDIR)/$(TESTBIN) $(WORKDIR)/$(TESTSCN) $(CURDIR)/$(TESTBIN) $(BINDIR)/$(TESTBIN)
 
-$(WORKDIR):
-	mkdir -p $@
 $(BINDIR):
+	mkdir -p $@
+$(DATADIR):
 	mkdir -p $@
 
 test_docker:
@@ -48,12 +50,14 @@ build: setup
 testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
+
 $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN)
 
-setup: testbin
-	cp $(TESTSCN) $(WORKDIR)
-	ln -sf $(LINKDIR)/$(TESTBIN) $(BINDIR)
+setup: testbin $(BINDIR) $(DATADIR)
+	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(DATADIR)
+	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
+	ln -sf ../$(TESTDIR)/$(TESTBIN) $(BINDIR)
 
 .PHONY: test build setup clean all testbin
 

--- a/tests/eclient/Makefile
+++ b/tests/eclient/Makefile
@@ -25,23 +25,24 @@ IMAGE_DIR=$(CURDIR)/image
 override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
 
 WORKDIR ?= $(CURDIR)/../../dist
+TESTDIR := tests/$(shell basename $(CURDIR))
 BINDIR := $(WORKDIR)/bin
+DATADIR := $(WORKDIR)/$(TESTDIR)
 BIN := eden
 LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
 TESTNAME := eden.eclient
 TESTBIN := $(TESTNAME).test
 TESTSCN := $(TESTNAME).tests.txt
 LOCALTESTBIN := $(TESTBIN)-$(OS)-$(ARCH)
-LINKDIR := ../../tests/eclient
 
 .DEFAULT_GOAL := help
 
 clean:
 	rm -rf $(LOCALTESTBIN) $(BINDIR)/$(TESTBIN) $(WORKDIR)/$(TESTSCN) $(CURDIR)/$(TESTBIN) $(BINDIR)/$(TESTBIN)
 
-$(WORKDIR):
-	mkdir -p $@
 $(BINDIR):
+	mkdir -p $@
+$(DATADIR):
 	mkdir -p $@
 
 test:
@@ -49,11 +50,14 @@ test:
 
 build: setup
 
-setup:
-	cp eden+ports.sh eden-ports.sh $(BINDIR)/
-	cp $(TESTSCN) $(WORKDIR)
+setup: $(BINDIR) $(DATADIR)
+	cp -a *.sh *.yml $(TESTSCN) testdata $(DATADIR)
+	ln -sf ../$(TESTDIR)/eden+ports.sh $(BINDIR)/
+	ln -sf ../$(TESTDIR)/eden-ports.sh $(BINDIR)/
 	chmod 700 image/cert/
 	chmod 600 image/cert/id_rsa*
+	mkdir -p $(DATADIR)/image/cert/
+	cp -a image/cert/id_rsa* $(DATADIR)/image/cert/
 
 .PHONY: test build setup clean all image testbin
 

--- a/tests/eclient/eden+ports.sh
+++ b/tests/eclient/eden+ports.sh
@@ -7,7 +7,8 @@ then
 fi
 
 EDEN=eden
-which $EDEN || EDEN=../../eden
+DIR=$(dirname "$0")
+PATH=$DIR:$DIR/../../bin:$PATH
 CFG=$($EDEN config get)
 
 OLD=$($EDEN config get "$CFG" --key eve.hostfwd)

--- a/tests/eclient/eden-ports.sh
+++ b/tests/eclient/eden-ports.sh
@@ -7,7 +7,8 @@ then
 fi
 
 EDEN=eden
-which $EDEN || EDEN=../../eden
+DIR=$(dirname "$0")
+PATH=$DIR:$DIR/../../bin:$PATH
 CFG=$($EDEN config get)
 
 OLD=$($EDEN config get "$CFG" --key eve.hostfwd)

--- a/tests/eclient/testdata/eclient.txt
+++ b/tests/eclient/testdata/eclient.txt
@@ -40,6 +40,6 @@ for i in `seq 20`
 do
 sleep 20
 # Test SSH-access to container
-echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue
-ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue && break
+echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue
+ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue && break
 done

--- a/tests/eclient/testdata/host-only.txt
+++ b/tests/eclient/testdata/host-only.txt
@@ -1,7 +1,7 @@
 # Test host-only ACL application isolation
 
 {{$test_msg := "This is a test"}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa root@{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop

--- a/tests/eclient/testdata/maridb.txt
+++ b/tests/eclient/testdata/maridb.txt
@@ -3,7 +3,7 @@
 {{$server := "mariadb"}}
 {{$test_msg := "MariaDB [(none)]> "}}
 {{define "port"}}2223{{end}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop

--- a/tests/eclient/testdata/networking_light.txt
+++ b/tests/eclient/testdata/networking_light.txt
@@ -2,7 +2,7 @@
 
 {{$test_msg := "This is a test"}}
 {{define "port"}}2223{{end}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop

--- a/tests/eclient/testdata/ngnix.txt
+++ b/tests/eclient/testdata/ngnix.txt
@@ -3,7 +3,7 @@
 {{$server := "ngnix"}}
 {{$test_msg := "Welcome to nginx!"}}
 {{define "port"}}2223{{end}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop

--- a/tests/eclient/testdata/nw_switch.txt
+++ b/tests/eclient/testdata/nw_switch.txt
@@ -1,7 +1,7 @@
 # Test for apllications network connectivity switching
 
 {{$test_msg := "This is a test"}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.root"}}/../tests/eclient/image/cert/id_rsa root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa root@{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop

--- a/tests/escript/Makefile
+++ b/tests/escript/Makefile
@@ -18,7 +18,9 @@ OS ?= $(HOSTOS)
 override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
 
 WORKDIR ?= $(CURDIR)/../../dist
+TESTDIR := tests/$(shell basename $(CURDIR))
 BINDIR := $(WORKDIR)/bin
+DATADIR := $(WORKDIR)/$(TESTDIR)
 BIN := eden
 LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
 TESTNAME := eden.escript
@@ -32,9 +34,9 @@ LINKDIR := ../../tests/escript
 clean:
 	rm -rf $(LOCALTESTBIN) $(BINDIR)/$(TESTBIN) $(WORKDIR)/$(TESTSCN) $(CURDIR)/$(TESTBIN) $(BINDIR)/$(TESTBIN)
 
-$(WORKDIR):
-	mkdir -p $@
 $(BINDIR):
+	mkdir -p $@
+$(DATADIR):
 	mkdir -p $@
 
 test_escript:
@@ -48,12 +50,15 @@ build: setup
 testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
+
 $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN)
 
-setup: testbin
+setup: testbin $(BINDIR) $(DATADIR)
+	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(DATADIR)
+	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
 	cp custom.fail.scenario.txt failScenario.txt $(TESTSCN) $(WORKDIR)
-	ln -sf $(LINKDIR)/$(TESTBIN) $(BINDIR)
+	ln -sf ../$(TESTDIR)/$(TESTBIN) $(BINDIR)
 
 .PHONY: test build setup clean all testbin
 

--- a/tests/escript/testdata/fail_scenario.txt
+++ b/tests/escript/testdata/fail_scenario.txt
@@ -1,5 +1,5 @@
-! test eden.escript.test -test.run TestEdenScripts/fail_test -test.v -testdata {{EdenConfig "eden.root"}}/../tests/escript/testdata/
+! test eden.escript.test -test.run TestEdenScripts/fail_test -test.v -testdata {{EdenConfig "eden.root"}}/tests/escript/testdata/
 stdout 'Default test fail scenario'
 
-! test eden.escript.test -test.run TestEdenScripts/fail_test -test.v -testdata {{EdenConfig "eden.root"}}/../tests/escript/testdata/ -fail_scenario custom.fail.scenario.txt
+! test eden.escript.test -test.run TestEdenScripts/fail_test -test.v -testdata {{EdenConfig "eden.root"}}/tests/escript/testdata/ -fail_scenario custom.fail.scenario.txt
 stdout 'Custom test fail scenario'

--- a/tests/escript/testdata/nested_scripts.txt
+++ b/tests/escript/testdata/nested_scripts.txt
@@ -1,4 +1,4 @@
-test eden.escript.test -test.run TestEdenScripts/message -test.v -testdata {{EdenConfig "eden.root"}}/../tests/escript/testdata/
+test eden.escript.test -test.run TestEdenScripts/message -test.v -testdata {{EdenConfig "eden.root"}}/tests/escript/testdata/
 cp stdout out
 
 mkdir testdata

--- a/tests/escript/testdata/source.txt
+++ b/tests/escript/testdata/source.txt
@@ -3,13 +3,13 @@
 
 # Show current variable value
 env time
-test eden.escript.test -test.run TestEdenScripts/nested_source -test.v -testdata {{EdenConfig "eden.root"}}/../tests/escript/testdata/
+test eden.escript.test -test.run TestEdenScripts/nested_source -test.v -testdata {{EdenConfig "eden.root"}}/tests/escript/testdata/
 ! stdout '05 Aug 2020 12:23:27'
 
 # Source .env file defined below
 source .env
 env time
-test eden.escript.test -test.run TestEdenScripts/nested_source -test.v -testdata {{EdenConfig "eden.root"}}/../tests/escript/testdata/
+test eden.escript.test -test.run TestEdenScripts/nested_source -test.v -testdata {{EdenConfig "eden.root"}}/tests/escript/testdata/
 stdout '05 Aug 2020 12:23:27'
 
 # Override .env by bash script
@@ -18,7 +18,7 @@ exec bash set_from_bash.sh
 # Source .env modified by bash
 source .env
 env time
-test eden.escript.test -test.run TestEdenScripts/nested_source -test.v -testdata {{EdenConfig "eden.root"}}/../tests/escript/testdata/
+test eden.escript.test -test.run TestEdenScripts/nested_source -test.v -testdata {{EdenConfig "eden.root"}}/tests/escript/testdata/
 ! stdout '05 Aug 2020 12:23:27'
 
 -- .env --

--- a/tests/flir/Makefile
+++ b/tests/flir/Makefile
@@ -25,7 +25,9 @@ IMAGE_DIR=$(CURDIR)/image
 override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
 
 WORKDIR ?= $(CURDIR)/../../dist
+TESTDIR := tests/$(shell basename $(CURDIR))
 BINDIR := $(WORKDIR)/bin
+DATADIR := $(WORKDIR)/$(TESTDIR)/
 BIN := eden
 LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
 TESTNAME := eden.flir
@@ -38,9 +40,9 @@ LOCALTESTBIN := $(TESTBIN)-$(OS)-$(ARCH)
 clean:
 	rm -rf $(LOCALTESTBIN) $(BINDIR)/$(TESTBIN) $(WORKDIR)/$(TESTSCN) $(CURDIR)/$(TESTBIN) $(BINDIR)/$(TESTBIN)
 
-$(WORKDIR):
-	mkdir -p $@
 $(BINDIR):
+	mkdir -p $@
+$(DATADIR):
 	mkdir -p $@
 
 test:
@@ -48,8 +50,8 @@ test:
 
 build: setup
 
-setup:
-	cp $(TESTSCN) $(WORKDIR)
+setup: $(BINDIR) $(DATADIR)
+	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
 
 .PHONY: image
 

--- a/tests/io_perfomance/Makefile
+++ b/tests/io_perfomance/Makefile
@@ -25,7 +25,9 @@ IMAGE_DIR=$(CURDIR)/image
 override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
 
 WORKDIR ?= $(CURDIR)/../../dist
+TESTDIR := tests/$(shell basename $(CURDIR))
 BINDIR := $(WORKDIR)/bin
+DATADIR := $(WORKDIR)/$(TESTDIR)/
 BIN := eden
 LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
 TESTNAME := eden.fio
@@ -38,9 +40,9 @@ LOCALTESTBIN := $(TESTBIN)-$(OS)-$(ARCH)
 clean:
 	rm -rf $(LOCALTESTBIN) $(BINDIR)/$(TESTBIN) $(WORKDIR)/$(TESTSCN) $(CURDIR)/$(TESTBIN) $(BINDIR)/$(TESTBIN)
 
-$(WORKDIR):
-	mkdir -p $@
 $(BINDIR):
+	mkdir -p $@
+$(DATADIR):
 	mkdir -p $@
 
 test:
@@ -48,8 +50,8 @@ test:
 
 build: setup
 
-setup:
-	cp $(TESTSCN) $(WORKDIR)
+setup: $(BINDIR) $(DATADIR)
+	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
 
 .PHONY: image
 

--- a/tests/lim/Makefile
+++ b/tests/lim/Makefile
@@ -18,7 +18,9 @@ OS ?= $(HOSTOS)
 override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
 
 WORKDIR ?= $(CURDIR)/../../dist
+TESTDIR := tests/$(shell basename $(CURDIR))
 BINDIR := $(WORKDIR)/bin
+DATADIR := $(WORKDIR)/$(TESTDIR)/
 BIN := eden
 LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
 TESTNAME := eden.lim
@@ -32,9 +34,9 @@ LINKDIR := ../../tests/lim
 clean:
 	rm -rf $(LOCALTESTBIN) $(BINDIR)/$(TESTBIN) $(WORKDIR)/$(TESTSCN) $(CURDIR)/$(TESTBIN) $(BINDIR)/$(TESTBIN)
 
-$(WORKDIR):
-	mkdir -p $@
 $(BINDIR):
+	mkdir -p $@
+$(DATADIR):
 	mkdir -p $@
 
 test_lim:
@@ -48,12 +50,14 @@ build: setup
 testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
+
 $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN)
 
-setup: testbin
-	cp $(TESTSCN) $(WORKDIR)
-	ln -sf $(LINKDIR)/$(TESTBIN) $(BINDIR)
+setup: testbin $(BINDIR) $(DATADIR)
+	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(DATADIR)
+	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
+	ln -sf ../$(TESTDIR)/$(TESTBIN) $(BINDIR)
 
 .PHONY: test build setup clean all testbin
 

--- a/tests/network/Makefile
+++ b/tests/network/Makefile
@@ -25,7 +25,9 @@ IMAGE_DIR=$(CURDIR)/image
 override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
 
 WORKDIR ?= $(CURDIR)/../../dist
+TESTDIR := tests/$(shell basename $(CURDIR))
 BINDIR := $(WORKDIR)/bin
+DATADIR := $(WORKDIR)/$(TESTDIR)/
 BIN := eden
 LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
 TESTNAME := eden.network
@@ -38,9 +40,9 @@ LOCALTESTBIN := $(TESTBIN)-$(OS)-$(ARCH)
 clean:
 	rm -rf $(LOCALTESTBIN) $(BINDIR)/$(TESTBIN) $(WORKDIR)/$(TESTSCN) $(CURDIR)/$(TESTBIN) $(BINDIR)/$(TESTBIN)
 
-$(WORKDIR):
-	mkdir -p $@
 $(BINDIR):
+	mkdir -p $@
+$(DATADIR):
 	mkdir -p $@
 
 test:
@@ -48,8 +50,8 @@ test:
 
 build: setup
 
-setup:
-	cp $(TESTSCN) $(WORKDIR)
+setup: $(BINDIR) $(DATADIR)
+	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
 
 .PHONY: test build setup clean all image
 

--- a/tests/network/testdata/test_networking.txt
+++ b/tests/network/testdata/test_networking.txt
@@ -35,7 +35,7 @@ exec bash networks_process.sh
 source .env
 
 # deploy the first application by nested escript
-test eden.escript.test -test.run TestEdenScripts/deploy_app -test.v  -testdata {{EdenConfig "eden.root"}}/../tests/network/testdata/
+test eden.escript.test -test.run TestEdenScripts/deploy_app -test.v  -testdata {{EdenConfig "eden.root"}}/tests/network/testdata/
 
 # execute the script for waiting RUNNING state and obtain internal IP
 message 'waiting for app1 running state'
@@ -47,7 +47,7 @@ exec -t 15m bash wait_and_get_ip.sh
 source .env
 
 # deploy the second application by nested escript
-test eden.escript.test -test.run TestEdenScripts/deploy_app -test.v  -testdata {{EdenConfig "eden.root"}}/../tests/network/testdata/
+test eden.escript.test -test.run TestEdenScripts/deploy_app -test.v  -testdata {{EdenConfig "eden.root"}}/tests/network/testdata/
 
 # execute the script for waiting RUNNING state and obtain the testing sequence from the second app
 message 'waiting for app2 running state'
@@ -65,7 +65,7 @@ exec -t 15m bash app3.sh
 source .env
 
 # deploy the third application by nested escript
-test eden.escript.test -test.run TestEdenScripts/deploy_app -test.v  -testdata {{EdenConfig "eden.root"}}/../tests/network/testdata/
+test eden.escript.test -test.run TestEdenScripts/deploy_app -test.v  -testdata {{EdenConfig "eden.root"}}/tests/network/testdata/
 
 message 'waiting for app3 running state'
 test eden.app.test -test.v -timewait 10m RUNNING app3

--- a/tests/phoronix/Makefile
+++ b/tests/phoronix/Makefile
@@ -25,7 +25,9 @@ IMAGE_DIR=$(CURDIR)/image
 override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
 
 WORKDIR ?= $(CURDIR)/../../dist
+TESTDIR := tests/$(shell basename $(CURDIR))
 BINDIR := $(WORKDIR)/bin
+DATADIR := $(WORKDIR)/$(TESTDIR)/
 BIN := eden
 LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
 TESTNAME := eden.phoronix
@@ -38,9 +40,9 @@ LOCALTESTBIN := $(TESTBIN)-$(OS)-$(ARCH)
 clean:
 	rm -rf $(LOCALTESTBIN) $(BINDIR)/$(TESTBIN) $(WORKDIR)/$(TESTSCN) $(CURDIR)/$(TESTBIN) $(BINDIR)/$(TESTBIN)
 
-$(WORKDIR):
-	mkdir -p $@
 $(BINDIR):
+	mkdir -p $@
+$(DATADIR):
 	mkdir -p $@
 
 test:
@@ -48,8 +50,8 @@ test:
 
 build: setup
 
-setup:
-	cp $(TESTSCN) $(WORKDIR)
+setup: $(BINDIR) $(DATADIR)
+	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
 
 .PHONY: image
 

--- a/tests/phoronix/testdata/test_phoronix.txt
+++ b/tests/phoronix/testdata/test_phoronix.txt
@@ -13,7 +13,7 @@ arg benchmark benchmark
 source .env
 
 # deploy the application by nested escript
-test eden.escript.test -test.run TestEdenScripts/deploy_app -test.v  -testdata {{EdenConfig "eden.root"}}/../tests/phoronix/testdata/
+test eden.escript.test -test.run TestEdenScripts/deploy_app -test.v  -testdata {{EdenConfig "eden.root"}}/tests/phoronix/testdata/
 
 exec -t 180m bash wait_app.sh
 exec cat result

--- a/tests/reboot/Makefile
+++ b/tests/reboot/Makefile
@@ -18,7 +18,9 @@ OS ?= $(HOSTOS)
 override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
 
 WORKDIR ?= $(CURDIR)/../../dist
+TESTDIR := tests/$(shell basename $(CURDIR))
 BINDIR := $(WORKDIR)/bin
+DATADIR := $(WORKDIR)/$(TESTDIR)/
 BIN := eden
 LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
 TESTNAME := eden.reboot
@@ -32,9 +34,9 @@ LINKDIR := ../../tests/reboot
 clean:
 	rm -rf $(LOCALTESTBIN) $(BINDIR)/$(TESTBIN) $(WORKDIR)/$(TESTSCN) $(CURDIR)/$(TESTBIN) $(BINDIR)/$(TESTBIN)
 
-$(WORKDIR):
-	mkdir -p $@
 $(BINDIR):
+	mkdir -p $@
+$(DATADIR):
 	mkdir -p $@
 
 test_reboot:
@@ -48,12 +50,14 @@ build: setup
 testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
+
 $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN)
 
-setup: testbin
-	cp $(TESTSCN) $(WORKDIR)
-	ln -sf $(LINKDIR)/$(TESTBIN) $(BINDIR)
+setup: testbin $(BINDIR) $(DATADIR)
+	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(DATADIR)
+	cp -a *.yml $(TESTSCN) $(DATADIR)
+	ln -sf ../$(TESTDIR)/$(TESTBIN) $(BINDIR)
 
 .PHONY: test build setup clean all testbin
 

--- a/tests/registry/Makefile
+++ b/tests/registry/Makefile
@@ -18,7 +18,9 @@ OS ?= $(HOSTOS)
 override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
 
 WORKDIR ?= $(CURDIR)/../../dist
+TESTDIR := tests/$(shell basename $(CURDIR))
 BINDIR := $(WORKDIR)/bin
+DATADIR := $(WORKDIR)/$(TESTDIR)/
 BIN := eden
 LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
 TESTNAME := eden.registry
@@ -32,9 +34,9 @@ LINKDIR := ../../tests/registry
 clean:
 	rm -rf $(LOCALTESTBIN) $(BINDIR)/$(TESTBIN) $(WORKDIR)/$(TESTSCN) $(CURDIR)/$(TESTBIN) $(BINDIR)/$(TESTBIN)
 
-$(WORKDIR):
-	mkdir -p $@
 $(BINDIR):
+	mkdir -p $@
+$(DATADIR):
 	mkdir -p $@
 
 test:
@@ -42,8 +44,8 @@ test:
 
 build: setup
 
-setup:
-	cp $(TESTSCN) $(WORKDIR)
+setup: $(BINDIR) $(DATADIR)
+	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
 
 .PHONY: test build setup clean all testbin
 

--- a/tests/update_eve_image/Makefile
+++ b/tests/update_eve_image/Makefile
@@ -18,7 +18,9 @@ OS ?= $(HOSTOS)
 override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
 
 WORKDIR ?= $(CURDIR)/../../dist
+TESTDIR := tests/$(shell basename $(CURDIR))
 BINDIR := $(WORKDIR)/bin
+DATADIR := $(WORKDIR)/$(TESTDIR)/
 BIN := eden
 LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
 TESTNAME := eden.escript
@@ -31,9 +33,9 @@ LOCALTESTBIN := $(TESTBIN)-$(OS)-$(ARCH)
 clean:
 	rm -rf $(WORKDIR)/$(TESTSCN)
 
-$(WORKDIR):
-	mkdir -p $@
 $(BINDIR):
+	mkdir -p $@
+$(DATADIR):
 	mkdir -p $@
 
 test:
@@ -42,8 +44,8 @@ test:
 build: setup
 
 
-setup:
-	cp $(TESTSCN) $(WORKDIR)
+setup: $(BINDIR) $(DATADIR)
+	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
 
 .PHONY: test build setup clean all
 

--- a/tests/vnc/Makefile
+++ b/tests/vnc/Makefile
@@ -18,7 +18,9 @@ OS ?= $(HOSTOS)
 override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
 
 WORKDIR ?= $(CURDIR)/../../dist
+TESTDIR := tests/$(shell basename $(CURDIR))
 BINDIR := $(WORKDIR)/bin
+DATADIR := $(WORKDIR)/$(TESTDIR)/
 BIN := eden
 LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
 TESTNAME := eden.vnc
@@ -32,9 +34,9 @@ LINKDIR := ../../tests/vnc
 clean:
 	rm -rf $(LOCALTESTBIN) $(BINDIR)/$(TESTBIN) $(WORKDIR)/$(TESTSCN) $(CURDIR)/$(TESTBIN) $(BINDIR)/$(TESTBIN)
 
-$(WORKDIR):
-	mkdir -p $@
 $(BINDIR):
+	mkdir -p $@
+$(DATADIR):
 	mkdir -p $@
 
 test_vnc:
@@ -48,12 +50,14 @@ build: setup
 testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
+
 $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN)
 
-setup: testbin
-	cp $(TESTSCN) $(WORKDIR)
-	ln -sf $(LINKDIR)/$(TESTBIN) $(BINDIR)
+setup: testbin $(BINDIR) $(DATADIR)
+	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(DATADIR)
+	cp -a *.yml $(TESTSCN) $(DATADIR)
+	ln -sf ../$(TESTDIR)/$(TESTBIN) $(BINDIR)
 
 .PHONY: test build setup clean all testbin
 

--- a/tests/workflow/Makefile
+++ b/tests/workflow/Makefile
@@ -18,7 +18,9 @@ OS ?= $(HOSTOS)
 override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
 
 WORKDIR ?= $(CURDIR)/../../dist
+TESTDIR := tests/$(shell basename $(CURDIR))
 BINDIR := $(WORKDIR)/bin
+DATADIR := $(WORKDIR)/$(TESTDIR)/
 BIN := eden
 LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
 TESTNAME := eden.workflow
@@ -34,19 +36,21 @@ clean:
 
 $(WORKDIR):
 	mkdir -p $@
+$(DATADIR):
+	mkdir -p $@
 
 test:
 	$(LOCALBIN) test $(CURDIR) -v $(DEBUG)
 
 build: setup
 
-setup:
-	cp $(TESTSCN) $(WORKDIR)
+setup: $(BINDIR) $(DATADIR)
 ifeq ($(OS), $(HOSTOS))
 	$(LOCALBIN) utils template eden.workflow.tests.txt > workflow.default.txt
 	EDEN_TEST=small $(LOCALBIN) utils template eden.workflow.tests.txt > workflow.small.txt
 	EDEN_TEST=large $(LOCALBIN) utils template eden.workflow.tests.txt > workflow.large.txt
 endif
+	cp -a *.yml *.txt testdata $(DATADIR)
 
 .PHONY: test build setup clean all
 


### PR DESCRIPTION
Added `dist` rule to main Makefile. Now we can run `make dist` and get `dist/eden_dist.tgz` distribution. Then on the other hand:
1. tar xvzf eden_dist.tgz
2. ./dist/bin/eden config add default
3. ./dist/bin/eden setup
4. source ~/.eden/activate.sh
5. eden test dist/tests/workflow/

Signed-off-by: Oleg Sadov <oleg.sadov@gmail.com>