### PR TITLE
eserver move to eve-alpine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DO_DOCKER ?= 1
 # ESERVER_TAG is the tag for eserver image to build
 ESERVER_TAG ?= "lfedge/eden-http-server"
 # ESERVER_VERSION is the version of eserver image to build
-ESERVER_VERSION ?= "1.4"
+ESERVER_VERSION ?= "1.5"
 # ESERVER_DIR is the directory with eserver Dockerfile to build
 ESERVER_DIR=$(CURDIR)/eserver
 # check if eserver image already exists in local docker and get its IMAGE_ID

--- a/eserver/Dockerfile
+++ b/eserver/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.15.7-alpine3.13 AS build
+FROM lfedge/eve-alpine:6.2.0 as build
+ENV BUILD_PKGS git go openssh-keygen
+RUN eve-alpine-deploy.sh
 
 ENV CGO_ENABLED=0
 ENV GO111MODULE=on
-
-RUN apk --no-cache add git=2.30.2-r0 openssh-keygen=8.4_p1-r2
 
 RUN ssh-keygen -t rsa -q -P "" -f /root/.ssh/id_rsa
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -62,11 +62,11 @@ const (
 	DefaultEveRegistry          = "lfedge"
 	DefaultRegistry             = "docker.io"
 
-	DefaultSFTPUser     = "user"
-	DefaultSFTPPassword = "password"
+	DefaultSFTPUser      = "user"
+	DefaultSFTPPassword  = "password"
 	DefaultSFTPDirPrefix = "/eserver/run"
 
-	DefaultEServerTag          = "1.4"
+	DefaultEServerTag          = "1.5"
 	DefaultEServerContainerRef = "lfedge/eden-http-server"
 
 	//DefaultRepeatCount is repeat count for requests


### PR DESCRIPTION
In order to resolve problems with packets versions we should move to eve-alpine as a base for our images.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>