### PR TITLE
initial acl support

### DIFF
--- a/cmd/edenPod.go
+++ b/cmd/edenPod.go
@@ -36,6 +36,7 @@ var (
 	diskSize    string
 	imageFormat string
 	volumeType  string
+	acl         []string
 
 	deleteVolumes bool
 
@@ -103,7 +104,11 @@ var podDeployCmd = &cobra.Command{
 		opts = append(opts, expect.WithVolumeType(expect.VolumeTypeByName(volumeType)))
 		opts = append(opts, expect.WithResources(appCpus, uint32(appMemoryParsed/1000)))
 		opts = append(opts, expect.WithImageFormat(imageFormat))
-		opts = append(opts, expect.WithACL(aclOnlyHost))
+		if aclOnlyHost {
+			opts = append(opts, expect.WithACL([]string{""}))
+		} else {
+			opts = append(opts, expect.WithACL(acl))
+		}
 		opts = append(opts, expect.WithSFTPLoad(sftpLoad))
 		if !sftpLoad {
 			opts = append(opts, expect.WithHTTPDirectLoad(directLoad))
@@ -444,6 +449,7 @@ func podInit() {
 	podDeployCmd.Flags().BoolVar(&directLoad, "direct", true, "Use direct download for image instead of eserver")
 	podDeployCmd.Flags().BoolVar(&sftpLoad, "sftp", false, "Force use of sftp to load http/file image from eserver")
 	podDeployCmd.Flags().StringSliceVar(&disks, "disks", nil, "Additional disks to use")
+	podDeployCmd.Flags().StringSliceVar(&acl, "acl", nil, "Allow access only to defined hosts/ips/subnets")
 	podCmd.AddCommand(podPsCmd)
 	podCmd.AddCommand(podStopCmd)
 	podCmd.AddCommand(podStartCmd)

--- a/cmd/podModify.go
+++ b/cmd/podModify.go
@@ -13,7 +13,7 @@ import (
 
 //podModifyCmd is a command to modify app
 var podModifyCmd = &cobra.Command{
-	Use:   "modify",
+	Use:   "modify <app>",
 	Short: "Modify pod",
 	Args:  cobra.ExactArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -50,6 +50,7 @@ var podModifyCmd = &cobra.Command{
 				} else {
 					opts = append(opts, expect.WithPortsPublish(portPublish))
 				}
+				opts = append(opts, expect.WithACL(acl))
 				opts = append(opts, expect.WithOldApp(appName))
 				expectation := expect.AppExpectationFromURL(ctrl, dev, defaults.DefaultDummyExpect, appName, opts...)
 				appInstanceConfig := expectation.Application()
@@ -88,4 +89,5 @@ func podModifyInit() {
 	podModifyCmd.Flags().StringSliceVarP(&portPublish, "publish", "p", nil, "Ports to publish in format EXTERNAL_PORT:INTERNAL_PORT")
 	podModifyCmd.Flags().BoolVar(&aclOnlyHost, "only-host", false, "Allow access only to host and external networks")
 	podModifyCmd.Flags().StringSliceVar(&podNetworks, "networks", nil, "Networks to connect to app (ports will be mapped to first network)")
+	podModifyCmd.Flags().StringSliceVar(&acl, "acl", nil, "Allow access only to defined hosts/ips/subnets")
 }

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -1,0 +1,60 @@
+# Applications
+
+## Deployment
+
+In order to deploy application you can use `eden pod deploy` command:
+
+```console
+Deploy app in pod.
+
+Usage:
+eden pod deploy (docker|http(s)|file)://(<TAG>[:<VERSION>] | <URL for qcow2 image> | <path to qcow2 image>) [flags]
+
+Flags:
+--acl strings           Allow access only to defined hosts/ips/subnets
+--adapters strings      adapters to assign to the application instance
+--cpus uint32           cpu number for app (default 1)
+--direct                Use direct download for image instead of eserver (default true)
+--disk-size string      disk size (empty or 0 - same as in image) (default "0 B")
+--disks strings         Additional disks to use
+--format string         format for image, one of 'container','qcow2','raw','qcow','vmdk','vhdx'; if not provided, defaults to container image for docker and oci transports, qcow2 for file and http/s transports
+-h, --help                  help for deploy
+--memory string         memory for app (default "1.0 GB")
+--metadata string       metadata for pod
+-n, --name string           name for pod
+--networks strings      Networks to connect to app (ports will be mapped to first network)
+--no-hyper              Run pod without hypervisor
+--only-host             Allow access only to host and external networks
+-p, --publish strings       Ports to publish in format EXTERNAL_PORT:INTERNAL_PORT
+--registry string       Select registry to use for containers (remote/local) (default "remote")
+--sftp                  Force use of sftp to load http/file image from eserver
+--vnc-display uint32    display number for VNC pod (0 - no VNC)
+--vnc-password string   VNC password (empty - no password)
+--volume-type string    volume type for empty volumes (qcow2, raw, qcow, vmdk, vhdx or oci); set it to none to not use volumes (default "qcow2")
+
+Global Flags:
+--config string      Name of config (default "default")
+-v, --verbosity string   Log level (debug, info, warn, error, fatal, panic (default "info")
+```
+
+## Modification
+
+In order to modify existing application you can use `eden pod modify` command:
+
+```console
+Modify pod
+
+Usage:
+eden pod modify <app> [flags]
+
+Flags:
+--acl strings        Allow access only to defined hosts/ips/subnets
+-h, --help               help for modify
+--networks strings   Networks to connect to app (ports will be mapped to first network)
+--only-host          Allow access only to host and external networks
+-p, --publish strings    Ports to publish in format EXTERNAL_PORT:INTERNAL_PORT
+
+Global Flags:
+--config string      Name of config (default "default")
+-v, --verbosity string   Log level (debug, info, warn, error, fatal, panic (default "info")
+```

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -48,7 +48,7 @@ const (
 	DefaultRegistryPort = 5000
 
 	//tags, versions, repos
-	DefaultEVETag               = "6.1.0" //DefaultEVETag tag for EVE image
+	DefaultEVETag               = "0.0.0-master-efa32c66" //DefaultEVETag tag for EVE image
 	DefaultAdamTag              = "0.0.12"
 	DefaultRedisTag             = "6"
 	DefaultRegistryTag          = "2.7"

--- a/pkg/expect/application.go
+++ b/pkg/expect/application.go
@@ -2,7 +2,6 @@ package expect
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eve/api/go/config"
@@ -69,47 +68,10 @@ func (exp *AppExpectation) createAppInstanceConfig(img *config.Image, netInstanc
 	bundle.appInstanceConfig.Interfaces = []*config.NetworkAdapter{}
 
 	for k, ni := range netInstances {
-		var acls []*config.ACE
-		if exp.onlyHostACL {
-			acls = append(acls, &config.ACE{
-				Matches: []*config.ACEMatch{{
-					Type: "host",
-				}},
-				Id: 1,
-			})
-		} else {
-			acls = append(acls, &config.ACE{
-				Matches: []*config.ACEMatch{{
-					Type:  "ip",
-					Value: "0.0.0.0/0",
-				}},
-				Id: 1,
-			})
-		}
-		var aclID int32 = 2
-		if k.ports != nil {
-			for po, pi := range k.ports {
-				acls = append(acls, &config.ACE{
-					Id: aclID,
-					Matches: []*config.ACEMatch{{
-						Type:  "protocol",
-						Value: "tcp",
-					}, {
-						Type:  "lport",
-						Value: strconv.Itoa(po),
-					}},
-					Actions: []*config.ACEAction{{
-						Portmap: true,
-						AppPort: uint32(pi),
-					}},
-					Dir: config.ACEDirection_BOTH})
-				aclID++
-			}
-		}
 		bundle.appInstanceConfig.Interfaces = append(bundle.appInstanceConfig.Interfaces, &config.NetworkAdapter{
 			Name:      "default",
 			NetworkId: ni.Uuidandversion.Uuid,
-			Acls:      acls,
+			Acls:      exp.getAcls(k),
 		})
 	}
 	if exp.vncDisplay != 0 {

--- a/pkg/expect/expectation.go
+++ b/pkg/expect/expectation.go
@@ -55,8 +55,6 @@ type AppExpectation struct {
 
 	volumesType VolumeType
 
-	onlyHostACL bool
-
 	registry string
 
 	oldAppName string
@@ -65,6 +63,7 @@ type AppExpectation struct {
 	sftpLoad       bool
 
 	disks []string
+	acl   []string
 }
 
 //AppExpectationFromURL init AppExpectation with defined:
@@ -96,7 +95,6 @@ func AppExpectationFromURL(ctrl controller.Cloud, device *device.Ctx, appLink st
 		uplinkAdapter: adapter,
 		device:        device,
 		volumesType:   VolumeQcow2,
-		onlyHostACL:   false,
 	}
 	switch expectation.ctrl.GetVars().ZArch {
 	case "amd64":

--- a/pkg/expect/options.go
+++ b/pkg/expect/options.go
@@ -157,10 +157,10 @@ func WithVolumeType(volumesType VolumeType) ExpectationOption {
 	}
 }
 
-//WithACL sets access for app only to external networks if onlyHost sets
-func WithACL(onlyHost bool) ExpectationOption {
+//WithACL sets access only for defined hosts
+func WithACL(acl []string) ExpectationOption {
 	return func(expectation *AppExpectation) {
-		expectation.onlyHostACL = onlyHost
+		expectation.acl = acl
 	}
 }
 

--- a/tests/eclient/testdata/acl.txt
+++ b/tests/eclient/testdata/acl.txt
@@ -1,0 +1,67 @@
+# Test particular host access
+
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+[!exec:chmod] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
+
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait 40m -reboot=0 -count=1 &
+
+# Define access only to github.com
+eden pod deploy -n curl-acl --memory=512MB docker://itmoeve/eclient:0.4 -p 2223:22 --acl=github.com
+
+test eden.app.test -test.v -timewait 10m RUNNING curl-acl
+
+exec -t 10m bash wait_ssh.sh 2223
+
+exec sleep 10
+
+# Try to curl host we defined
+exec -t 1m bash curl.sh 2223 github.com
+stderr 'Connected to github.com'
+
+# Try to curl another host
+! exec -t 1m bash curl.sh 2223 google.com
+! stderr 'Connected'
+
+eden pod delete curl-acl
+
+test eden.app.test -test.v -timewait 10m - curl-acl
+
+-- wait_ssh.sh --
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for p in $*
+do
+  for i in `seq 20`
+  do
+    sleep 20
+    # Test SSH-access to container
+    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
+    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
+  done
+done
+
+-- curl.sh --
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+echo {{template "ssh"}}$HOST -p $1 curl -v --max-time 30 "$2"
+{{template "ssh"}}$HOST -p $1 curl -v --max-time 30 "$2"
+
+-- eden-config.yml --
+{{/* Test's config file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -75,8 +75,10 @@ eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/volume
 /bin/echo Eden sftp volumes test (17.2/{{$tests}})
 eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/volume_sftp
 
-/bin/echo Eden Host only ACL (18/{{$tests}})
+/bin/echo Eden Host only ACL (18.1/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/host-only
+/bin/echo Eden ACL to particular host (18.2/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/acl
 /bin/echo Eden Network light (19/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/networking_light
 /bin/echo Eden Networks switch (20/{{$tests}})


### PR DESCRIPTION
Add ability to set the particular hosts pod can access to with `--acl` flag, which can be set to host, ip or subnet. To set multiple values you can use this flag several times in one the command.
Also there is the test for acl, in which we have allowed host (github) and we try to access to it and to another (which one should be filter out).

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>