### PR TITLE
Reboot 2 USB test

### DIFF
--- a/tests/hardware_reboot/eden.hardware_reboot.tests.txt
+++ b/tests/hardware_reboot/eden.hardware_reboot.tests.txt
@@ -1,1 +1,2 @@
 eden.escript.test -test.run TestEdenScripts/hardware_usb_reboot
+eden.escript.test -test.run TestEdenScripts/hardware_2usb_reboot

--- a/tests/hardware_reboot/qemu+2usb.sh
+++ b/tests/hardware_reboot/qemu+2usb.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+test -n "$EDEN_CONFIG" || EDEN_CONFIG=default
+
+EDEN=eden
+DIR=$(dirname "$0")
+PATH=$DIR:$DIR/../../bin:$PATH
+
+dist=$($EDEN config get "$EDEN_CONFIG" --key eden.root)
+
+dd if=/dev/zero of="$dist/stick.raw" bs=1K count=1
+
+cat >> ~/.eden/"$EDEN_CONFIG"-qemu.conf <<END
+
+
+[drive "stick"]
+  if = "none"
+  file = "$dist/stick.raw"
+  format = "raw"
+
+[device]
+  driver = "usb-storage"
+  bus = "usb.0"
+  drive = "stick"
+
+[drive "stick"]
+  if = "none"
+  file = "$dist/empty.raw"
+  format = "raw"
+
+[device]
+  driver = "usb-storage"
+  bus = "usb.0"
+  drive = "stick2"
+END
+
+cat <<END
+To activate the changes in the config, you need to restart EVE:
+  $EDEN eve stop
+  $EDEN eve start
+END

--- a/tests/hardware_reboot/qemu+usb.sh
+++ b/tests/hardware_reboot/qemu+usb.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+test -n "$EDEN_CONFIG" || EDEN_CONFIG=default
+
+EDEN=eden
+DIR=$(dirname "$0")
+PATH=$DIR:$DIR/../../bin:$PATH
+
+dist=$($EDEN config get "$EDEN_CONFIG" --key eden.root)
+
+dd if=/dev/zero of="$dist/stick.raw" bs=1K count=1
+
+cat >> ~/.eden/"$EDEN_CONFIG"-qemu.conf <<END
+
+
+[drive "stick"]
+  if = "none"
+  file = "$dist/stick.raw"
+  format = "raw"
+
+[device]
+  driver = "usb-storage"
+  bus = "usb.0"
+  drive = "stick"
+END
+
+cat <<END
+To activate the changes in the config, you need to restart EVE:
+  $EDEN eve stop
+  $EDEN eve start
+END

--- a/tests/hardware_reboot/testdata/hardware_2usb_reboot.txt
+++ b/tests/hardware_reboot/testdata/hardware_2usb_reboot.txt
@@ -1,0 +1,97 @@
+# Simple test of USB passthrough functionality after reboot of guest
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+
+eden pod deploy -n n11 --memory=512MB docker://itmoeve/eclient:0.4 -p 8027:22 --adapters USB2:2 --adapters USB2:3
+test eden.app.test -test.v -timewait 20m RUNNING n11
+
+exec -t 20m bash ssh.sh 8027
+stdout 'Ubuntu'
+
+exec -t 20m bash get-lshw.sh 8027
+stdout '1024B QEMU HARDDISK'
+stdout '10MB QEMU HARDDISK'
+
+exec -t 20m bash get-lshw.sh 8027
+cp stdout before_reboot
+
+# get last reboot time
+exec -t 20m bash get-last-reboot-time.sh {{$port}}
+cp stdout timestamp1
+
+# reboot from guest
+exec -t 20m bash reboot.sh 8027
+exec sleep 60
+
+# reboot detector
+test eden.reboot.test -test.v -timewait 20m -reboot=1
+
+exec -t 20m bash ssh.sh 8027
+stdout 'Ubuntu'
+
+exec -t 20m bash get-lshw.sh 8027
+stdout '1024B QEMU HARDDISK'
+stdout '10MB QEMU HARDDISK'
+
+exec -t 20m bash get-lshw.sh 8027
+cp stdout after_reboot
+
+# get last reboot time
+exec -t 20m bash get-last-reboot-time.sh {{$port}}
+cp stdout timestamp2
+
+# comparison of lshw output
+cmp before_reboot after_reboot
+
+# comparison of reboot time output
+! exec diff timestamp1 timestamp2
+
+# teardown applications
+eden pod delete n11
+
+test eden.app.test -test.v -timewait 20m - n11
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- ssh.sh --
+port=$1
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for i in `seq 20`
+do
+ sleep 20
+ # Test SSH-access to container
+ echo $i\) ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST grep Ubuntu /etc/issue
+ ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST grep Ubuntu /etc/issue && break
+done
+
+-- get-lshw.sh --
+port=$1
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+ echo ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST lshw -businfo
+ ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST lshw -businfo
+
+-- get-last-reboot-time.sh --
+port=$1
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+ echo ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST 'last -n 1 --time-format iso reboot'
+ ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST 'last -n 1 --time-format iso reboot'
+
+-- reboot.sh --
+port=$1
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+ echo ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST 'busybox reboot -f -d 1 &>/dev/null &'
+ ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.root"}}/tests/eclient/image/cert/id_rsa -p $port root@$HOST 'busybox reboot -f -d 1 &>/dev/null &'


### PR DESCRIPTION
Reboot Test with 2 USB 
Assumes a USB controller. Key purpose is to verify that a reboot (sudo shutdown -r +1) from the guest doesn’t disrupt the set of assigned adapters.

Signed-off-by: Ruslan Dautov <dautov2@gmail.com>