### PR TITLE
follow log of gcp instance

### DIFF
--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -73,6 +73,7 @@ jobs:
         run: |
           ./eden log --format json > trace.log
           ./eden info > info.log
+          ./eden utils gcp vm console --vm-name eve-eden-actions-${{ matrix.hv }}-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS" > console.log
       - name: Clean
         if: ${{ always() }}
         run: |
@@ -88,3 +89,4 @@ jobs:
           path: |
             ${{ github.workspace }}/trace.log
             ${{ github.workspace }}/info.log
+            ${{ github.workspace }}/console.log

--- a/cmd/edenGcp.go
+++ b/cmd/edenGcp.go
@@ -23,6 +23,8 @@ var (
 	gcpFirewallRuleName     string
 	gcpFirewallRuleSources  []string
 	gcpFirewallRulePriority int64
+
+	follow bool
 )
 
 var gcpCmd = &cobra.Command{
@@ -198,7 +200,7 @@ var gcpLog = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Unable to connect to GCP: %v", err)
 		}
-		if err := gcpClient.GetInstanceSerialOutput(gcpVMName, gcpZone); err != nil {
+		if err := gcpClient.GetInstanceSerialOutput(gcpVMName, gcpZone, follow); err != nil {
 			log.Fatalf("GetInstanceSerialOutput: %s", err)
 		}
 	},
@@ -273,6 +275,7 @@ func gcpInit() {
 	gcpVMCmd.AddCommand(gcpLog)
 	gcpLog.Flags().StringVar(&gcpVMName, "vm-name", defaults.DefaultGcpImageName, "vm name")
 	gcpLog.Flags().StringVar(&gcpZone, "zone", defaults.DefaultGcpZone, "gcp zone")
+	gcpLog.Flags().BoolVarP(&follow, "follow", "f", false, "follow log")
 	gcpVMCmd.AddCommand(gcpGetIP)
 	gcpGetIP.Flags().StringVar(&gcpVMName, "vm-name", defaults.DefaultGcpImageName, "vm name")
 	gcpGetIP.Flags().StringVar(&gcpZone, "zone", defaults.DefaultGcpZone, "gcp zone")

--- a/pkg/linuxkit/gcp.go
+++ b/pkg/linuxkit/gcp.go
@@ -351,7 +351,8 @@ func (g GCPClient) DeleteInstance(instance, zone string, wait bool) error {
 }
 
 // GetInstanceSerialOutput streams the serial output of an instance
-func (g GCPClient) GetInstanceSerialOutput(instance, zone string) error {
+// follow log if follow set to true
+func (g GCPClient) GetInstanceSerialOutput(instance, zone string, follow bool) error {
 	log.Infof("Getting serial port output for instance %s", instance)
 	var next int64
 	for {
@@ -369,6 +370,9 @@ func (g GCPClient) GetInstanceSerialOutput(instance, zone string) error {
 			return err
 		}
 		fmt.Printf(res.Contents)
+		if !follow {
+			break
+		}
 		next = res.Next
 		// When the instance has been stopped, Start and Next will both be 0
 		if res.Start > 0 && next == 0 {


### PR DESCRIPTION
Adds the ability to save log of gcp console to file.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>