### PR TITLE
move to q35 machine

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -109,7 +109,10 @@ const (
 
 	DefaultQemuAccelDarwin     = "-machine q35,accel=hvf -cpu kvm64,kvmclock=off "
 	DefaultQemuAccelLinuxAmd64 = "-machine q35,accel=kvm,dump-guest-core=off,kernel-irqchip=split -cpu host,invtsc=on,kvmclock=off -device intel-iommu,intremap=on,caching-mode=on,aw-bits=48 "
-	DefaultQemuAccelLinuxArm64 = "-machine virt,accel=kvm -cpu=host "
+	DefaultQemulAmd64          = "-machine q35 --cpu SandyBridge "
+
+	DefaultQemuAccelArm64 = "-machine virt,accel=kvm,usb=off,dump-guest-core=off -cpu host "
+	DefaultQemulArm64     = "-machine virt,virtualization=true -cpu cortex-a57 "
 
 	DefaultAppSubnet        = "10.11.12.0/24"
 	DefaultHostOnlyNotation = "host-only-acl"

--- a/pkg/eden/qemu.go
+++ b/pkg/eden/qemu.go
@@ -37,7 +37,7 @@ func StartEVEQemu(qemuARCH, qemuOS, eveImageFile, qemuSMBIOSSerial string, eveTe
 			log.Errorf("Failed converting %s to Integer", v)
 			break
 		}
-		qemuOptions += fmt.Sprintf(",hostfwd=tcp::%d-:%d", origPort + offset, newPort + offset)
+		qemuOptions += fmt.Sprintf(",hostfwd=tcp::%d-:%d", origPort+offset, newPort+offset)
 	}
 	qemuOptions += fmt.Sprintf(" -device virtio-net-pci,netdev=eth%d ", 0)
 	offset += 10
@@ -81,12 +81,14 @@ func StartEVEQemu(qemuARCH, qemuOS, eveImageFile, qemuSMBIOSSerial string, eveTe
 				qemuOptions += defaults.DefaultQemuAccelLinuxAmd64
 			}
 		} else {
-			qemuOptions += "--cpu SandyBridge "
+			qemuOptions += defaults.DefaultQemulAmd64
 		}
 	case "arm64":
 		qemuCommand = "qemu-system-aarch64"
 		if qemuAccel {
-			qemuOptions += defaults.DefaultQemuAccelLinuxArm64
+			qemuOptions += defaults.DefaultQemuAccelArm64
+		} else {
+			qemuOptions += defaults.DefaultQemulArm64
 		}
 	default:
 		return fmt.Errorf("StartEVEQemu: Arch not supported: %s", qemuARCH)


### PR DESCRIPTION
Update non-acceleration machine type to q35 to be in sync with [EVE](https://github.com/lf-edge/eve/blob/b83b8f089480da25e51e48ce0023307e0c7ae32a/Makefile#L163)

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>