### PR TITLE
relax pattern for baseos

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -85,7 +85,7 @@ const (
 	NetWiFiID                    = "6822e35f-c1b8-43ca-b344-0bbc0ece8cf3"
 	DefaultTestProg              = ""
 	DefaultTestScenario          = ""
-	DefaultRootFSVersionPattern  = `^(\d+\.*){2,3}.*-(xen|kvm|acrn|rpi|rpi-xen|rpi-kvm)-(amd64|arm64)$`
+	DefaultRootFSVersionPattern  = `^.*-(xen|kvm|acrn|rpi|rpi-xen|rpi-kvm)-(amd64|arm64)$`
 	DefaultControllerModePattern = `^(?P<Type>(file|proto|adam|zedcloud)):\/\/(?P<URL>.*)$`
 	DefaultPodLinkPattern        = `^(?P<TYPE>(oci|docker|http[s]{0,1}|file)):\/\/(?P<TAG>[^:]+):*(?P<VERSION>.*)$`
 	DefaultRedisContainerName    = "eden_redis"


### PR DESCRIPTION
In some cases we [have](https://github.com/lf-edge/eve/runs/2266071106?check_suite_focus=true#step:9:4105) just `lfedge/eve:pr-kvm-amd64` and I can't find any reason not to reduce the parameters of the template.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>