### PR TITLE
wait for certs during onboard

### DIFF
--- a/pkg/controller/functions.go
+++ b/pkg/controller/functions.go
@@ -142,6 +142,10 @@ func (cloud *CloudCtx) OnBoardDev(node *device.Ctx) error {
 				if err = cloud.ConfigSync(node); err != nil {
 					log.Fatal(err)
 				}
+				//wait for certs
+				if _, err = cloud.CertsGet(node.GetID()); err != nil {
+					log.Fatal(err)
+				}
 			}
 			return nil
 		}


### PR DESCRIPTION
Seems, we need to wait for certificates during onboard before calling reset in our workflow.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>