### PR TITLE
support multiarch build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
       - name: setup
         run: |
           sudo apt update
@@ -61,6 +63,7 @@ jobs:
         with:
           context: eserver
           file: eserver/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{env.ESERVER_IMAGE_NAME}}:${{env.RELEASE_VERSION}}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -49,7 +49,7 @@ const (
 
 	//tags, versions, repos
 	DefaultEVETag               = "0.0.0-master-41772163" //DefaultEVETag tag for EVE image
-	DefaultAdamTag              = "df661d7e3d547a8a984a7bd342ad821cc7d533ac"
+	DefaultAdamTag              = "0b72a46462c4e1e7de5acce00cea076feb3f8585"
 	DefaultRedisTag             = "6"
 	DefaultRegistryTag          = "2.7"
 	DefaultProcTag              = "1.2"

--- a/tests/eclient/Makefile
+++ b/tests/eclient/Makefile
@@ -70,6 +70,10 @@ push:
 	docker push $(IMAGE_TAG):$(IMAGE_VERSION)
 	docker push $(IMAGE_TAG):latest
 
+push-multi-arch:
+	@echo "Push image"
+	docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag $(IMAGE_TAG):$(IMAGE_VERSION) $(IMAGE_DIR)
+
 help:
 	@echo "EDEN is the harness for testing EVE and ADAM"
 	@echo

--- a/tests/eclient/image/Dockerfile
+++ b/tests/eclient/image/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:20.04
+FROM ubuntu:focal-20210119
 
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-  curl=7.68.0-1ubuntu2.2 \
+  curl=7.68.0-1ubuntu2.4 \
   iproute2=5.5.0-1ubuntu1 \
   iputils-ping=3:20190709-3 \
   mariadb-client=1:10.3.22-1ubuntu1 \

--- a/tests/io_performance/Makefile
+++ b/tests/io_performance/Makefile
@@ -59,6 +59,10 @@ image:
 	@echo "Build image"
 	docker build -t $(IMAGE_TAG):$(IMAGE_VERSION) $(IMAGE_DIR)
 
+push-multi-arch:
+	@echo "Push image"
+	docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag $(IMAGE_TAG):$(IMAGE_VERSION) $(IMAGE_DIR)
+
 .PHONY: test build setup clean all
 
 help:

--- a/tests/network/Makefile
+++ b/tests/network/Makefile
@@ -68,6 +68,10 @@ image:
 	@echo "Build image"
 	docker build -t $(IMAGE_TAG):$(IMAGE_VERSION) $(IMAGE_DIR)
 
+push-multi-arch:
+	@echo "Push image"
+	docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag $(IMAGE_TAG):$(IMAGE_VERSION) $(IMAGE_DIR)
+
 help:
 	@echo "EDEN is the harness for testing EVE and ADAM"
 	@echo


### PR DESCRIPTION
We need to build eclient and docker-test for arm64 for tests on rpi.

Adds `push-multi-arch` target.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>