### PR TITLE
Bash/Zsh/Fish shell completions for Eden

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ In setup files defined some functions (BASH) and aliases (TCSH) for work with co
 
 To deactivate this settings call `eden_deactivate` function.
 
+You may configure Bash/Zsh/Fish shell completions for Eden by command `eden utils completion`.
+
 ## Eden Config
 
 Eden's config is controlled via a yaml file, overriddable using command-line options.

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// completionCmd represents the completion command
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish]",
+	Short: "Generate completion script",
+	Long: `To load completions:
+
+Bash:
+
+$ source <(eden completion bash)
+
+# To load completions for each session, execute once:
+Linux:
+  $ eden utils completion bash > /etc/bash_completion.d/eden
+MacOS:
+  $ eden utils completion bash > /usr/local/etc/bash_completion.d/eden
+
+Zsh:
+
+# If shell completion is not already enabled in your environment you will need
+# to enable it.  You can execute the following once:
+
+$ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+# To load completions for each session, execute once:
+$ eden utils completion zsh > "${fpath[1]}/_eden"
+
+# You will need to start a new shell for this setup to take effect.
+
+Fish:
+
+$ eden utils completion fish | source
+
+# To load completions for each session, execute once:
+$ eden utils completion fish > ~/.config/fish/completions/eden.fish
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish"},
+	Args:                  cobra.ExactValidArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch args[0] {
+		case "bash":
+			err := cmd.Root().GenBashCompletion(os.Stdout)
+			if err != nil {
+				fmt.Fprintf(os.Stderr,
+					"Completions generation error: %s",
+					err.Error())
+			}
+		case "zsh":
+			err := cmd.Root().GenZshCompletion(os.Stdout)
+			if err != nil {
+				fmt.Fprintf(os.Stderr,
+					"Completions generation error: %s",
+					err.Error())
+			}
+		case "fish":
+			err := cmd.Root().GenFishCompletion(os.Stdout, true)
+			if err != nil {
+				fmt.Fprintf(os.Stderr,
+					"Completions generation error: %s",
+					err.Error())
+			}
+		}
+	},
+}

--- a/cmd/edenUtils.go
+++ b/cmd/edenUtils.go
@@ -88,6 +88,7 @@ func utilsInit() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	utilsCmd.AddCommand(completionCmd)
 	utilsCmd.AddCommand(templateCmd)
 	utilsCmd.AddCommand(downloaderCmd)
 	downloaderInit()


### PR DESCRIPTION
Just run `./eden utils completion -h` for instructions on setting up shell completions.

Signed-off-by: Oleg Sadov <oleg.sadov@gmail.com>