### PR TITLE
move subnet of network test and limit timeouts

### DIFF
--- a/tests/network/testdata/network_test.txt
+++ b/tests/network/testdata/network_test.txt
@@ -1,17 +1,17 @@
 eden -t 5s network ls
 
-# Starting of reboot detector with a 3 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait 20m -reboot=0 -count=1 &
 
 # Create n1 network
-eden -t 1m network create 10.1.0.0/24 -n n1
+eden -t 1m network create 10.11.12.0/24 -n n1
 stdout 'deploy network .* with name n1 request sent'
 
 # Wait for run
-test eden.network.test -test.v -timewait 20m ACTIVATED n1
+test eden.network.test -test.v -timewait 10m ACTIVATED n1
 # Need to fix -- another try of detecting not passing
 #exec sleep 20
-#test eden.network.test -test.v -timewait 20m ACTIVATED n1
+#test eden.network.test -test.v -timewait 10m ACTIVATED n1
 
 # Networks detecting
 eden -t 1m network ls
@@ -23,8 +23,8 @@ eden -t 5m network delete n1
 stdout 'network n1 delete done'
 
 # Wait for delete
-test eden.network.test -test.v -timewait 20m - n1
-#test eden.network.test -test.v -timewait 20m - n1
+test eden.network.test -test.v -timewait 10m - n1
+#test eden.network.test -test.v -timewait 10m - n1
 stdout 'no network with n1 found'
 
 # Networks detecting


### PR DESCRIPTION
We need to move subnet inside our test to not conflict with GH Action`s VM one.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>