### PR TITLE
fix eve image revert in сase of snapshot

### DIFF
--- a/cmd/edenController.go
+++ b/cmd/edenController.go
@@ -213,13 +213,18 @@ var edgeNodeEVEImageRemove = &cobra.Command{
 		}
 
 		if getFromFileName {
-			rootFSName := utils.FileNameWithoutExtension(rootFsPath)
-			rootFSName = strings.TrimPrefix(rootFSName, "rootfs-")
-			re := regexp.MustCompile(defaults.DefaultRootFSVersionPattern)
-			if !re.MatchString(rootFSName) {
-				log.Fatalf("Filename of rootfs %s does not match pattern %s", rootFSName, defaults.DefaultRootFSVersionPattern)
+			correctionFileName := fmt.Sprintf("%s.ver", rootFsPath)
+			if rootFSFromCorrectionFile, err := ioutil.ReadFile(correctionFileName); err == nil {
+				baseOSVersion = string(rootFSFromCorrectionFile)
+			} else {
+				rootFSName := utils.FileNameWithoutExtension(rootFsPath)
+				rootFSName = strings.TrimPrefix(rootFSName, "rootfs-")
+				re := regexp.MustCompile(defaults.DefaultRootFSVersionPattern)
+				if !re.MatchString(rootFSName) {
+					log.Fatalf("Filename of rootfs %s does not match pattern %s", rootFSName, defaults.DefaultRootFSVersionPattern)
+				}
+				baseOSVersion = rootFSName
 			}
-			baseOSVersion = rootFSName
 		}
 
 		log.Infof("Will use rootfs version %s", baseOSVersion)

--- a/pkg/expect/baseOSImage.go
+++ b/pkg/expect/baseOSImage.go
@@ -1,10 +1,12 @@
 package expect
 
 import (
+	"fmt"
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eden/pkg/utils"
 	"github.com/lf-edge/eve/api/go/config"
 	log "github.com/sirupsen/logrus"
+	"io/ioutil"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -15,6 +17,11 @@ import (
 func (exp *AppExpectation) getBaseOSVersion() string {
 	if exp.appType == dockerApp {
 		return exp.appVersion
+	}
+
+	correctionFileName := fmt.Sprintf("%s.ver", exp.appURL)
+	if rootFSFromCorrectionFile, err := ioutil.ReadFile(correctionFileName); err == nil {
+		return string(rootFSFromCorrectionFile)
 	}
 	rootFSName := path.Base(exp.appURL)
 	rootFSName = strings.TrimSuffix(rootFSName, filepath.Ext(rootFSName))

--- a/tests/update_eve_image/testdata/revert_eve_image_update.txt
+++ b/tests/update_eve_image/testdata/revert_eve_image_update.txt
@@ -30,12 +30,19 @@ eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.di
 # Check stderr, it must be empty
 ! stderr .
 
-# Run monitoring of Info messages to obtain info with PartitionState active and previously defined ShortVersion
-message 'Waiting for EVE update...'
-{{$test}} -out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:active InfoContent.dinfo.SwList[0].ShortVersion:{{ $short_version }}'
+# Run monitoring of Info messages to obtain info with PartitionState inprogress
+message 'Waiting for EVE starting testing...'
+{{$test}} -out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:inprogress'
 
-# Check stdout of previous command. Expected to get previously defined ShortVersion
-stdout '{{ $short_version }}'
+eden -t 1m info --out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:inprogress' --tail=1
+cp stdout ver
+
+message 'Waiting for EVE updated...'
+# Run monitoring of Info messages to obtain info with PartitionState active
+{{$test}} -out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:active'
+
+eden -t 1m info --out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:active' --tail=1
+cmp stdout ver
 
 # Test's config file
 -- eden-config.yml --


### PR DESCRIPTION
In case of "virtual" versions of EVE (for example, snapshot), we should use real version inside of docker image for doing and reverting of EVE update.

https://github.com/lf-edge/eve/pull/1986#issuecomment-804812106

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>