### PR TITLE
[WIP] reboot after ipxe install

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -48,7 +48,7 @@ const (
 	DefaultRegistryPort = 5000
 
 	//tags, versions, repos
-	DefaultEVETag               = "5.21.1" //DefaultEVETag tag for EVE image
+	DefaultEVETag               = "5.21.2" //DefaultEVETag tag for EVE image
 	DefaultAdamTag              = "0.0.12"
 	DefaultRedisTag             = "6"
 	DefaultRegistryTag          = "2.7"
@@ -101,9 +101,9 @@ const (
 	DefaultEveLogLevel  = "info"    //min level of logs saved in files on EVE device
 	DefaultAdamLogLevel = "warning" //min level of logs sent from EVE to Adam
 
-	DefaultQemuAccelDarwin = "-machine q35,accel=hvf -cpu kvm64,kvmclock=off "
-	DefaultQemuAccelLinuxAmd64  = "-machine q35,accel=kvm,dump-guest-core=off,kernel-irqchip=split -cpu host,invtsc=on,kvmclock=off -device intel-iommu,intremap=on,caching-mode=on,aw-bits=48 "
-  DefaultQemuAccelLinuxArm64  = "-machine virt,accel=kvm -cpu=host "
+	DefaultQemuAccelDarwin     = "-machine q35,accel=hvf -cpu kvm64,kvmclock=off "
+	DefaultQemuAccelLinuxAmd64 = "-machine q35,accel=kvm,dump-guest-core=off,kernel-irqchip=split -cpu host,invtsc=on,kvmclock=off -device intel-iommu,intremap=on,caching-mode=on,aw-bits=48 "
+	DefaultQemuAccelLinuxArm64 = "-machine virt,accel=kvm -cpu=host "
 
 	DefaultAppSubnet = "10.11.12.0/24"
 

--- a/pkg/defaults/templates.go
+++ b/pkg/defaults/templates.go
@@ -274,7 +274,7 @@ const DefaultIPXEConfig = `#!ipxe
 # dhcp
 # chain --autofree https://github.com/lf-edge/eve/releases/download/1.2.3/ipxe.efi.cfg
 echo Installing with an ID ${ip}
-kernel http://{{.ADDRESS}}/kernel eve_installer=${ip} fastboot console=ttyS0 console=ttyS1 console=ttyS2 console=ttyAMA0 console=ttyAMA1 console=tty0 initrd=initrd.img initrd=initrd.bits
+kernel http://{{.ADDRESS}}/kernel eve_installer=${ip} eve_reboot_after_install fastboot console=ttyS0 console=ttyS1 console=ttyS2 console=ttyAMA0 console=ttyAMA1 console=tty0 initrd=initrd.img initrd=initrd.bits
 initrd http://{{.ADDRESS}}/initrd.img
 initrd http://{{.ADDRESS}}/initrd.bits
 boot


### PR DESCRIPTION
With new versions of EVE we can use `eve_reboot_after_install` parameter to automatically reboot after install.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>