### PR TITLE
new version of EVE; update for reboot test

### DIFF
--- a/cmd/eve.go
+++ b/cmd/eve.go
@@ -342,7 +342,6 @@ var onboardEveCmd = &cobra.Command{
 		dev.SetSerial(vars.EveSerial)
 		dev.SetOnboardKey(vars.EveCert)
 		dev.SetDevModel(vars.DevModel)
-		dev.SetName(vars.EveName)
 		err = ctrl.OnBoardDev(dev)
 		if err != nil {
 			log.Fatal(err)
@@ -391,7 +390,6 @@ var resetEveCmd = &cobra.Command{
 		dev.SetSerial(vars.EveSerial)
 		dev.SetOnboardKey(vars.EveCert)
 		dev.SetDevModel(vars.DevModel)
-		dev.SetName(vars.EveName)
 		err = ctrl.OnBoardDev(dev)
 		if err != nil {
 			log.Fatal(err)

--- a/pkg/controller/cloud.go
+++ b/pkg/controller/cloud.go
@@ -29,7 +29,6 @@ type CloudCtx struct {
 type Cloud interface {
 	Controller
 	AddDevice(devUUID uuid.UUID) (dev *device.Ctx, err error)
-	GetEdgeNode(name string) *device.Ctx
 	GetDeviceUUID(devUUID uuid.UUID) (dev *device.Ctx, err error)
 	GetBaseOSConfig(id string) (baseOSConfig *config.BaseOSConfig, err error)
 	ListBaseOSConfig() []*config.BaseOSConfig

--- a/pkg/controller/device.go
+++ b/pkg/controller/device.go
@@ -279,26 +279,6 @@ func (cloud *CloudCtx) GetAllNodes() {
 	}
 }
 
-//GetEdgeNode by name
-func (cloud *CloudCtx) GetEdgeNode(name string) *device.Ctx {
-	if name == "" {
-		node, _ := cloud.GetDeviceCurrent()
-		if node != nil {
-			return node
-		}
-		return nil
-	}
-	if len(cloud.devices) == 0 {
-		return nil
-	}
-	for _, el := range cloud.devices {
-		if el.GetName() == name {
-			return el
-		}
-	}
-	return nil
-}
-
 //AddDevice add device with specified devUUID
 func (cloud *CloudCtx) AddDevice(devUUID uuid.UUID) (dev *device.Ctx, err error) {
 	for _, el := range cloud.devices {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -48,8 +48,8 @@ const (
 	DefaultRegistryPort = 5000
 
 	//tags, versions, repos
-	DefaultEVETag               = "0.0.0-master-41772163" //DefaultEVETag tag for EVE image
-	DefaultAdamTag              = "0b72a46462c4e1e7de5acce00cea076feb3f8585"
+	DefaultEVETag               = "5.21.1" //DefaultEVETag tag for EVE image
+	DefaultAdamTag              = "0.0.12"
 	DefaultRedisTag             = "6"
 	DefaultRegistryTag          = "2.7"
 	DefaultProcTag              = "1.2"

--- a/pkg/device/device.go
+++ b/pkg/device/device.go
@@ -20,7 +20,6 @@ type Ctx struct {
 	onboardKey                 string
 	serial                     string
 	state                      EdgeNodeState
-	name                       string
 	project                    string
 	hash                       [32]byte
 	id                         uuid.UUID
@@ -203,16 +202,6 @@ func (cfg *Ctx) Reboot() {
 	}
 	c, _ := cfg.GetRebootCounter()
 	cfg.SetRebootCounter(c+1, true)
-}
-
-//GetName getter
-func (cfg *Ctx) GetName() string {
-	return cfg.name
-}
-
-//SetName setter
-func (cfg *Ctx) SetName(name string) {
-	cfg.name = name
 }
 
 //GetState setter

--- a/pkg/models/gcp.go
+++ b/pkg/models/gcp.go
@@ -87,9 +87,9 @@ func (ctx *DevModelGCP) GetFirstAdapterForSwitches() string {
 
 func createGCP() (DevModel, error) {
 	return &DevModelGCP{
-		physicalIOs:        generatePhysicalIOs(2, 0, 0),
-		networks:           generateNetworkConfigs(2, 0),
-		adapters:           generateSystemAdapters(2, 0),
-		adapterForSwitches: []string{"eth1"},
+		physicalIOs:        generatePhysicalIOs(1, 0, 0),
+		networks:           generateNetworkConfigs(1, 0),
+		adapters:           generateSystemAdapters(1, 0),
+		adapterForSwitches: []string{},
 	}, nil
 }

--- a/pkg/projects/edgeNodeDescription.go
+++ b/pkg/projects/edgeNodeDescription.go
@@ -4,7 +4,6 @@ import "github.com/lf-edge/eden/pkg/device"
 
 //EdgeNodeDescription must be defined in config file
 type EdgeNodeDescription struct {
-	Name   string
 	Key    string
 	Serial string
 	Model  string
@@ -24,7 +23,7 @@ func (nodeDescription *EdgeNodeDescription) GetEdgeNode(tc *TestContext) *device
 		}
 		return dev
 	}
-	return ctrl.GetEdgeNode(nodeDescription.Name)
+	return nil
 }
 
 //EdgeNodeOption is type to use for creation of device.Ctx
@@ -33,7 +32,6 @@ type EdgeNodeOption func(description *device.Ctx)
 //WithNodeDescription sets device info
 func (tc *TestContext) WithNodeDescription(nodeDescription *EdgeNodeDescription) EdgeNodeOption {
 	return func(d *device.Ctx) {
-		d.SetName(nodeDescription.Name)
 		d.SetDevModel(nodeDescription.Model)
 		d.SetOnboardKey(nodeDescription.Key)
 		d.SetSerial(nodeDescription.Serial)

--- a/pkg/projects/testContext.go
+++ b/pkg/projects/testContext.go
@@ -104,12 +104,11 @@ func (tc *TestContext) GetNodeDescriptions() (nodes []*EdgeNodeDescription) {
 			eveKey := viper.GetString(fmt.Sprintf("test.eve.%s.onboard-cert", name))
 			eveSerial := viper.GetString(fmt.Sprintf("test.eve.%s.serial", name))
 			eveModel := viper.GetString(fmt.Sprintf("test.eve.%s.model", name))
-			nodes = append(nodes, &EdgeNodeDescription{Name: name, Key: eveKey, Serial: eveSerial, Model: eveModel})
+			nodes = append(nodes, &EdgeNodeDescription{Key: eveKey, Serial: eveSerial, Model: eveModel})
 		}
 	} else {
 		log.Debug("NodeDescriptions not found. Will use default one.")
 		nodes = append(nodes, &EdgeNodeDescription{
-			Name: viper.GetString("eve.name"),
 			Key: utils.ResolveAbsPath(viper.GetString("eve.cert")),
 			Serial: viper.GetString("eve.serial"),
 			Model: viper.GetString("eve.devModel"),
@@ -153,13 +152,6 @@ func (tc *TestContext) AddEdgeNodesFromDescription() {
 
 //GetEdgeNodeOpts pattern to pass device modifications
 type GetEdgeNodeOpts func(*device.Ctx) bool
-
-//FilterByName check EdgeNode name
-func (tc *TestContext) FilterByName(name string) GetEdgeNodeOpts {
-	return func(d *device.Ctx) bool {
-		return d.GetName() == name
-	}
-}
 
 //WithTest assign *testing.T for device
 func (tc *TestContext) WithTest(t *testing.T) GetEdgeNodeOpts {
@@ -219,7 +211,7 @@ func (tc *TestContext) ConfigSync(edgeNode *device.Ctx) {
 		log.Debugf("Device %s onboarded", edgeNode.GetID().String())
 	}
 	if err := tc.GetController().ConfigSync(edgeNode); err != nil {
-		log.Fatalf("Cannot send config of %s", edgeNode.GetName())
+		log.Fatalf("Cannot send config of %s", edgeNode.GetID())
 	}
 }
 
@@ -245,7 +237,7 @@ func (tc *TestContext) WaitForProcWithErrorCallback(secs int, callback Callback)
 		select {
 		case <-waitChan:
 			for node, el := range tc.tests {
-				el.Logf("done for device %s", node.GetName())
+				el.Logf("done for device %s", node.GetID())
 			}
 			return
 		case <-ticker.C:
@@ -317,7 +309,7 @@ func (tc *TestContext) StartTrackingState(onlyNewElements bool) {
 func (tc *TestContext) WaitForState(edgeNode *device.Ctx, secs int) {
 	state, isOk := tc.states[edgeNode]
 	if !isOk {
-		log.Fatalf("edgeNode not found with name %s", edgeNode.GetName())
+		log.Fatalf("edgeNode not found with name %s", edgeNode.GetID())
 	}
 	timeout := time.Duration(secs) * time.Second
 	waitChan := make(chan struct{})

--- a/tests/app/testdata/2dockers_test.txt
+++ b/tests/app/testdata/2dockers_test.txt
@@ -9,11 +9,11 @@ eden -t 5s pod ps
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
 
 # Run t1 docker
-eden -t 1m pod deploy -p 8027:80 docker://nginx -n t1
+eden -t 1m pod deploy -p 8027:80 docker://nginx -n t1 --memory 512MB
 stdout 'deploy pod t1 with docker://nginx request sent'
 
 # Run t2 docker
-eden -t 1m pod deploy -p 8028:80 docker://nginx -n t2
+eden -t 1m pod deploy -p 8028:80 docker://nginx -n t2 --memory 512MB
 stdout 'deploy pod t2 with docker://nginx request sent'
 
 # Wait for run

--- a/tests/eclient/testdata/host-only.txt
+++ b/tests/eclient/testdata/host-only.txt
@@ -7,14 +7,14 @@
 [!exec:sleep] stop
 [!exec:ssh] stop
 
-# Starting of reboot detector with a 2 reboot limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait 40m -reboot=0 -count=1 &
 
 eden pod deploy -n ping-nw --memory=512MB docker://itmoeve/eclient:0.3 -p 2223:22
 eden pod deploy -n ping-fw --memory=512MB docker://itmoeve/eclient:0.3 -p 2224:22 --only-host=true
 eden pod deploy -n pong --memory=512MB docker://itmoeve/eclient:0.3
 
-test eden.app.test -test.v -timewait 20m RUNNING ping-nw ping-fw pong
+test eden.app.test -test.v -timewait 25m RUNNING ping-nw ping-fw pong
 
 exec -t 20m bash wait_ssh.sh 2223 2224
 

--- a/tests/lim/lim_test.go
+++ b/tests/lim/lim_test.go
@@ -145,12 +145,12 @@ func TestLog(t *testing.T) {
 	edgeNode := tc.GetEdgeNode(tc.WithTest(t))
 
 	t.Logf("Wait for log of %s number=%d timewait=%s\n",
-		edgeNode.GetName(), *number, timewait)
+		edgeNode.GetID(), *number, timewait)
 
 	tc.AddProcLog(edgeNode, func(log *elog.FullLogEntry) error {
 		return func(t *testing.T, edgeNode *device.Ctx,
 			log *elog.FullLogEntry) error {
-			name := edgeNode.GetName()
+			name := edgeNode.GetID()
 			if query != nil {
 				if elog.LogItemFind(log, query) {
 					found = true
@@ -166,7 +166,7 @@ func TestLog(t *testing.T) {
 					strings.Split(*out, ":")).Print()
 			}
 
-			cnt := count("Recieved %d logs from %s", name)
+			cnt := count("Recieved %d logs from %s", name.String())
 			if cnt != "" {
 				return fmt.Errorf(cnt)
 			}
@@ -186,12 +186,12 @@ func TestInfo(t *testing.T) {
 	edgeNode := tc.GetEdgeNode(tc.WithTest(t))
 
 	t.Logf("Wait for info of %s number=%d timewait=%s\n",
-		edgeNode.GetName(), *number, timewait)
+		edgeNode.GetID(), *number, timewait)
 
 	tc.AddProcInfo(edgeNode, func(ei *info.ZInfoMsg) error {
 		return func(t *testing.T, edgeNode *device.Ctx,
 			ei *info.ZInfoMsg) error {
-			name := edgeNode.GetName()
+			name := edgeNode.GetID()
 			if query != nil {
 				if einfo.ZInfoFind(ei, query) != nil {
 					found = true
@@ -207,7 +207,7 @@ func TestInfo(t *testing.T) {
 				einfo.ZInfoPrint(ei,
 					strings.Split(*out, ":")).Print()
 			}
-			cnt := count("Recieved %d infos from %s", name)
+			cnt := count("Recieved %d infos from %s", name.String())
 			if cnt != "" {
 				return fmt.Errorf(cnt)
 			}
@@ -227,12 +227,12 @@ func TestMetrics(t *testing.T) {
 	edgeNode := tc.GetEdgeNode(tc.WithTest(t))
 
 	t.Logf("Wait for metric of %s number=%d timewait=%s\n",
-		edgeNode.GetName(), *number, timewait)
+		edgeNode.GetID(), *number, timewait)
 
 	tc.AddProcMetric(edgeNode, func(metric *metrics.ZMetricMsg) error {
 		return func(t *testing.T, edgeNode *device.Ctx,
 			mtr *metrics.ZMetricMsg) error {
-			name := edgeNode.GetName()
+			name := edgeNode.GetID()
 			if query != nil {
 				if emetric.MetricItemFind(mtr, query) {
 					found = true
@@ -250,7 +250,7 @@ func TestMetrics(t *testing.T) {
 					strings.Split(*out, ":")).Print()
 			}
 
-			cnt := count("Recieved %d metrics from %s", name)
+			cnt := count("Received %d metrics from %s", name.String())
 			if cnt != "" {
 				return fmt.Errorf(cnt)
 			}

--- a/tests/update_eve_image/testdata/update_eve_image.txt
+++ b/tests/update_eve_image/testdata/update_eve_image.txt
@@ -1,5 +1,5 @@
 # Default EVE version to update
-{{$eve_ver := "5.12.4"}}
+{{$eve_ver := "5.19.0"}}
 
 # Obtain EVE version from environment variable EVE_VERSION
 {{$env := EdenGetEnv "EVE_VERSION"}}
@@ -16,8 +16,8 @@
 # Combine variables into $short_version
 {{$short_version := printf "%s-%s-%s" $eve_ver $eve_hv $eve_arch}}
 
-# Use eden.lim.test for access Infos with timewait 20m
-{{$test := "test eden.lim.test -test.v -timewait 20m -test.run TestInfo"}}
+# Use eden.lim.test for access Infos with timewait 30m
+{{$test := "test eden.lim.test -test.v -timewait 30m -test.run TestInfo"}}
 
 
 # Download EVE rootfs into eve-dist

--- a/tests/workflow/testdata/reboot_test.txt
+++ b/tests/workflow/testdata/reboot_test.txt
@@ -1,4 +1,4 @@
-test eden.reboot.test -test.v -timewait 10m
+test eden.reboot.test -test.v -timewait 15m
 stdout 'Number of reboots:'
 
 -- eden-config.yml --


### PR DESCRIPTION
Sync EVE and Adam versions and refactoring of reboot test.
Inside the new version of EVE api we cannot rely on `name` field in our test because of removal.
Also, we set count of ethernet ports for gcp to actual count (one port) to be the same as on machine.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>