### PR TITLE
Return Eden setup to 'y' by default in main test workflow

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -26,7 +26,7 @@ jobs:
           ./eden config add default
           ./eden config set default --key=eve.accel --value=false
           echo > tests/workflow/testdata/eden_stop.txt
-          EDEN_TEST_SETUP=y ./eden test ./tests/workflow -v debug
+          ./eden test ./tests/workflow -v debug
       - name: Collect logs
         if: ${{ always() }}
         run: |

--- a/tests/workflow/README.MD
+++ b/tests/workflow/README.MD
@@ -5,9 +5,9 @@
 Basic testing [workflow](eden.workflow.tests.txt) for CI/CD of project.
 
 Supported environment variables:
-* EDEN_TEST_SETUP -- make EDEN's setup steps
-* EDEN_TEST_STOP -- stop EDEN after tests
-* EDEN_TEST -- flavour of test set: "small", "medium"(default) and "large"
+* EDEN_TEST_SETUP -- "y" performs the EDEN setup steps ("y" by default);
+* EDEN_TEST_STOP -- "y" stops EDEN after tests ("n" by default);
+* EDEN_TEST -- flavour of test set: "small", "medium"(default) and "large";
 
 Example of running:
 ```

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -3,7 +3,7 @@
 {{$setup := EdenGetEnv "EDEN_TEST_SETUP"}}
 {{$stop := EdenGetEnv "EDEN_TEST_STOP"}}
 
-{{if (eq $setup "y")}}
+{{if (ne $setup "n")}}
 #./eden config add default
 /bin/echo Eden setup (01/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_setup


### PR DESCRIPTION
Signed-off-by: Oleg Sadov <oleg.sadov@gmail.com>