### PR TITLE
Test option '-e' to make Escripts easier to run

### DIFF
--- a/cmd/edenTest.go
+++ b/cmd/edenTest.go
@@ -13,6 +13,7 @@ import (
 var (
 	testArgs     string
 	testOpts     bool
+	testEscript  string
 	testRun      string
 	testTimeout  string
 	testList     string
@@ -84,6 +85,9 @@ test <test_dir> -r <regexp> [-t <timewait>] [-v <level>]
 		case testOpts:
 			tests.RunTest(testProg, []string{"-h"}, "", testTimeout, failScenario, configFile, verbosity)
 			return
+		case testEscript != "":
+			tests.RunTest("eden.escript.test", []string{"-test.run", "TestEdenScripts/" + testEscript}, testArgs, testTimeout, failScenario, configFile, verbosity)
+			return
 		case testRun != "":
 			tests.RunTest(testProg, []string{"-test.run", testRun}, testArgs, testTimeout, failScenario, configFile, verbosity)
 			return
@@ -95,6 +99,7 @@ test <test_dir> -r <regexp> [-t <timewait>] [-v <level>]
 }
 
 func testInit() {
+	testCmd.Flags().StringVarP(&testEscript, "escript", "e", "", "run EScript matching the regular expression")
 	testCmd.Flags().StringVarP(&testProg, "prog", "p", defaults.DefaultTestProg, "program binary to run tests")
 	testCmd.Flags().StringVarP(&testRun, "run", "r", "", "run only those tests matching the regular expression")
 	testCmd.Flags().StringVarP(&testTimeout, "timeout", "t", "", "panic if test exceded the timeout")

--- a/docs/test-examples.md
+++ b/docs/test-examples.md
@@ -12,53 +12,53 @@ eden start
 eden onboard
 
 ## tests/app
-eden test tests/app -p eden.escript.test -r TestEdenScripts/2dockers_test
+eden test tests/app -e 2dockers_test
 eden eve reset
 ## tests/docker
-eden test tests/docker -p eden.escript.test -r TestEdenScripts/2dockers_test
+eden test tests/docker -e 2dockers_test
 eden eve reset
 ## tests/eclient
 # Just a simple test of eclient image functionality -- tested in more complex tests
-#eden test tests/eclient -p eden.escript.test -r TestEdenScripts/eclient -t 15m
-eden test tests/eclient -p eden.escript.test -r TestEdenScripts/host-only -t 15m
+#eden test tests/eclient -e eclient -t 15m
+eden test tests/eclient -e host-only -t 15m
 eden eve reset
-eden test tests/eclient -p eden.escript.test -r TestEdenScripts/networking_light -t 15m
+eden test tests/eclient -e networking_light -t 15m
 eden eve reset
-eden test tests/eclient -p eden.escript.test -r TestEdenScripts/nw_switch -t 20m
+eden test tests/eclient -e nw_switch -t 20m
 eden eve reset
-eden test tests/eclient -p eden.escript.test -r TestEdenScripts/port_switch -t 20m
+eden test tests/eclient -e port_switch -t 20m
 eden eve reset
 # Just a simple test of nginx image -- tested in port_switch test
-#eden test tests/eclient -p eden.escript.test -r TestEdenScripts/ngnix -t 20m
-eden test tests/eclient -p eden.escript.test -r TestEdenScripts/maridb -t 20m
+#eden test tests/eclient -e ngnix -t 20m
+eden test tests/eclient -e maridb -t 20m
 eden eve reset
 ## tests/escript
-eden test tests/escript -p eden.escript.test -r TestEdenScripts/arg -a "-args=test1=123,test2=456"
+eden test tests/escript -e arg -a "-args=test1=123,test2=456"
 eden eve reset
-eden test tests/escript -p eden.escript.test -r TestEdenScripts/template
+eden test tests/escript -e template
 eden eve reset
-eden test tests/escript -p eden.escript.test -r TestEdenScripts/message
+eden test tests/escript -e message
 eden eve reset
-eden test tests/escript -p eden.escript.test -r TestEdenScripts/nested_scripts
+eden test tests/escript -e nested_scripts
 eden eve reset
-eden test tests/escript -p eden.escript.test -r TestEdenScripts/time
+eden test tests/escript -e time
 eden eve reset
-eden test tests/escript -p eden.escript.test -r TestEdenScripts/source
+eden test tests/escript -e source
 eden eve reset
-eden test tests/escript -p eden.escript.test -r TestEdenScripts/fail_scenario
+eden test tests/escript -e fail_scenario
 eden eve reset
 ## tests/lim
-eden test tests/lim -p eden.escript.test -r TestEdenScripts/log_test
+eden test tests/lim -e log_test
 eden eve reset
-eden test tests/lim -p eden.escript.test -r TestEdenScripts/info_test
+eden test tests/lim -e info_test
 eden eve reset
-eden test tests/lim -p eden.escript.test -r TestEdenScripts/metric_test
+eden test tests/lim -e metric_test
 eden eve reset
 ## tests/network
-eden test tests/network -p eden.escript.test -r TestEdenScripts/test_networking -t 40m
+eden test tests/network -e test_networking -t 40m
 eden eve reset
 ## tests/phoronix
-eden test tests/phoronix -p eden.escript.test -r TestEdenScripts/test_phoronix -a "benchmark=fio-basic"
+eden test tests/phoronix -e test_phoronix -a "benchmark=fio-basic"
 eden eve reset
 ## tests/reboot
 eden test tests/reboot -p eden.reboot.test
@@ -66,34 +66,34 @@ eden eve reset
 ## tests/units
 make -C tests/units test
 ## tests/update_eve_image
-eden test tests/update_eve_image -p eden.escript.test -r TestEdenScripts/update_eve_image -t 10m
+eden test tests/update_eve_image -e update_eve_image -t 10m
 eden eve reset
 ## tests/vnc
 eden test tests/vnc -p eden.vnc.test
 ## tests/workflow
-eden test tests/workflow -p eden.escript.test -r TestEdenScripts/log_test -a '-testdata ../lim/testdata/'
+eden test tests/workflow -e log_test -a '-testdata ../lim/testdata/'
 eden eve reset
-eden test tests/workflow -p eden.escript.test -r TestEdenScripts/ssh
+eden test tests/workflow -e ssh
 eden eve reset
-eden test tests/workflow -p eden.escript.test -r TestEdenScripts/info_test -a '-testdata ../lim/testdata/'
+eden test tests/workflow -e info_test -a '-testdata ../lim/testdata/'
 eden eve reset
-eden test tests/workflow -p eden.escript.test -r TestEdenScripts/metric_test -a '-testdata ../lim/testdata/'
+eden test tests/workflow -e metric_test -a '-testdata ../lim/testdata/'
 eden eve reset
-eden test tests/workflow -p eden.escript.test -r TestEdenScripts/test_networking -a '-testdata ../network/testdata/'
+eden test tests/workflow -e test_networking -a '-testdata ../network/testdata/'
 eden eve reset
-eden test tests/workflow -p eden.escript.test -r TestEdenScripts/2dockers_test -a '-testdata ../app/testdata/'
+eden test tests/workflow -e 2dockers_test -a '-testdata ../app/testdata/'
 eden eve reset
 eden test tests/workflow -p eden.vnc.test
 eden eve reset
-eden test tests/workflow -p eden.escript.test -r TestEdenScripts/host-only -a '-testdata ../eclient/testdata/'
+eden test tests/workflow -e host-only -a '-testdata ../eclient/testdata/'
 eden eve reset
-eden test tests/workflow -p eden.escript.test -r TestEdenScripts/networking_light -a '-testdata ../eclient/testdata/'
+eden test tests/workflow -e networking_light -a '-testdata ../eclient/testdata/'
 eden eve reset
-eden test tests/workflow -p eden.escript.test -r TestEdenScripts/ngnix -a '-testdata ../eclient/testdata/'
+eden test tests/workflow -e ngnix -a '-testdata ../eclient/testdata/'
 eden eve reset
-eden test tests/workflow -p eden.escript.test -r TestEdenScripts/maridb -a '-testdata ../eclient/testdata/'
+eden test tests/workflow -e maridb -a '-testdata ../eclient/testdata/'
 eden eve reset
-eden test tests/workflow -p eden.escript.test -r TestEdenScripts/reboot_test
+eden test tests/workflow -e reboot_test
 eden eve reset
-eden test tests/workflow -p eden.escript.test -r TestEdenScripts/update_eve_image -a '-testdata ../update_eve_image/testdata/'
+eden test tests/workflow -e update_eve_image -a '-testdata ../update_eve_image/testdata/'
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -46,6 +46,7 @@ Usage:
 
 Flags:
   -a, --args string            Arguments for test binary
+  -e, --escript string         run EScript matching the regular expression
   -f, --fail_scenario string   scenario for test failing (default "failScenario.txt")
   -h, --help                   help for test
   -l, --list string            list tests matching the regular expression
@@ -209,6 +210,18 @@ Test scripts can be used as glue logic for test binaries “detectors”
 and “actors”. All components that are required for tests,
 such as configuration files, test data, or external scripts,
 can be placed in a test script and processed by the Eden template engine.
+
+The easiest way to run a script from the test's `testdata` directory is to use the '-e' option:
+
+```console
+eden test tests/escript -e message
+```
+
+This is the short form of:
+
+```console
+eden test tests/escript -p eden.escript.test -r TestEdenScripts/message
+```
 
 You can read more about the test scripting for Eden testing
 at [escript/README.md](escript/README.md).

--- a/tests/escript/README.md
+++ b/tests/escript/README.md
@@ -8,6 +8,18 @@ The `eden.escript.test` test-binary is an adaptation to
 testscript machinery from
 [github.com/rogpeppe/go-internal/testscript](https://pkg.go.dev/github.com/rogpeppe/go-internal/testscript).
 
+The easiest way to run a script from the test's `testdata` directory is to use the '-e' option:
+
+```console
+eden test tests/escript -e message
+```
+
+This is the short form of:
+
+```console
+eden test tests/escript -p eden.escript.test -r TestEdenScripts/message
+```
+
 To invoke the tests from /tmp directory, for example, call the such command:
 
 ```console


### PR DESCRIPTION
The easiest way to run a script from the test's `testdata` directory is to use the '-e' option:
```console
eden test tests/escript -e message
```
This is the short form of:
```console
eden test tests/escript -p eden.escript.test -r TestEdenScripts/message
```
Signed-off-by: Oleg Sadov <oleg.sadov@gmail.com>