### PR TITLE
flowlog support

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ from the list (or define multiple fields separated by the comma):
 * `log` - to view log objects
 * `info` - to view info objects
 * `metric` - to view metric objects
+* `netstat` - to view network packages counts
 * `app` - to view console output
 
 You can show only N last lines by setting of `--tail` flag.

--- a/cmd/flowlog.go
+++ b/cmd/flowlog.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/lf-edge/eden/pkg/controller"
+	"github.com/lf-edge/eden/pkg/controller/eflowlog"
+	"github.com/lf-edge/eden/pkg/utils"
+	"github.com/lf-edge/eve/api/go/flowlog"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var netStatCmd = &cobra.Command{
+	Use:   "netstat [field:regexp ...]",
+	Short: "Get logs of network packets from a running EVE device",
+	Long: `Scans the ADAM flow messages for correspondence with regular expressions to show network flow statistics
+(TCP and UDP flows with IP addresses, port numbers, counters, whether dropped or accepted)`,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		assignCobraToViper(cmd)
+		viperLoaded, err := utils.LoadConfigFile(configFile)
+		if err != nil {
+			return fmt.Errorf("error reading config: %s", err.Error())
+		}
+		if viperLoaded {
+			certsIP = viper.GetString("adam.ip")
+			adamPort = viper.GetInt("adam.port")
+			adamDist = utils.ResolveAbsPath(viper.GetString("adam.dist"))
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		ctrl, err := controller.CloudPrepare()
+		if err != nil {
+			log.Fatalf("CloudPrepare: %s", err)
+		}
+		devFirst, err := ctrl.GetDeviceCurrent()
+		if err != nil {
+			log.Fatalf("GetDeviceCurrent error: %s", err)
+		}
+		devUUID := devFirst.GetID()
+		follow, err := cmd.Flags().GetBool("follow")
+		if err != nil {
+			log.Fatalf("Error in get param 'follow'")
+		}
+
+		q := make(map[string]string)
+
+		for _, a := range args[0:] {
+			s := strings.Split(a, ":")
+			q[s[0]] = s[1]
+		}
+
+		handleFunc := func(le *flowlog.FlowMessage) bool {
+			if printFields == nil {
+				eflowlog.FlowLogPrn(le)
+			} else {
+				eflowlog.FlowLogItemPrint(le, printFields).Print()
+			}
+			return false
+		}
+
+		if logTail > 0 {
+			if err = ctrl.FlowLogChecker(devUUID, q, handleFunc, eflowlog.FlowLogTail(logTail), 0); err != nil {
+				log.Fatalf("FlowLogChecker: %s", err)
+			}
+		} else {
+			if follow {
+				// Monitoring of new files
+				if err = ctrl.FlowLogChecker(devUUID, q, handleFunc, eflowlog.FlowLogNew, 0); err != nil {
+					log.Fatalf("FlowLogChecker: %s", err)
+				}
+			} else {
+				if err = ctrl.FlowLogLastCallback(devUUID, q, handleFunc); err != nil {
+					log.Fatalf("FlowLogLastCallback: %s", err)
+				}
+			}
+		}
+	},
+}
+
+func netStatInit() {
+	netStatCmd.Flags().UintVar(&logTail, "tail", 0, "Show only last N lines")
+	netStatCmd.Flags().StringSliceVarP(&printFields, "out", "o", nil, "Fields to print. Whole message if empty.")
+	netStatCmd.Flags().BoolP("follow", "f", false, "Monitor changes in selected directory")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,8 @@ func init() {
 	infoInit()
 	rootCmd.AddCommand(logCmd)
 	logInit()
+	rootCmd.AddCommand(netStatCmd)
+	netStatInit()
 	rootCmd.AddCommand(metricCmd)
 	metricInit()
 	rootCmd.AddCommand(startCmd)

--- a/docs/adam.md
+++ b/docs/adam.md
@@ -22,15 +22,15 @@ To use `adam admin`:
 docker exec eden_adam adam admin <command>
 ```
 
-To use `redis-cli`:
+To use `redis-cli` (with password from file `~/.eden/certs/redis.pass`):
 
 ```sh
-docker exec -it eden_redis redis-cli
+docker exec -it eden_redis redis-cli -a $(cat ~/.eden/certs/redis.pass)
 ```
 
 For the redis keys, you can run `keys *` inside the redis CLI.
-Note that the `INFO_EVE_*` and `LOGS_EVE_*` keys are of type `stream`,
+Note that the `INFO_EVE_*`, `LOGS_EVE_*`, `METRICS_EVE_*` and `FLOW_MESSAGE_EVE_*` keys are of type `stream`,
 and thus you need to use `xread stream`, `xinfo stream`
 and their family of commands to read them.
 
-It may be much easier to just use `adam admin` or `eden info`/`eden logs`.
+It may be much easier to just use `adam admin` or `eden info`/`eden logs`/`eden metric`/`eden netstat`.

--- a/docs/data-from-eve.md
+++ b/docs/data-from-eve.md
@@ -1,0 +1,124 @@
+# Data flow from running EVE
+
+Eden support several commands to show information coming from EVE in raw format.
+
+## LOGS
+
+To view logs from EVE you can use the following command:
+
+```bash
+./eden log
+
+Scans the ADAM logs for correspondence with regular expressions requests to json fields.
+
+Usage:
+eden log [field:regexp ...] [flags]
+
+Flags:
+-f, --follow          Monitor changes in selected directory
+--format string   Format to print logs, supports: lines, json (default "lines")
+-h, --help            help for log
+-o, --out strings     Fields to print. Whole message if empty.
+--tail uint       Show only last N lines
+
+Global Flags:
+--config string      Name of config (default "default")
+-v, --verbosity string   Log level (debug, info, warn, error, fatal, panic (default "info")
+```
+
+For example: `eden log --tail=1 --format=json` will output something like:
+
+```bash
+{"severity":"info","source":"zedagent","iid":"1533","content":"{\"file\":\"/pillar/types/zedroutertypes.go:1044\",\"func\":\"github.com/lf-edge/eve/pkg/pillar/types.DeviceNetworkStatus.LogModify\",\"ifname\":\"eth1\",\"last-error\":\"\",\"last-failed\":\"0001-01-01T00:00:00Z\",\"last-succeeded\":\"2021-05-17T14:49:46.899694181Z\",\"level\":\"info\",\"log_event_type\":\"log\",\"msg\":\"DeviceNetworkStatus port modify\",\"obj_key\":\"devicenetwork_status-global\",\"obj_type\":\"devicenetwork_status\",\"old-last-error\":\"\",\"old-last-failed\":\"0001-01-01T00:00:00Z\",\"old-last-succeeded\":\"2021-05-17T14:44:46.824730731Z\",\"pid\":1533,\"source\":\"zedagent\",\"time\":\"2021-05-17T14:49:46.930133344Z\"}\n","msgid":3555,"timestamp":{"seconds":1621262986,"nanos":930133344},"filename":"/pillar/types/zedroutertypes.go:1044","function":"github.com/lf-edge/eve/pkg/pillar/types.DeviceNetworkStatus.LogModify"}
+```
+
+## INFO messages
+
+To view info messages from EVE you can use the following command:
+
+```bash
+./eden info
+
+Scans the ADAM Info for correspondence with regular expressions requests to json fields.
+
+Usage:
+  eden info [field:regexp ...] [flags]
+
+Flags:
+  -f, --follow        Monitor changes in selected directory
+  -h, --help          help for info
+  -o, --out strings   Fields to print. Whole message if empty.
+      --tail uint     Show only last N lines
+
+Global Flags:
+      --config string      Name of config (default "default")
+  -v, --verbosity string   Log level (debug, info, warn, error, fatal, panic (default "info")
+```
+
+For example: `eden info --tail=1` will output something like:
+
+```bash
+ztype: ZiDevice
+devId: a9ee33b7-a5f7-4a5b-b1c3-fce73fbabd6f
+[0]: ztype:ZiDevice devId:"a9ee33b7-a5f7-4a5b-b1c3-fce73fbabd6f" dinfo:{machineArch:"x86_64" cpuArch:"unknown" platform:"unknown" ncpu:4 memory:3928 storage:7369 powerCycleCounter:-1 minfo:{manufacturer:"QEMU" productName:"Standard PC (Q35 + ICH9, 2009)" version:"pc-q35-5.2" serialNumber:"31415926" UUID:"Not Settable" biosVendor:"EFI Development Kit II / OVMF" biosVersion:"0.0.0" biosReleaseDate:"02/06/2015"} network:{macAddr:"52:54:00:12:34:56" devName:"eth0" IPAddrs:"192.168.0.10" IPAddrs:"fec0::38fe:ce67:fcf7:def1" IPAddrs:"fec0::f309:dd8a:2b6b:db21" IPAddrs:"fe80::f3b:569c:ffb9:71bd" defaultRouters:"192.168.0.2" defaultRouters:"fe80::2" dns:{DNSservers:"192.168.0.3"} up:true location:{UnderlayIP:"109.71.177.101" Hostname:"101.177.smarthome.spb.ru" City:"Saint Petersburg" Country:"RU" Loc:"59.9386,30.3141" Org:"AS31376 Smart Telecom Limited" Postal:"190000"} uplink:true networkErr:{timestamp:{seconds:1621262986 nanos:903656353}} localName:"eth0" proxy:{}} network:{macAddr:"52:54:00:12:34:57" devName:"eth1" IPAddrs:"192.168.0.11" IPAddrs:"fec0::39e7:4582:e951:8836" IPAddrs:"fec0::82f6:c59:a169:efa8" IPAddrs:"fe80::5054:ff:fe12:3457" defaultRouters:"192.168.0.2" defaultRouters:"fe80::2" dns:{DNSservers:"192.168.0.3"} up:true location:{UnderlayIP:"109.71.177.101" Hostname:"101.177.smarthome.spb.ru" City:"Saint Petersburg" Country:"RU" Loc:"59.9386,30.3141" Org:"AS31376 Smart Telecom Limited" Postal:"190000"} networkErr:{timestamp:{seconds:1621262986 nanos:899694181}} localName:"eth1" proxy:{}} assignableAdapters:{type:PhyIoNetEth name:"eth0" members:"eth0" usedByBaseOS:true ioAddressList:{macAddress:"52:54:00:12:34:56"} usage:PhyIoUsageShared err:{description:"Not PCI virtio0" timestamp:{seconds:1621261186 nanos:139984208}}} assignableAdapters:{type:PhyIoNetEth name:"eth1" members:"eth1" usedByBaseOS:true ioAddressList:{macAddress:"52:54:00:12:34:57"} usage:PhyIoUsageMgmtAndApps err:{description:"Not PCI virtio1" timestamp:{seconds:1621261186 nanos:141401690}}} assignableAdapters:{type:PhyIoUSB name:"USB0" members:"USB0:1" usage:PhyIoUsageDedicated} assignableAdapters:{type:PhyIoUSB name:"USB1" members:"USB0:2" usage:PhyIoUsageDedicated} assignableAdapters:{type:PhyIoUSB name:"USB2" members:"USB0:3" usage:PhyIoUsageDedicated} assignableAdapters:{type:PhyIoUSB name:"USB3" members:"USB1:1" usage:PhyIoUsageDedicated} assignableAdapters:{type:PhyIoUSB name:"USB4" members:"USB1:2" usage:PhyIoUsageDedicated} assignableAdapters:{type:PhyIoUSB name:"USB5" members:"USB1:3" usage:PhyIoUsageDedicated} assignableAdapters:{type:PhyIoUSB name:"USB6" members:"USB2:1" usage:PhyIoUsageDedicated} assignableAdapters:{type:PhyIoUSB name:"USB7" members:"USB2:2" usage:PhyIoUsageDedicated} assignableAdapters:{type:PhyIoUSB name:"USB8" members:"USB2:3" usage:PhyIoUsageDedicated} assignableAdapters:{type:PhyIoUSB name:"USB9" members:"USB3:1" usage:PhyIoUsageDedicated} assignableAdapters:{type:PhyIoUSB name:"USB10" members:"USB3:2" usage:PhyIoUsageDedicated} assignableAdapters:{type:PhyIoUSB name:"USB11" members:"USB3:3" usage:PhyIoUsageDedicated} dns:{DNSservers:"192.168.0.3:53"} storageList:{mountPath:"/persist/vault/downloader"} storageList:{mountPath:"/persist/vault/volumes"} storageList:{mountPath:"/persist/log"} storageList:{mountPath:"/persist/vault/verifier"} storageList:{device:"sda2" total:300} storageList:{mountPath:"/persist/tmp"} storageList:{mountPath:"/persist/newlog"} storageList:{mountPath:"/persist/checkpoint"} storageList:{mountPath:"/persist/status"} storageList:{device:"sda3" total:300} storageList:{mountPath:"/persist/certs"} storageList:{device:"sda" total:8192} storageList:{device:"sda4" total:1} storageList:{device:"sda9" total:7553} storageList:{mountPath:"/persist/containerd"} storageList:{mountPath:"/config" total:1} storageList:{device:"sda1" total:36} storageList:{mountPath:"/persist/clear/volumes"} storageList:{mountPath:"/persist" total:7369 storageLocation:true} storageList:{mountPath:"/" total:1964} bootTime:{seconds:1621261079} swList:{activated:true partitionLabel:"IMGA" partitionDevice:"/dev/sda2" partitionState:"active" status:INSTALLED shortVersion:"0.0.0-master-37a88878-kvm-amd64" downloadProgress:100 userStatus:UPDATED} swList:{partitionLabel:"IMGB" partitionDevice:"/dev/sda3" partitionState:"unused" status:INITIAL} HostName:"a9ee33b7-a5f7-4a5b-b1c3-fce73fbabd6f" metricItems:{key:"lte-networks"} lastRebootReason:"NORMAL: First boot of device - at 2021-05-17T14:18:39.843661991Z" lastRebootTime:{seconds:1621261119 nanos:843661991} systemAdapter:{status:{version:1 key:"zedagent" timePriority:{seconds:1621261186 nanos:77231499} lastSucceeded:{seconds:1621262986 nanos:903707053} ports:{ifname:"eth0" name:"eth0" isMgmt:true free:true dhcpType:4 ntpServer:"<nil>" proxy:{} defaultRouters:"<nil>" dns:{} err:{timestamp:{seconds:1621262986 nanos:903656353}} usage:PhyIoUsageShared networkUUID:"6822e35f-c1b8-43ca-b344-0bbc0ece8cf1"} ports:{ifname:"eth1" name:"eth1" free:true dhcpType:4 ntpServer:"<nil>" proxy:{} defaultRouters:"<nil>" dns:{} err:{timestamp:{seconds:1621262986 nanos:899694181}} usage:PhyIoUsageMgmtAndApps networkUUID:"6822e35f-c1b8-43ca-b344-0bbc0ece8cf2"}} status:{version:1 key:"lastresort" timePriority:{} lastFailed:{seconds:1621261145 nanos:66278397} ports:{ifname:"eth0" name:"eth0" isMgmt:true free:true dhcpType:4 ntpServer:"<nil>" proxy:{} defaultRouters:"<nil>" dns:{} err:{description:"SendOnIntf to https://mydomain.adam:3333/api/v2/edgedevice/ping reqlen 0 statuscode 401 Unauthorized" timestamp:{seconds:1621261145 nanos:65604290}} usage:PhyIoUsageShared} ports:{ifname:"eth1" name:"eth1" isMgmt:true free:true dhcpType:4 ntpServer:"<nil>" proxy:{} defaultRouters:"<nil>" dns:{} err:{} usage:PhyIoUsageMgmtAndApps}}} HSMStatus:NOTFOUND HSMInfo:"Not Available" dataSecAtRestInfo:{status:DATASEC_AT_REST_DISABLED info:"TPM is either absent or not in use" vaultList:{name:"Application Data Store" status:DATASEC_AT_REST_DISABLED vaultErr:{description:"TPM is either absent or not in use" timestamp:{seconds:1621261193 nanos:163352964}}}} sec_info:{sha_root_ca:"߄[\x17'\xdd\xfe\x9fI\xedm\x00\xbcҦ\xebG\x1f\x9d\x1c\xb5rv\xf9\xf7(\x87\x84\xce[I\xec" sha_tls_root_ca:"\xbb\x14Q\xb83\\\xd0\xef\x0f\x8dnQQT\xc9MvO\x1d\xdd\x0b$\x7f^a\x99\xae;-\xee\xc90"} configItemStatus:{configItems:{key:"app.allow.vnc" value:{value:"true"}} configItems:{key:"debug.default.loglevel" value:{value:"info"}} configItems:{key:"debug.default.remote.loglevel" value:{value:"warning"}} configItems:{key:"newlog.allow.fastupload" value:{value:"true"}} configItems:{key:"timer.config.interval" value:{value:"5"}} configItems:{key:"timer.metric.interval" value:{value:"10"}}} rebootConfigCounter:1000 last_boot_reason:BOOT_REASON_FIRST hardware_watchdog_present:true capabilities:{HWAssistedVirtualization:true IOVirtualization:true}} atTimeStamp:{seconds:1621262986 nanos:961325577}
+atTimeStamp: seconds:1621262986 nanos:961325577
+```
+
+## Metrics messages
+
+To view metrics messages from EVE you can use the following command:
+
+```bash
+./eden metric
+
+Scans the ADAM metrics for correspondence with regular expressions requests to json fields.
+
+Usage:
+  eden metric [field:regexp ...] [flags]
+
+Flags:
+  -f, --follow        Monitor changes in selected metrics
+  -h, --help          help for metric
+  -o, --out strings   Fields to print. Whole message if empty.
+      --tail uint     Show only last N lines
+
+Global Flags:
+      --config string      Name of config (default "default")
+  -v, --verbosity string   Log level (debug, info, warn, error, fatal, panic (default "info")
+```
+
+For example: `eden metric --tail=1` will output something like:
+
+```bash
+DevID: a9ee33b7-a5f7-4a5b-b1c3-fce73fbabd6f     AtTimeStamp: 2021-05-17 14:56:08.096166558 +0000 UTC    Dm: memory:{usedMem:476 availMem:3452 usedPercentage:12.118126272912424 availPercentage:87.88187372708758} network:{iName:"eth0" txBytes:6748987 rxBytes:72164442 txPkts:34085 rxPkts:80542 localName:"eth0"} network:{iName:"eth1" txBytes:83686 rxBytes:92301 txPkts:486 rxPkts:430 localName:"eth1"} zedcloud:{ifName:"eth0" success:1371 lastSuccess:{seconds:1621263366 nanos:235463285} urlMetrics:{url:"https://mydomain.adam:3333/api/v2/edgedevice/id/a9ee33b7-a5f7-4a5b-b1c3-fce73fbabd6f/flowlog" sentMsgCount:1 sentByteCount:816 recvMsgCount:1 total_time_spent:9} urlMetrics:{url:"https://mydomain.adam:3333/api/v2/edgedevice/config" sentMsgCount:1 recvMsgCount:1 recvByteCount:197 total_time_spent:16} urlMetrics:{url:"https://mydomain.adam:3333/api/v2/edgedevice/uuid" sentMsgCount:1 recvMsgCount:1 recvByteCount:10 total_time_spent:8} urlMetrics:{url:"docker://index.docker.io/itmoeve/eclient@sha256:a1f26a56ef2fee1d5ee254cbda33fb7a5844f7d7e2e99668347733e88b1a1f75" sentMsgCount:1 sentByteCount:1024 recvMsgCount:1 recvByteCount:765 total_time_spent:1653} urlMetrics:{url:"docker://index.docker.io/itmoeve/eclient@sha256:c51ff6ae8403909a1cd6fcc9ec52309fbcf4b91948905d5ee6be056407c3d4f3" sentMsgCount:1 sentByteCount:1024 recvMsgCount:1 recvByteCount:1645 total_time_spent:1661} urlMetrics:{url:"docker://index.docker.io/itmoeve/eclient@sha256:f9625b9acd847c7633a8227ce4450c4a0645f83923482ef836cbe53ce1098067" sentMsgCount:1 sentByteCount:1024 recvMsgCount:1 recvByteCount:444 total_time_spent:1631} urlMetrics:{url:"https://mydomain.adam:3333/api/v2/edgedevice/id/a9ee33b7-a5f7-4a5b-b1c3-fce73fbabd6f/metrics" sentMsgCount:343 sentByteCount:2485161 recvMsgCount:343 total_time_spent:3292} urlMetrics:{url:"https://mydomain.adam:3333/api/v2/edgedevice/certs" sentMsgCount:2 recvMsgCount:2 recvByteCount:5448 total_time_spent:5} urlMetrics:{url:"docker://index.docker.io/itmoeve/eclient@sha256:a4b77138cbadd7341e855095ec7f7ff57eb7db0d0e7a5478f21cac89ab79374b" sentMsgCount:1 sentByteCount:1024 recvMsgCount:1 recvByteCount:119 total_time_spent:1614} urlMetrics:{url:"docker://index.docker.io/itmoeve/eclient@sha256:5aa46b441e6f215479a8de4fb64fef561b2103ae91d630b7214fea51c3a20a28" sentMsgCount:1 sentByteCount:1024 recvMsgCount:1 recvByteCount:158 total_time_spent:1680} urlMetrics:{url:"https://mydomain.adam:3333/api/v2/edgedevice/register" sentMsgCount:1 sentByteCount:899 recvMsgCount:1 total_time_spent:297} urlMetrics:{url:"docker://index.docker.io/itmoeve/eclient@sha256:051e2b8d242baf92d678f63b84ed4a4af5a8bc3efe11487164c1e2413190e85d" sentMsgCount:1 sentByteCount:1024 recvMsgCount:1 recvByteCount:3229 total_time_spent:1600} urlMetrics:{url:"docker://index.docker.io/itmoeve/eclient@sha256:2b61c0590645f44cde086dc05885c0fe1ae6c46f17b7e44cc16259a04520f4d6" sentMsgCount:1 sentByteCount:1024 recvMsgCount:1 recvByteCount:1039 total_time_spent:1592} urlMetrics:{url:"docker://index.docker.io/itmoeve/eclient@sha256:83ee3a23efb7c75849515a6d46551c608b255d8402a4d3753752b88e0dc188fa" sentMsgCount:1 sentByteCount:1024 recvMsgCount:1 recvByteCount:28565893 total_time_spent:5859} urlMetrics:{url:"docker://index.docker.io/itmoeve/eclient@sha256:654864fa19a37c13059f91f4f5e227d96c9ace3aaa59b53ef1d2f37a67794127" sentMsgCount:1 sentByteCount:1024 recvMsgCount:1 recvByteCount:6523 total_time_spent:1542} urlMetrics:{url:"docker://index.docker.io/itmoeve/eclient@sha256:57a7e84f11b2df67e5c485852c2dbd08c678b51ed69043152829a28216c88d9d" sentMsgCount:1 sentByteCount:1024 recvMsgCount:1 recvByteCount:36576501 total_time_spent:6659} urlMetrics:{url:"https://mydomain.adam:3333/api/v2/edgedevice/id/a9ee33b7-a5f7-4a5b-b1c3-fce73fbabd6f/config" sentMsgCount:680 sentByteCount:46713 recvMsgCount:680 recvByteCount:6830 total_time_spent:5277} urlMetrics:{url:"https://mydomain.adam:3333/api/v2/edgedevice/id/a9ee33b7-a5f7-4a5b-b1c3-fce73fbabd6f/info" sentMsgCount:237 sentByteCount:139946 recvMsgCount:237 total_time_spent:885} urlMetrics:{url:"https://mydomain.adam:3333/api/v2/edgedevice/id/a9ee33b7-a5f7-4a5b-b1c3-fce73fbabd6f/attest" sentMsgCount:3 sentByteCount:2484 recvMsgCount:3 recvByteCount:351 total_time_spent:176} urlMetrics:{url:"docker://index.docker.io/itmoeve/eclient@sha256:0d6f6830ca9a91a2707b4bdcb6d4bda90a1a81b3e5bf3ce6cf2c6b131fe7d45a" sentMsgCount:1 sentByteCount:1024 recvMsgCount:1 recvByteCount:120 total_time_spent:1556} urlMetrics:{url:"docker://index.docker.io/itmoeve/eclient@sha256:db98fc6f11f08950985a203e07755c3262c680d00084f601e7304b768c83b3b1" sentMsgCount:1 sentByteCount:1024 recvMsgCount:1 recvByteCount:843 total_time_spent:1762} urlMetrics:{url:"docker://index.docker.io/itmoeve/eclient@sha256:126ad37f6270cd8f55a9fad211a06845b805c1e7caed5dd1f2832d4007c98695" sentMsgCount:1 sentByteCount:1024 recvMsgCount:1 recvByteCount:370 total_time_spent:1693} urlMetrics:{url:"docker://index.docker.io/itmoeve/eclient@sha256:c280633a416de433f317dd64395c5669d4483dd153104367b911c7735026a38d" sentMsgCount:1 sentByteCount:1024 recvMsgCount:1 recvByteCount:3021 total_time_spent:1134} urlMetrics:{url:"docker://index.docker.io/itmoeve/eclient@sha256:f611acd52c6cad803b06b5ba932e4aabd0f2d0d5a4d050c81de2832fcb781274" sentMsgCount:1 sentByteCount:1024 recvMsgCount:1 recvByteCount:162 total_time_spent:1575} urlMetrics:{url:"https://mydomain.adam:3333/api/v2/edgedevice/id/a9ee33b7-a5f7-4a5b-b1c3-fce73fbabd6f/apps/instanceid/dbd53bf1-d7f7-4f7a-ac27-fc0621be50ba/newlogs" sentMsgCount:2 sentByteCount:4267 recvMsgCount:2 total_time_spent:20} urlMetrics:{url:"https://mydomain.adam:3333/api/v2/edgedevice/id/a9ee33b7-a5f7-4a5b-b1c3-fce73fbabd6f/newlogs" sentMsgCount:85 sentByteCount:176050 recvMsgCount:85 total_time_spent:1288}} zedcloud:{ifName:"eth1" success:5 lastSuccess:{seconds:1621261186 nanos:210610374} urlMetrics:{url:"https://mydomain.adam:3333/api/v2/edgedevice/id/a9ee33b7-a5f7-4a5b-b1c3-fce73fbabd6f/metrics" sentMsgCount:1 sentByteCount:438 recvMsgCount:1 total_time_spent:60} urlMetrics:{url:"https://mydomain.adam:3333/api/v2/edgedevice/id/a9ee33b7-a5f7-4a5b-b1c3-fce73fbabd6f/attest" sentMsgCount:1 sentByteCount:2 recvMsgCount:1 recvByteCount:123 total_time_spent:4} urlMetrics:{url:"https://mydomain.adam:3333/api/v2/edgedevice/id/a9ee33b7-a5f7-4a5b-b1c3-fce73fbabd6f/info" sentMsgCount:2 sentByteCount:6540 recvMsgCount:2 total_time_spent:12} urlMetrics:{url:"https://mydomain.adam:3333/api/v2/edgedevice/uuid" sentMsgCount:1 recvMsgCount:1 recvByteCount:10 total_time_spent:7}} disk:{mountPath:"/persist" total:7369 used:35 free:6941} disk:{mountPath:"/persist/vault/downloader"} disk:{disk:"sda4" readBytes:1 readCount:213 writeCount:25 total:1} disk:{mountPath:"/persist/log"} disk:{mountPath:"/persist/clear/volumes"} disk:{mountPath:"/persist/checkpoint"} disk:{disk:"sda2" readBytes:109 readCount:3678 total:300} disk:{mountPath:"/persist/containerd" used:1} disk:{mountPath:"/persist/certs"} disk:{mountPath:"/persist/status"} disk:{disk:"sda" readBytes:141 writeBytes:946 readCount:5308 writeCount:38181 total:8192} disk:{mountPath:"/persist/vault/verifier"} disk:{disk:"sda1" readBytes:6 readCount:503 total:36} disk:{disk:"sda9" readBytes:4 writeBytes:945 readCount:144 writeCount:37071 total:7553} disk:{disk:"sda3" readBytes:20 readCount:641 total:300} disk:{mountPath:"/" total:1964 free:1964} disk:{mountPath:"/config" total:1 free:1} disk:{mountPath:"/persist/tmp"} disk:{mountPath:"/persist/vault/volumes"} disk:{mountPath:"/persist/newlog"} cpuMetric:{upTime:{seconds:2289} total:33} runtimeStorageOverheadMB:35 systemServicesMemoryMB:{usedMem:476 availMem:3452 usedPercentage:12 availPercentage:88} cipher:{agent_name:"downloader" failure_count:4074837394752758774 last_failure:{seconds:1621261216 nanos:942838209} tc:{} tc:{error_code:CIPHER_ERROR_NOT_READY} tc:{error_code:CIPHER_ERROR_DECRYPT_FAILED} tc:{error_code:CIPHER_ERROR_UNMARSHAL_FAILED} tc:{error_code:CIPHER_ERROR_CLEARTEXT_FALLBACK} tc:{error_code:CIPHER_ERROR_MISSING_FALLBACK} tc:{error_code:CIPHER_ERROR_NO_CIPHER} tc:{error_code:CIPHER_ERROR_NO_DATA count:4074837394752758774}} acl:{} newlog:{failSentStartTime:{seconds:1621261165 nanos:962416566} currentUploadIntv:3 logfileTimeout:10 maxGzipFileSize:26968 avgGzipFileSize:2125 deviceMetrics:{numGzipBytesWrite:173710 numBytesWrite:2194978 numInputEvent:3578 numGzipFileRetry:81} appMetrics:{numGzipBytesWrite:4267 numBytesWrite:28357 numInputEvent:144 numGzipFileRetry:2} top10_input_sources:{key:"baseosmgr" value:2} top10_input_sources:{key:"domainmgr" value:2} top10_input_sources:{key:"downloader" value:13} top10_input_sources:{key:"kernel" value:5} top10_input_sources:{key:"nim" value:8} top10_input_sources:{key:"verifier" value:5} top10_input_sources:{key:"volumemgr" value:22} top10_input_sources:{key:"zedagent" value:14} top10_input_sources:{key:"zedbox" value:6} top10_input_sources:{key:"zedrouter" value:2}} zedbox:{numGoRoutines:439} last_received_config:{seconds:1621261555 nanos:513166958} last_processed_config:{seconds:1621261555 nanos:517204083}      Am: []  Nm: [networkID:"96ed0239-6ec3-4c50-88a8-650101ded47c" networkVersion:"1" instType:2 displayname:"pensive_lewin" networkStats:{rx:{} tx:{}}]   Vm: []
+```
+
+## Netstat
+
+To view network statistic messages from EVE you can use the following command:
+
+```bash
+./eden netstat
+
+Scans the ADAM flow messages for correspondence with regular expressions to show network flow statistics
+(TCP and UDP flows with IP addresses, port numbers, counters, whether dropped or accepted)
+
+Usage:
+  eden netstat [field:regexp ...] [flags]
+
+Flags:
+  -f, --follow        Monitor changes in selected directory
+  -h, --help          help for netstat
+  -o, --out strings   Fields to print. Whole message if empty.
+      --tail uint     Show only last N lines
+
+Global Flags:
+      --config string      Name of config (default "default")
+  -v, --verbosity string   Log level (debug, info, warn, error, fatal, panic (default "info")
+```
+
+For example: `eden netstat --tail=1` will output something like:
+
+```bash
+{"devId":"a9ee33b7-a5f7-4a5b-b1c3-fce73fbabd6f","scope":{"uuid":"dbd53bf1-d7f7-4f7a-ac27-fc0621be50ba","localIntf":"bn1","netInstUUID":"96ed0239-6ec3-4c50-88a8-650101ded47c"},"flows":[{"flow":{"src":"10.11.12.2","srcPort":33678,"dest":"140.82.121.3","destPort":80,"protocol":6},"aclId":1,"startTime":{"seconds":1621261310,"nanos":907129900},"endTime":{"seconds":1621261430,"nanos":141507000},"txBytes":334,"txPkts":6,"rxBytes":288,"rxPkts":5,"action":2},{"flow":{"src":"10.11.12.2","srcPort":22,"dest":"192.168.31.137","destPort":40284,"protocol":6},"inbound":true,"aclId":2,"startTime":{"seconds":1621261299,"nanos":172136400},"endTime":{"seconds":1621261419,"nanos":141512000},"txBytes":4509,"txPkts":26,"rxBytes":4947,"rxPkts":28,"action":2},{"flow":{"src":"10.11.12.2","srcPort":22,"dest":"192.168.31.137","destPort":40496,"protocol":6},"inbound":true,"aclId":2,"startTime":{"seconds":1621261309,"nanos":947387600},"endTime":{"seconds":1621261430,"nanos":141514800},"txBytes":16245,"txPkts":131,"rxBytes":9195,"rxPkts":134,"action":2},{"flow":{"src":"10.11.12.2","srcPort":33784,"dest":"173.194.73.101","destPort":80,"protocol":6},"startTime":{"seconds":1621261312,"nanos":344697600},"endTime":{"seconds":1621261447,"nanos":141518300},"txBytes":300,"txPkts":5,"action":1},{"flow":{"src":"10.11.12.2","srcPort":22,"dest":"192.168.31.137","destPort":40512,"protocol":6},"inbound":true,"aclId":2,"startTime":{"seconds":1621261311,"nanos":168963000},"endTime":{"seconds":1621261462,"nanos":141524200},"txBytes":48369,"txPkts":236,"rxBytes":13475,"rxPkts":241,"action":2}],"dnsReqs":[{"hostName":"github.com","addrs":["140.82.121.3"],"requestTime":{"seconds":1621261310,"nanos":886307600}},{"hostName":"google.com","addrs":["173.194.73.101","173.194.73.100","173.194.73.139","173.194.73.113","173.194.73.102","173.194.73.138"],"requestTime":{"seconds":1621261312,"nanos":346228200}},{"hostName":"google.com","addrs":["2a00:1450:4010:c0d::71","2a00:1450:4010:c0d::64","2a00:1450:4010:c0d::65","2a00:1450:4010:c0d::8b"],"requestTime":{"seconds":1621261312,"nanos":346235100}}]}
+```

--- a/pkg/controller/adam/adam.go
+++ b/pkg/controller/adam/adam.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/lf-edge/eden/pkg/controller/cachers"
 	"github.com/lf-edge/eden/pkg/controller/eapps"
+	"github.com/lf-edge/eden/pkg/controller/eflowlog"
 	"github.com/lf-edge/eden/pkg/controller/einfo"
 	"github.com/lf-edge/eden/pkg/controller/elog"
 	"github.com/lf-edge/eden/pkg/controller/emetric"
@@ -76,6 +77,7 @@ func (adam *Ctx) getLoader() (loader loaders.Loader) {
 				StreamLogs:    adam.getLogsRedisStream,
 				StreamInfo:    adam.getInfoRedisStream,
 				StreamMetrics: adam.getMetricsRedisStream,
+				StreamFlowLog: adam.getFlowLogRedisStream,
 				StreamRequest: adam.getRequestRedisStream,
 				StreamApps:    adam.getAppsLogsRedisStream,
 			}
@@ -224,6 +226,18 @@ func (adam *Ctx) LogLastCallback(devUUID uuid.UUID, q map[string]string, handler
 	var loader = adam.getLoader()
 	loader.SetUUID(devUUID)
 	return elog.LogLast(loader, q, handler)
+}
+
+//FlowLogChecker check FlowLogs by pattern from existence files with FlowLogLast and use FlowLogWatchWithTimeout with timeout for observe new files
+func (adam *Ctx) FlowLogChecker(devUUID uuid.UUID, q map[string]string, handler eflowlog.HandlerFunc, mode eflowlog.FlowLogCheckerMode, timeout time.Duration) (err error) {
+	return eflowlog.FlowLogChecker(adam.getLoader(), devUUID, q, handler, mode, timeout)
+}
+
+//FlowLogLastCallback check FlowLogs by pattern from existence files with callback
+func (adam *Ctx) FlowLogLastCallback(devUUID uuid.UUID, q map[string]string, handler eflowlog.HandlerFunc) (err error) {
+	var loader = adam.getLoader()
+	loader.SetUUID(devUUID)
+	return eflowlog.FlowLogLast(loader, q, handler)
 }
 
 //InfoChecker checks the information in the regular expression pattern 'query' and processes the info.ZInfoMsg found by the function 'handler' from existing files (mode=einfo.InfoExist), new files (mode=einfo.InfoNew) or any of them (mode=einfo.InfoAny) with timeout.

--- a/pkg/controller/adam/loaders.go
+++ b/pkg/controller/adam/loaders.go
@@ -30,6 +30,11 @@ func (adam *Ctx) getMetricsRedisStream(devUUID uuid.UUID) (dir string) {
 	return fmt.Sprintf("%s%s", defaults.DefaultMetricsRedisPrefix, devUUID.String())
 }
 
+//getFlowLogRedisStream return flowLog stream for devUUID for flowLog from redis
+func (adam *Ctx) getFlowLogRedisStream(devUUID uuid.UUID) (dir string) {
+	return fmt.Sprintf("%s%s", defaults.DefaultFlowLogRedisPrefix, devUUID.String())
+}
+
 //getRequestRedisStream return request stream for devUUID for requests from redis
 func (adam *Ctx) getRequestRedisStream(devUUID uuid.UUID) (dir string) {
 	return fmt.Sprintf("%s%s", defaults.DefaultRequestsRedisPrefix, devUUID.String())

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lf-edge/eden/pkg/controller/eapps"
+	"github.com/lf-edge/eden/pkg/controller/eflowlog"
 	"github.com/lf-edge/eden/pkg/controller/einfo"
 	"github.com/lf-edge/eden/pkg/controller/elog"
 	"github.com/lf-edge/eden/pkg/controller/emetric"
@@ -23,6 +24,8 @@ type Controller interface {
 	LogAppsLastCallback(devUUID uuid.UUID, appUUID uuid.UUID, q map[string]string, handler eapps.HandlerFunc) (err error)
 	LogChecker(devUUID uuid.UUID, q map[string]string, handler elog.HandlerFunc, mode elog.LogCheckerMode, timeout time.Duration) (err error)
 	LogLastCallback(devUUID uuid.UUID, q map[string]string, handler elog.HandlerFunc) (err error)
+	FlowLogChecker(devUUID uuid.UUID, q map[string]string, handler eflowlog.HandlerFunc, mode eflowlog.FlowLogCheckerMode, timeout time.Duration) (err error)
+	FlowLogLastCallback(devUUID uuid.UUID, q map[string]string, handler eflowlog.HandlerFunc) (err error)
 	InfoChecker(devUUID uuid.UUID, q map[string]string, handler einfo.HandlerFunc, mode einfo.InfoCheckerMode, timeout time.Duration) (err error)
 	InfoLastCallback(devUUID uuid.UUID, q map[string]string, handler einfo.HandlerFunc) (err error)
 	MetricChecker(devUUID uuid.UUID, q map[string]string, handler emetric.HandlerFunc, mode emetric.MetricCheckerMode, timeout time.Duration) (err error)

--- a/pkg/controller/eflowlog/eflowlog.go
+++ b/pkg/controller/eflowlog/eflowlog.go
@@ -1,0 +1,192 @@
+//Package eflowlog provides primitives for searching and processing data
+//in FlowMessage files.
+package eflowlog
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/lf-edge/eden/pkg/controller/loaders"
+	"github.com/lf-edge/eden/pkg/controller/types"
+	"github.com/lf-edge/eden/pkg/utils"
+	"github.com/lf-edge/eve/api/go/flowlog"
+	uuid "github.com/satori/go.uuid"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+//FlowLogCheckerMode is FlowLogExist, FlowLogNew and FlowLogAny
+type FlowLogCheckerMode int
+
+//FlowLogTail returns FlowLogCheckerMode for process only defined count of last messages
+func FlowLogTail(count uint) FlowLogCheckerMode {
+	return FlowLogCheckerMode(count)
+}
+
+// FlowLogChecker modes FlowLogExist, FlowLogNew and FlowLogAny.
+const (
+	FlowLogExist FlowLogCheckerMode = -3 // just look to existing files
+	FlowLogNew   FlowLogCheckerMode = -2 // wait for new files
+	FlowLogAny   FlowLogCheckerMode = -1 // use both mechanisms
+)
+
+//ParseFullLogEntry unmarshal FlowMessage
+func ParseFullLogEntry(data []byte) (*flowlog.FlowMessage, error) {
+	var lb flowlog.FlowMessage
+	err := protojson.Unmarshal(data, &lb)
+	return &lb, err
+}
+
+//FlowLogItemPrint find FlowMessage elements by paths in 'query'
+func FlowLogItemPrint(le *flowlog.FlowMessage, query []string) *types.PrintResult {
+	result := make(types.PrintResult)
+	for _, v := range query {
+		// Uppercase of filed's name first letter
+		var n []string
+		for _, pathElement := range strings.Split(v, ".") {
+			n = append(n, strings.Title(pathElement))
+		}
+		var clb = func(inp reflect.Value) {
+			f := fmt.Sprint(inp)
+			result[v] = append(result[v], f)
+		}
+		utils.LookupWithCallback(reflect.Indirect(reflect.ValueOf(le)).Interface(), strings.Join(n, "."), clb)
+	}
+	return &result
+}
+
+//FlowLogItemFind find FlowMessage records by reqexps in 'query' corresponded to FlowMessage structure.
+func FlowLogItemFind(le *flowlog.FlowMessage, query map[string]string) bool {
+	matched := true
+	for k, v := range query {
+		// Uppercase of filed's name first letter
+		var n []string
+		for _, pathElement := range strings.Split(k, ".") {
+			n = append(n, strings.Title(pathElement))
+		}
+		var clb = func(inp reflect.Value) {
+			f := fmt.Sprint(inp)
+			newMatched, err := regexp.Match(v, []byte(f))
+			if err != nil {
+				log.Debug(err)
+			}
+			if !matched && newMatched {
+				matched = newMatched
+			}
+		}
+		matched = false
+		utils.LookupWithCallback(reflect.Indirect(reflect.ValueOf(le)).Interface(), strings.Join(n, "."), clb)
+		if !matched {
+			return matched
+		}
+	}
+	return matched
+}
+
+//HandleFactory implements HandlerFunc which prints log in the provided format
+func HandleFactory(once bool) HandlerFunc {
+	return func(le *flowlog.FlowMessage) bool {
+		FlowLogPrn(le)
+		return once
+	}
+}
+
+//FlowLogPrn print FlowMessage data
+func FlowLogPrn(le *flowlog.FlowMessage) {
+	enc := json.NewEncoder(os.Stdout)
+	_ = enc.Encode(le)
+}
+
+//HandlerFunc must process FlowMessage and return true to exit
+//or false to continue
+type HandlerFunc func(*flowlog.FlowMessage) bool
+
+func flowLogProcess(query map[string]string, handler HandlerFunc) loaders.ProcessFunction {
+	devID, ok := query["devId"]
+	if ok {
+		delete(query, "devId")
+	}
+	_, ok = query["eveVersion"]
+	if ok {
+		delete(query, "eveVersion")
+	}
+	return func(bytes []byte) (bool, error) {
+		lb, err := ParseFullLogEntry(bytes)
+		if err != nil {
+			return true, nil
+		}
+		if devID != "" && devID != lb.DevId {
+			return true, nil
+		}
+		if FlowLogItemFind(lb, query) {
+			if handler(lb) {
+				return false, nil
+			}
+		}
+		return true, nil
+	}
+}
+
+//FlowLogWatch monitors the change of FlowLog files in the 'filepath' directory
+//according to the 'query' reqexps and processing using the 'handler' function.
+func FlowLogWatch(loader loaders.Loader, query map[string]string, handler HandlerFunc, timeoutSeconds time.Duration) error {
+	return loader.ProcessStream(flowLogProcess(query, handler), types.FlowLogType, timeoutSeconds)
+}
+
+//FlowLogLast function process FlowLog files in the 'filepath' directory
+//according to the 'query' reqexps and return last founded item
+func FlowLogLast(loader loaders.Loader, query map[string]string, handler HandlerFunc) error {
+	return loader.ProcessExisting(flowLogProcess(query, handler), types.FlowLogType)
+}
+
+//FlowLogChecker check logs by pattern from existence files with FlowLogLast and use FlowLogWatchWithTimeout with timeout for observe new files
+func FlowLogChecker(loader loaders.Loader, devUUID uuid.UUID, q map[string]string, handler HandlerFunc, mode FlowLogCheckerMode, timeout time.Duration) (err error) {
+	loader.SetUUID(devUUID)
+	done := make(chan error)
+
+	// observe new files
+	if mode == FlowLogNew || mode == FlowLogAny {
+		go func() {
+			done <- FlowLogWatch(loader.Clone(), q, handler, timeout)
+		}()
+	}
+	// check FlowLog by pattern in existing files
+	if mode == FlowLogExist || mode == FlowLogAny {
+		go func() {
+			handler := func(item *flowlog.FlowMessage) (result bool) {
+				if result = handler(item); result {
+					done <- nil
+				}
+				return
+			}
+			done <- FlowLogLast(loader.Clone(), q, handler)
+		}()
+	}
+	// use for process only defined count of last messages
+	if mode > 0 {
+		logQueue := utils.InitQueueWithCapacity(int(mode))
+		handlerLocal := func(item *flowlog.FlowMessage) (result bool) {
+			if err = logQueue.Enqueue(item); err != nil {
+				done <- err
+			}
+			return false
+		}
+		if err = FlowLogLast(loader.Clone(), q, handlerLocal); err != nil {
+			done <- err
+		}
+		el, err := logQueue.Dequeue()
+		for err == nil {
+			if result := handler(el.(*flowlog.FlowMessage)); result {
+				return nil
+			}
+			el, err = logQueue.Dequeue()
+		}
+		return nil
+	}
+	return <-done
+}

--- a/pkg/controller/loaders/fileLoader.go
+++ b/pkg/controller/loaders/fileLoader.go
@@ -50,6 +50,8 @@ func (loader *FileLoader) getFilePath(typeToProcess types.LoaderObjectType) stri
 		return loader.getters.InfoGetter(loader.devUUID)
 	case types.MetricsType:
 		return loader.getters.MetricsGetter(loader.devUUID)
+	case types.FlowLogType:
+		return loader.getters.FlowLogGetter(loader.devUUID)
 	case types.RequestType:
 		return loader.getters.RequestGetter(loader.devUUID)
 	case types.AppsType:

--- a/pkg/controller/loaders/redisLoader.go
+++ b/pkg/controller/loaders/redisLoader.go
@@ -64,6 +64,8 @@ func (loader *RedisLoader) getStream(typeToProcess types.LoaderObjectType) strin
 		return loader.streamGetters.StreamInfo(loader.devUUID)
 	case types.MetricsType:
 		return loader.streamGetters.StreamMetrics(loader.devUUID)
+	case types.FlowLogType:
+		return loader.streamGetters.StreamFlowLog(loader.devUUID)
 	case types.RequestType:
 		return loader.streamGetters.StreamRequest(loader.devUUID)
 	case types.AppsType:

--- a/pkg/controller/loaders/remoteLoader.go
+++ b/pkg/controller/loaders/remoteLoader.go
@@ -80,6 +80,8 @@ func (loader *RemoteLoader) getURL(typeToProcess types.LoaderObjectType) string 
 		return loader.urlGetters.URLInfo(loader.devUUID)
 	case types.MetricsType:
 		return loader.urlGetters.URLMetrics(loader.devUUID)
+	case types.FlowLogType:
+		return loader.urlGetters.URLFlowLog(loader.devUUID)
 	case types.RequestType:
 		return loader.urlGetters.URLRequest(loader.devUUID)
 	case types.AppsType:

--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -68,6 +68,7 @@ type DirGetters struct {
 	LogsGetter    getDir
 	InfoGetter    getDir
 	MetricsGetter getDir
+	FlowLogGetter getDir
 	RequestGetter getDir
 	AppsGetter    getDirApps
 }
@@ -81,6 +82,7 @@ type StreamGetters struct {
 	StreamLogs    getStream
 	StreamInfo    getStream
 	StreamMetrics getStream
+	StreamFlowLog getStream
 	StreamRequest getStream
 	StreamApps    getStreamApps
 }
@@ -94,6 +96,7 @@ type URLGetters struct {
 	URLLogs    getURL
 	URLInfo    getURL
 	URLMetrics getURL
+	URLFlowLog getURL
 	URLRequest getURL
 	URLApps    getURLApps
 }
@@ -115,6 +118,9 @@ var RequestType LoaderObjectType = 4
 
 //AppsType for observe logs of apps
 var AppsType LoaderObjectType = 5
+
+//FlowLogType for observe FlowMessages
+var FlowLogType LoaderObjectType = 6
 
 //APIRequest stores information about requests from EVE
 type APIRequest struct {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -49,7 +49,7 @@ const (
 
 	//tags, versions, repos
 	DefaultEVETag               = "0.0.0-master-37a88878" //DefaultEVETag tag for EVE image
-	DefaultAdamTag              = "0.0.22"
+	DefaultAdamTag              = "0.0.24"
 	DefaultRedisTag             = "6"
 	DefaultRegistryTag          = "2.7"
 	DefaultProcTag              = "1.2"
@@ -103,6 +103,7 @@ const (
 	DefaultInfoRedisPrefix       = "INFO_EVE_"
 	DefaultMetricsRedisPrefix    = "METRICS_EVE_"
 	DefaultRequestsRedisPrefix   = "REQUESTS_EVE_"
+	DefaultFlowLogRedisPrefix    = "FLOW_MESSAGE_EVE_"
 
 	DefaultEveLogLevel  = "info"    //min level of logs saved in files on EVE device
 	DefaultAdamLogLevel = "warning" //min level of logs sent from EVE to Adam

--- a/pkg/expect/networkInstance.go
+++ b/pkg/expect/networkInstance.go
@@ -154,7 +154,7 @@ func parseACE(inp string) *config.ACE {
 func (exp *AppExpectation) getAcls(ni *NetInstanceExpectation) []*config.ACE {
 	var acls []*config.ACE
 	var aclID int32 = 1
-	if exp.acl != nil && len(exp.acl[ni.name]) > 0 {
+	if exp.acl != nil && (len(exp.acl[ni.name]) > 0 || len(exp.acl[""]) > 0) {
 		// in case of defined acl allow access only to them
 		for netName, acl := range exp.acl {
 			if netName != "" && netName != ni.name {

--- a/pkg/projects/testContext.go
+++ b/pkg/projects/testContext.go
@@ -270,6 +270,11 @@ func (tc *TestContext) AddProcLog(edgeNode *device.Ctx, processFunction ProcLogF
 	tc.procBus.addProc(edgeNode, processFunction)
 }
 
+//AddProcFlowLog add processFunction, that will get all FlowLogs for edgeNode
+func (tc *TestContext) AddProcFlowLog(edgeNode *device.Ctx, processFunction ProcLogFlowFunc) {
+	tc.procBus.addProc(edgeNode, processFunction)
+}
+
 //AddProcInfo add processFunction, that will get all info for edgeNode
 func (tc *TestContext) AddProcInfo(edgeNode *device.Ctx, processFunction ProcInfoFunc) {
 	tc.procBus.addProc(edgeNode, processFunction)

--- a/tests/eclient/testdata/acl.txt
+++ b/tests/eclient/testdata/acl.txt
@@ -29,6 +29,11 @@ stderr 'Connected to github.com'
 ! exec -t 1m bash curl.sh 2223 google.com
 ! stderr 'Connected'
 
+# Wait for network packets information information
+exec -t 10m bash wait_netstat.sh
+stdout 'google.com'
+
+# Cleanup
 eden pod delete curl-acl
 
 test eden.app.test -test.v -timewait 10m - curl-acl
@@ -55,6 +60,14 @@ HOST=$($EDEN eve ip)
 
 echo {{template "ssh"}}$HOST -p $1 curl -v --max-time 30 "$2"
 {{template "ssh"}}$HOST -p $1 curl -v --max-time 30 "$2"
+
+-- wait_netstat.sh --
+#!/bin/sh
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+echo "Waiting for flowlog results"
+until "$EDEN" pod logs --fields=netstat curl-acl | grep 'google.com'; do sleep 30; done
+"$EDEN" pod logs --fields=netstat curl-acl
 
 -- eden-config.yml --
 {{/* Test's config file */}}


### PR DESCRIPTION
Support flowlog command in Eden to show network flow statistics (TCP and UDP flows with IP addresses, port numbers, counters, whether dropped or accepted),

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>