### PR TITLE
remove volume duplicates and remove volume from baseos

### DIFF
--- a/cmd/edenController.go
+++ b/cmd/edenController.go
@@ -25,6 +25,7 @@ import (
 var (
 	controllerMode      string
 	baseOSImageActivate bool
+	baseOSVDrive        bool
 	configItems         map[string]string
 	baseOSVersion       string
 	getFromFileName     bool
@@ -142,7 +143,7 @@ var edgeNodeEVEImageUpdate = &cobra.Command{
 		if len(qemuPorts) == 0 {
 			qemuPorts = nil
 		}
-		baseOSImageConfig := expectation.BaseOSImage()
+		baseOSImageConfig := expectation.BaseOSImage(baseOSVDrive)
 		dev.SetBaseOSConfig(append(dev.GetBaseOSConfigs(), baseOSImageConfig.Uuidandversion.Uuid))
 		if err = changer.setControllerAndDev(ctrl, dev); err != nil {
 			log.Fatalf("setControllerAndDev: %s", err)
@@ -393,6 +394,7 @@ func controllerInit() {
 	edgeNodeEVEImageUpdateFlags.StringVar(&registry, "registry", "remote", "Select registry to use for containers (remote/local)")
 	edgeNodeEVEImageUpdateFlags.BoolVarP(&getFromFileName, "from-filename", "", true, "get version from filename")
 	edgeNodeEVEImageUpdateFlags.BoolVarP(&baseOSImageActivate, "activate", "", true, "activate image")
+	edgeNodeEVEImageUpdateFlags.BoolVar(&baseOSVDrive, "drive", false, "provide drive to baseOS")
 	edgeNodeUpdateFlags := edgeNodeUpdate.Flags()
 	configUsage := `set of key=value items.
 Supported keys are defined in https://github.com/lf-edge/eve/blob/master/docs/CONFIG-PROPERTIES.md`

--- a/pkg/controller/device.go
+++ b/pkg/controller/device.go
@@ -377,6 +377,7 @@ func (cloud *CloudCtx) GetConfigBytes(dev *device.Ctx, pretty bool) ([]byte, err
 	var volumes []*config.Volume
 	var baseOS []*config.BaseOSConfig
 	var dataStores []*config.DatastoreConfig
+baseOSLoop:
 	for _, baseOSConfigID := range dev.GetBaseOSConfigs() {
 		baseOSConfig, err := cloud.GetBaseOSConfig(baseOSConfigID)
 		if err != nil {
@@ -399,6 +400,11 @@ func (cloud *CloudCtx) GetConfigBytes(dev *device.Ctx, pretty bool) ([]byte, err
 				return nil, err
 			}
 
+			for _, v := range volumes {
+				if v.Uuid == baseOSConfig.VolumeID {
+					continue baseOSLoop
+				}
+			}
 			volumes = append(volumes, volumeConfig)
 
 			if contentTreeConfig, err := cloud.GetContentTree(volumeConfig.Origin.DownloadContentTreeID); err == nil {
@@ -425,6 +431,11 @@ volumeLoop:
 		volumeConfig, err := cloud.GetVolume(volumeID)
 		if err != nil {
 			return nil, err
+		}
+		for _, v := range volumes {
+			if v.Uuid == volumeID {
+				continue volumeLoop
+			}
 		}
 		volumes = append(volumes, volumeConfig)
 		if contentTreeConfig, err := cloud.GetContentTree(volumeConfig.Origin.DownloadContentTreeID); err == nil {

--- a/pkg/expect/baseOSImage.go
+++ b/pkg/expect/baseOSImage.go
@@ -65,7 +65,8 @@ func (exp *AppExpectation) createBaseOSConfig(img *config.Image) (*config.BaseOS
 
 //BaseOSImage expectation gets or creates Image definition,
 //gets BaseOSConfig and returns it or creates BaseOSConfig, adds it into internal controller and returns it
-func (exp *AppExpectation) BaseOSImage() (baseOSConfig *config.BaseOSConfig) {
+//if withDrive set will only create drive and content tree
+func (exp *AppExpectation) BaseOSImage(withDrive bool) (baseOSConfig *config.BaseOSConfig) {
 	var err error
 	if exp.appType == fileApp {
 		if exp.appURL, err = utils.GetFileFollowLinks(exp.appURL); err != nil {
@@ -93,7 +94,7 @@ func (exp *AppExpectation) BaseOSImage() (baseOSConfig *config.BaseOSConfig) {
 	}
 
 	// provision content tree and volume in addition to Drive record in config
-	if len(baseOSConfig.Drives) == 1 {
+	if withDrive && len(baseOSConfig.Drives) == 1 {
 		contentTree := exp.imageToContentTree(image, image.Name)
 		_ = exp.ctrl.AddContentTree(contentTree)
 		exp.device.SetContentTreeConfig(append(exp.device.GetContentTrees(), contentTree.Uuid))


### PR DESCRIPTION
Seems, that we should not provide volume for baseOS by default, only image

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>