### PR TITLE
run tests from docker image directly

### DIFF
--- a/tests/update_eve_image/eden.update_eve_image.tests.txt
+++ b/tests/update_eve_image/eden.update_eve_image.tests.txt
@@ -1,1 +1,2 @@
 eden.escript.test -test.run TestEdenScripts/update_eve_image_http -test.timeout 60m
+eden.escript.test -test.run TestEdenScripts/update_eve_image_oci -test.timeout 60m

--- a/tests/update_eve_image/testdata/update_eve_image_oci.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_oci.txt
@@ -1,0 +1,53 @@
+# Default EVE version to update
+{{$eve_ver := "6.0.0"}}
+
+# Obtain EVE version from environment variable EVE_VERSION
+{{$env := EdenGetEnv "EVE_VERSION"}}
+
+# If environment variable EVE_VERSION set, use it instead of default
+{{if $env}}{{$eve_ver = $env}}{{end}}
+
+# Obtain eve.hv from config
+{{$eve_hv := EdenConfig "eve.hv"}}
+
+# Obtain eve.arch from config
+{{$eve_arch := EdenConfig "eve.arch"}}
+
+# Combine variables into $short_version
+{{$short_version := printf "%s-%s-%s" $eve_ver $eve_hv $eve_arch}}
+
+# Use eden.lim.test for access Infos with timewait 30m
+{{$test := "test eden.lim.test -test.v -timewait 30m -test.run TestInfo"}}
+
+# Decrease update testing time
+eden controller edge-node update --config timer.test.baseimage.update=30
+
+# Send command to update eveimage from OCI image
+message 'EVE update request'
+eden -t 10m controller edge-node eveimage-update oci://docker.io/lfedge/eve:{{$eve_ver}}-{{$eve_hv}}-{{$eve_arch}} -m adam://
+
+# Check stderr, it must be empty
+! stderr .
+
+# Run monitoring of Info messages to obtain info with PartitionState inprogress or active and previously defined ShortVersion
+message 'Waiting for EVE update...'
+{{$test}} -out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:active InfoContent.dinfo.SwList[0].ShortVersion:{{ $short_version }}'
+
+# Check stdout of previous command. Expected to get previously defined ShortVersion
+stdout '{{ $short_version }}'
+
+# Reset EVE version
+test eden.escript.test -test.run TestEdenScripts/revert_eve_image_update -test.v -testdata {{EdenConfig "eden.tests"}}/update_eve_image/testdata/
+
+# Reset EVE config
+eden eve reset
+
+# Test's config file
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -119,11 +119,13 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/eclie
 /bin/echo Eden Reboot test (33/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/reboot_test
 {{ if ne $workflow "small" }}
-/bin/echo Eden base OS update (34/{{$tests}})
+/bin/echo Eden base OS update http (34/{{$tests}})
 eden.escript.test -testdata ../update_eve_image/testdata/ -test.run TestEdenScripts/update_eve_image_http
+/bin/echo Eden base OS update oci (35/{{$tests}})
+eden.escript.test -testdata ../update_eve_image/testdata/ -test.run TestEdenScripts/update_eve_image_oci
 {{end}}
 
 {{if (eq $stop "y")}}
-/bin/echo Eden stop (35/{{$tests}})
+/bin/echo Eden stop (36/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_stop
 {{end}}


### PR DESCRIPTION
This adds tests to update the image from an OCI image directly.

It uses version 6.1.0. I checked, and that version does, indeed, have the right labels to work.

A few open questions:

1. Did I do this correctly? Added a test line to `tests/update_eve_image/eden.update_eve_image.tests.txt`, and then the test in `tests/update_eve_image/testdata/update_eve_image_oci.txt`
2. Should we be resetting the image back to the base (pre-update) in `testdata/update_eve_image.txt` before running the next test? Should we in `testdata/update_eve_image_oci.txt`? If so, how do we do it?

