### PR TITLE
move from pygrub to ovmf bootloader

### DIFF
--- a/pkg/expect/application.go
+++ b/pkg/expect/application.go
@@ -45,6 +45,10 @@ func (exp *AppExpectation) createAppInstanceConfig(img *config.Image, netInstanc
 	default:
 		return nil, fmt.Errorf("not supported appType")
 	}
+	if exp.virtualizationMode == config.VmMode_PV {
+		bundle.appInstanceConfig.Fixedresources.Rootdev = "/dev/xvda1"
+		bundle.appInstanceConfig.Fixedresources.Bootloader = "/usr/lib/xen/boot/ovmf.bin"
+	}
 	bundle.appInstanceConfig.Interfaces = []*config.NetworkAdapter{}
 
 	for k, ni := range netInstances {

--- a/pkg/expect/vm.go
+++ b/pkg/expect/vm.go
@@ -24,10 +24,6 @@ func (exp *AppExpectation) createAppInstanceConfigVM(img *config.Image, id uuid.
 		Activate:    true,
 		Displayname: exp.appName,
 	}
-	if exp.virtualizationMode == config.VmMode_PV {
-		app.Fixedresources.Rootdev = "/dev/xvda1"
-		app.Fixedresources.Bootloader = "/usr/bin/pygrub"
-	}
 	app.Fixedresources.VirtualizationMode = exp.virtualizationMode
 	maxSizeBytes := img.SizeBytes
 	if exp.diskSize > 0 {


### PR DESCRIPTION
We need to avoid using [deprecated](https://github.com/lf-edge/eve/blob/master/pkg/pillar/cmd/zedmanager/handledomainmgr.go#L74-L79) firmware and use new one to fix booting of Ubuntu and Windows on RPi (kvm).

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>