### PR TITLE
point ssh test onto /etc/issue

### DIFF
--- a/tests/workflow/testdata/ssh.txt
+++ b/tests/workflow/testdata/ssh.txt
@@ -8,20 +8,16 @@
 #eden start
 #eden eve onboard
 
-# Get EVE's onboarded UUID
-eden -t 1m eve onboard
-cp stdout onboard
-exec bash uuid.sh
-
 # Get redirected SSH port
 eden config get --key eve.hostfwd
 cp stdout eve.hostfwd
 
-# SSH login to EVE and getting UUID
+# SSH login to EVE and getting issue
 exec -t 2m bash ssh.sh
+cp stdout issue
 
-# UUID's comparison
-cmp stdout uuid
+# issue comparison
+grep 'Edge Virtualization Engine' issue
 
 # Test's config. file
 -- eden-config.yml --
@@ -33,9 +29,6 @@ test:
         serial: "{{EdenConfig "eve.serial"}}"
         model: {{EdenConfig "eve.devmodel"}}
 
--- uuid.sh --
-grep 'device UUID' onboard | sed 's/.*device UUID: \(.*\)"/\1/' > uuid
-
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 PORT=`cat eve.hostfwd | sed 's/.*[^0-9]\([0-9]*\)":"22[^0-9].*/\1/'`
@@ -45,4 +38,4 @@ if [ $? -ne 0 ]; then
 fi
 CERT=`echo {{EdenConfig "eden.root"}}/{{EdenConfig "eden.ssh-key"}} | sed 's/\.pub$//'`
 HOST=$($EDEN eve ip)
-until ssh -o ConnectTimeout=5 -oStrictHostKeyChecking=no -i $CERT -p $PORT root@$HOST cat /config/uuid; do sleep 10; done
+until ssh -o ConnectTimeout=5 -oStrictHostKeyChecking=no -i $CERT -p $PORT root@$HOST cat /hostfs/etc/issue; do sleep 10; done


### PR DESCRIPTION
`/config/uuid` is not reliable file for testing, so we should move onto another file (`/etc/issue` in the ssh test).

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>