### PR TITLE
escript tests export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ tests/workflow/workflow.small.txt
 tests/workflow/workflow.large.txt
 
 eve-config-dir/*
+
+export

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
 EMPTY_DRIVE := $(WORKDIR)/empty
 EMPTY_DRIVE_SIZE := 10M
 
+DIRECTORY_EXPORT ?= $(CURDIR)/export
+
 ZARCH ?= $(HOSTARCH)
 export ZARCH
 
@@ -59,6 +61,9 @@ $(WORKDIR):
 	mkdir -p $@
 
 $(BINDIR):
+	mkdir -p $@
+
+$(DIRECTORY_EXPORT):
 	mkdir -p $@
 
 test: build
@@ -110,7 +115,7 @@ stop: build
 dist: build-tests
 	tar cvzf dist/eden_dist.tgz dist/bin dist/scripts dist/tests dist/*.txt
 
-.PHONY: processing eserver all clean test build build-tests config setup stop testbin gotestsum dist
+.PHONY: processing eserver all clean test build build-tests tests-export config setup stop testbin gotestsum dist
 
 eserver:
 	@echo "Build eserver image"
@@ -119,6 +124,10 @@ eserver:
 processing:
 	@echo "Build processing image"
 	@if [ $(DO_DOCKER) -ne 0 ]; then docker build -t $(PROCESSING_TAG):$(PROCESSING_VERSION) $(PROCESSING_DIR); fi
+
+tests-export: $(DIRECTORY_EXPORT) build-tests
+	@cp -af $(WORKDIR)/tests/* $(DIRECTORY_EXPORT)
+	@echo "Your tests inside $(DIRECTORY_EXPORT)"
 
 yetus:
 	@echo Running yetus
@@ -146,7 +155,8 @@ help:
 	@echo "   CONFIG        additional parameters for 'eden config add default', for ex. \"make CONFIG='--devmodel RPi4' run\" or \"make CONFIG='--devmodel GCP' run\""
 	@echo "   TESTS         list of tests for 'make test' to run, for ex. make TESTS='lim units' test"
 	@echo "   DEBUG         debug level for 'eden' command ('debug' by default)"
-	@echo "yetus          run Apache Yetus to check the quality of the source tree"
+	@echo "yetus            run Apache Yetus to check the quality of the source tree"
+	@echo "tests-export     exports escripts into export directory, content of export directory should be inside tests directory in root of another repo"
 	@echo
 	@echo "You need install requirements for EVE (look at https://github.com/lf-edge/eve#install-dependencies)."
 	@echo "You need access to docker socket and installed qemu packages."

--- a/pkg/defaults/templates.go
+++ b/pkg/defaults/templates.go
@@ -140,6 +140,8 @@ eve:
 eden:
     #root directory of eden
     root: '{{parse "eden.root"}}'
+    #directory with tests
+    tests: '{{parse "eden.tests"}}'
     images:
         #directory to save images
         dist: '{{parse "eden.images.dist"}}'

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -363,6 +363,8 @@ func generateConfigFileFromTemplate(filePath string, templateString string, cont
 
 		case "eden.root":
 			return filepath.Join(currentPath, defaults.DefaultDist)
+		case "eden.tests":
+			return filepath.Join(currentPath, defaults.DefaultDist, "tests")
 		case "eden.images.dist":
 			return defaults.DefaultEserverDist
 		case "eden.download":
@@ -448,7 +450,7 @@ func generateConfigFileFromViperTemplate(filePath string, templateString string)
 		if result != nil {
 			return result
 		}
-		log.Fatalf("Not found argument %s in config", inp)
+		log.Warnf("Not found argument %s in config", inp)
 		return ""
 	}
 	var fm = template.FuncMap{

--- a/tests/app/Makefile
+++ b/tests/app/Makefile
@@ -55,9 +55,8 @@ $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(TESTBIN)
 
 setup: testbin $(BINDIR) $(DATADIR)
-	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(DATADIR)
+	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(BINDIR)
 	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
-	ln -sf ../$(TESTDIR)/$(TESTBIN) $(BINDIR)
 
 .PHONY: test build setup clean all testbin
 

--- a/tests/docker/Makefile
+++ b/tests/docker/Makefile
@@ -55,9 +55,8 @@ $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN)
 
 setup: testbin $(BINDIR) $(DATADIR)
-	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(DATADIR)
+	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(BINDIR)
 	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
-	ln -sf ../$(TESTDIR)/$(TESTBIN) $(BINDIR)
 
 .PHONY: test build setup clean all testbin
 

--- a/tests/eclient/Makefile
+++ b/tests/eclient/Makefile
@@ -51,10 +51,8 @@ test:
 build: setup
 
 setup: $(BINDIR) $(DATADIR)
-	cp -a *.sh *.yml $(TESTSCN) testdata $(DATADIR)
-	ln -sf ../$(TESTDIR)/eden+ports.sh $(BINDIR)/
-	ln -sf ../$(TESTDIR)/eden-ports.sh $(BINDIR)/
-	ln -sf ../$(TESTDIR)/qemu+usb.sh $(BINDIR)/
+	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
+	cp *.sh $(BINDIR)
 	chmod 700 image/cert/
 	chmod 600 image/cert/id_rsa*
 	mkdir -p $(DATADIR)/image/cert/

--- a/tests/eclient/testdata/disk.txt
+++ b/tests/eclient/testdata/disk.txt
@@ -5,6 +5,9 @@
 [!exec:bash] stop
 [!exec:sleep] stop
 [!exec:ssh] stop
+[!exec:chmod] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
@@ -40,6 +43,6 @@ for i in `seq 20`
 do
 sleep 20
 # Test SSH-access to container
-echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue
-ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p {{$port}} root@$HOST lsblk && break
+echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue
+ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST lsblk && break
 done

--- a/tests/eclient/testdata/eclient.txt
+++ b/tests/eclient/testdata/eclient.txt
@@ -5,6 +5,9 @@
 [!exec:bash] stop
 [!exec:sleep] stop
 [!exec:ssh] stop
+[!exec:chmod] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
@@ -40,6 +43,6 @@ for i in `seq 20`
 do
 sleep 20
 # Test SSH-access to container
-echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue
-ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue && break
+echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue
+ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue && break
 done

--- a/tests/eclient/testdata/eclients.txt
+++ b/tests/eclient/testdata/eclients.txt
@@ -17,6 +17,9 @@
 [!exec:bash] stop
 [!exec:sleep] stop
 [!exec:ssh] stop
+[!exec:chmod] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 # Starting of reboot detector with a 2 reboot limit
 # Default time -- 30m
@@ -61,7 +64,7 @@ echo {{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden+ports.sh $PO
 {{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden+ports.sh $PORTS
 
 # Restarting EVE to confirm configuration changes
-$EDEN test {{EdenConfig "eden.root"}}/tests/workflow/ -e eve_restart
+$EDEN test {{EdenConfig "eden.tests"}}/workflow/ -e eve_restart
 {{end}}
 
 PODS=""
@@ -133,7 +136,7 @@ echo {{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden-ports.sh $PO
 {{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden-ports.sh $PORTS
 
 # Restarting EVE to confirm configuration changes
-$EDEN test {{EdenConfig "eden.root"}}/tests/workflow/ -e eve_restart
+$EDEN test {{EdenConfig "eden.tests"}}/workflow/ -e eve_restart
 {{end}}
 
 {{end}}

--- a/tests/eclient/testdata/host-only.txt
+++ b/tests/eclient/testdata/host-only.txt
@@ -1,11 +1,14 @@
 # Test host-only ACL application isolation
 
 {{$test_msg := "This is a test"}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
 [!exec:ssh] stop
+[!exec:chmod] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 # Starting of reboot detector with a 1 reboot limit
 ! test eden.reboot.test -test.v -timewait 40m -reboot=0 -count=1 &

--- a/tests/eclient/testdata/maridb.txt
+++ b/tests/eclient/testdata/maridb.txt
@@ -3,11 +3,14 @@
 {{$server := "mariadb"}}
 {{$test_msg := "MariaDB [(none)]> "}}
 {{define "port"}}2223{{end}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
 [!exec:ssh] stop
+[!exec:chmod] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 # Starting of reboot detector with a 2 reboot limit
 #! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &

--- a/tests/eclient/testdata/networking_light.txt
+++ b/tests/eclient/testdata/networking_light.txt
@@ -2,11 +2,14 @@
 
 {{$test_msg := "This is a test"}}
 {{define "port"}}2223{{end}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
 [!exec:ssh] stop
+[!exec:chmod] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &

--- a/tests/eclient/testdata/ngnix.txt
+++ b/tests/eclient/testdata/ngnix.txt
@@ -3,11 +3,14 @@
 {{$server := "ngnix"}}
 {{$test_msg := "Welcome to nginx!"}}
 {{define "port"}}2223{{end}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} root@{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
 [!exec:ssh] stop
+[!exec:chmod] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &

--- a/tests/eclient/testdata/nw_switch.txt
+++ b/tests/eclient/testdata/nw_switch.txt
@@ -1,11 +1,14 @@
 # Test for apllications network connectivity switching
 
 {{$test_msg := "This is a test"}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa root@{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
 [!exec:ssh] stop
+[!exec:chmod] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 # Starting of reboot detector with 2 reboots limit
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &

--- a/tests/eclient/testdata/usb-pt_test.txt
+++ b/tests/eclient/testdata/usb-pt_test.txt
@@ -5,6 +5,9 @@
 [!exec:bash] stop
 [!exec:sleep] stop
 [!exec:ssh] stop
+[!exec:chmod] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 # Starting of reboot detector with a 2 reboot limit
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
@@ -49,13 +52,13 @@ for i in `seq 20`
 do
  sleep 20
  # Test SSH-access to container
- echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST grep Ubuntu /etc/issue
- ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST grep Ubuntu /etc/issue && break
+ echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port root@$HOST grep Ubuntu /etc/issue
+ ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port root@$HOST grep Ubuntu /etc/issue && break
 done
 
 -- get-usb.sh --
 port=$1
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 HOST=$($EDEN eve ip)
- echo ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST cat /sys/bus/usb/devices/{{$usb_dev}}/product
- ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST cat /sys/bus/usb/devices/{{$usb_dev}}/product > {{$usb_dev}}.usb.product
+ echo ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port root@$HOST cat /sys/bus/usb/devices/{{$usb_dev}}/product
+ ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p $port root@$HOST cat /sys/bus/usb/devices/{{$usb_dev}}/product > {{$usb_dev}}.usb.product

--- a/tests/escript/Makefile
+++ b/tests/escript/Makefile
@@ -55,10 +55,9 @@ $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN)
 
 setup: testbin $(BINDIR) $(DATADIR)
-	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(DATADIR)
+	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(BINDIR)
 	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
 	cp custom.fail.scenario.txt failScenario.txt $(TESTSCN) $(WORKDIR)
-	ln -sf ../$(TESTDIR)/$(TESTBIN) $(BINDIR)
 
 .PHONY: test build setup clean all testbin
 

--- a/tests/escript/testdata/fail_scenario.txt
+++ b/tests/escript/testdata/fail_scenario.txt
@@ -1,5 +1,5 @@
-! test eden.escript.test -test.run TestEdenScripts/fail_test -test.v -testdata {{EdenConfig "eden.root"}}/tests/escript/testdata/
+! test eden.escript.test -test.run TestEdenScripts/fail_test -test.v -testdata {{EdenConfig "eden.tests"}}/escript/testdata/
 stdout 'Default test fail scenario'
 
-! test eden.escript.test -test.run TestEdenScripts/fail_test -test.v -testdata {{EdenConfig "eden.root"}}/tests/escript/testdata/ -fail_scenario custom.fail.scenario.txt
+! test eden.escript.test -test.run TestEdenScripts/fail_test -test.v -testdata {{EdenConfig "eden.tests"}}/escript/testdata/ -fail_scenario custom.fail.scenario.txt
 stdout 'Custom test fail scenario'

--- a/tests/escript/testdata/nested_scripts.txt
+++ b/tests/escript/testdata/nested_scripts.txt
@@ -1,7 +1,7 @@
 [!exec:ssh] bash
 [!exec:ssh] sed
 
-test eden.escript.test -test.run TestEdenScripts/message -test.v -testdata {{EdenConfig "eden.root"}}/tests/escript/testdata/
+test eden.escript.test -test.run TestEdenScripts/message -test.v -testdata {{EdenConfig "eden.tests"}}/escript/testdata/
 cp stdout out
 exec bash untime.sh out1
 

--- a/tests/escript/testdata/source.txt
+++ b/tests/escript/testdata/source.txt
@@ -3,13 +3,13 @@
 
 # Show current variable value
 env time
-test eden.escript.test -test.run TestEdenScripts/nested_source -test.v -testdata {{EdenConfig "eden.root"}}/tests/escript/testdata/
+test eden.escript.test -test.run TestEdenScripts/nested_source -test.v -testdata {{EdenConfig "eden.tests"}}/escript/testdata/
 ! stdout '05 Aug 2020 12:23:27'
 
 # Source .env file defined below
 source .env
 env time
-test eden.escript.test -test.run TestEdenScripts/nested_source -test.v -testdata {{EdenConfig "eden.root"}}/tests/escript/testdata/
+test eden.escript.test -test.run TestEdenScripts/nested_source -test.v -testdata {{EdenConfig "eden.tests"}}/escript/testdata/
 stdout '05 Aug 2020 12:23:27'
 
 # Override .env by bash script
@@ -18,7 +18,7 @@ exec bash set_from_bash.sh
 # Source .env modified by bash
 source .env
 env time
-test eden.escript.test -test.run TestEdenScripts/nested_source -test.v -testdata {{EdenConfig "eden.root"}}/tests/escript/testdata/
+test eden.escript.test -test.run TestEdenScripts/nested_source -test.v -testdata {{EdenConfig "eden.tests"}}/escript/testdata/
 ! stdout '05 Aug 2020 12:23:27'
 
 -- .env --

--- a/tests/lim/Makefile
+++ b/tests/lim/Makefile
@@ -55,9 +55,8 @@ $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN)
 
 setup: testbin $(BINDIR) $(DATADIR)
-	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(DATADIR)
+	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(BINDIR)
 	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
-	ln -sf ../$(TESTDIR)/$(TESTBIN) $(BINDIR)
 
 .PHONY: test build setup clean all testbin
 

--- a/tests/network/Makefile
+++ b/tests/network/Makefile
@@ -58,9 +58,8 @@ $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(TESTBIN)
 
 setup: testbin $(BINDIR) $(DATADIR)
-	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(DATADIR)
+	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(BINDIR)
 	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
-	ln -sf ../$(TESTDIR)/$(TESTBIN) $(BINDIR)
 
 .PHONY: test build setup clean all testbin image
 

--- a/tests/network/testdata/test_networking.txt
+++ b/tests/network/testdata/test_networking.txt
@@ -35,7 +35,7 @@ exec bash networks_process.sh
 source .env
 
 # deploy the first application by nested escript
-test eden.escript.test -test.run TestEdenScripts/deploy_app -test.v  -testdata {{EdenConfig "eden.root"}}/tests/network/testdata/
+test eden.escript.test -test.run TestEdenScripts/deploy_app -test.v  -testdata {{EdenConfig "eden.tests"}}/network/testdata/
 
 # execute the script for waiting RUNNING state and obtain internal IP
 message 'waiting for app1 running state'
@@ -47,7 +47,7 @@ exec -t 15m bash wait_and_get_ip.sh
 source .env
 
 # deploy the second application by nested escript
-test eden.escript.test -test.run TestEdenScripts/deploy_app -test.v  -testdata {{EdenConfig "eden.root"}}/tests/network/testdata/
+test eden.escript.test -test.run TestEdenScripts/deploy_app -test.v  -testdata {{EdenConfig "eden.tests"}}/network/testdata/
 
 # execute the script for waiting RUNNING state and obtain the testing sequence from the second app
 message 'waiting for app2 running state'
@@ -65,7 +65,7 @@ exec -t 15m bash app3.sh
 source .env
 
 # deploy the third application by nested escript
-test eden.escript.test -test.run TestEdenScripts/deploy_app -test.v  -testdata {{EdenConfig "eden.root"}}/tests/network/testdata/
+test eden.escript.test -test.run TestEdenScripts/deploy_app -test.v  -testdata {{EdenConfig "eden.tests"}}/network/testdata/
 
 message 'waiting for app3 running state'
 test eden.app.test -test.v -timewait 10m RUNNING app3

--- a/tests/phoronix/testdata/test_phoronix.txt
+++ b/tests/phoronix/testdata/test_phoronix.txt
@@ -13,7 +13,7 @@ arg benchmark benchmark
 source .env
 
 # deploy the application by nested escript
-test eden.escript.test -test.run TestEdenScripts/deploy_app -test.v  -testdata {{EdenConfig "eden.root"}}/tests/phoronix/testdata/
+test eden.escript.test -test.run TestEdenScripts/deploy_app -test.v  -testdata {{EdenConfig "eden.tests"}}/phoronix/testdata/
 
 exec -t 180m bash wait_app.sh
 exec cat result

--- a/tests/reboot/Makefile
+++ b/tests/reboot/Makefile
@@ -55,9 +55,8 @@ $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN)
 
 setup: testbin $(BINDIR) $(DATADIR)
-	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(DATADIR)
+	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(BINDIR)
 	cp -a *.yml $(TESTSCN) $(DATADIR)
-	ln -sf ../$(TESTDIR)/$(TESTBIN) $(BINDIR)
 
 .PHONY: test build setup clean all testbin
 

--- a/tests/vnc/Makefile
+++ b/tests/vnc/Makefile
@@ -55,9 +55,8 @@ $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN)
 
 setup: testbin $(BINDIR) $(DATADIR)
-	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(DATADIR)
+	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(BINDIR)
 	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
-	ln -sf ../$(TESTDIR)/$(TESTBIN) $(BINDIR)
 
 .PHONY: test build setup clean all testbin
 

--- a/tests/volume/Makefile
+++ b/tests/volume/Makefile
@@ -52,9 +52,8 @@ $(TESTBIN): $(LOCALTESTBIN)
 	ln -sf $(LOCALTESTBIN) $(TESTBIN)
 
 setup: testbin $(BINDIR) $(DATADIR)
-	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(DATADIR)
+	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(BINDIR)
 	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
-	ln -sf ../$(TESTDIR)/$(TESTBIN) $(BINDIR)
 
 .PHONY: test build setup clean all testbin
 


### PR DESCRIPTION
In this PR I do the following:

- Split binaries (dist/bin) and escripts (dist/tests)
- Add `tests-export` target which exports dist/tests into export directory
- Add `eden.tests` config which should be pointed onto actual tests directory
- Fix mod of id_rsa files during tests (they may have wrong permissions in case of external directories)

Those modifications allow us to use exported escripts in our tests

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>