### PR TITLE
reduce info inside annotations

### DIFF
--- a/tests/app/app_test.go
+++ b/tests/app/app_test.go
@@ -61,8 +61,6 @@ func checkNewLastState(appName, state string) bool {
 	if ok {
 		lastState := appStates[len(appStates)-1]
 		if lastState.state != state {
-			fmt.Printf("lastState: %s expected state: %s time: %s\n", lastState.state, state,
-				time.Now().Format(time.RFC3339Nano))
 			return true
 		}
 	}
@@ -88,7 +86,7 @@ func checkState(eveState *eve.State, state string, appNames []string) error {
 		}
 		for _, app := range eveState.Applications() {
 			if _, inSlice := utils.FindEleInSlice(appNames, app.Name); inSlice {
-				checkAndAppendState(app.Name, "EXISTS")
+				checkAndAppendState(app.Name, app.EVEState)
 				foundAny = true
 			}
 		}

--- a/tests/escript/go-internal/testscript/testscript.go
+++ b/tests/escript/go-internal/testscript/testscript.go
@@ -776,8 +776,10 @@ func (ts *TestScript) addGHAnnotation() {
 			pathToPrint = filepath.Join(testDirectory, split[1])
 		}
 	}
+	//we should return only text after last [stdout] line
+	lastIndexOfStdout := strings.LastIndex(ts.log.String(), "\n[stdout]\n") + 1
 	// replace symbols to be compatible with GH Actions
-	ghAnnotation := strings.ReplaceAll(ts.log.String(), "\n", "%0A")
+	ghAnnotation := strings.ReplaceAll(ts.log.String()[lastIndexOfStdout:], "\n", "%0A")
 	ghAnnotation = strings.ReplaceAll(ghAnnotation, "\r", "%0D")
 	// print annotation
 	fmt.Printf("::error file=%s,line=%d::%s\n", pathToPrint, ts.lineno, ghAnnotation)

--- a/tests/network/nw_test.go
+++ b/tests/network/nw_test.go
@@ -51,22 +51,20 @@ func TestMain(m *testing.M) {
 }
 
 // checkNewLastState returns true if provided state not equals with last
-func checkNewLastState(volName, state string) bool {
-	volStates, ok := states[volName]
+func checkNewLastState(netName, state string) bool {
+	netStates, ok := states[netName]
 	if ok {
-		lastState := volStates[len(volStates)-1]
+		lastState := netStates[len(netStates)-1]
 		if lastState.state != state {
-			fmt.Printf("lastState: %s state: %s time: %s\n", lastState.state, state,
-				time.Now().Format(time.RFC3339Nano))
 			return true
 		}
 	}
 	return false
 }
 
-func checkAndAppendState(volName, state string) {
-	if checkNewLastState(volName, state) {
-		states[volName] = append(states[volName], nwState{state: state, timestamp: time.Now()})
+func checkAndAppendState(netName, state string) {
+	if checkNewLastState(netName, state) {
+		states[netName] = append(states[netName], nwState{state: state, timestamp: time.Now()})
 	}
 }
 
@@ -74,9 +72,9 @@ func checkState(eveState *eve.State, state string, netNames []string) error {
 	out := "\n"
 	if state == "-" {
 		foundAny := false
-		for _, vol := range eveState.Networks() {
-			if _, inSlice := utils.FindEleInSlice(netNames, vol.Name); inSlice {
-				checkAndAppendState(vol.Name, "EXISTS")
+		for _, net := range eveState.Networks() {
+			if _, inSlice := utils.FindEleInSlice(netNames, net.Name); inSlice {
+				checkAndAppendState(net.Name, net.EveState)
 				foundAny = true
 			}
 		}
@@ -92,7 +90,6 @@ func checkState(eveState *eve.State, state string, netNames []string) error {
 	}
 	for _, net := range eveState.Networks() {
 		if _, inSlice := utils.FindEleInSlice(netNames, net.Name); inSlice {
-			fmt.Printf("%s: %s\n", net.Name, net.EveState)
 			checkAndAppendState(net.Name, net.EveState)
 		}
 	}

--- a/tests/volume/vol_test.go
+++ b/tests/volume/vol_test.go
@@ -56,8 +56,6 @@ func checkNewLastState(volName, state string) bool {
 	if ok {
 		lastState := volStates[len(volStates)-1]
 		if lastState.state != state {
-			fmt.Printf("lastState: %s expected state: %s time: %s\n", lastState.state, state,
-				time.Now().Format(time.RFC3339Nano))
 			return true
 		}
 	}
@@ -80,7 +78,7 @@ func checkState(eveState *eve.State, state string, volNames []string) error {
 		}
 		for _, vol := range eveState.Volumes() {
 			if _, inSlice := utils.FindEleInSlice(volNames, vol.Name); inSlice {
-				checkAndAppendState(vol.Name, "EXISTS")
+				checkAndAppendState(vol.Name, vol.EveState)
 				foundAny = true
 			}
 		}
@@ -96,7 +94,6 @@ func checkState(eveState *eve.State, state string, volNames []string) error {
 	}
 	for _, vol := range eveState.Volumes() {
 		if _, inSlice := utils.FindEleInSlice(volNames, vol.Name); inSlice {
-			fmt.Printf("%s: %s\n", vol.Name, vol.EveState)
 			checkAndAppendState(vol.Name, vol.EveState)
 		}
 	}


### PR DESCRIPTION
We should limit information inside output of tests, annotation has limit.

In this PR I remove duplicates in output inside our detectors (we do not need state from every info message in stdout, only changes and only in case of error).
Inside the annotation I filter out all data before the last `[stdout]`, because it is about the previous tests inside escript, not about the current with error.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>