### PR TITLE
workaround host-only acl

### DIFF
--- a/cmd/edenPod.go
+++ b/cmd/edenPod.go
@@ -120,7 +120,7 @@ var podDeployCmd = &cobra.Command{
 		opts = append(opts, expect.WithResources(appCpus, uint32(appMemoryParsed/1000)))
 		opts = append(opts, expect.WithImageFormat(imageFormat))
 		if aclOnlyHost {
-			opts = append(opts, expect.WithACL(map[string][]string{"": {""}}))
+			opts = append(opts, expect.WithACL(map[string][]string{"": {defaults.DefaultHostOnlyNotation}}))
 		} else {
 			opts = append(opts, expect.WithACL(processAcls(acl)))
 		}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -111,7 +111,8 @@ const (
 	DefaultQemuAccelLinuxAmd64 = "-machine q35,accel=kvm,dump-guest-core=off,kernel-irqchip=split -cpu host,invtsc=on,kvmclock=off -device intel-iommu,intremap=on,caching-mode=on,aw-bits=48 "
 	DefaultQemuAccelLinuxArm64 = "-machine virt,accel=kvm -cpu=host "
 
-	DefaultAppSubnet = "10.11.12.0/24"
+	DefaultAppSubnet        = "10.11.12.0/24"
+	DefaultHostOnlyNotation = "host-only-acl"
 
 	DefaultQemuModel = "ZedVirtual-4G"
 


### PR DESCRIPTION
Seems, I broke host-only acl and [test_networking](https://github.com/lf-edge/eden/runs/2474813730?check_suite_focus=true#step:11:3772). In this PR I use constant to define host-only machinery.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>