### PR TITLE
test for logs passing from /dev/console

### DIFF
--- a/pkg/projects/functions.go
+++ b/pkg/projects/functions.go
@@ -5,19 +5,21 @@ import (
 	"strings"
 
 	"github.com/lf-edge/eden/pkg/controller/eapps"
+	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eden/pkg/device"
 	"github.com/lf-edge/eve/api/go/logs"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
 )
 
 //CheckMessageInAppLog try to find message in logs of app
-func (tc *TestContext) CheckMessageInAppLog(edgeNode *device.Ctx, appID uuid.UUID, message string) ProcTimerFunc {
+func (tc *TestContext) CheckMessageInAppLog(edgeNode *device.Ctx, appID uuid.UUID, message string, callbacks ...Callback) ProcTimerFunc {
 	return func() error {
 		foundedMessage := ""
 		handler := func(le *logs.LogEntry) bool {
 			if strings.Contains(le.Content, message) {
-				foundedMessage = le.Content
+				foundedMessage = strings.TrimSpace(le.Content)
 				return true
 			}
 			return false
@@ -26,7 +28,48 @@ func (tc *TestContext) CheckMessageInAppLog(edgeNode *device.Ctx, appID uuid.UUI
 			log.Fatalf("LogAppsChecker: %s", err)
 		}
 		if foundedMessage != "" {
+			for _, clb := range callbacks {
+				clb()
+			}
 			return fmt.Errorf("founded in app logs: %s", foundedMessage)
+		}
+		return nil
+	}
+}
+
+//SendCommandSSH try to access SSH with timer and sends command
+func SendCommandSSH(ip *string, port *int, user, password, command string, foreground bool, callbacks ...Callback) ProcTimerFunc {
+	return func() error {
+		if *ip != "" {
+			configSSH := &ssh.ClientConfig{
+				User: user,
+				Auth: []ssh.AuthMethod{
+					ssh.Password(password),
+				},
+				HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+				Timeout:         defaults.DefaultRepeatTimeout,
+			}
+			conn, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", *ip, *port), configSSH)
+			if err != nil {
+				return nil
+			}
+			session, _ := conn.NewSession()
+			if foreground {
+				defer session.Close()
+				if err := session.Run(command); err != nil {
+					fmt.Println(err)
+					return nil
+				}
+			} else {
+				go func() {
+					_ = session.Run(command) //we cannot get answer for this command
+					session.Close()
+				}()
+			}
+			for _, clb := range callbacks {
+				clb()
+			}
+			return fmt.Errorf("command \"%s\" sended via SSH on %s:%d", command, *ip, *port)
 		}
 		return nil
 	}

--- a/pkg/projects/testContext.go
+++ b/pkg/projects/testContext.go
@@ -230,7 +230,7 @@ func (tc *TestContext) ExpandOnSuccess(secs int) {
 
 //WaitForProcWithErrorCallback blocking execution until the time elapses or all Procs gone
 //and fires callback in case of timeout
-func (tc *TestContext) WaitForProcWithErrorCallback(secs int, callback TimeoutCallback) {
+func (tc *TestContext) WaitForProcWithErrorCallback(secs int, callback Callback) {
 	defer func() { tc.addTime = 0 }() //reset addTime on exit
 	timeout := time.Duration(secs) * time.Second
 	tc.stopTime = time.Now().Add(timeout)

--- a/pkg/projects/testProc.go
+++ b/pkg/projects/testProc.go
@@ -24,8 +24,8 @@ type ProcLogFunc func(log *elog.FullLogEntry) error
 //ProcMetricFunc provides callback to process metric
 type ProcMetricFunc func(metric *metrics.ZMetricMsg) error
 
-//TimeoutCallback provides callback to process timeout
-type TimeoutCallback func()
+//Callback provides callback to process
+type Callback func()
 
 //ProcTimerFunc provides callback to process on timer event
 type ProcTimerFunc func() error
@@ -61,16 +61,15 @@ func (lb *processingBus) clean() {
 func (lb *processingBus) processReturn(edgeNode *device.Ctx, procFunc *absFunc, result error) {
 	if result != nil {
 		if lb.tc.addTime != 0 {
-			log.Infof("Expand timewait by %s with return: %s", lb.tc.addTime, result.Error())
+			log.Infof("Expand timewait by %s", lb.tc.addTime)
 			lb.tc.stopTime.Add(lb.tc.addTime)
 		}
 		procFunc.disabled = true
-		toRet := fmt.Sprintf("%T done with return: \"%s\"", procFunc.proc, result)
+		toRet := fmt.Sprintf("%T done with return: %s", procFunc.proc, result.Error())
 		if t, ok := lb.tc.tests[edgeNode]; ok {
 			t.Log(toRet)
-		} else {
-			log.Println(toRet)
 		}
+		log.Info(toRet)
 		lb.wg.Done()
 	}
 }

--- a/tests/vnc/eden.vnc.tests.txt
+++ b/tests/vnc/eden.vnc.tests.txt
@@ -1,1 +1,1 @@
-eden.vnc.test -panic=true
+eden.vnc.test -panic=true -logger=true

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -89,7 +89,7 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/usb-p
 
 {{ if or (eq $workflow "large") (eq $workflow "gcp") }}
 /bin/echo Eden VNC (23/{{$tests}})
-eden.vnc.test
+eden.vnc.test -panic=true -logger=true
 /bin/echo Eden registry (24/{{$tests}})
 eden.escript.test -testdata ../registry/testdata/ -test.run TestEdenScripts/registry_test
 /bin/echo Eden Network test (25/{{$tests}})


### PR DESCRIPTION
Adds into test steps to print uptime to `/dev/console` and obtain it from logs of app. 

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>