### PR TITLE
more verbose output in detectors

### DIFF
--- a/tests/app/app_test.go
+++ b/tests/app/app_test.go
@@ -61,7 +61,7 @@ func checkNewLastState(appName, state string) bool {
 	if ok {
 		lastState := appStates[len(appStates)-1]
 		if lastState.state != state {
-			fmt.Printf("lastState: %s state: %s time: %s\n", lastState.state, state,
+			fmt.Printf("lastState: %s expected state: %s time: %s\n", lastState.state, state,
 				time.Now().Format(time.RFC3339Nano))
 			return true
 		}
@@ -155,13 +155,13 @@ func TestAppStatus(t *testing.T) {
 		tc.AddProcInfo(edgeNode, checkApp(state, apps))
 
 		callback := func() {
-			t.Errorf("ASSERTION FAILED: expected apps %s in %s state", apps, state)
+			t.Errorf("ASSERTION FAILED (%s): expected apps %s in %s state", time.Now().Format(time.RFC3339Nano), apps, state)
 			for k, v := range states {
 				t.Errorf("\tactual %s: %s", k, v[len(v)-1].state)
 				if checkNewLastState(k, state) {
 					t.Errorf("\thistory of states for %s:", k)
 					for _, st := range v {
-						t.Errorf("\t\tstate: %s time: %s", st.state, st.timestamp.Format(time.RFC3339Nano))
+						t.Errorf("\t\tstate: %s received in: %s", st.state, st.timestamp.Format(time.RFC3339Nano))
 					}
 				}
 				for _, app := range eveState.Applications() {

--- a/tests/lim/lim_test.go
+++ b/tests/lim/lim_test.go
@@ -208,7 +208,7 @@ func TestInfo(t *testing.T) {
 				einfo.ZInfoPrint(ei,
 					strings.Split(*out, ":")).Print()
 			}
-			cnt := count("Recieved %d infos from %s", name.String())
+			cnt := count("Received %d infos from %s", name.String())
 			if cnt != "" {
 				return fmt.Errorf(cnt)
 			}

--- a/tests/network/nw_test.go
+++ b/tests/network/nw_test.go
@@ -130,7 +130,7 @@ func TestNetworkStatus(t *testing.T) {
 	} else {
 		secs := int(timewait.Seconds())
 		state := args[0]
-		t.Log(utils.AddTimestamp(fmt.Sprintf("networks: '%s' state: '%s' secs: %d\n",
+		t.Log(utils.AddTimestamp(fmt.Sprintf("networks: '%s' expected state: '%s' secs: %d\n",
 			args[1:], state, secs)))
 
 		vols := args[1:]
@@ -150,13 +150,13 @@ func TestNetworkStatus(t *testing.T) {
 			tc.AddProcInfo(edgeNode, checkNet(state, vols))
 
 			callback := func() {
-				t.Errorf("ASSERTION FAILED: expected networks %s in %s state", vols, state)
+				t.Errorf("ASSERTION FAILED (%s): expected networks %s in %s state", time.Now().Format(time.RFC3339Nano), vols, state)
 				for k, v := range states {
 					t.Errorf("\tactual %s: %s", k, v[len(v)-1].state)
 					if checkNewLastState(k, state) {
 						t.Errorf("\thistory of states for %s:", k)
 						for _, st := range v {
-							t.Errorf("\t\tstate: %s time: %s", st.state, st.timestamp.Format(time.RFC3339Nano))
+							t.Errorf("\t\tstate: %s received in: %s", st.state, st.timestamp.Format(time.RFC3339Nano))
 						}
 					}
 				}

--- a/tests/volume/vol_test.go
+++ b/tests/volume/vol_test.go
@@ -56,7 +56,7 @@ func checkNewLastState(volName, state string) bool {
 	if ok {
 		lastState := volStates[len(volStates)-1]
 		if lastState.state != state {
-			fmt.Printf("lastState: %s state: %s time: %s\n", lastState.state, state,
+			fmt.Printf("lastState: %s expected state: %s time: %s\n", lastState.state, state,
 				time.Now().Format(time.RFC3339Nano))
 			return true
 		}
@@ -154,13 +154,13 @@ func TestVolStatus(t *testing.T) {
 			tc.AddProcInfo(edgeNode, checkVol(state, vols))
 
 			callback := func() {
-				t.Errorf("ASSERTION FAILED: expected volumes %s in %s state", vols, state)
+				t.Errorf("ASSERTION FAILED (%s): expected volumes %s in %s state", time.Now().Format(time.RFC3339Nano), vols, state)
 				for k, v := range states {
 					t.Errorf("\tactual %s: %s", k, v[len(v)-1].state)
 					if checkNewLastState(k, state) {
 						t.Errorf("\thistory of states for %s:", k)
 						for _, st := range v {
-							t.Errorf("\t\tstate: %s time: %s", st.state, st.timestamp.Format(time.RFC3339Nano))
+							t.Errorf("\t\tstate: %s received in: %s", st.state, st.timestamp.Format(time.RFC3339Nano))
 						}
 					}
 				}


### PR DESCRIPTION
We should output time of assertion failure. Also includes corrections of sentences.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>