### PR TITLE
Disks for eci and pod deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DO_DOCKER ?= 1
 # ESERVER_TAG is the tag for eserver image to build
 ESERVER_TAG ?= "lfedge/eden-http-server"
 # ESERVER_VERSION is the version of eserver image to build
-ESERVER_VERSION ?= "1.2"
+ESERVER_VERSION ?= "1.3"
 # ESERVER_DIR is the directory with eserver Dockerfile to build
 ESERVER_DIR=$(CURDIR)/eserver
 # check if eserver image already exists in local docker and get its IMAGE_ID

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ the `--format` flag (`container`,`qcow2` or `raw`). The defaults are:
 * `https://` - VM qcow2 image
 * `file://` - VM qcow2 image
 
+You can also pass additional disks for your app with `--disks` flag.
+
 #### Docker Image
 
 Deploy nginx server from dockerhub. Expose port 80 of the container

--- a/cmd/eci.go
+++ b/cmd/eci.go
@@ -21,6 +21,7 @@ var (
 	formatStr  string
 	arch       string
 	local      bool
+	disks      []string
 )
 
 // convert a "path:type" to a Disk struct
@@ -87,10 +88,18 @@ var podPublishCmd = &cobra.Command{
 		if initrdFile != "" {
 			initrdSource = &edgeRegistry.FileSource{Path: initrdFile}
 		}
+
 		artifact := &edgeRegistry.Artifact{
 			Kernel: kernelSource,
 			Initrd: initrdSource,
 			Root:   rootDisk,
+		}
+		for _, disk := range disks {
+			additionalDisk, err := diskToStruct(disk)
+			if err != nil {
+				log.Fatalf("unable to read disk %s: %v", disk, err)
+			}
+			artifact.Disks = append(artifact.Disks, additionalDisk)
 		}
 		if kernelFile == "" {
 			artifact.Kernel = nil
@@ -128,6 +137,7 @@ func eciInit() {
 	podPublishCmd.Flags().StringVar(&kernelFile, "kernel", "", "path to kernel file, optional")
 	podPublishCmd.Flags().StringVar(&initrdFile, "initrd", "", "path to initrd file, optional")
 	podPublishCmd.Flags().StringVar(&rootFile, "root", "", "path to root disk file and format (for example: image.img:qcow2)")
+	podPublishCmd.Flags().StringSliceVar(&disks, "disks", []string{}, "disks to add into image")
 	podPublishCmd.Flags().BoolVar(&local, "local", false, "push to local registry")
 	podPublishCmd.Flags().StringVar(&formatStr, "format", "artifacts", "which format to use, one of: artifacts, legacy")
 	podPublishCmd.Flags().StringVar(&arch, "arch", edgeRegistry.DefaultArch, "arch to deploy")

--- a/cmd/edenPod.go
+++ b/cmd/edenPod.go
@@ -104,6 +104,7 @@ var podDeployCmd = &cobra.Command{
 		opts = append(opts, expect.WithImageFormat(imageFormat))
 		opts = append(opts, expect.WithACL(aclOnlyHost))
 		opts = append(opts, expect.WithHTTPDirectLoad(directLoad))
+		opts = append(opts, expect.WithAdditionalDisks(disks))
 		registryToUse := registry
 		switch registry {
 		case "local":
@@ -437,6 +438,7 @@ func podInit() {
 	podDeployCmd.Flags().BoolVar(&noHyper, "no-hyper", false, "Run pod without hypervisor")
 	podDeployCmd.Flags().StringVar(&registry, "registry", "remote", "Select registry to use for containers (remote/local)")
 	podDeployCmd.Flags().BoolVar(&directLoad, "direct", true, "Use direct download for image instead of eserver")
+	podDeployCmd.Flags().StringSliceVar(&disks, "disks", nil, "Additional disks to use")
 	podCmd.AddCommand(podPsCmd)
 	podCmd.AddCommand(podStopCmd)
 	podCmd.AddCommand(podStartCmd)

--- a/eserver/Dockerfile
+++ b/eserver/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.12.5-alpine3.9 AS build
+FROM golang:1.15.7-alpine3.13 AS build
 
 ENV CGO_ENABLED=0
 ENV GO111MODULE=on
 
-RUN apk --no-cache add git=2.20.4-r0
+RUN apk --no-cache add git=2.30.0-r0
 
 RUN mkdir -p /eserver/src && mkdir -p /eserver/bin
 WORKDIR /eserver/src
@@ -16,9 +16,9 @@ COPY . /eserver/src
 ARG GOOS=linux
 ARG GOARCH=amd64
 
-RUN go build -o /eserver/bin/eserver main.go
+RUN go build -ldflags "-s -w" -o /eserver/bin/eserver main.go
 
-FROM alpine:3.11
+FROM alpine:3.13
 
 COPY --from=build /eserver/bin/eserver /bin/
 WORKDIR /eserver

--- a/eserver/go.mod
+++ b/eserver/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/magiconair/properties v1.8.4 // indirect
-	github.com/mitchellh/mapstructure v1.4.0 // indirect
+	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pelletier/go-toml v1.8.1 // indirect
 	github.com/sirupsen/logrus v1.7.0
@@ -15,8 +15,8 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.7.1
-	golang.org/x/sys v0.0.0-20201211090839-8ad439b19e0f // indirect
-	golang.org/x/text v0.3.4 // indirect
+	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c // indirect
+	golang.org/x/text v0.3.5 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/eserver/go.sum
+++ b/eserver/go.sum
@@ -132,6 +132,8 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.4.0 h1:7ks8ZkOP5/ujthUsT07rNv+nkLXCQWKNHuwzOAesEks=
 github.com/mitchellh/mapstructure v1.4.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
+github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -269,6 +271,8 @@ golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201211090839-8ad439b19e0f h1:QdHQnPce6K4XQewki9WNbG5KOROuDzqO3NaYjI1cXJ0=
 golang.org/x/sys v0.0.0-20201211090839-8ad439b19e0f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
@@ -276,6 +280,8 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4 h1:0YWbFKbhXG/wIiuHDSKpS0Iy7FSA+u45VtBMfQcFTTc=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
+golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/eserver/pkg/manager/manager.go
+++ b/eserver/pkg/manager/manager.go
@@ -102,7 +102,11 @@ func (mgr *EServerManager) AddFileFromMultipart(part *multipart.Part) *api.FileI
 	filePath := filepath.Join(mgr.Dir, part.FileName())
 	if _, err := os.Stat(filePath); !os.IsNotExist(err) {
 		log.Println("file already exists ", filePath)
-		return mgr.GetFileInfo(part.FileName())
+		// remove file if exists, we have new file in request
+		if err := os.Remove(filePath); err != nil {
+			result.Error = err.Error()
+			return result
+		}
 	}
 	filePathTemp := filepath.Join(mgr.Dir, fmt.Sprintf("%s.tmp", part.FileName()))
 	out, err := os.Create(filePathTemp)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -62,7 +62,7 @@ const (
 	DefaultEveRegistry          = "lfedge"
 	DefaultRegistry             = "docker.io"
 
-	DefaultEServerTag          = "1.2"
+	DefaultEServerTag          = "1.3"
 	DefaultEServerContainerRef = "lfedge/eden-http-server"
 
 	//DefaultRepeatCount is repeat count for requests

--- a/pkg/expect/expectation.go
+++ b/pkg/expect/expectation.go
@@ -62,6 +62,8 @@ type AppExpectation struct {
 	oldAppName string
 
 	httpDirectLoad bool // use eserver for SHA calculation only
+
+	disks []string
 }
 
 //AppExpectationFromURL init AppExpectation with defined:

--- a/pkg/expect/file.go
+++ b/pkg/expect/file.go
@@ -20,7 +20,7 @@ func (exp *AppExpectation) createImageFile(id uuid.UUID, dsID string) *config.Im
 	sha256 := ""
 	filePath := ""
 	status := server.EServerCheckStatus(filepath.Base(exp.appURL))
-	if !status.ISReady || status.Size != utils.GetFileSize(exp.appURL) {
+	if !status.ISReady || status.Size != utils.GetFileSize(exp.appURL) || status.Sha256 != utils.SHA256SUM(exp.appURL){
 		log.Infof("Start uploading into eserver of %s", exp.appLink)
 		status = server.EServerAddFile(exp.appURL)
 		if status.Error != "" {

--- a/pkg/expect/options.go
+++ b/pkg/expect/options.go
@@ -172,3 +172,10 @@ func WithHTTPDirectLoad(direct bool) ExpectationOption {
 		expectation.httpDirectLoad = direct
 	}
 }
+
+//WithAdditionalDisks adds disks to application
+func WithAdditionalDisks(disks []string) ExpectationOption {
+	return func(expectation *AppExpectation) {
+		expectation.disks = disks
+	}
+}

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -14,19 +14,18 @@ import (
 )
 
 //SHA256SUM calculates sha256 of file
-func SHA256SUM(filePath string) (result string, err error) {
+func SHA256SUM(filePath string) string {
 	file, err := os.Open(filePath)
 	if err != nil {
-		return
+		log.Fatal(err)
 	}
 	defer file.Close()
 	hash := sha256.New()
 	if _, err = io.Copy(hash, file); err != nil {
-		return
+		log.Fatal(err)
 	}
 
-	result = hex.EncodeToString(hash.Sum(nil))
-	return
+	return hex.EncodeToString(hash.Sum(nil))
 }
 
 //CopyFileNotExists copy file from src to dst with same permission if not exists

--- a/tests/eclient/eden.eclient.tests.txt
+++ b/tests/eclient/eden.eclient.tests.txt
@@ -1,6 +1,7 @@
 eden+ports.sh 2223:2223 2224:2224
 # Just a simple test of eclient image functionality -- tested in more complex tests
 #eden.escript.test -test.run TestEdenScripts/eclient -test.timeout 15m
+eden.escript.test -test.run TestEdenScripts/disk -test.timeout 15m
 eden.escript.test -test.run TestEdenScripts/host-only -test.timeout 15m
 eden.escript.test -test.run TestEdenScripts/networking_light -test.timeout 15m
 eden.escript.test -test.run TestEdenScripts/nw_switch -test.timeout 20m

--- a/tests/eclient/testdata/disk.txt
+++ b/tests/eclient/testdata/disk.txt
@@ -1,0 +1,45 @@
+# Test for additional disk connected to eclient
+
+{{$port := "2223"}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+
+# Starting of reboot detector with a 2 reboot limit
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+
+eden pod deploy -n eclient-disk --memory=512MB docker://itmoeve/eclient:0.3 -p {{$port}}:22 --disks=file://{{EdenConfig "eden.root"}}/empty.qcow2
+
+test eden.app.test -test.v -timewait 20m RUNNING eclient-disk
+
+#eden -t 20m pod logs eclient-disk
+#stdout 'Executing "/usr/sbin/sshd" "-D"'
+
+exec -t 20m bash ssh.sh
+stdout 'vda'
+
+eden pod delete eclient-disk
+
+test eden.app.test -test.v -timewait 10m - eclient-disk
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for i in `seq 20`
+do
+sleep 20
+# Test SSH-access to container
+echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue
+ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p {{$port}} root@$HOST lsblk && break
+done

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -1,5 +1,5 @@
 # Number of tests
-{{$tests := 34}}
+{{$tests := 35}}
 # EDEN_TEST env. var. -- flavour of test set: "small", "medium"(default) and "large"
 {{$workflow := EdenGetEnv "EDEN_TEST"}}
 # EDEN_TEST_SETUP env. var. -- "y"(default) performs the EDEN setup steps
@@ -102,22 +102,24 @@ eden.escript.test -testdata ../app/testdata/ -test.run TestEdenScripts/2dockers_
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/ngnix
 /bin/echo Eden Mariadb (29/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/maridb
-/bin/echo EVE reset (30/{{$tests}})
+/bin/echo Eden eclient with disk (30/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/disk
+/bin/echo EVE reset (31/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_reset
 {{end}}
 {{ if  (eq $workflow "large")  }}
-/bin/echo Eden's testing the maximum application limit (31/{{$tests}})
+/bin/echo Eden's testing the maximum application limit (32/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/eclients
 {{end}}
 
-/bin/echo Eden Reboot test (32/{{$tests}})
+/bin/echo Eden Reboot test (33/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/reboot_test
 {{ if ne $workflow "small" }}
-/bin/echo Eden base OS update (33/{{$tests}})
+/bin/echo Eden base OS update (34/{{$tests}})
 eden.escript.test -testdata ../update_eve_image/testdata/ -test.run TestEdenScripts/update_eve_image
 {{end}}
 
 {{if (eq $stop "y")}}
-/bin/echo Eden stop (34/{{$tests}})
+/bin/echo Eden stop (35/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_stop
 {{end}}


### PR DESCRIPTION
Initial support for multiple disks in `pod deploy`:
`./eden pod deploy file:///data/root.qcow2 --disks=file:///data/1.qcow2 --disks=file:///data/2.qcow2`

Support for ECI also added in step of creating image, not in step of deploy.