### PR TITLE
use current device to obtain information

### DIFF
--- a/pkg/expect/application.go
+++ b/pkg/expect/application.go
@@ -110,7 +110,11 @@ func (exp *AppExpectation) createAppInstanceConfig(img *config.Image, netInstanc
 func (exp *AppExpectation) Application() *config.AppInstanceConfig {
 	image := exp.Image()
 	networkInstances := exp.NetworkInstances()
-	for _, app := range exp.ctrl.ListApplicationInstanceConfig() {
+	for _, appID := range exp.device.GetApplicationInstances() {
+		app, err := exp.ctrl.GetApplicationInstanceConfig(appID)
+		if err != nil {
+			log.Fatalf("no app %s found in controller: %s", appID, err)
+		}
 		if exp.checkAppInstanceConfig(app) {
 			return app
 		}

--- a/pkg/expect/expectation.go
+++ b/pkg/expect/expectation.go
@@ -143,7 +143,11 @@ func AppExpectationFromURL(ctrl controller.Cloud, device *device.Ctx, appLink st
 	//check used ports
 	for _, ni := range expectation.netInstances {
 		if len(ni.ports) > 0 {
-			for _, app := range ctrl.ListApplicationInstanceConfig() {
+			for _, appID := range device.GetApplicationInstances() {
+				app, err := ctrl.GetApplicationInstanceConfig(appID)
+				if err != nil {
+					log.Fatalf("app %s not found: %s", appID, err)
+				}
 				if app.Displayname == expectation.oldAppName {
 					//if we try to modify the app, we skip this check
 					continue

--- a/pkg/expect/image.go
+++ b/pkg/expect/image.go
@@ -69,10 +69,28 @@ func (exp *AppExpectation) imageFormatEnum() config.Format {
 func (exp *AppExpectation) Image() (image *config.Image) {
 	datastore := exp.DataStore()
 	var err error
-	for _, img := range exp.ctrl.ListImage() {
-		if exp.checkImage(img, datastore.Id) {
-			image = img
-			break
+	for _, appID := range exp.device.GetApplicationInstances() {
+		app, err := exp.ctrl.GetApplicationInstanceConfig(appID)
+		if err != nil {
+			log.Fatalf("no app %s found in controller: %s", appID, err)
+		}
+		for _, drive := range app.Drives {
+			if exp.checkImage(drive.Image, datastore.Id) {
+				image = drive.Image
+				break
+			}
+		}
+	}
+	for _, baseID := range exp.device.GetBaseOSConfigs() {
+		base, err := exp.ctrl.GetBaseOSConfig(baseID)
+		if err != nil {
+			log.Fatalf("no baseOS %s found in controller: %s", baseID, err)
+		}
+		for _, drive := range base.Drives {
+			if exp.checkImage(drive.Image, datastore.Id) {
+				image = drive.Image
+				break
+			}
 		}
 	}
 	if image == nil { //if image not exists, create it

--- a/pkg/expect/networkInstance.go
+++ b/pkg/expect/networkInstance.go
@@ -86,7 +86,11 @@ func (exp *AppExpectation) NetworkInstances() (networkInstances map[*NetInstance
 	for _, ni := range exp.netInstances {
 		var err error
 		var networkInstance *config.NetworkInstanceConfig
-		for _, netInst := range exp.ctrl.ListNetworkInstanceConfig() {
+		for _, netInstID := range exp.device.GetNetworkInstances() {
+			netInst, err := exp.ctrl.GetNetworkInstanceConfig(netInstID)
+			if err != nil {
+				log.Fatalf("no baseOS %s found in controller: %s", netInstID, err)
+			}
 			if exp.checkNetworkInstance(netInst, ni) {
 				networkInstance = netInst
 				break

--- a/pkg/expect/volume.go
+++ b/pkg/expect/volume.go
@@ -9,7 +9,11 @@ import (
 
 //driveToVolume converts information about drive, its number and content tree into volume representation
 func (exp *AppExpectation) driveToVolume(dr *config.Drive, numberOfDrive int, contentTree *config.ContentTree) *config.Volume {
-	for _, el := range exp.ctrl.ListVolume() {
+	for _, volID := range exp.device.GetVolumes() {
+		el, err := exp.ctrl.GetVolume(volID)
+		if err != nil {
+			log.Fatalf("no volume %s found in controller: %s", volID, err)
+		}
 		if el.DisplayName == fmt.Sprintf("%s_%d_m_0", contentTree.DisplayName, numberOfDrive) {
 			// we already have this one in controller
 			return el


### PR DESCRIPTION
We must use current device for our checks inside expect package, because the controller stores info about multiple EVE.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>