### PR TITLE
Extend ACL test with long and static DNS entries

### DIFF
--- a/cmd/edenNetwork.go
+++ b/cmd/edenNetwork.go
@@ -13,9 +13,10 @@ import (
 )
 
 var (
-	networkType string
-	networkName string
-	uplinkAdapter string
+	networkType      string
+	networkName      string
+	uplinkAdapter    string
+	staticDNSEntries []string
 )
 
 var networkCmd = &cobra.Command{
@@ -127,6 +128,7 @@ var networkCreateCmd = &cobra.Command{
 		}
 		var opts []expect.ExpectationOption
 		opts = append(opts, expect.AddNetInstanceAndPortPublish(subnet, networkType, networkName, nil, uplinkAdapter))
+		opts = append(opts, expect.WithStaticDNSEntries(networkName, staticDNSEntries))
 		expectation := expect.AppExpectationFromURL(ctrl, dev, defaults.DefaultDummyExpect, podName, opts...)
 		netInstancesConfigs := expectation.NetworkInstances()
 	mainloop:
@@ -153,4 +155,5 @@ func networkInit() {
 	networkCreateCmd.Flags().StringVar(&networkType, "type", "local", "Type of network: local or switch")
 	networkCreateCmd.Flags().StringVarP(&networkName, "name", "n", "", "Name of network (empty for auto generation)")
 	networkCreateCmd.Flags().StringVarP(&uplinkAdapter, "uplink", "u", "eth0", "Name of uplink adapter, set to 'none' to not use uplink")
+	networkCreateCmd.Flags().StringSliceVarP(&staticDNSEntries, "static-dns-entries", "s", []string{}, "List of static DNS entries in format HOSTNAME:IP_ADDR,IP_ADDR,...")
 }

--- a/pkg/expect/networkInstance.go
+++ b/pkg/expect/networkInstance.go
@@ -17,13 +17,14 @@ import (
 
 //NetInstanceExpectation stores options for create NetworkInstanceConfigs for apps
 type NetInstanceExpectation struct {
-	mac           string
-	name          string
-	subnet        string
-	portsReceived []string
-	ports         map[int]int
-	netInstType   string
-	uplinkAdapter string
+	mac              string
+	name             string
+	subnet           string
+	portsReceived    []string
+	ports            map[int]int
+	netInstType      string
+	uplinkAdapter    string
+	staticDNSEntries map[string][]string
 }
 
 //checkNetworkInstance checks if provided netInst match expectation
@@ -66,7 +67,6 @@ func (exp *AppExpectation) createNetworkInstance(instanceExpect *NetInstanceExpe
 		Cfg:      &config.NetworkInstanceOpaqueConfig{},
 		IpType:   config.AddressType_IPV4,
 		Ip:       &config.Ipspec{},
-		Dns:      nil,
 	}
 	if instanceExpect.netInstType == "switch" {
 		netInst.InstType = config.ZNetworkInstType_ZnetInstSwitch
@@ -87,6 +87,12 @@ func (exp *AppExpectation) createNetworkInstance(instanceExpect *NetInstanceExpe
 		instanceExpect.name = namesgenerator.GetRandomName(0)
 	}
 	netInst.Displayname = instanceExpect.name
+	for hostname, ipAddrs := range instanceExpect.staticDNSEntries {
+		netInst.Dns = append(netInst.Dns, &config.ZnetStaticDNSEntry{
+			HostName: hostname,
+			Address:  ipAddrs,
+		})
+	}
 	return netInst, nil
 }
 

--- a/pkg/expect/options.go
+++ b/pkg/expect/options.go
@@ -103,7 +103,7 @@ func AddNetInstanceNameAndPortPublish(netInstance string, portPublish []string) 
 
 //AddNetInstanceAndPortPublish adds NetInstance with defined subnet cidr, networkType,
 //netInstanceName and ports mapping for apps in format ["EXTERNAL_PORT:INTERNAL_PORT"]
-func AddNetInstanceAndPortPublish(subnetCidr string, networkType string, netInstanceName string, portPublish []string, uplinkAdapter string) ExpectationOption {
+func AddNetInstanceAndPortPublish(subnetCidr, networkType, netInstanceName string, portPublish []string, uplinkAdapter string) ExpectationOption {
 	return func(expectation *AppExpectation) {
 		expectation.netInstances = append(expectation.netInstances, &NetInstanceExpectation{
 			name:          netInstanceName,
@@ -126,6 +126,28 @@ func WithPortsPublish(portPublish []string) ExpectationOption {
 			}}
 		}
 		expectation.netInstances[0].portsReceived = portPublish
+	}
+}
+
+//WithStaticDNSEntries extends network configuration with static DNS entries
+//in format ["HOSTNAME:IP_ADDRESS,IP_ADDRESS,..."]
+func WithStaticDNSEntries(networkName string, dnsEntries []string) ExpectationOption {
+	return func(expectation *AppExpectation) {
+		for _, netInstance := range expectation.netInstances {
+			if netInstance.name != networkName {
+				continue
+			}
+			netInstance.staticDNSEntries = make(map[string][]string)
+			for _, entry := range dnsEntries {
+				mapping := strings.SplitN(entry, ":", 2)
+				if len(mapping) != 2 {
+					continue
+				}
+				hostname := mapping[0]
+				ips := strings.Split(mapping[1], ",")
+				netInstance.staticDNSEntries[hostname] = ips
+			}
+		}
 	}
 }
 

--- a/tests/eclient/testdata/acl.txt
+++ b/tests/eclient/testdata/acl.txt
@@ -2,6 +2,12 @@
 
 {{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
 
+# source for very long domains: https://longest.domains/
+{{$long_domain := "theofficialabsolutelongestdomainnameregisteredontheworldwideweb.international"}}
+
+# non-existent domain statically assigned to an (existing public) IP address through a host file
+{{$fake_domain := "this-fake-domain-is-associated-with-zededa.com"}}
+
 [!exec:bash] stop
 [!exec:sleep] stop
 [!exec:ssh] stop
@@ -12,31 +18,72 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 1 reboot limit
 ! test eden.reboot.test -test.v -timewait 40m -reboot=0 -count=1 &
 
-# Define access only to github.com
-eden pod deploy -n curl-acl --memory=512MB docker://itmoeve/eclient:0.4 -p 2223:22 --acl=github.com
+message 'Resetting of EVE'
+eden eve reset
+exec sleep 20
 
-test eden.app.test -test.v -timewait 10m RUNNING curl-acl
+# use zededa.com IP address as a target for $fake_domain
+exec -t 10m bash dns_lookup.sh zededa.com
+# read the result of dns lookup (host_ip variable)
+source .env
+
+# Create network for which ACLs will be defined.
+eden network create 10.11.12.0/24 -n n1 -s {{$fake_domain}}:$host_ip
+test eden.network.test -test.v -timewait 10m ACTIVATED n1
+
+# First app is only allowed to access github.com and $long_domain.
+eden pod deploy -n curl-acl1 --memory=512MB docker://itmoeve/eclient:0.4 -p 2223:22 --networks=n1 --acl=n1:github.com --acl=n1:{{$long_domain}}
+# Second app is only allowed to access $long_domain and $fake_domain.
+eden pod deploy -n curl-acl2 --memory=512MB docker://itmoeve/eclient:0.4 -p 2224:22 --networks=n1 --acl=n1:{{$long_domain}} --acl=n1:{{$fake_domain}}
+
+test eden.app.test -test.v -timewait 10m RUNNING curl-acl1 curl-acl2
 
 exec -t 10m bash wait_ssh.sh 2223
+exec -t 10m bash wait_ssh.sh 2224
 
 exec sleep 10
 
-# Try to curl host we defined
+# Try to curl hosts allowed by ACLs
 exec -t 1m bash curl.sh 2223 github.com
 stderr 'Connected to github.com'
-
-# Try to curl another host
+exec -t 1m bash curl.sh 2223 {{$long_domain}}
+stderr 'Connected to {{$long_domain}}'
+! exec -t 1m bash curl.sh 2223 {{$fake_domain}}
+! stderr 'Connected'
 ! exec -t 1m bash curl.sh 2223 google.com
 ! stderr 'Connected'
 
-# Wait for network packets information information
-exec -t 10m bash wait_netstat.sh
+exec -t 1m bash curl.sh 2224 {{$long_domain}}
+stderr 'Connected to {{$long_domain}}'
+# TODO: ACLs + static DNS entries do not work together
+#exec -t 1m bash curl.sh 2224 {{$fake_domain}}
+#stderr 'Connected to {{$fake_domain}}'
+! exec -t 1m bash curl.sh 2224 github.com
+! stderr 'Connected'
+! exec -t 1m bash curl.sh 2224 google.com
+! stderr 'Connected'
+
+# Wait for network packets information
+exec -t 10m bash wait_netstat.sh curl-acl1
 stdout 'google.com'
+stdout 'github.com'
+stdout '{{$long_domain}}'
+stdout '{{$fake_domain}}'
+exec -t 10m bash wait_netstat.sh curl-acl2
+stdout 'google.com'
+stdout 'github.com'
+stdout '{{$long_domain}}'
 
-# Cleanup
-eden pod delete curl-acl
+# Cleanup - undeploy applications
+eden pod delete curl-acl1
+eden pod delete curl-acl2
+test eden.app.test -test.v -timewait 10m - curl-acl1 curl-acl2
 
-test eden.app.test -test.v -timewait 10m - curl-acl
+# Cleanup - remove network
+eden network delete n1
+test eden.network.test -test.v -timewait 10m - n1
+eden network ls
+! stdout '^n1\s'
 
 -- wait_ssh.sh --
 
@@ -53,6 +100,15 @@ do
   done
 done
 
+-- dns_lookup.sh --
+
+# Performs DNS lookup for a given hostname and adds host_ip=<ip> into the .env file
+# The script uses 'getent' command to avoid dependencies on tools like 'host', 'dig', etc.
+# Usage: dns_lookup.sh <hostname>
+
+IP=$(getent hosts $1 | head -n 1 | cut -d ' ' -f 1)
+echo host_ip=$IP>>.env
+
 -- curl.sh --
 
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
@@ -66,8 +122,8 @@ echo {{template "ssh"}}$HOST -p $1 curl -v --max-time 30 "$2"
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 
 echo "Waiting for flowlog results"
-until "$EDEN" pod logs --fields=netstat curl-acl | grep 'google.com'; do sleep 30; done
-"$EDEN" pod logs --fields=netstat curl-acl
+until "$EDEN" pod logs --fields=netstat $1 | grep 'google.com'; do sleep 30; done
+"$EDEN" pod logs --fields=netstat $1
 
 -- eden-config.yml --
 {{/* Test's config file */}}


### PR DESCRIPTION
This PR extends the `acl` test from the `eclient` test suite to cover two additional scenarios:

1. ACL with `host` match containing a very long domain name (>31 characters).
There is currently a known bug in EVE which causes the zedrouter to fail in applying of such an ACL.
Bug fix is provided by [this PR](https://github.com/lf-edge/eve/pull/2080).
Until the fix is merged and the eden is updated to test EVE with tag recent enough to include the fix, this PR will keep failing and should not be merged, hence marking as Draft.
2. A combination of a static DNS entry (added into a host file for dnsmasq to load) and an ACL with `host` match referencing domain from the static entry.
Originally, I intended to test the long domains (see 1.) using a long fake domain name mapped to an IP address of a well known stable website (instead of searching for a long domain on the Internet and relying on it). However, as I found out later, ACL referencing statically configured DNS entry doesn't work in EVE. After studying the dnsmasq source code, it became apparent that the ipsets are updated by dnsmasq only for domains for which IP addresses are learned from remote DNS servers. Therefore, if we want to support this case, we have to add IP addresses of static domain names into ipsets ourselves. I have kept this scenario in the test, although assertions that would fail because of this issue are currently commented out.
If we decide that this scenario doesn't need to be supported, I will remove it from the test.

Also, just in case I have added a second app into the test which has the same config for one of the ACLs as the first application (for the same network). In this case zedrouter has to be careful to properly reuse some of the configuration (ipsets, dnsmasq, etc.) or else the access control might not work correctly for one or both apps. Adding this test to ensure that the functionality is preserved moving forward.

Signed-off-by: Milan Lenco <milan@zededa.com>