### PR TITLE
direct download for image

### DIFF
--- a/cmd/edenPod.go
+++ b/cmd/edenPod.go
@@ -43,6 +43,8 @@ var (
 	outputFields []string
 
 	logAppsFormat eapps.LogFormat
+
+	directLoad bool
 )
 
 var podCmd = &cobra.Command{
@@ -101,6 +103,7 @@ var podDeployCmd = &cobra.Command{
 		opts = append(opts, expect.WithResources(appCpus, uint32(appMemoryParsed/1000)))
 		opts = append(opts, expect.WithImageFormat(imageFormat))
 		opts = append(opts, expect.WithACL(aclOnlyHost))
+		opts = append(opts, expect.WithHTTPDirectLoad(directLoad))
 		registryToUse := registry
 		switch registry {
 		case "local":
@@ -433,6 +436,7 @@ func podInit() {
 	podDeployCmd.Flags().BoolVar(&aclOnlyHost, "only-host", false, "Allow access only to host and external networks")
 	podDeployCmd.Flags().BoolVar(&noHyper, "no-hyper", false, "Run pod without hypervisor")
 	podDeployCmd.Flags().StringVar(&registry, "registry", "remote", "Select registry to use for containers (remote/local)")
+	podDeployCmd.Flags().BoolVar(&directLoad, "direct", true, "Use direct download for image instead of eserver")
 	podCmd.AddCommand(podPsCmd)
 	podCmd.AddCommand(podStopCmd)
 	podCmd.AddCommand(podStartCmd)

--- a/pkg/defaults/images.go
+++ b/pkg/defaults/images.go
@@ -1,0 +1,19 @@
+package defaults
+
+//ImageOptions indicates parameters of predefined VMs
+type ImageOptions struct {
+	Size   int64
+	Sha256 string
+}
+
+//ImageStore contains image options for images used inside tests
+var ImageStore = map[string]*ImageOptions {
+	"https://cloud-images.ubuntu.com/releases/groovy/release-20201022.1/ubuntu-20.10-server-cloudimg-amd64.img": {
+		Size: 558760448,
+		Sha256: "ef3ed6aaf9c8fe1d063d556ace6c4dfbb51920d12ba8312e09a1baf3b3eedf3d",
+	},
+	"https://cloud-images.ubuntu.com/releases/groovy/release-20201022.1/ubuntu-20.10-server-cloudimg-arm64.img": {
+		Size: 525336576,
+		Sha256: "c64a5e20dd61cc112de2a47d8b0a3ec30a553fe5fe54ca0a5f83c840778aa300",
+	},
+}

--- a/pkg/expect/expectation.go
+++ b/pkg/expect/expectation.go
@@ -60,6 +60,8 @@ type AppExpectation struct {
 	registry string
 
 	oldAppName string
+
+	httpDirectLoad bool // use eserver for SHA calculation only
 }
 
 //AppExpectationFromURL init AppExpectation with defined:

--- a/pkg/expect/options.go
+++ b/pkg/expect/options.go
@@ -165,3 +165,10 @@ func WithOldApp(appName string) ExpectationOption {
 		expectation.oldAppName = appName
 	}
 }
+
+//WithHTTPDirectLoad use eserver only for SHA calculation
+func WithHTTPDirectLoad(direct bool) ExpectationOption {
+	return func(expectation *AppExpectation) {
+		expectation.httpDirectLoad = direct
+	}
+}

--- a/tests/vnc/vnc_test.go
+++ b/tests/vnc/vnc_test.go
@@ -37,6 +37,7 @@ var (
 	sshPort      = flag.Int("sshPort", 8027, "Port to publish ssh")
 	cpus         = flag.Uint("cpus", 1, "Cpu number for app")
 	memory       = flag.String("memory", "1G", "Memory for app")
+	direct       = flag.Bool("direct", true, "Load image from url, not from eserver")
 	metadata     = flag.String("metadata", "#cloud-config\npassword: passw0rd\nchpasswd: { expire: False }\nssh_pwauth: True\n", "Metadata to pass into VM")
 	appLink      = flag.String("applink", "https://cloud-images.ubuntu.com/releases/groovy/release-20201022.1/ubuntu-20.10-server-cloudimg-%s.img", "Link to qcow2 image. You can pass %s for automatically set of arch (amd64/arm64)")
 	tc           *projects.TestContext
@@ -198,6 +199,8 @@ func TestVNCVMStart(t *testing.T) {
 	opts = append(opts, expect.WithVnc(uint32(*vncDisplay)))
 
 	opts = append(opts, expect.WithVncPassword(*vncPassword))
+
+	opts = append(opts, expect.WithHTTPDirectLoad(*direct))
 
 	if *sshPort != 0 {
 


### PR DESCRIPTION
In case of gcp+actions we need to use direct download of image for VNC test. So, we can use eserver for SHA calculation only.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>