### PR TITLE
mountpoint of additional disks

### DIFF
--- a/cmd/edenPod.go
+++ b/cmd/edenPod.go
@@ -35,6 +35,8 @@ var (
 	appCpus     uint32
 	appMemory   string
 	diskSize    string
+	volumes     []string
+	volumeSize  string
 	imageFormat string
 	volumeType  string
 	acl         []string
@@ -112,6 +114,11 @@ var podDeployCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 		opts = append(opts, expect.WithDiskSize(int64(diskSizeParsed)))
+		volumeSizeParsed, err := humanize.ParseBytes(volumeSize)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, expect.WithVolumeSize(int64(volumeSizeParsed)))
 		appMemoryParsed, err := humanize.ParseBytes(appMemory)
 		if err != nil {
 			log.Fatal(err)
@@ -128,7 +135,7 @@ var podDeployCmd = &cobra.Command{
 		if !sftpLoad {
 			opts = append(opts, expect.WithHTTPDirectLoad(directLoad))
 		}
-		opts = append(opts, expect.WithAdditionalDisks(disks))
+		opts = append(opts, expect.WithAdditionalDisks(append(disks, volumes...)))
 		registryToUse := registry
 		switch registry {
 		case "local":
@@ -463,7 +470,9 @@ func podInit() {
 	podDeployCmd.Flags().StringVar(&registry, "registry", "remote", "Select registry to use for containers (remote/local)")
 	podDeployCmd.Flags().BoolVar(&directLoad, "direct", true, "Use direct download for image instead of eserver")
 	podDeployCmd.Flags().BoolVar(&sftpLoad, "sftp", false, "Force use of sftp to load http/file image from eserver")
-	podDeployCmd.Flags().StringSliceVar(&disks, "disks", nil, "Additional disks to use")
+	podDeployCmd.Flags().StringSliceVar(&disks, "disks", nil, `Additional disks to use. You can write it in notation <link> or <mount point>:<link>. Deprecated. Please use volumes instead.`)
+	podDeployCmd.Flags().StringSliceVar(&volumes, "volume", nil, `Additional volumes to use. You can write it in notation <link> or <mount point>:<link>.`)
+	podDeployCmd.Flags().StringVar(&volumeSize, "volume-size", humanize.IBytes(defaults.DefaultVolumeSize), "volume size")
 	podDeployCmd.Flags().StringSliceVar(&acl, "acl", nil, `Allow access only to defined hosts/ips/subnets
 You can set acl for particular network in format '<network_name:acl>'
 To remove acls you can set empty line '<network_name>:'`)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -139,7 +139,7 @@ const (
 
 	DefaultDummyExpect = "docker://image"
 
-	DefaultVolumeSize = 2 * 1024 * 1024 * 1024
+	DefaultVolumeSize = 200 * 1024 * 1024
 
 	DefaultEmptyVolumeLinkDocker = "docker://hello-world"
 	DefaultEmptyVolumeLinkQcow2  = "empty.qcow2"

--- a/pkg/expect/docker.go
+++ b/pkg/expect/docker.go
@@ -220,19 +220,32 @@ func (exp *AppExpectation) createAppInstanceConfigDocker(img *config.Image, id u
 	volumes := []*config.Volume{volume}
 	app.VolumeRefList = []*config.VolumeRef{{MountDir: "/", Uuid: volume.Uuid}}
 
-	// we need to add volumes for every mount point
-	for ind, el := range mountPointsList {
+	if len(mountPointsList) > 0 {
+		// we need to add volumes for every mount point
 		image := exp.prepareImage()
-		if image != nil {
-			drive := &config.Drive{
-				Image:        image,
-				Maxsizebytes: defaults.DefaultVolumeSize,
+		for ind, el := range mountPointsList {
+			if image != nil {
+				drive := &config.Drive{
+					Image:        image,
+					Maxsizebytes: exp.volumeSize,
+				}
+				toAppend := true
+				var contentTree *config.ContentTree
+				for _, ct := range contentTrees {
+					if ct.URL == image.Name && ct.Sha256 == image.Sha256 {
+						//skip append of existent ContentTree
+						toAppend = false
+						contentTree = ct
+					}
+				}
+				if toAppend {
+					contentTree = exp.imageToContentTree(image, fmt.Sprintf("%s-%d", exp.appName, ind))
+					contentTrees = append(contentTrees, contentTree)
+				}
+				volume := exp.driveToVolume(drive, ind+1, contentTree)
+				volumes = append(volumes, volume)
+				app.VolumeRefList = append(app.VolumeRefList, &config.VolumeRef{MountDir: el, Uuid: volume.Uuid})
 			}
-			contentTree := exp.imageToContentTree(image, fmt.Sprintf("%s-%d", exp.appName, ind))
-			contentTrees = append(contentTrees, contentTree)
-			volume := exp.driveToVolume(drive, ind+1, contentTree)
-			volumes = append(volumes, volume)
-			app.VolumeRefList = append(app.VolumeRefList, &config.VolumeRef{MountDir: el, Uuid: volume.Uuid})
 		}
 	}
 	app.Fixedresources.VirtualizationMode = exp.virtualizationMode

--- a/pkg/expect/expectation.go
+++ b/pkg/expect/expectation.go
@@ -54,6 +54,7 @@ type AppExpectation struct {
 	device *device.Ctx
 
 	volumesType VolumeType
+	volumeSize  int64
 
 	registry string
 

--- a/pkg/expect/http.go
+++ b/pkg/expect/http.go
@@ -85,6 +85,11 @@ func (exp *AppExpectation) checkImageHTTP(img *config.Image, dsID string) bool {
 
 //checkDataStoreHTTP checks if provided ds match expectation
 func (exp *AppExpectation) checkDataStoreHTTP(ds *config.DatastoreConfig) bool {
+	if exp.sftpLoad && ds.DType == config.DsType_DsSFTP {
+		if ds.Fqdn == fmt.Sprintf("%s:%s", exp.ctrl.GetVars().AdamDomain, exp.ctrl.GetVars().EServerPort) {
+			return true
+		}
+	} else
 	if ds.DType == config.DsType_DsHttp || ds.DType == config.DsType_DsHttps {
 		if !exp.httpDirectLoad && ds.Fqdn == fmt.Sprintf("http://%s:%s", exp.ctrl.GetVars().AdamDomain, exp.ctrl.GetVars().EServerPort) {
 			return true

--- a/pkg/expect/options.go
+++ b/pkg/expect/options.go
@@ -129,6 +129,13 @@ func WithDiskSize(diskSizeBytes int64) ExpectationOption {
 	}
 }
 
+//WithVolumeSize set volume size for created app
+func WithVolumeSize(volumeSizeBytes int64) ExpectationOption {
+	return func(expectation *AppExpectation) {
+		expectation.volumeSize = volumeSizeBytes
+	}
+}
+
 //WithResources sets cpu count and memory for app
 func WithResources(cpus uint32, memory uint32) ExpectationOption {
 	return func(expectation *AppExpectation) {

--- a/tests/eclient/testdata/mount.txt
+++ b/tests/eclient/testdata/mount.txt
@@ -1,0 +1,44 @@
+# Test for additional disk mounted to eclient
+
+{{$port := "2223"}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
+
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
+
+eden pod deploy -n eclient-mount --memory=512MB docker://itmoeve/eclient:0.7 -p {{$port}}:22 --volume=/tst:docker://nginx:1.20.0
+
+test eden.app.test -test.v -timewait 20m RUNNING eclient-mount
+
+exec -t 5m bash ssh.sh
+stdout 'docker-entrypoint.sh'
+
+eden pod delete eclient-mount
+
+test eden.app.test -test.v -timewait 10m - eclient-mount
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for i in `seq 20`
+do
+sleep 20
+# Test SSH-access to container
+echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST ls /tst
+ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST ls /tst && break
+done

--- a/tests/io_performance/testdata/fio_tests.txt
+++ b/tests/io_performance/testdata/fio_tests.txt
@@ -7,7 +7,7 @@
 {{$volume_type := EdenGetEnv "VOLUME_TYPE"}}
 
 # Deploy the application
-eden pod deploy --volume-type={{if $volume_type}}{{$volume_type}}{{else}}qcow2{{end}} --metadata='EVE_VERSION={{EdenConfig "eve.tag"}}\nGIT_BRANCH={{EdenGetEnv "GIT_BRANCH"}}\nGIT_REPO={{EdenGetEnv "GIT_REPO"}}\nGIT_FOLDER={{EdenGetEnv "GIT_FOLDER"}}\nGIT_PATH={{EdenGetEnv "GIT_PATH"}}\nGIT_LOGIN={{EdenGetEnv "GIT_LOGIN"}}\nGIT_TOKEN={{EdenGetEnv "GIT_TOKEN"}}\nFIO_TIME={{EdenGetEnv "FIO_TIME"}}\nFIO_OPTYPE={{EdenGetEnv "FIO_OPTYPE"}}\nFIO_BS={{EdenGetEnv "FIO_BS"}}\nFIO_JOBS={{EdenGetEnv "FIO_JOBS"}}\nFIO_DEPTH={{EdenGetEnv "FIO_DEPTH"}}' --name=fio_test --memory=2GB --cpus=2 docker://itmoeve/fio_tests:v.1.2.1
+eden pod deploy --volume-type={{if $volume_type}}{{$volume_type}}{{else}}qcow2{{end}} --metadata='EVE_VERSION={{EdenConfig "eve.tag"}}\nGIT_BRANCH={{EdenGetEnv "GIT_BRANCH"}}\nGIT_REPO={{EdenGetEnv "GIT_REPO"}}\nGIT_FOLDER={{EdenGetEnv "GIT_FOLDER"}}\nGIT_PATH={{EdenGetEnv "GIT_PATH"}}\nGIT_LOGIN={{EdenGetEnv "GIT_LOGIN"}}\nGIT_TOKEN={{EdenGetEnv "GIT_TOKEN"}}\nFIO_TIME={{EdenGetEnv "FIO_TIME"}}\nFIO_OPTYPE={{EdenGetEnv "FIO_OPTYPE"}}\nFIO_BS={{EdenGetEnv "FIO_BS"}}\nFIO_JOBS={{EdenGetEnv "FIO_JOBS"}}\nFIO_DEPTH={{EdenGetEnv "FIO_DEPTH"}}' --name=fio_test --memory=2GB --cpus=2 docker://itmoeve/fio_tests:v.1.2.1 --volume-size=2GB
 
 test eden.app.test -test.v -timewait 5m RUNNING fio_test
 

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -76,6 +76,8 @@ eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/netwo
 eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/volumes_test
 /bin/echo Eden sftp volumes test (17.2/{{$tests}})
 eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/volume_sftp
+/bin/echo Eden eclient with mounted volume (17.3/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/mount
 
 /bin/echo Eden Host only ACL (18.1/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/host-only


### PR DESCRIPTION
Support for mountpoint in pod disks: You can write it in notation `<mount point>:<link>` to pass mount point for particular volume. Also added volume-size field and rework overriding of mountpoints inside expect.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>