### PR TITLE
[WIP] eth reboot test

### DIFF
--- a/tests/eclient/qemu+eth.sh
+++ b/tests/eclient/qemu+eth.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+test -n "$EDEN_CONFIG" || EDEN_CONFIG=default
+
+EDEN=eden
+DIR=$(dirname "$0")
+PATH=$DIR:$DIR/../../bin:$PATH
+
+dist=$($EDEN config get "$EDEN_CONFIG" --key eden.root)
+
+dd if=/dev/zero of="$dist/stick.raw" bs=1K count=1
+
+cat >> ~/.eden/"$EDEN_CONFIG"-qemu.conf <<END
+
+
+[netdev "hostnet"]
+  type = "user"
+
+[device "net"]
+  driver = "virtio-net-pci"
+  netdev = "hostnet"
+  bus = "pcie.0"
+  addr = "19.0"
+END
+
+cat <<END
+To activate the changes in the config, you need to restart EVE:
+  $EDEN eve stop
+  $EDEN eve start
+END

--- a/tests/hardware_reboot/eden.hardware_reboot.tests.txt
+++ b/tests/hardware_reboot/eden.hardware_reboot.tests.txt
@@ -1,2 +1,3 @@
-eden.escript.test -test.run TestEdenScripts/hardware_usb_reboot
-eden.escript.test -test.run TestEdenScripts/hardware_2usb_reboot
+#eden.escript.test -test.run TestEdenScripts/hardware_usb_reboot
+#eden.escript.test -test.run TestEdenScripts/hardware_2usb_reboot
+eden.escript.test -test.run TestEdenScripts/hardware_eth_reboot

--- a/tests/hardware_reboot/testdata/hardware_eth_reboot.txt
+++ b/tests/hardware_reboot/testdata/hardware_eth_reboot.txt
@@ -1,15 +1,14 @@
-# Simple test of 2 USB passthrough functionality after reboot of guest
 # Works only on KVM
 
-{{define "port"}}2223{{end}}
+{{define "port"}}8027{{end}}
 {{define "ssh"}} ssh -oServerAliveInterval=10 -oConnectTimeout=10 -oStrictHostKeyChecking=no -oPasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} root@$HOST {{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
 [!exec:ssh] stop
 
-# Starting of reboot detector with a 2 reboot limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait 60m -reboot=0 -count=3 &
 
 eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.7 -p {{template "port"}}:22
 
@@ -17,6 +16,16 @@ test eden.app.test -test.v -timewait 20m RUNNING eclient
 
 exec -t 20m bash ssh.sh {{template "port"}}
 stdout 'Ubuntu'
+
+# Audio device passthrough setup
+exec -t 20m bash set_eth.sh eclient
+stdout 'msg="Config loaded"'
+
+exec -t 20m bash eve_ssh.sh
+stdout 'keth2'
+
+exec -t 20m bash get-lshw.sh  {{template "port"}}
+stdout 'Ethernet interfacedfd'
 
 exec -t 5m bash get_reboot_time.sh
 cp stdout reboot_time
@@ -28,10 +37,13 @@ cp stdout reboot_time
 exec -t 20m bash ssh.sh
 stdout 'Ubuntu'
 
+#exec -t 20m bash get-lshw.sh  {{template "port"}}
+#stdout 'Ethernet interface'
+
 exec -t 5m bash get_reboot_time.sh
 #! cmp stdout reboot_time
 
-# teardown applications
+message 'Resource cleaning'
 eden pod delete eclient
 
 test eden.app.test -test.v -timewait 20m - eclient
@@ -59,7 +71,6 @@ echo $i\) {{template "ssh"}} grep Ubuntu /etc/issue
 {{template "ssh"}} grep Ubuntu /etc/issue && break
 done
 
-
 -- get_reboot_time.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 HOST=$($EDEN eve ip)
@@ -80,3 +91,22 @@ HOST=$($EDEN eve ip)
 
 echo {{template "ssh"}} reboot
 {{template "ssh"}} reboot
+
+-- eve_ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+$EDEN eve ssh 'ifconfig'
+
+
+-- set_eth.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+CNF=eve.cfg
+
+$EDEN controller edge-node get-config --file $CNF
+
+jq '.deviceIoList += [{ "ptype": 1, "phylabel": "eth2", "phyaddrs": { "Ifname": "eth2","PciLong": "0000:00:19.0" }, "logicallabel": "eth2", "assigngrp": "eth2", "usage": 2, "usagePolicy": {"freeUplink": true }  }]' < $CNF | \
+jq '.systemAdapterList += [{ "name": "eth2", "uplink": true, "networkUUID":"6822e35f-c1b8-43ca-b344-0bbc0ece8cf1" }]' | \
+jq '.networks += [{ "id": "6822e35f-c1b8-43ca-b344-0bbc0ece8cf1", "type": 4, "ip": { "dhcp": 4, "dhcpRange": {}} }]' > $CNF.new
+
+$EDEN controller edge-node set-config --file $CNF.new

--- a/tests/hardware_reboot/testdata/hardware_eth_reboot.txt
+++ b/tests/hardware_reboot/testdata/hardware_eth_reboot.txt
@@ -1,6 +1,6 @@
 # Works only on KVM
 
-{{define "port"}}8027{{end}}
+{{define "port"}}2223{{end}}
 {{define "ssh"}} ssh -oServerAliveInterval=10 -oConnectTimeout=10 -oStrictHostKeyChecking=no -oPasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} root@$HOST {{end}}
 
 [!exec:bash] stop
@@ -25,7 +25,7 @@ exec -t 20m bash eve_ssh.sh
 stdout 'keth2'
 
 exec -t 20m bash get-lshw.sh  {{template "port"}}
-stdout 'Ethernet interfacedfd'
+stdout 'Ethernet interface'
 
 exec -t 5m bash get_reboot_time.sh
 cp stdout reboot_time

--- a/tests/hardware_reboot/testdata/hardware_eth_reboot.txt
+++ b/tests/hardware_reboot/testdata/hardware_eth_reboot.txt
@@ -1,0 +1,82 @@
+# Simple test of 2 USB passthrough functionality after reboot of guest
+# Works only on KVM
+
+{{define "port"}}2223{{end}}
+{{define "ssh"}} ssh -oServerAliveInterval=10 -oConnectTimeout=10 -oStrictHostKeyChecking=no -oPasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} root@$HOST {{end}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+
+# Starting of reboot detector with a 2 reboot limit
+! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+
+eden pod deploy -n eclient --memory=512MB docker://itmoeve/eclient:0.7 -p {{template "port"}}:22
+
+test eden.app.test -test.v -timewait 20m RUNNING eclient
+
+exec -t 20m bash ssh.sh {{template "port"}}
+stdout 'Ubuntu'
+
+exec -t 5m bash get_reboot_time.sh
+cp stdout reboot_time
+
+# Reboot application
+! exec -t 1m bash reboot.sh
+
+# Wait for reboot
+exec -t 20m bash ssh.sh
+stdout 'Ubuntu'
+
+exec -t 5m bash get_reboot_time.sh
+#! cmp stdout reboot_time
+
+# teardown applications
+eden pod delete eclient
+
+test eden.app.test -test.v -timewait 20m - eclient
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- ssh.sh --
+port=$1
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+for i in `seq 20`
+do
+sleep 20
+# Test SSH-access to container
+echo $i\) {{template "ssh"}} grep Ubuntu /etc/issue
+{{template "ssh"}} grep Ubuntu /etc/issue && break
+done
+
+
+-- get_reboot_time.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+echo {{template "ssh"}} uptime -s
+{{template "ssh"}} uptime -s
+
+-- get-lshw.sh --
+port=$1
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+ echo {{template "ssh"}} lshw -businfo
+ {{template "ssh"}} lshw -businfo
+
+-- reboot.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+echo {{template "ssh"}} reboot
+{{template "ssh"}} reboot


### PR DESCRIPTION
Assumes a second connected Ethernet. Key purpose is to verify that a reboot (sudo shutdown -r +1) from the guest doesn’t disrupt the set of assigned adapters. (We had bugs there in the past.) This test verifies that the application can communicate over the assigned Ethernet, and that it can not communicate via the NAT in EVE (due to the ACL blocking communication via the default network instance.) Note that the deployed application has two Ethernet interfaces.


Signed-off-by: Ruslan Dautov <dautov2@gmail.com>