### PR TITLE
Assume EVE is down if no answer comes in 10 min

### DIFF
--- a/cmd/edenStatus.go
+++ b/cmd/edenStatus.go
@@ -84,7 +84,12 @@ func eveStatusRemote() {
 				ips = append(ips, nw.IPAddrs...)
 			}
 			fmt.Printf("%s EVE REMOTE IPs: %s\n", statusOK(), strings.Join(ips, "; "))
-			fmt.Printf("\tLast info received time: %s\n", time.Unix(eveState.InfoAndMetrics().GetLastInfoTime().GetSeconds(), 0))
+			var lastseen = time.Unix(eveState.InfoAndMetrics().GetLastInfoTime().GetSeconds(), 0)
+			var timenow = time.Now().Unix()
+			fmt.Printf("\tLast info received time: %s\n", lastseen)
+			if (timenow - lastseen.Unix()) > 600 {
+				fmt.Printf("\t EVE MIGHT BE DOWN OR CONNECTIVITY BETWEEN EVE AND ADAM WAS LOST\n")
+			}
 		} else {
 			fmt.Printf("%s EVE REMOTE IPs: %s\n", statusWarn(), "waiting for info...")
 		}


### PR DESCRIPTION
Final fix for https://github.com/lf-edge/eden/issues/126

Assume that EVE is down if in 10 min no answer comes (Last seen is too late)
We may change it to 5 min 

@giggsoff 


Signed-off-by: fleandr <svfly@yandex.ru>