### PR TITLE
add registry option to controller

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -64,6 +64,21 @@ To update the running eve os base image to another one, for example one stored i
 eden controller -m adam:// edge-node eveimage-update dist/amd64/installer/rootfs.img
 ```
 
+The last argument is the path tp the new rootfs image. It can be one of:
+
+* relative file path, like the example above, `dist/amd64/installer/rootfs.img`
+* absolute file path, e.g. `/home/user1/eve/dist/amd64/installer/rootfs.img`
+* file URL, e.g. `file:///home/user1/eve/dist/amd64/installer/rootfs.img`
+* http/s URL, e.g. `https://some.server.com/path/to/rootfs.img`
+* OCI registry, e.g. `docker.io/lfedge/eve:6.7.8`
+
+Note that when providing the OCI registry option, you can select to get the image from the local, eden-launched registry with
+the `--registry=local` argument, e.g.
+
+```console
+eden controller -m adam:// edge-node eveimage-update --registry=local oci://docker.io/lfedge/eve:6.7.8
+```
+
 To set config property of EVE from [list](https://github.com/lf-edge/eve/blob/master/docs/CONFIG-PROPERTIES.md) you
 can use the following command:
 


### PR DESCRIPTION
When passing an OCI url, e.g. `oci://docker.io/foo/bar:1.2.3`, to launching pods, we already have an option to pass it `--registry=local` so that it uses the local registry. This has been useful for images that are built locally and not available on the remote registry hub.

This adds the same `--registry` option to `eveimage-update`, so we can do the same.