### PR TITLE
WIP: initial support Nvidia jetson nano model B

### DIFF
--- a/cmd/downloader.go
+++ b/cmd/downloader.go
@@ -51,6 +51,7 @@ var downloadEVECmd = &cobra.Command{
 			log.Fatalf("GetDevModelByName: %s", err)
 		}
 		format := model.DiskFormat()
+		target := model.GetTarget()
 		eveDesc := utils.EVEDescription{
 			ConfigPath:  adamDist,
 			Arch:        eveArch,
@@ -58,6 +59,7 @@ var downloadEVECmd = &cobra.Command{
 			Registry:    eveRegistry,
 			Tag:         eveTag,
 			Format:      format,
+			Target:      target,
 			ImageSizeMB: eveImageSizeMB,
 		}
 		uefiDesc := utils.UEFIDescription{

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -110,6 +110,8 @@ const (
 
 	DefaultRPIModel = "RPi4"
 
+	DefaultJetsonNanoBModel = "jetson-nano-b"
+
 	DefaultGCPModel = "GCP"
 
 	DefaultGeneralModel = "general"

--- a/pkg/models/devModel.go
+++ b/pkg/models/devModel.go
@@ -16,6 +16,7 @@ type DevModel interface {
 	PhysicalIOs() []*config.PhysicalIO
 	AdapterForSwitches() []string
 	DevModelType() string
+	GetTarget() string
 	GetFirstAdapterForSwitches() string
 	SetWiFiParams(ssid string, psk string)
 	GetPortConfig(ssid string, psk string) string

--- a/pkg/models/devModel.go
+++ b/pkg/models/devModel.go
@@ -41,7 +41,8 @@ func GetDevModel(devModelType devModelType) (DevModel, error) {
 		return createGCP()
 	case devModelTypeRaspberry:
 		return createRpi()
-
+	case devModelTypeJetsonNanoB:
+		return createJetsonNanoB()
 	}
 	return nil, fmt.Errorf("not implemented type: %s", devModelType)
 }

--- a/pkg/models/gcp.go
+++ b/pkg/models/gcp.go
@@ -85,6 +85,11 @@ func (ctx *DevModelGCP) GetFirstAdapterForSwitches() string {
 	return "uplink"
 }
 
+//GetTarget not used for Rpi
+func (ctx *DevModelGCP) GetTarget() string {
+	return ""
+}
+
 func createGCP() (DevModel, error) {
 	return &DevModelGCP{
 		physicalIOs:        generatePhysicalIOs(2, 0, 0),

--- a/pkg/models/general.go
+++ b/pkg/models/general.go
@@ -85,6 +85,11 @@ func (ctx *DevModelGeneral) GetFirstAdapterForSwitches() string {
 	return "uplink"
 }
 
+//GetTarget not used for general
+func (ctx *DevModelGeneral) GetTarget() string {
+	return ""
+}
+
 func createGeneral() (DevModel, error) {
 	return &DevModelGeneral{
 		physicalIOs:        generatePhysicalIOs(2, 0, 0),

--- a/pkg/models/jetson-nano-b-sdcard.go
+++ b/pkg/models/jetson-nano-b-sdcard.go
@@ -1,0 +1,95 @@
+package models
+
+import (
+	"github.com/lf-edge/eden/pkg/defaults"
+	"github.com/lf-edge/eve/api/go/config"
+	log "github.com/sirupsen/logrus"
+)
+
+//devModelTypeRaspberry is model type for rpi
+const devModelTypeJetsonNanoB devModelType = defaults.DefaultJetsonNanoBModel
+
+//DevModelJetsonNanoB is dev model fields
+type DevModelJetsonNanoB struct {
+	//physicalIOs is PhysicalIO slice for DevModel
+	physicalIOs []*config.PhysicalIO
+	//networks is NetworkConfig slice for DevModel
+	networks []*config.NetworkConfig
+	//adapters is SystemAdapter slice for DevModel
+	adapters []*config.SystemAdapter
+}
+
+//Config returns map with config overwrites
+func (ctx *DevModelJetsonNanoB) Config() map[string]interface{} {
+	cfg := make(map[string]interface{})
+	cfg["eve.serial"] = "*"
+	cfg["eve.remote"] = true
+	cfg["eve.remote-addr"] = ""
+	cfg["eve.arch"] = "arm64"
+	cfg["eve.hostfwd"] = map[string]string{}
+	cfg["eve.devmodel"] = ctx.DevModelType()
+	return cfg
+}
+
+//DiskReadyMessage to show when image is ready
+func (ctx *DevModelJetsonNanoB) DiskReadyMessage() string {
+	return "Write file %s to sd (it is in raw format)"
+}
+
+//DiskFormat to use for build image
+func (ctx *DevModelJetsonNanoB) DiskFormat() string {
+	return "raw"
+}
+
+//GetPortConfig returns PortConfig overwrite
+func (ctx *DevModelJetsonNanoB) GetPortConfig(_ string, _ string) string {
+	return ""
+}
+
+//Adapters returns adapters of devModel
+func (ctx *DevModelJetsonNanoB) Adapters() []*config.SystemAdapter {
+	return ctx.adapters
+}
+
+//Networks returns networks of devModel
+func (ctx *DevModelJetsonNanoB) Networks() []*config.NetworkConfig {
+	return ctx.networks
+}
+
+//SetWiFiParams not implemented for jetson-nano-b
+func (ctx *DevModelJetsonNanoB) SetWiFiParams(_ string, _ string) {
+	log.Warning("not implemented for jetson-nano-b")
+}
+
+//PhysicalIOs returns physicalIOs of devModel
+func (ctx *DevModelJetsonNanoB) PhysicalIOs() []*config.PhysicalIO {
+	return ctx.physicalIOs
+}
+
+//AdapterForSwitches returns adapterForSwitches of devModel
+func (ctx *DevModelJetsonNanoB) AdapterForSwitches() []string {
+	return nil
+}
+
+//DevModelType returns devModelType of devModel
+func (ctx *DevModelJetsonNanoB) DevModelType() string {
+	return string(devModelTypeJetsonNanoB)
+}
+
+//GetFirstAdapterForSwitches return first adapter available for switch networkInstance
+func (ctx *DevModelJetsonNanoB) GetFirstAdapterForSwitches() string {
+	return "uplink"
+}
+
+//GetTarget not used for DevModelJetson
+func (ctx *DevModelJetsonNanoB) GetTarget() string {
+	return ctx.DevModelType()
+}
+
+func createJetsonNanoB() (DevModel, error) {
+	return &DevModelJetsonNanoB{
+		physicalIOs: generatePhysicalIOs(1, 0, 4),
+		networks:    generateNetworkConfigs(1, 0),
+		adapters:    generateSystemAdapters(1, 0),
+	}, nil
+}

--- a/pkg/models/qemu.go
+++ b/pkg/models/qemu.go
@@ -79,6 +79,11 @@ func (ctx *DevModelQemu) GetFirstAdapterForSwitches() string {
 	return "uplink"
 }
 
+//GetTarget not used for Qemu
+func (ctx *DevModelQemu) GetTarget() string {
+	return ""
+}
+
 func createQemu() (DevModel, error) {
 	return &DevModelQemu{
 			physicalIOs:        generatePhysicalIOs(2, 0, 4),

--- a/pkg/models/rpi.go
+++ b/pkg/models/rpi.go
@@ -146,6 +146,11 @@ func (ctx *DevModelRpi) GetFirstAdapterForSwitches() string {
 	return "uplink"
 }
 
+//GetTarget not used for Rpi
+func (ctx *DevModelRpi) GetTarget() string {
+	return ""
+}
+
 func createRpi() (DevModel, error) {
 	return &DevModelRpi{
 		physicalIOs: generatePhysicalIOs(1, 1, 0),

--- a/pkg/utils/downloaders.go
+++ b/pkg/utils/downloaders.go
@@ -19,6 +19,7 @@ type EVEDescription struct {
 	Registry    string
 	Tag         string
 	Format      string
+	Target      string
 	ImageSizeMB int
 }
 
@@ -103,7 +104,7 @@ func DownloadEveLive(eve EVEDescription, uefi UEFIDescription, outputFile string
 	if eve.Format == "gcp" {
 		size = eve.ImageSizeMB
 	}
-	fileName, err := genEVELiveImage(image, filepath.Dir(outputFile), eve.Format, eve.ConfigPath, size)
+	fileName, err := genEVELiveImage(image, filepath.Dir(outputFile), eve.Format, eve.ConfigPath, size, eve.Target)
 	if err != nil {
 		return fmt.Errorf("genEVEImage: %s", err)
 	}
@@ -114,7 +115,7 @@ func DownloadEveLive(eve EVEDescription, uefi UEFIDescription, outputFile string
 }
 
 //genEVELiveImage downloads EVE live image from docker to outputDir with configDir (if defined)
-func genEVELiveImage(image, outputDir string, format string, configDir string, size int) (fileName string, err error) {
+func genEVELiveImage(image, outputDir string, format string, configDir string, size int, target string) (fileName string, err error) {
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return "", err
 	}
@@ -132,6 +133,9 @@ func genEVELiveImage(image, outputDir string, format string, configDir string, s
 	dockerCommand := fmt.Sprintf("-f %s live %d", format, size)
 	if size == 0 {
 		dockerCommand = fmt.Sprintf("-f %s live", format)
+	}
+	if target != "" {
+		dockerCommand = fmt.Sprintf("-t %s %s", target, dockerCommand)
 	}
 	u, err := RunDockerCommand(image, dockerCommand, volumeMap)
 	if err != nil {


### PR DESCRIPTION
for example:
make clean
make build
./eden config add default --devmodel jetson-nano-b
./eden config set default --key eve.tag --value=0.0.0-jetson-wip-nkernel-f30f7db5
./eden config set default --key eve.registry --value=goodmobiledevices
./eden setup
./eden start
./eden eve onboard
e.t.c.