### PR TITLE
Reboot test with USB

### DIFF
--- a/tests/hardware_reboot/Makefile
+++ b/tests/hardware_reboot/Makefile
@@ -1,0 +1,67 @@
+DEBUG ?= "debug"
+
+# HOSTARCH is the host architecture
+# ARCH is the target architecture
+# we need to keep track of them separately
+HOSTARCH ?= $(shell uname -m)
+HOSTOS ?= $(shell uname -s | tr A-Z a-z)
+
+# canonicalized names for host architecture
+override HOSTARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(HOSTARCH)))
+
+# unless otherwise set, I am building for my own architecture, i.e. not cross-compiling
+# and for my OS
+ARCH ?= $(HOSTARCH)
+OS ?= $(HOSTOS)
+
+# canonicalized names for target architecture
+override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
+
+WORKDIR ?= $(CURDIR)/../../dist
+TESTDIR := tests/$(shell basename $(CURDIR))
+BINDIR := $(WORKDIR)/bin
+DATADIR := $(WORKDIR)/$(TESTDIR)/
+BIN := eden
+LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
+TESTNAME := eden.hardware_reboot
+TESTBIN := $(TESTNAME).test
+TESTSCN := $(TESTNAME).tests.txt
+LOCALTESTBIN := $(TESTBIN)-$(OS)-$(ARCH)
+
+.DEFAULT_GOAL := help
+
+clean:
+	rm -rf $(LOCALTESTBIN) $(BINDIR)/$(TESTBIN) $(WORKDIR)/$(TESTSCN) $(CURDIR)/$(TESTBIN) $(BINDIR)/$(TESTBIN)
+
+$(BINDIR):
+	mkdir -p $@
+$(DATADIR):
+	mkdir -p $@
+
+test:
+	$(LOCALBIN) test $(CURDIR) -v $(DEBUG)
+
+build: setup
+
+setup: $(BINDIR) $(DATADIR)
+	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
+
+.PHONY: image
+
+
+.PHONY: test build setup clean all
+
+help:
+	@echo "EDEN is the harness for testing EVE and ADAM"
+	@echo
+	@echo "This Makefile automates commons tasks of EDEN testing"
+	@echo
+	@echo "Commonly used maintenance and development targets:"
+	@echo "   build         build test-binary (OS and ARCH options supported, for ex. OS=linux ARCH=arm64)"
+	@echo "   image         build image for upload into docker"
+	@echo "   setup         setup of test environment"
+	@echo "   test          run tests"
+	@echo "   clean         cleanup of test harness"
+	@echo
+	@echo "You need install requirements for EVE (look at https://github.com/lf-edge/eve#install-dependencies)."
+	@echo "You need access to docker socket and installed qemu packages."

--- a/tests/hardware_reboot/README.md
+++ b/tests/hardware_reboot/README.md
@@ -1,0 +1,9 @@
+# Test Description
+
+Key purpose is to verify that a reboot (sudo shutdown -r +1) from the guest doesn’t disrupt the set of assigned adapters.
+
+## Test structure
+
+eden.hardware_reboot.tests.txt - escript scenario file
+
+* /testdata - a folder with custom escripts for a workload

--- a/tests/hardware_reboot/eden-config.yml
+++ b/tests/hardware_reboot/eden-config.yml
@@ -1,0 +1,7 @@
+---
+eden:
+    # test binary
+    test-bin: "eden.hardware_reboot.test"
+
+    # test scenario
+    test-scenario: "eden.hardware_reboot.tests.txt"

--- a/tests/hardware_reboot/eden.hardware_reboot.tests.txt
+++ b/tests/hardware_reboot/eden.hardware_reboot.tests.txt
@@ -1,1 +1,1 @@
-eden.escript.test -test.run TestEdenScripts/hardware_reboot
+eden.escript.test -test.run TestEdenScripts/hardware_usb_reboot

--- a/tests/hardware_reboot/eden.hardware_reboot.tests.txt
+++ b/tests/hardware_reboot/eden.hardware_reboot.tests.txt
@@ -1,0 +1,1 @@
+eden.escript.test -test.run TestEdenScripts/hardware_reboot

--- a/tests/hardware_reboot/testdata/hardware_reboot.txt
+++ b/tests/hardware_reboot/testdata/hardware_reboot.txt
@@ -1,0 +1,82 @@
+# Simple test of USB passthrough functionality after reboot of guest
+
+{{$usb_dev := "2-2"}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+
+eden pod deploy -n n11 --memory=512MB docker://itmoeve/eclient:0.4 -p 2223:22 --adapters USB2:2
+test eden.app.test -test.v -timewait 20m RUNNING n11
+
+exec -t 20m bash ssh.sh 2223
+stdout 'Ubuntu'
+
+exec -t 20m bash get-lshw.sh 2223
+cp stdout before_reboot
+
+exec -t 20m bash get-usb.sh 2223
+grep 'QEMU USB HARDDRIVE' {{$usb_dev}}.usb.product
+
+# reboot from guest
+exec -t 20m bash reboot.sh 2223
+exec sleep 10
+
+exec -t 20m bash ssh.sh 2223
+stdout 'Ubuntu'
+
+exec -t 20m bash get-usb.sh 2223
+grep 'QEMU USB HARDDRIVE' {{$usb_dev}}.usb.product
+
+exec -t 20m bash get-lshw.sh 2223
+cp stdout after_reboot
+
+# comparison of lshw output
+cmp before_reboot after_reboot
+
+eden pod delete n11
+
+test eden.app.test -test.v -timewait 5m - n11
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- ssh.sh --
+port=$1
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for i in `seq 20`
+do
+ sleep 20
+ # Test SSH-access to container
+ echo $i\) ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST grep Ubuntu /etc/issue
+ ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST grep Ubuntu /etc/issue && break
+done
+
+-- get-usb.sh --
+port=$1
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+ echo ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST cat /sys/bus/usb/devices/{{$usb_dev}}/product
+ ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST cat /sys/bus/usb/devices/{{$usb_dev}}/product > {{$usb_dev}}.usb.product
+
+-- get-lshw.sh --
+port=$1
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+ echo ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST lshw
+ ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST lshw
+
+-- reboot.sh --
+port=$1
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+ echo ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST busybox reboot -f -d 1 &>/dev/null &
+ ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST busybox reboot -f -d 1 &>/dev/null &

--- a/tests/hardware_reboot/testdata/hardware_usb_reboot.txt
+++ b/tests/hardware_reboot/testdata/hardware_usb_reboot.txt
@@ -34,6 +34,7 @@ cp stdout after_reboot
 # comparison of lshw output
 cmp before_reboot after_reboot
 
+# teardown applications
 eden pod delete n11
 
 test eden.app.test -test.v -timewait 5m - n11
@@ -78,5 +79,5 @@ HOST=$($EDEN eve ip)
 port=$1
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 HOST=$($EDEN eve ip)
- echo ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST busybox reboot -f -d 1 &>/dev/null &
- ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST busybox reboot -f -d 1 &>/dev/null &
+ echo ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST 'busybox reboot -f -d 1 &>/dev/null &'
+ ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST 'busybox reboot -f -d 1 &>/dev/null &'

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -85,41 +85,43 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_
 {{if (eq $usb_pt "y")}}
 /bin/echo EVE USB Passthrough (22/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/usb-pt_test
+/bin/echo Hardware reboot - USB (23/{{$tests}})
+eden.escript.test -testdata ../hardware_reboot/testdata/ -test.run TestEdenScripts/hardware_reboot
 {{end}}
 
 {{ if or (eq $workflow "large") (eq $workflow "gcp") }}
-/bin/echo Eden VNC (23/{{$tests}})
+/bin/echo Eden VNC (24/{{$tests}})
 eden.vnc.test -panic=true -logger=true
-/bin/echo Eden registry (24/{{$tests}})
+/bin/echo Eden registry (25/{{$tests}})
 eden.escript.test -testdata ../registry/testdata/ -test.run TestEdenScripts/registry_test
-/bin/echo Eden Network test (25/{{$tests}})
+/bin/echo Eden Network test (26/{{$tests}})
 eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/test_networking
-/bin/echo Eden 2 dockers test (26/{{$tests}})
+/bin/echo Eden 2 dockers test (27/{{$tests}})
 eden.escript.test -testdata ../docker/testdata/ -test.run TestEdenScripts/2dockers_test
-/bin/echo Eden 2 dockers test with app state detector (27/{{$tests}})
+/bin/echo Eden 2 dockers test with app state detector (28/{{$tests}})
 eden.escript.test -testdata ../app/testdata/ -test.run TestEdenScripts/2dockers_test
-/bin/echo Eden Nginx (28/{{$tests}})
+/bin/echo Eden Nginx (29/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/ngnix
-/bin/echo Eden Mariadb (29/{{$tests}})
+/bin/echo Eden Mariadb (30/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/maridb
-/bin/echo Eden eclient with disk (30/{{$tests}})
+/bin/echo Eden eclient with disk (31/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/disk
-/bin/echo EVE reset (31/{{$tests}})
+/bin/echo EVE reset (32/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_reset
 {{end}}
 {{ if  (eq $workflow "large")  }}
-/bin/echo Eden's testing the maximum application limit (32/{{$tests}})
+/bin/echo Eden's testing the maximum application limit (33/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/eclients
 {{end}}
 
-/bin/echo Eden Reboot test (33/{{$tests}})
+/bin/echo Eden Reboot test (34/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/reboot_test
 {{ if ne $workflow "small" }}
-/bin/echo Eden base OS update (34/{{$tests}})
+/bin/echo Eden base OS update (35/{{$tests}})
 eden.escript.test -testdata ../update_eve_image/testdata/ -test.run TestEdenScripts/update_eve_image
 {{end}}
 
 {{if (eq $stop "y")}}
-/bin/echo Eden stop (35/{{$tests}})
+/bin/echo Eden stop (36/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_stop
 {{end}}

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -83,45 +83,43 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/nw_sw
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_switch
 
 {{if (eq $usb_pt "y")}}
-/bin/echo EVE USB Passthrough (22/{{$tests}})
-eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/usb-pt_test
-/bin/echo Hardware reboot - USB (23/{{$tests}})
-eden.escript.test -testdata ../hardware_reboot/testdata/ -test.run TestEdenScripts/hardware_reboot
+/bin/echo Hardware reboot - USB (22/{{$tests}})
+eden.escript.test -testdata ../hardware_reboot/testdata/ -test.run TestEdenScripts/hardware_usb_reboot
 {{end}}
 
 {{ if or (eq $workflow "large") (eq $workflow "gcp") }}
-/bin/echo Eden VNC (24/{{$tests}})
+/bin/echo Eden VNC (23/{{$tests}})
 eden.vnc.test -panic=true -logger=true
-/bin/echo Eden registry (25/{{$tests}})
+/bin/echo Eden registry (24/{{$tests}})
 eden.escript.test -testdata ../registry/testdata/ -test.run TestEdenScripts/registry_test
-/bin/echo Eden Network test (26/{{$tests}})
+/bin/echo Eden Network test (25/{{$tests}})
 eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/test_networking
-/bin/echo Eden 2 dockers test (27/{{$tests}})
+/bin/echo Eden 2 dockers test (26/{{$tests}})
 eden.escript.test -testdata ../docker/testdata/ -test.run TestEdenScripts/2dockers_test
-/bin/echo Eden 2 dockers test with app state detector (28/{{$tests}})
+/bin/echo Eden 2 dockers test with app state detector (27/{{$tests}})
 eden.escript.test -testdata ../app/testdata/ -test.run TestEdenScripts/2dockers_test
-/bin/echo Eden Nginx (29/{{$tests}})
+/bin/echo Eden Nginx (28/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/ngnix
-/bin/echo Eden Mariadb (30/{{$tests}})
+/bin/echo Eden Mariadb (29/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/maridb
-/bin/echo Eden eclient with disk (31/{{$tests}})
+/bin/echo Eden eclient with disk (30/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/disk
-/bin/echo EVE reset (32/{{$tests}})
+/bin/echo EVE reset (31/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_reset
 {{end}}
 {{ if  (eq $workflow "large")  }}
-/bin/echo Eden's testing the maximum application limit (33/{{$tests}})
+/bin/echo Eden's testing the maximum application limit (32/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/eclients
 {{end}}
 
-/bin/echo Eden Reboot test (34/{{$tests}})
+/bin/echo Eden Reboot test (33/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/reboot_test
 {{ if ne $workflow "small" }}
-/bin/echo Eden base OS update (35/{{$tests}})
+/bin/echo Eden base OS update (34/{{$tests}})
 eden.escript.test -testdata ../update_eve_image/testdata/ -test.run TestEdenScripts/update_eve_image
 {{end}}
 
 {{if (eq $stop "y")}}
-/bin/echo Eden stop (36/{{$tests}})
+/bin/echo Eden stop (35/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_stop
 {{end}}


### PR DESCRIPTION
Assumes a USB controller. Key purpose is to verify that a reboot (sudo shutdown -r +1) from the guest doesn’t disrupt the set of assigned adapters.