### PR TITLE
Main workflow and tests extensions and fixes

### DIFF
--- a/pkg/models/common.go
+++ b/pkg/models/common.go
@@ -115,17 +115,21 @@ func generatePhysicalIOs(ethCount, wifiCount, usbCount uint) []*config.PhysicalI
 			},
 		})
 	}
+	usbGroup := 0
 	for i := uint(0); i < usbCount; i++ {
-		num := fmt.Sprintf("%d:1", i)
-		name := fmt.Sprintf("USB%s", num)
-		physicalIOs = append(physicalIOs, &config.PhysicalIO{
-			Ptype:        evecommon.PhyIoType_PhyIoUSB,
-			Phylabel:     name,
-			Logicallabel: name,
-			Assigngrp:    fmt.Sprintf("USB%d", i),
-			Phyaddrs:     map[string]string{"UsbAddr": num},
-			Usage:        evecommon.PhyIoMemberUsage_PhyIoUsageDedicated,
-		})
+		for j := uint(1); j < 4; j++ {
+			num := fmt.Sprintf("%d:%d", i, j)
+			name := fmt.Sprintf("USB%s", num)
+			physicalIOs = append(physicalIOs, &config.PhysicalIO{
+				Ptype:        evecommon.PhyIoType_PhyIoUSB,
+				Phylabel:     name,
+				Logicallabel: name,
+				Assigngrp:    fmt.Sprintf("USB%d", usbGroup),
+				Phyaddrs:     map[string]string{"UsbAddr": num},
+				Usage:        evecommon.PhyIoMemberUsage_PhyIoUsageDedicated,
+			})
+			usbGroup++
+		}
 	}
 	return physicalIOs
 }

--- a/tests/eclient/Makefile
+++ b/tests/eclient/Makefile
@@ -54,6 +54,7 @@ setup: $(BINDIR) $(DATADIR)
 	cp -a *.sh *.yml $(TESTSCN) testdata $(DATADIR)
 	ln -sf ../$(TESTDIR)/eden+ports.sh $(BINDIR)/
 	ln -sf ../$(TESTDIR)/eden-ports.sh $(BINDIR)/
+	ln -sf ../$(TESTDIR)/qemu+usb.sh $(BINDIR)/
 	chmod 700 image/cert/
 	chmod 600 image/cert/id_rsa*
 	mkdir -p $(DATADIR)/image/cert/

--- a/tests/eclient/eden+ports.sh
+++ b/tests/eclient/eden+ports.sh
@@ -6,6 +6,8 @@ then
   exit
 fi
 
+test -n "$EDEN_CONFIG" || EDEN_CONFIG=default
+
 EDEN=eden
 DIR=$(dirname "$0")
 PATH=$DIR:$DIR/../../bin:$PATH
@@ -31,9 +33,9 @@ then
   $EDEN config set "$EDEN_CONFIG" --key eve.hostfwd --value "$NEW"
   echo $EDEN config get "$EDEN_CONFIG" --key eve.hostfwd
   $EDEN config get "$EDEN_CONFIG" --key eve.hostfwd
-  echo $EDEN eve stop
+  cat <<END
+To activate the changes in the config, you need to restart EVE:
   $EDEN eve stop
-  sleep 5
-  echo $EDEN eve start
   $EDEN eve start
+END
 fi

--- a/tests/eclient/eden-ports.sh
+++ b/tests/eclient/eden-ports.sh
@@ -6,6 +6,8 @@ then
   exit
 fi
 
+test -n "$EDEN_CONFIG" || EDEN_CONFIG=default
+
 EDEN=eden
 DIR=$(dirname "$0")
 PATH=$DIR:$DIR/../../bin:$PATH
@@ -31,9 +33,9 @@ then
   $EDEN config set "$EDEN_CONFIG" --key eve.hostfwd --value "$NEW"
   echo $EDEN config get "$EDEN_CONFIG" --key eve.hostfwd
   $EDEN config get "$EDEN_CONFIG" --key eve.hostfwd
-  echo $EDEN eve stop
+  cat <<END
+To activate the changes in the config, you need to restart EVE:
   $EDEN eve stop
-  sleep 5
-  echo $EDEN eve start
   $EDEN eve start
+END
 fi

--- a/tests/eclient/qemu+usb.sh
+++ b/tests/eclient/qemu+usb.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+test -n "$EDEN_CONFIG" || EDEN_CONFIG=default
+
+EDEN=eden
+DIR=$(dirname "$0")
+PATH=$DIR:$DIR/../../bin:$PATH
+
+dist=$($EDEN config get "$EDEN_CONFIG" --key eden.root)
+
+dd if=/dev/zero of="$dist/stick.raw" bs=1K count=1
+
+cat >> ~/.eden/"$EDEN_CONFIG"-qemu.conf <<END
+
+
+[drive "stick"]
+  if = "none"
+  file = "$dist/stick.raw"
+  format = "raw"
+
+[device]
+  driver = "usb-storage"
+  bus = "usb.0"
+  drive = "stick"
+END
+
+cat <<END
+To activate the changes in the config, you need to restart EVE:
+  $EDEN eve stop
+  $EDEN eve start
+END

--- a/tests/eclient/testdata/eclients.txt
+++ b/tests/eclient/testdata/eclients.txt
@@ -2,9 +2,17 @@
 
 {{$port := "2222"}}
 {{$test_opts := "-test.v -timewait 20m"}}
+# Number of apps
 {{$apps := EdenGetEnv "EDEN_TEST_APPS"}}
+# Time of app waiting (default -- 30 min)
 {{$time := EdenGetEnv "EDEN_TEST_TIME"}}
+# Image for app (default -- docker://itmoeve/eclient:0.3)
 {{$img := EdenGetEnv "EDEN_TEST_IMG"}}
+
+{{$devmodel := EdenConfig "eve.devmodel"}}
+
+# Run test if EDEN_TEST_APPS > 0
+{{if (gt $apps "0")}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
@@ -37,8 +45,7 @@ EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "ede
 TAPP={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden.app.test
 HOST=$($EDEN eve ip)
 
-# 20 apps by default
-APPS="{{if $apps}}{{$apps}}{{else}}20{{end}}"
+APPS="{{$apps}}"
 # Default image -- docker://itmoeve/eclient:0.3
 IMG="{{if $img}}{{$img}}{{else}}docker://itmoeve/eclient:0.3{{end}}"
 
@@ -48,8 +55,14 @@ do
  PORTS="$PORTS $(({{$port}}+$i)):$(({{$port}}+$i))"
 done
 
+# Is it QEMU?
+{{if (eq $devmodel "ZedVirtual-4G")}}
 echo {{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden+ports.sh $PORTS
 {{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden+ports.sh $PORTS
+
+# Restarting EVE to confirm configuration changes
+$EDEN test {{EdenConfig "eden.root"}}/tests/workflow/ -e eve_restart
+{{end}}
 
 PODS=""
 for i in `seq $APPS`
@@ -92,8 +105,7 @@ EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "ede
 TAPP={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden.app.test
 HOST=$($EDEN eve ip)
 
-# 20 apps by default
-APPS="{{if $apps}}{{$apps}}{{else}}20{{end}}"
+APPS="{{$apps}}"
 # Default image -- docker://itmoeve/eclient:3
 #IMG="{{if $img}}{{$img}}{{else}}docker://itmoeve/eclient:latest{{end}}"
 IMG="{{if $img}}{{$img}}{{else}}docker://itmoeve/eclient:3{{end}}"
@@ -115,5 +127,13 @@ do
  PORTS="$PORTS $(({{$port}}+$i)):$(({{$port}}+$i))"
 done
 
+# Is it QEMU?
+{{if (eq $devmodel "ZedVirtual-4G")}}
 echo {{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden-ports.sh $PORTS
 {{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden-ports.sh $PORTS
+
+# Restarting EVE to confirm configuration changes
+$EDEN test {{EdenConfig "eden.root"}}/tests/workflow/ -e eve_restart
+{{end}}
+
+{{end}}

--- a/tests/eclient/testdata/usb-pt_test.txt
+++ b/tests/eclient/testdata/usb-pt_test.txt
@@ -1,0 +1,61 @@
+# Simple test of USB passthrough functionality
+
+{{$usb_dev := "2-2"}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+
+# Starting of reboot detector with a 2 reboot limit
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+
+eden pod deploy -n n1 --memory=512MB docker://itmoeve/eclient:0.3 -p 2223:22
+eden pod deploy -n n2 --memory=512MB docker://itmoeve/eclient:0.3 -p 2224:22 --adapters USB2:2
+
+test eden.app.test -test.v -timewait 20m RUNNING n1 n2
+
+exec -t 20m bash ssh.sh 2223
+stdout 'Ubuntu'
+
+exec -t 20m bash ssh.sh 2224
+stdout 'Ubuntu'
+
+! exec -t 20m bash get-usb.sh 2223
+stderr 'No such file or directory'
+
+exec -t 20m bash get-usb.sh 2224
+grep 'QEMU USB HARDDRIVE' {{$usb_dev}}.usb.product
+
+eden pod delete n1
+eden pod delete n2
+
+test eden.app.test -test.v -timewait 10m - n1 n2
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- ssh.sh --
+port=$1
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for i in `seq 20`
+do
+ sleep 20
+ # Test SSH-access to container
+ echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST grep Ubuntu /etc/issue
+ ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST grep Ubuntu /etc/issue && break
+done
+
+-- get-usb.sh --
+port=$1
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+ echo ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST cat /sys/bus/usb/devices/{{$usb_dev}}/product
+ ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST cat /sys/bus/usb/devices/{{$usb_dev}}/product > {{$usb_dev}}.usb.product

--- a/tests/workflow/README.MD
+++ b/tests/workflow/README.MD
@@ -8,10 +8,11 @@ Supported environment variables:
 * EDEN_TEST_SETUP -- "y" performs the EDEN setup steps ("y" by default);
 * EDEN_TEST_STOP -- "y" stops EDEN after tests ("n" by default);
 * EDEN_TEST -- flavour of test set: "small", "medium"(default) and "large";
+* EDEN_TEST_USB_PT -- "y" enables USB Passthrough test (disabled by default).
 
 Example of running:
 ```
-EDEN_TEST_STOP=y EDEN_TEST_SETUP=y EDEN_TEST=large eden test tests/workflow/ -v debug
+EDEN_TEST_SETUP=n EDEN_TEST_STOP=y EDEN_TEST_USB_PT=y EDEN_TEST=large eden test tests/workflow/ -v debug
 ```
 
 # Quickstart

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -1,92 +1,123 @@
-{{$tests := 31}}
+# Number of tests
+{{$tests := 34}}
+# EDEN_TEST env. var. -- flavour of test set: "small", "medium"(default) and "large"
 {{$workflow := EdenGetEnv "EDEN_TEST"}}
+# EDEN_TEST_SETUP env. var. -- "y"(default) performs the EDEN setup steps
 {{$setup := EdenGetEnv "EDEN_TEST_SETUP"}}
+# EDEN_TEST_STOP -- "y" stops EDEN after tests ("n" by default)
 {{$stop := EdenGetEnv "EDEN_TEST_STOP"}}
+# EDEN_TEST_USB_PT -- "y" enables USB Passthrough test (disabled by default).
+{{$usb_pt := EdenGetEnv "EDEN_TEST_USB_PT"}}
+
+{{$devmodel := EdenConfig "eve.devmodel"}}
 
 {{if (ne $setup "n")}}
 #./eden config add default
 /bin/echo Eden setup (01/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_setup
 #source ~/.eden/activate.sh
+{{end}}
+
+# Making some settings for test configuration if we work with QEMU
+{{if (eq $devmodel "ZedVirtual-4G")}}
+{{if (eq $usb_pt "y")}}
+qemu+usb.sh
+{{end}}
+eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027
+{{end}}
+
+{{if (ne $setup "n")}}
 /bin/echo Eden start (02/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_start
 /bin/echo Eden onboard (03/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_onboard
 {{end}}
 
-/bin/echo Eden Log test (04/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/log_test -testdata ../lim/testdata/
-/bin/echo Eden SSH test (05/{{$tests}})
+{{if (ne $setup "y")}}
+# Just restart EVE if not using the SETUP steps
+# Is it QEMU?
+{{if (eq $devmodel "ZedVirtual-4G")}}
+/bin/echo EVE restart (04/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eve_restart
+{{end}}
+{{end}}
+
+/bin/echo Eden Log test (05/{{$tests}})
+eden.escript.test -testdata ../lim/testdata/ -test.run TestEdenScripts/log_test
+/bin/echo Eden SSH test (06/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/ssh
 {{ if or (eq $workflow "large") (eq $workflow "gcp") }}
-/bin/echo Eden Info test (06/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/info_test -testdata ../lim/testdata/
+/bin/echo Eden Info test (07/{{$tests}})
+eden.escript.test -testdata ../lim/testdata/ -test.run TestEdenScripts/info_test
 {{end}}
-/bin/echo Eden Metric test (07/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/metric_test -testdata ../lim/testdata/
+/bin/echo Eden Metric test (08/{{$tests}})
+eden.escript.test -testdata ../lim/testdata/ -test.run TestEdenScripts/metric_test
 
-/bin/echo Escript args test (08/{{$tests}})
+/bin/echo Escript args test (09/{{$tests}})
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/arg -args=test1=123,test2=456
-/bin/echo Escript template test (09/{{$tests}})
+/bin/echo Escript template test (10/{{$tests}})
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/template
-/bin/echo Escript message test (10/{{$tests}})
+/bin/echo Escript message test (11/{{$tests}})
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/message
-/bin/echo Escript nested scripts test (11/{{$tests}})
+/bin/echo Escript nested scripts test (12/{{$tests}})
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/nested_scripts
-/bin/echo Escript time test (12/{{$tests}})
+/bin/echo Escript time test (13/{{$tests}})
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/time
-/bin/echo Escript source test (13/{{$tests}})
+/bin/echo Escript source test (14/{{$tests}})
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/source
-/bin/echo Escript fail scenario test (14/{{$tests}})
+/bin/echo Escript fail scenario test (15/{{$tests}})
 eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/fail_scenario
 
-eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027
+/bin/echo Eden basic network test (16/{{$tests}})
+eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/network_test
+/bin/echo Eden basic volumes test (17/{{$tests}})
+eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/volumes_test
 
-/bin/echo Eden basic network test (15/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/network_test -testdata ../network/testdata/
-/bin/echo Eden basic volumes test (16/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/volumes_test -testdata ../volume/testdata/
+/bin/echo Eden Host only ACL (18/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/host-only
+/bin/echo Eden Network light (19/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/networking_light
+/bin/echo Eden Networks switch (20/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/nw_switch
+/bin/echo Eden Network Ports switch (21/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_switch
 
-/bin/echo Eden Host only ACL (16/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/host-only -testdata ../eclient/testdata/
-/bin/echo Eden Network light (17/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/networking_light -testdata ../eclient/testdata/
-/bin/echo Eden Networks switch (18/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/nw_switch -testdata ../eclient/testdata/
-/bin/echo Eden Network Ports switch (19/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/port_switch -testdata ../eclient/testdata/
+{{if (eq $usb_pt "y")}}
+/bin/echo EVE USB Passthrough (22/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/usb-pt_test
+{{end}}
 
 {{ if or (eq $workflow "large") (eq $workflow "gcp") }}
-/bin/echo Eden VNC (20/{{$tests}})
+/bin/echo Eden VNC (23/{{$tests}})
 eden.vnc.test
-/bin/echo Eden registry (21/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/registry_test -testdata ../registry/testdata/
-/bin/echo Eden Network test (22/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/test_networking -testdata ../network/testdata/
-/bin/echo Eden 2 dockers test (23/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/2dockers_test -testdata ../docker/testdata/
-/bin/echo Eden 2 dockers test with app state detector (24/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/2dockers_test -testdata ../app/testdata/
-/bin/echo Eden Nginx (25/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/ngnix -testdata ../eclient/testdata/
-/bin/echo Eden Mariadb (26/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/maridb -testdata ../eclient/testdata/
-/bin/echo EVE reset (27/{{$tests}})
+/bin/echo Eden registry (24/{{$tests}})
+eden.escript.test -testdata ../registry/testdata/ -test.run TestEdenScripts/registry_test
+/bin/echo Eden Network test (25/{{$tests}})
+eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/test_networking
+/bin/echo Eden 2 dockers test (26/{{$tests}})
+eden.escript.test -testdata ../docker/testdata/ -test.run TestEdenScripts/2dockers_test
+/bin/echo Eden 2 dockers test with app state detector (27/{{$tests}})
+eden.escript.test -testdata ../app/testdata/ -test.run TestEdenScripts/2dockers_test
+/bin/echo Eden Nginx (28/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/ngnix
+/bin/echo Eden Mariadb (29/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/maridb
+/bin/echo EVE reset (30/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_reset
 {{end}}
 {{ if  (eq $workflow "large")  }}
-/bin/echo Eden's testing the maximum application limit (28/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/eclients -testdata ../eclient/testdata/
+/bin/echo Eden's testing the maximum application limit (31/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/eclients
 {{end}}
 
-/bin/echo Eden Reboot test (29/{{$tests}})
+/bin/echo Eden Reboot test (32/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/reboot_test
 {{ if ne $workflow "small" }}
-/bin/echo Eden base OS update (30/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/update_eve_image -testdata ../update_eve_image/testdata/
+/bin/echo Eden base OS update (33/{{$tests}})
+eden.escript.test -testdata ../update_eve_image/testdata/ -test.run TestEdenScripts/update_eve_image
 {{end}}
 
 {{if (eq $stop "y")}}
-/bin/echo Eden stop (31/{{$tests}})
+/bin/echo Eden stop (34/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_stop
 {{end}}

--- a/tests/workflow/testdata/eve_restart.txt
+++ b/tests/workflow/testdata/eve_restart.txt
@@ -1,0 +1,13 @@
+eden -t 2m eve stop
+! stderr .
+
+eden eve status
+stdout 'EVE on Qemu status: process doesn''t exist'
+! stderr .
+
+eden -t 2m eve start
+! stderr .
+
+eden eve status
+stdout 'EVE on Qemu status: running with pid \d+'
+! stderr .


### PR DESCRIPTION
Added USB Passthtrough test and some fixes related to `eve.devmodel` checking. [Eclients](https://github.com/itmo-eve/eden/blob/tests_extension/tests/eclient/testdata/eclients.txt) stress test will run now only with non zero EDEN_TEST_APPS env. var.

Added tests:
* [usb-pt_test](https://github.com/itmo-eve/eden/blob/tests_extension/tests/eclient/testdata/usb-pt_test.txt) -- USB Passthtrough test;
* [eve_restart](https://github.com/itmo-eve/eden/blob/tests_extension/tests/workflow/testdata/eve_restart.txt) -- Eve restart after config changes for QEMU variant.

Signed-off-by: Oleg Sadov <oleg.sadov@gmail.com>