### PR TITLE
wrap vnc test into escript

### DIFF
--- a/tests/escript/go-internal/testscript/testscript.go
+++ b/tests/escript/go-internal/testscript/testscript.go
@@ -748,10 +748,11 @@ func (ts *TestScript) removeGHAnnotation() {
 	bytesReader := bytes.NewReader(ts.log.Bytes())
 	scanner := bufio.NewScanner(bytesReader)
 	for scanner.Scan() {
-		if strings.Contains(scanner.Text(), "::error file") {
+		text := scanner.Text()
+		if strings.Contains(text, "::error file") {
 			continue
 		}
-		if _, err := filteredBuffer.Write(scanner.Bytes()); err != nil {
+		if _, err := filteredBuffer.WriteString(text + "\n"); err != nil {
 			fmt.Printf("cannot write to filteredBuffer: %s", err)
 			os.Exit(1)
 		}

--- a/tests/vnc/Makefile
+++ b/tests/vnc/Makefile
@@ -56,7 +56,7 @@ $(TESTBIN): $(LOCALTESTBIN)
 
 setup: testbin $(BINDIR) $(DATADIR)
 	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(DATADIR)
-	cp -a *.yml $(TESTSCN) $(DATADIR)
+	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
 	ln -sf ../$(TESTDIR)/$(TESTBIN) $(BINDIR)
 
 .PHONY: test build setup clean all testbin

--- a/tests/vnc/eden.vnc.tests.txt
+++ b/tests/vnc/eden.vnc.tests.txt
@@ -1,1 +1,1 @@
-eden.vnc.test -panic=true -logger=true
+eden.escript.test -test.run TestEdenScripts/vnc_test

--- a/tests/vnc/testdata/vnc_test.txt
+++ b/tests/vnc/testdata/vnc_test.txt
@@ -1,0 +1,30 @@
+{{$test_opts := "-test.v -name vnc-app"}}
+
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait 45m -reboot=0 -count=1 &
+
+#TestVNCVMStart checks if app processed by EVE, app in RUNNING state
+test eden.vnc.test {{$test_opts}} -timewait 15m -test.run TestVNCVMStart
+stdout '--- PASS: TestVNCVMStart'
+
+# TestAccess checks if VNC and SSH of app is accessible
+test eden.vnc.test {{$test_opts}} -timewait 10m -test.run TestAccess
+stdout '--- PASS: TestAccess'
+
+# TestAppLogs checks if logs of app is accessible also it initiates panic
+test eden.vnc.test {{$test_opts}} -panic=true -logger=true -timewait 10m -test.run TestAppLogs
+stdout '--- PASS: TestAppLogs'
+
+#TestVNCVMDelete initiates deleting of app and checks if app deleted from EVE
+test eden.vnc.test {{$test_opts}} -timewait 10m -test.run TestVNCVMDelete
+stdout '--- PASS: TestVNCVMDelete'
+
+# Test's config. file
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/vnc/vnc_test.go
+++ b/tests/vnc/vnc_test.go
@@ -66,6 +66,12 @@ func TestMain(m *testing.M) {
 
 	tc.StartTrackingState(false)
 
+	res := m.Run()
+
+	os.Exit(res)
+}
+
+func setAppName(){
 	if appName == "" { //if previous appName not defined
 		if *name == "" {
 			rand.Seed(time.Now().UnixNano())
@@ -74,10 +80,6 @@ func TestMain(m *testing.M) {
 			appName = *name
 		}
 	}
-
-	res := m.Run()
-
-	os.Exit(res)
 }
 
 //getVNCPort calculate port for vnc
@@ -168,6 +170,8 @@ func TestVNCVMStart(t *testing.T) {
 		return *appLink
 	}
 
+	setAppName()
+
 	var opts []expect.ExpectationOption
 
 	appMemoryParsed, err := humanize.ParseBytes(*memory)
@@ -244,6 +248,8 @@ func TestAccess(t *testing.T) {
 
 	edgeNode := tc.GetEdgeNode(tc.WithTest(t))
 
+	setAppName()
+
 	appInstanceConfig := getAppInstanceConfig(edgeNode, appName)
 
 	if appInstanceConfig == nil {
@@ -260,6 +266,8 @@ func TestAccess(t *testing.T) {
 	tc.AddProcTimer(edgeNode, getEVEIP(edgeNode))
 
 	t.Log(utils.AddTimestamp("Add trying to access VNC of app"))
+
+	externalPort = getVNCPort(edgeNode, *vncDisplay)
 
 	tc.AddProcTimer(edgeNode, checkVNCAccess())
 
@@ -285,6 +293,8 @@ func TestAccess(t *testing.T) {
 func TestAppLogs(t *testing.T) {
 
 	edgeNode := tc.GetEdgeNode(tc.WithTest(t))
+
+	setAppName()
 
 	appInstanceConfig := getAppInstanceConfig(edgeNode, appName)
 
@@ -328,6 +338,8 @@ func TestAppLogs(t *testing.T) {
 func TestVNCVMDelete(t *testing.T) {
 
 	edgeNode := tc.GetEdgeNode(tc.WithTest(t))
+
+	setAppName()
 
 	t.Log(utils.AddTimestamp(fmt.Sprintf("Add waiting for app %s absent", appName)))
 

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -89,7 +89,7 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/usb-p
 
 {{ if or (eq $workflow "large") (eq $workflow "gcp") }}
 /bin/echo Eden VNC (23/{{$tests}})
-eden.vnc.test -panic=true -logger=true
+eden.escript.test -testdata ../vnc/testdata/ -test.run TestEdenScripts/vnc_test
 /bin/echo Eden registry (24/{{$tests}})
 eden.escript.test -testdata ../registry/testdata/ -test.run TestEdenScripts/registry_test
 /bin/echo Eden Network test (25/{{$tests}})


### PR DESCRIPTION
We should wrap VNC test into escript to provide annotations on it in case of error.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>