### PR TITLE
remove debug info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ ifeq ($(ESERVER_IMAGE_ID), ) # if we need to build eserver
 build: $(BIN) $(EMPTY_DRIVE_RAW) $(EMPTY_DRIVE_QCOW2) eserver
 endif
 $(LOCALBIN): $(BINDIR) cmd/*.go pkg/*/*.go pkg/*/*/*.go
-	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o $@ .
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -ldflags "-s -w" -o $@ .
 	mkdir -p dist/scripts/shell
 	cp shell-scripts/* dist/scripts/shell/
 

--- a/tests/app/Makefile
+++ b/tests/app/Makefile
@@ -49,7 +49,7 @@ build: setup
 
 testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
-	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -ldflags "-s -w" -o $@ *.go
 
 $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(TESTBIN)

--- a/tests/docker/Makefile
+++ b/tests/docker/Makefile
@@ -49,7 +49,7 @@ build: setup
 
 testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
-	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -ldflags "-s -w" -o $@ *.go
 
 $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN)

--- a/tests/escript/Makefile
+++ b/tests/escript/Makefile
@@ -49,7 +49,7 @@ build: setup
 
 testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
-	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -ldflags "-s -w" -o $@ *.go
 
 $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN)

--- a/tests/lim/Makefile
+++ b/tests/lim/Makefile
@@ -49,7 +49,7 @@ build: setup
 
 testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
-	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -ldflags "-s -w" -o $@ *.go
 
 $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN)

--- a/tests/network/Makefile
+++ b/tests/network/Makefile
@@ -52,7 +52,7 @@ build: setup
 
 testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
-	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -ldflags "-s -w" -o $@ *.go
 
 $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(TESTBIN)

--- a/tests/reboot/Makefile
+++ b/tests/reboot/Makefile
@@ -49,7 +49,7 @@ build: setup
 
 testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
-	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -ldflags "-s -w" -o $@ *.go
 
 $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN)

--- a/tests/vnc/Makefile
+++ b/tests/vnc/Makefile
@@ -49,7 +49,7 @@ build: setup
 
 testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
-	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -ldflags "-s -w" -o $@ *.go
 
 $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN)

--- a/tests/volume/Makefile
+++ b/tests/volume/Makefile
@@ -46,7 +46,7 @@ build: setup
 
 testbin: $(TESTBIN)
 $(LOCALTESTBIN): $(BINDIR) *.go
-	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -o $@ *.go
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -ldflags "-s -w" -o $@ *.go
 
 $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(TESTBIN)


### PR DESCRIPTION
Remove debug symbols to reduce `dist` size from 230MB to 155MB.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>