### PR TITLE
Extended tests set. Improved tests documentation.

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -23,7 +23,7 @@ jobs:
           ./eden config add default
           ./eden config set default --key=eve.accel --value=false
           echo > tests/workflow/testdata/eden_stop.txt
-          ./eden test ./tests/workflow -v debug
+          EDEN_TEST_SETUP=y ./eden test ./tests/workflow -v debug
       - name: Collect logs
         if: ${{ always() }}
         run: |

--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -12,6 +12,9 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y qemu-utils qemu-system-x86
+      - name: host info
+        run: |
+          ip a
       - name: get eden
         uses: actions/checkout@v2
       - name: build eden

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -48,7 +48,7 @@ const (
 	DefaultRegistryPort = 5000
 
 	//tags, versions, repos
-	DefaultEVETag               = "0.0.0-master-d0af171f" //DefaultEVETag tag for EVE image
+	DefaultEVETag               = "0.0.0-master-79f610b8" //DefaultEVETag tag for EVE image
 	DefaultAdamTag              = "cf3e117efbe5f32846a6a84385ea429c65679f14"
 	DefaultRedisTag             = "6"
 	DefaultRegistryTag          = "2.7"
@@ -104,7 +104,7 @@ const (
 	DefaultQemuAccelDarwin = "-machine q35,accel=hvf -cpu kvm64,kvmclock=off "
 	DefaultQemuAccelLinux  = "-machine q35,accel=kvm,dump-guest-core=off -cpu host,invtsc=on,kvmclock=off -machine kernel-irqchip=split -device intel-iommu,intremap=on,caching-mode=on,aw-bits=48 "
 
-	DefaultAppSubnet = "10.1.0.0/24"
+	DefaultAppSubnet = "10.11.12.0/24"
 
 	DefaultQemuModel = "ZedVirtual-4G"
 

--- a/pkg/expect/application.go
+++ b/pkg/expect/application.go
@@ -2,11 +2,13 @@ package expect
 
 import (
 	"fmt"
+	"strconv"
+
+	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eve/api/go/config"
 	"github.com/lf-edge/eve/api/go/evecommon"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
-	"strconv"
 )
 
 //appBundle type for aggregate objects, needed for application
@@ -126,13 +128,17 @@ func (exp *AppExpectation) Application() *config.AppInstanceConfig {
 	if err = exp.ctrl.AddApplicationInstanceConfig(bundle.appInstanceConfig); err != nil {
 		log.Fatalf("AddApplicationInstanceConfig: %s", err)
 	}
-	for _, el := range bundle.contentTrees {
-		_ = exp.ctrl.AddContentTree(el)
-		exp.device.SetContentTreeConfig(append(exp.device.GetContentTrees(), el.Uuid))
-	}
-	for _, el := range bundle.volumes {
-		_ = exp.ctrl.AddVolume(el)
-		exp.device.SetVolumeConfigs(append(exp.device.GetVolumes(), el.Uuid))
+	if exp.appLink == defaults.DefaultDummyExpect {
+		log.Debug("skip modify of entities")
+	} else {
+		for _, el := range bundle.contentTrees {
+			_ = exp.ctrl.AddContentTree(el)
+			exp.device.SetContentTreeConfig(append(exp.device.GetContentTrees(), el.Uuid))
+		}
+		for _, el := range bundle.volumes {
+			_ = exp.ctrl.AddVolume(el)
+			exp.device.SetVolumeConfigs(append(exp.device.GetVolumes(), el.Uuid))
+		}
 	}
 	return bundle.appInstanceConfig
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,6 +9,8 @@ For testing Eden provides two essential services:
 You can read more about the general principles of Eden testing at:
 [EVE+Integration+Testing](https://wiki.lfedge.org/display/EVE/EVE+Integration+Testing)
 
+Basic testing workflow for CI/CD of project: [workflow/README.MD](workflow/README.MD)
+
 ## Test building
 
 Tests is a standard Go test [testing](https://golang.org/pkg/testing) compiled by
@@ -222,6 +224,14 @@ This is the short form of:
 ```console
 eden test tests/escript -p eden.escript.test -r TestEdenScripts/message
 ```
+
+List of detectors:
+
+* [eden.reboot.test -- Reboot detector](reboot/README.md)
+* [eden.lim.test -- Log/Info/Metric detector](lim/README.md)
+* [eden.app.test -- Application state detector](app/README.md)
+* [eden.network.test -- Network state detector](network/README.md)
+* [eden.vol.test -- Volume state detector](volume/README.md)
 
 You can read more about the test scripting for Eden testing
 at [escript/README.md](escript/README.md).

--- a/tests/app/README.md
+++ b/tests/app/README.md
@@ -9,4 +9,8 @@ eden.app.test [options] state app_name...
 Where "status" is the standard state of the application (for example, RUNNING)
 or "-" to detect deletion of applications.
 
+Test specific "options":
+
+* -timewait -- Timewait for waiting (1 min by default).
+
 [E-script test for 2 dockers](testdata/2dockers_test.txt).

--- a/tests/eclient/testdata/eclients.txt
+++ b/tests/eclient/testdata/eclients.txt
@@ -39,8 +39,8 @@ HOST=$($EDEN eve ip)
 
 # 20 apps by default
 APPS="{{if $apps}}{{$apps}}{{else}}20{{end}}"
-# Default image -- docker://itmoeve/eclient:latest
-IMG="{{if $img}}{{$img}}{{else}}docker://itmoeve/eclient:latest{{end}}"
+# Default image -- docker://itmoeve/eclient:0.3
+IMG="{{if $img}}{{$img}}{{else}}docker://itmoeve/eclient:0.3{{end}}"
 
 PORTS=""
 for i in `seq $APPS`

--- a/tests/eclient/testdata/eclients.txt
+++ b/tests/eclient/testdata/eclients.txt
@@ -102,10 +102,10 @@ PODS=""
 for i in `seq $APPS`
 do
  PODS="$PODS eclient$i"
+ echo $EDEN pod delete eclient$i
+ $EDEN pod delete eclient$i
 done
 
-echo $EDEN pod delete $PODS
-$EDEN pod delete $PODS
 echo $TAPP -test.v -timewait 20m - $PODS
 $TAPP -test.v -timewait 20m - $PODS
 
@@ -116,4 +116,4 @@ do
 done
 
 echo {{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden-ports.sh $PORTS
-{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/edenr-ports.sh $PORTS
+{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden-ports.sh $PORTS

--- a/tests/eclient/testdata/host-only.txt
+++ b/tests/eclient/testdata/host-only.txt
@@ -8,7 +8,7 @@
 [!exec:ssh] stop
 
 # Starting of reboot detector with a 2 reboot limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
 
 eden pod deploy -n ping-nw --memory=512MB docker://itmoeve/eclient:0.3 -p 2223:22
 eden pod deploy -n ping-fw --memory=512MB docker://itmoeve/eclient:0.3 -p 2224:22 --only-host=true

--- a/tests/eclient/testdata/nw_switch.txt
+++ b/tests/eclient/testdata/nw_switch.txt
@@ -16,13 +16,11 @@ exec sleep 20
 
 message 'Creating networks'
 #exec sleep 5
-eden network create 10.1.0.0/24 -n n1
+eden network create 10.11.12.0/24 -n n1
 #exec sleep 5
-eden network create 10.2.0.0/24 -n n2
+eden network create 10.11.13.0/24 -n n2
 
-exec bash wait_net.sh n1 n2
-stdout '^n1\s'
-stdout '^n2\s'
+test eden.network.test -test.v -timewait 10m ACTIVATED n1 n2
 
 message 'Starting applications'
 eden pod deploy -v debug -n ping1 docker://itmoeve/eclient:0.3 -p 2223:22 --networks=n1 --memory=512MB
@@ -86,24 +84,15 @@ test eden.app.test -test.v -timewait 10m - ping-nw ping-fw pong
 
 eden network delete n1
 eden network delete n2
-exec bash wait_off_net.sh n1 n2
-#eden network ls
+
+test eden.network.test -test.v -timewait 10m - n1 n2
+
+stdout 'no network with n1 found'
+stdout 'no network with n2 found'
+
+eden network ls
 ! stdout '^n1\s'
 ! stdout '^n2\s'
-
--- wait_net.sh --
-EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-
-for n in $*
-do
-  for i in `seq 10`
-  do
-    sleep 10
-    echo $n:$i
-    $EDEN network ls
-    $EDEN network ls | grep "^$n\s\+.*\s\+ACTIVATED$" && break
-  done
-done
 
 -- wait_ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
@@ -132,22 +121,6 @@ HOST=$($EDEN eve ip)
 
 echo {{template "ssh"}}$HOST -p $1 ping -c 5 "$PONG_IP"
 {{template "ssh"}}$HOST -p $1 ping -c 5 "$PONG_IP"
-
--- wait_off_net.sh --
-EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-
-for n in $*
-do
-  for i in `seq 10`
-  do
-    sleep 10
-    echo $n:$i
-    $EDEN network ls
-    $EDEN network ls | grep -v "^$n\s\+" && break
-  done
-done
-
-$EDEN network ls | grep -v [^n[12]\s\+
 
 -- eden-config.yml --
 {{/* Test's config. file */}}

--- a/tests/lim/README.md
+++ b/tests/lim/README.md
@@ -1,0 +1,19 @@
+# Log/Info/Metric detector
+
+The syntax for calling this detector is:
+
+```console
+eden.lim.test [options]
+```
+
+Test specific "options":
+
+* -number -- The number of items (0=unlimited) you need to get (1 by default)
+* -out -- Parameters for searching in out separated by ':'
+* -timewait -- Timewait for waiting (10 min by default)
+
+Testscripts:
+
+* [E-script test for logs](testdata/log_test.txt)
+* [E-script test for infos](testdata/info_test.txt)
+* [E-script test for metrics](testdata/metric_test.txt)

--- a/tests/lim/lim_test.go
+++ b/tests/lim/lim_test.go
@@ -23,7 +23,7 @@ import (
 var (
 	number   = flag.Int("number", 1, "The number of items (0=unlimited) you need to get")
 	timewait = flag.Duration("timewait", 10*time.Minute, "Timewait for items waiting")
-	out      = flag.String("out", "", "Paramters for out separated by ':'")
+	out      = flag.String("out", "", "Parameters for out separated by ':'")
 
 	// This context holds all the configuration items in the same
 	// way that Eden context works: the commands line options override

--- a/tests/network/Makefile
+++ b/tests/network/Makefile
@@ -50,10 +50,19 @@ test:
 
 build: setup
 
-setup: $(BINDIR) $(DATADIR)
-	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
+testbin: $(TESTBIN)
+$(LOCALTESTBIN): $(BINDIR) *.go
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
 
-.PHONY: test build setup clean all image
+$(TESTBIN): $(LOCALTESTBIN)
+	ln -sf $(LOCALTESTBIN) $(TESTBIN)
+
+setup: testbin $(BINDIR) $(DATADIR)
+	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(DATADIR)
+	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
+	ln -sf ../$(TESTDIR)/$(TESTBIN) $(BINDIR)
+
+.PHONY: test build setup clean all testbin image
 
 image:
 	@echo "Build image"

--- a/tests/network/README.md
+++ b/tests/network/README.md
@@ -4,6 +4,8 @@ This test creates and assignes a network to 2 applications, which communicate.
 One has nginx, the other uses curl.
 Creates 2 networks, checks internal IPs and does intercommunication
 
+[E-script test for networks](testdata/test_networking.txt).
+
 ## Test structure
 
 eden.network.tests.txt - escript scenario file
@@ -13,6 +15,24 @@ eden.network.tests.txt - escript scenario file
 * dhcpcd.conf - setup for dhcpcd
 * entrypoint.sh - entrypoint for Docker which runs required workload
 (curl, nginx, ip, dhcpcd)
+* nw\_test.go - source of networks detector
 * supervisord.conf - processing params and run strings for workloads
 * /testdata - a folder with custom escripts for a workload
-* test_networking.txt - main test file
+* test\_networking.txt - main test file
+
+## Network state detector
+
+The syntax for calling this detector is:
+
+```console
+eden.network.test [options] state nw_name...
+```
+
+Where "status" is the standard state of the network (for example, ACTIVATED)
+or "-" to detect deletion of network.
+
+Test specific "options":
+
+* -timewait -- Timewait for waiting (1 min by default).
+
+[E-script test for network](testdata/network_test.txt).

--- a/tests/network/nw_test.go
+++ b/tests/network/nw_test.go
@@ -1,0 +1,157 @@
+package network
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eden/pkg/eve"
+	"github.com/lf-edge/eden/pkg/projects"
+	"github.com/lf-edge/eden/pkg/utils"
+	"github.com/lf-edge/eve/api/go/info"
+)
+
+// This test wait for the network's state with a timewait.
+var (
+	timewait = flag.Duration("timewait", time.Minute, "Timewait for items waiting")
+	tc       *projects.TestContext
+	states   map[string][]string
+	eveState *eve.State
+)
+
+// TestMain is used to provide setup and teardown for the rest of the
+// tests. As part of setup we make sure that context has a slice of
+// EVE instances that we can operate on. For any action, if the instance
+// is not specified explicitly it is assumed to be the first one in the slice
+func TestMain(m *testing.M) {
+	fmt.Println("Docker network's state test")
+
+	tc = projects.NewTestContext()
+
+	projectName := fmt.Sprintf("%s_%s", "TestVolState", time.Now())
+
+	tc.InitProject(projectName)
+
+	tc.AddEdgeNodesFromDescription()
+
+	eveState = eve.Init(tc.GetController(), tc.GetEdgeNode())
+
+	tc.StartTrackingState(false)
+
+	res := m.Run()
+
+	os.Exit(res)
+}
+
+// checkNewLastState returns true if provided state not equals with last
+func checkNewLastState(volName, state string) bool {
+	volStates, ok := states[volName]
+	if ok {
+		lastState := volStates[len(volStates)-1]
+		fmt.Printf("lastState: %s state: %s\n", lastState, state)
+		if lastState != state {
+			return true
+		}
+	}
+	return false
+}
+
+func checkAndAppendState(volName, state string) {
+	if checkNewLastState(volName, state) {
+		states[volName] = append(states[volName], state)
+	}
+}
+
+func checkState(eveState *eve.State, state string, volNames []string) error {
+	out := "\n"
+	if state == "-" {
+		foundAny := false
+		if eveState.InfoAndMetrics().GetDinfo() == nil {
+			//we need to wait for info
+			return nil
+		}
+		for _, vol := range eveState.Networks() {
+			if _, inSlice := utils.FindEleInSlice(volNames, vol.Name); inSlice {
+				checkAndAppendState(vol.Name, "EXISTS")
+				foundAny = true
+			}
+		}
+		if foundAny {
+			return nil
+		}
+		for _, volName := range volNames {
+			out += fmt.Sprintf(
+				"no network with %s found\n",
+				volName)
+		}
+		return fmt.Errorf(out)
+	}
+	for _, vol := range eveState.Networks() {
+		if _, inSlice := utils.FindEleInSlice(volNames, vol.Name); inSlice {
+			fmt.Printf("%s: %s\n", vol.Name, vol.EveState)
+			checkAndAppendState(vol.Name, vol.EveState)
+		}
+	}
+	if len(states) == len(volNames) {
+		for _, volName := range volNames {
+			if !checkNewLastState(volName, state) {
+				out += fmt.Sprintf(
+					"network %s state %s\n",
+					volName, state)
+			} else {
+				return nil
+			}
+		}
+		return fmt.Errorf(out)
+	}
+	return nil
+}
+
+//checkVol wait for info of ZInfoApp type with state
+func checkVol(state string, volNames []string) projects.ProcInfoFunc {
+	return func(msg *info.ZInfoMsg) error {
+		eveState.InfoCallback()(msg, nil) //feed state with new info
+		return checkState(eveState, state, volNames)
+	}
+}
+
+//TestVolStatus wait for application reaching the selected state
+//with a timewait
+func TestVolStatus(t *testing.T) {
+	edgeNode := tc.GetEdgeNode(tc.WithTest(t))
+
+	args := flag.Args()
+	if len(args) == 0 {
+		t.Fatalf("Usage: %s [options] state vol_name...\n", os.Args[0])
+	} else {
+		secs := int(timewait.Seconds())
+		state := args[0]
+		fmt.Printf("networks: '%s' state: '%s' secs: %d\n",
+			args[1:], state, secs)
+
+		vols := args[1:]
+		states = make(map[string][]string)
+		for _, el := range vols {
+			states[el] = []string{"no info from controller"}
+		}
+
+		tc.AddProcInfo(edgeNode, checkVol(state, vols))
+
+		callback := func() {
+			t.Errorf("ASSERTION FAILED: expected networks %s in %s state", vols, state)
+			for k, v := range states {
+				t.Errorf("\tactual %s: %s", k, v[len(v)-1])
+				if checkNewLastState(k, state) {
+					t.Errorf("\thistory of states for %s:", k)
+					for _, st := range v {
+						t.Errorf("\t\t%s", st)
+					}
+				}
+			}
+		}
+
+		tc.WaitForProcWithErrorCallback(secs, callback)
+	}
+}

--- a/tests/network/testdata/network_test.txt
+++ b/tests/network/testdata/network_test.txt
@@ -1,7 +1,7 @@
 eden -t 5s network ls
 
 # Starting of reboot detector with a 3 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
 
 # Create n1 network
 eden -t 1m network create 10.1.0.0/24 -n n1
@@ -13,10 +13,10 @@ test eden.network.test -test.v -timewait 20m ACTIVATED n1
 #exec sleep 20
 #test eden.network.test -test.v -timewait 20m ACTIVATED n1
 
-# Volume detecting
+# Networks detecting
 eden -t 1m network ls
-cp stdout vol_ls
-grep '^n1\s*' vol_ls
+cp stdout net_ls
+grep '^n1\s*' net_ls
 
 # Delete by network's actor
 eden -t 5m network delete n1

--- a/tests/network/testdata/network_test.txt
+++ b/tests/network/testdata/network_test.txt
@@ -1,0 +1,42 @@
+eden -t 5s network ls
+
+# Starting of reboot detector with a 3 reboots limit
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
+
+# Create n1 network
+eden -t 1m network create 10.1.0.0/24 -n n1
+stdout 'deploy network .* with name n1 request sent'
+
+# Wait for run
+test eden.network.test -test.v -timewait 20m ACTIVATED n1
+# Need to fix -- another try of detecting not passing
+#exec sleep 20
+#test eden.network.test -test.v -timewait 20m ACTIVATED n1
+
+# Volume detecting
+eden -t 1m network ls
+cp stdout vol_ls
+grep '^n1\s*' vol_ls
+
+# Delete by network's actor
+eden -t 5m network delete n1
+stdout 'network n1 delete done'
+
+# Wait for delete
+test eden.network.test -test.v -timewait 20m - n1
+#test eden.network.test -test.v -timewait 20m - n1
+stdout 'no network with n1 found'
+
+# Networks detecting
+eden -t 1m network ls
+! stdout '^n1\s'
+
+# Test's config. file
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/network/testdata/test_networking.txt
+++ b/tests/network/testdata/test_networking.txt
@@ -19,8 +19,8 @@
 {{$test_data := "TEST_SEQUENCE"}}
 
 # create or get two networks for the test
-eden network create 10.1.0.0/24
-eden network create 10.2.0.0/24
+eden network create 10.11.12.0/24
+eden network create 10.11.13.0/24
 
 # obtain network list
 eden network ls
@@ -91,7 +91,7 @@ stdout 'no app with app3 found'
 
 echo "defining of environment variables for the first app"
 
-echo net=$(grep '10.2.0.0/24' network_ls | cut -f1)>.env
+echo net=$(grep '10.11.13.0/24' network_ls | cut -f1)>.env
 echo external_port=''>>.env
 echo metadata={{$test_data}}>>.env
 echo name=app1>>.env
@@ -106,9 +106,9 @@ $EDEN pod ps>pod_ps
 
 echo "defining of environment variables for the second app"
 
-echo net=$(grep '10.1.0.0/24' network_ls | cut -f1),$(grep '10.2.0.0/24' network_ls | cut -f1)>.env
+echo net=$(grep '10.11.12.0/24' network_ls | cut -f1),$(grep '10.11.13.0/24' network_ls | cut -f1)>.env
 echo external_port=-p 8027:80>>.env
-echo metadata=http://$(grep '10.2.0.' pod_ps | grep -o -E '10.2.0.[0-9]{1,3}')/user-data.html>>.env
+echo metadata=http://$(grep '10.11.13.' pod_ps | grep -o -E '10.11.13.[0-9]{1,3}')/user-data.html>>.env
 echo name=app2>>.env
 echo vnc=2>>.env
 echo firewall=false>>.env
@@ -128,9 +128,9 @@ until curl $address | grep {{$test_data}}; do sleep 3; done
 
 echo "defining of environment variables for the third app"
 
-echo net=$(grep '10.1.0.0/24' network_ls | cut -f1),$(grep '10.2.0.0/24' network_ls | cut -f1)>.env
+echo net=$(grep '10.11.12.0/24' network_ls | cut -f1),$(grep '10.11.13.0/24' network_ls | cut -f1)>.env
 echo external_port=-p 8028:80>>.env
-echo metadata=http://$(grep '10.2.0.' pod_ps |grep app1| grep -o -E '10.2.0.[0-9]{1,3}')/user-data.html>>.env
+echo metadata=http://$(grep '10.11.13.' pod_ps |grep app1| grep -o -E '10.11.13.[0-9]{1,3}')/user-data.html>>.env
 echo name=app3>>.env
 echo vnc=3>>.env
 echo firewall=true>>.env

--- a/tests/reboot/README.md
+++ b/tests/reboot/README.md
@@ -1,0 +1,13 @@
+# Reboot detector
+
+The syntax for calling this detector is:
+
+```console
+eden.reboot.test [options]
+```
+
+Where specific "options":
+
+* -timewait -- Timewait for waiting (1 min by default).
+* -count -- Number of reboots (1 by default).
+* -reboot -- Reboot or not reboot... ("true" by default)

--- a/tests/reboot/reboot_test.go
+++ b/tests/reboot/reboot_test.go
@@ -33,7 +33,7 @@ tc *TestContext // TestContext is at least {
 */
 
 var (
-	timewait = flag.Duration("timewait", time.Minute, "Timewait for items waiting")
+	timewait = flag.Duration("timewait", time.Minute, "Timewait for waiting")
 	reboot   = flag.Bool("reboot", true, "Reboot or not reboot...")
 	count    = flag.Int("count", 1, "Number of reboots")
 

--- a/tests/volume/README.md
+++ b/tests/volume/README.md
@@ -9,4 +9,8 @@ eden.vol.test [options] state vol_name...
 Where "status" is the standard state of the volume (for example, DELIVERED)
 or "-" to detect deletion of volume.
 
+Test specific "options":
+
+* -timewait -- Timewait for waiting (1 min by default).
+
 [E-script test for volumes](testdata/volumes_test.txt).

--- a/tests/volume/testdata/volumes_test.txt
+++ b/tests/volume/testdata/volumes_test.txt
@@ -1,7 +1,7 @@
 eden -t 5s volume ls
 
 # Starting of reboot detector with a 3 reboots limit
-! test eden.reboot.test -test.v -timewait 600 -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
 
 # Create v1 volume
 eden -t 1m volume create -n v1 docker://itmoeve/eclient:latest

--- a/tests/workflow/README.MD
+++ b/tests/workflow/README.MD
@@ -1,5 +1,19 @@
 ## This is the typical example of the test set
 
+# Test workflow
+
+Basic testing [workflow](eden.workflow.tests.txt) for CI/CD of project.
+
+Supported environment variables:
+* EDEN_TEST_SETUP -- make EDEN's setup steps
+* EDEN_TEST_STOP -- stop EDEN after tests
+* EDEN_TEST -- flavour of test set: "small", "medium"(default) and "large"
+
+Example of running:
+```
+EDEN_TEST_STOP=y EDEN_TEST_SETUP=y EDEN_TEST=large eden test tests/workflow/ -v debug
+```
+
 # Quickstart
 
 Each testset or individual test should contain:

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -1,52 +1,92 @@
-{{$tests := 18}}
+{{$tests := 31}}
 {{$workflow := EdenGetEnv "EDEN_TEST"}}
-{{ if and (ne $workflow "small") (ne $workflow "large") (ne $workflow "gcp") }}
-/bin/echo Eden setup (1/{{$tests}})
+{{$setup := EdenGetEnv "EDEN_TEST_SETUP"}}
+{{$stop := EdenGetEnv "EDEN_TEST_STOP"}}
+
+{{if (eq $setup "y")}}
+#./eden config add default
+/bin/echo Eden setup (01/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_setup
-/bin/echo Eden start (2/{{$tests}})
+#source ~/.eden/activate.sh
+/bin/echo Eden start (02/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_start
-/bin/echo Eden onboard (3/{{$tests}})
+/bin/echo Eden onboard (03/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_onboard
 {{end}}
-/bin/echo Eden Log test (4/{{$tests}})
+
+/bin/echo Eden Log test (04/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/log_test -testdata ../lim/testdata/
-/bin/echo Eden SSH test (5/{{$tests}})
+/bin/echo Eden SSH test (05/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/ssh
 {{ if eq $workflow "large" }}
-/bin/echo Eden Info test (6/{{$tests}})
+/bin/echo Eden Info test (06/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/info_test -testdata ../lim/testdata/
 {{end}}
-/bin/echo Eden Metric test (7/{{$tests}})
+/bin/echo Eden Metric test (07/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/metric_test -testdata ../lim/testdata/
-eden+ports.sh 2223:2223 2224:2224
-/bin/echo Eden Network test (8/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/test_networking -testdata ../network/testdata/
-/bin/echo Eden 2 dockers test (9/{{$tests}})
-#eden.escript.test -test.run TestEdenScripts/2dockers_test -testdata ../docker/testdata/
-eden.escript.test -test.run TestEdenScripts/2dockers_test -testdata ../app/testdata/
+
+/bin/echo Escript args test (08/{{$tests}})
+eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/arg -args=test1=123,test2=456
+/bin/echo Escript template test (09/{{$tests}})
+eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/template
+/bin/echo Escript message test (10/{{$tests}})
+eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/message
+/bin/echo Escript nested scripts test (11/{{$tests}})
+eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/nested_scripts
+/bin/echo Escript time test (12/{{$tests}})
+eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/time
+/bin/echo Escript source test (13/{{$tests}})
+eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/source
+/bin/echo Escript fail scenario test (14/{{$tests}})
+eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/fail_scenario
+
+/bin/echo Eden basic network test (15/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/network_test -testdata ../network/testdata/
+/bin/echo Eden basic volumes test (16/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/volumes_test -testdata ../volume/testdata/
+
+eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027
+
+/bin/echo Eden Host only ACL (16/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/host-only -testdata ../eclient/testdata/
+/bin/echo Eden Network light (17/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/networking_light -testdata ../eclient/testdata/
+/bin/echo Eden Networks switch (18/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/nw_switch -testdata ../eclient/testdata/
+/bin/echo Eden Network Ports switch (19/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/port_switch -testdata ../eclient/testdata/
+
 {{ if or (eq $workflow "large") (eq $workflow "gcp") }}
-/bin/echo Eden VNC (9.5/{{$tests}})
+/bin/echo Eden VNC (20/{{$tests}})
 eden.vnc.test
 {{end}}
 {{ if  (eq $workflow "large")  }}
-/bin/echo Eden registry (10/{{$tests}})
+/bin/echo Eden registry (21/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/registry_test -testdata ../registry/testdata/
-/bin/echo Eden Host only ACL (11/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/host-only -testdata ../eclient/testdata/
-/bin/echo Eden Network light (12/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/networking_light -testdata ../eclient/testdata/
-/bin/echo Eden Nginx (13/{{$tests}})
+/bin/echo Eden Network test (22/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/test_networking -testdata ../network/testdata/
+/bin/echo Eden 2 dockers test (23/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/2dockers_test -testdata ../docker/testdata/
+/bin/echo Eden 2 dockers test with app state detector (24/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/2dockers_test -testdata ../app/testdata/
+/bin/echo Eden Nginx (25/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/ngnix -testdata ../eclient/testdata/
-/bin/echo Eden Mariadb (14/{{$tests}})
+/bin/echo Eden Mariadb (26/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/maridb -testdata ../eclient/testdata/
-/bin/echo Eden's testing the maximum application limit (15/{{$tests}})
+/bin/echo EVE reset (27/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_reset
+/bin/echo Eden's testing the maximum application limit (28/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eclients -testdata ../eclient/testdata/
 {{end}}
-/bin/echo Eden Reboot test (16/{{$tests}})
+
+/bin/echo Eden Reboot test (29/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/reboot_test
 {{ if ne $workflow "small" }}
-/bin/echo Eden base OS update (17/{{$tests}})
+/bin/echo Eden base OS update (30/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/update_eve_image -testdata ../update_eve_image/testdata/
 {{end}}
-/bin/echo Eden stop (18/{{$tests}})
+
+{{if (eq $stop "y")}}
+/bin/echo Eden stop (31/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_stop
+{{end}}

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -18,7 +18,7 @@ eden.escript.test -test.run TestEdenScripts/eden_onboard
 eden.escript.test -test.run TestEdenScripts/log_test -testdata ../lim/testdata/
 /bin/echo Eden SSH test (05/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/ssh
-{{ if eq $workflow "large" }}
+{{ if or (eq $workflow "large") (eq $workflow "gcp") }}
 /bin/echo Eden Info test (06/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/info_test -testdata ../lim/testdata/
 {{end}}
@@ -40,12 +40,12 @@ eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/sourc
 /bin/echo Escript fail scenario test (14/{{$tests}})
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/fail_scenario
 
+eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027
+
 /bin/echo Eden basic network test (15/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/network_test -testdata ../network/testdata/
 /bin/echo Eden basic volumes test (16/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/volumes_test -testdata ../volume/testdata/
-
-eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027
 
 /bin/echo Eden Host only ACL (16/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/host-only -testdata ../eclient/testdata/
@@ -59,8 +59,6 @@ eden.escript.test -test.run TestEdenScripts/port_switch -testdata ../eclient/tes
 {{ if or (eq $workflow "large") (eq $workflow "gcp") }}
 /bin/echo Eden VNC (20/{{$tests}})
 eden.vnc.test
-{{end}}
-{{ if  (eq $workflow "large")  }}
 /bin/echo Eden registry (21/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/registry_test -testdata ../registry/testdata/
 /bin/echo Eden Network test (22/{{$tests}})
@@ -75,6 +73,8 @@ eden.escript.test -test.run TestEdenScripts/ngnix -testdata ../eclient/testdata/
 eden.escript.test -test.run TestEdenScripts/maridb -testdata ../eclient/testdata/
 /bin/echo EVE reset (27/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_reset
+{{end}}
+{{ if  (eq $workflow "large")  }}
 /bin/echo Eden's testing the maximum application limit (28/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eclients -testdata ../eclient/testdata/
 {{end}}

--- a/tests/workflow/testdata/eden_reset.txt
+++ b/tests/workflow/testdata/eden_reset.txt
@@ -10,11 +10,14 @@ stdout '^1$'
 exec bash chk_nets.sh
 stdout '^1$'
 
+exec bash chk_vols.sh
+stdout '^1$'
+
 -- chk_pods.sh --
 #!/bin/bash
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-for i in `seq 10`
+for i in `seq 30`
 do
     echo Step $i pod ps
     test `$EDEN pod ps | wc -l` -gt 1 || break
@@ -27,7 +30,7 @@ $EDEN pod ps | wc -l
 #!/bin/bash
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-for i in `seq 10`
+for i in `seq 30`
 do
     echo Step $i network ls
     test `$EDEN network ls | wc -l` -gt 1 || break
@@ -35,6 +38,19 @@ do
 done
 
 $EDEN network ls | wc -l
+
+-- chk_vols.sh --
+#!/bin/bash
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+for i in `seq 30`
+do
+    echo Step $i volume ls
+    test `$EDEN volume ls | wc -l` -gt 1 || break
+    sleep 10
+done
+
+$EDEN volume ls | wc -l
 
 -- eden-config.yml --
 test:


### PR DESCRIPTION
Extended CI/CD workflow. Now supported such env. vars.:
* EDEN_TEST_SETUP -- make EDEN's setup steps
* EDEN_TEST_STOP -- stop EDEN after tests
* EDEN_TEST -- flavour of test set: "small", "medium"(default) and "large"

Example of running:
```
EDEN_TEST_SETUP=y  EDEN_TEST_STOP=y EDEN_TEST=large eden test tests/workflow/ -v debug
```

Added network test detector. We have similar problems with repeated running of detector as in volume detector in https://github.com/lf-edge/eden/pull/455.

Signed-off-by: Oleg Sadov <oleg.sadov@gmail.com>