### PR TITLE
test panic in logs

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -48,7 +48,7 @@ const (
 	DefaultRegistryPort = 5000
 
 	//tags, versions, repos
-	DefaultEVETag               = "0.0.0-master-6aaa87a0" //DefaultEVETag tag for EVE image
+	DefaultEVETag               = "0.0.0-master-94033ce8" //DefaultEVETag tag for EVE image
 	DefaultAdamTag              = "cf3e117efbe5f32846a6a84385ea429c65679f14"
 	DefaultRedisTag             = "6"
 	DefaultRegistryTag          = "2.7"

--- a/pkg/projects/functions.go
+++ b/pkg/projects/functions.go
@@ -1,0 +1,33 @@
+package projects
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/lf-edge/eden/pkg/controller/eapps"
+	"github.com/lf-edge/eden/pkg/device"
+	"github.com/lf-edge/eve/api/go/logs"
+	uuid "github.com/satori/go.uuid"
+	log "github.com/sirupsen/logrus"
+)
+
+//CheckMessageInAppLog try to find message in logs of app
+func (tc *TestContext) CheckMessageInAppLog(edgeNode *device.Ctx, appID uuid.UUID, message string) ProcTimerFunc {
+	return func() error {
+		foundedMessage := ""
+		handler := func(le *logs.LogEntry) bool {
+			if strings.Contains(le.Content, message) {
+				foundedMessage = le.Content
+				return true
+			}
+			return false
+		}
+		if err := tc.GetController().LogAppsChecker(edgeNode.GetID(), appID, nil, handler, eapps.LogExist, 0); err != nil {
+			log.Fatalf("LogAppsChecker: %s", err)
+		}
+		if foundedMessage != "" {
+			return fmt.Errorf("founded in app logs: %s", foundedMessage)
+		}
+		return nil
+	}
+}

--- a/pkg/projects/testProc.go
+++ b/pkg/projects/testProc.go
@@ -61,7 +61,7 @@ func (lb *processingBus) clean() {
 func (lb *processingBus) processReturn(edgeNode *device.Ctx, procFunc *absFunc, result error) {
 	if result != nil {
 		if lb.tc.addTime != 0 {
-			log.Infof("Expand timewait by %s", lb.tc.addTime)
+			log.Infof("Expand timewait by %s with return: %s", lb.tc.addTime, result.Error())
 			lb.tc.stopTime.Add(lb.tc.addTime)
 		}
 		procFunc.disabled = true

--- a/tests/vnc/eden.vnc.tests.txt
+++ b/tests/vnc/eden.vnc.tests.txt
@@ -1,1 +1,1 @@
-eden.vnc.test
+eden.vnc.test -panic=true


### PR DESCRIPTION
Adds flag to fire kernel panic and wait for logs with it inside vnc_test.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>