### PR TITLE
[ arm ] equinix metal hosting scripts for automate tests

### DIFF
--- a/.github/workflows/eden_emh_arm.yml
+++ b/.github/workflows/eden_emh_arm.yml
@@ -1,5 +1,5 @@
 ---
-name: EdenPacketARM
+name: EdenEMH_ARM
 on:  # yamllint disable-line rule:truthy
   push:
     branches: [master]
@@ -21,7 +21,7 @@ jobs:
           sudo apt install -y golang jq expect
       - name: Get eden
         uses: actions/checkout@v2
-      - name: Create ubuntu on packet hosting
+      - name: Create ubuntu server on packet hosting
         id: ubuntu
         run: |
           packet_ubuntu_id=$(./shell-scripts/packet/create.sh ${{ matrix.conf_eden_server }} -p "$PACKET_PROJECT" -ns gh-action -os ubuntu_18_04)
@@ -36,7 +36,7 @@ jobs:
         env:
           PACKET_TOKEN: ${{ secrets.PACKET_TOKEN }}
           PACKET_PROJECT: ${{ secrets.PACKET_PROJECT }}
-      - name: Create ssh key
+      - name: Create SSH key
         run: |
           mkdir -p ~/.ssh/keys/
           echo "$SSH_PRIVATE_KEY" > "$SSH_KEY_PATH"
@@ -49,7 +49,7 @@ jobs:
           SSH_PASSPHRASE: ${{secrets.PACKET_SSH_PASSPHRASE}}
           SSH_KEY_PATH: ${{ github.workspace }}/../private.key
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-      - name: Install Dependencies to packet EDEN server
+      - name: Install Dependencies to packet ubuntu server for EDEN
         run: |
           ssh root@${{steps.ubuntu.outputs.ip}} 'sudo apt-get update && sudo apt-get remove docker docker-engine docker.io containerd runc'
           ssh root@${{steps.ubuntu.outputs.ip}} 'sudo apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release'
@@ -60,7 +60,7 @@ jobs:
           ssh root@${{steps.ubuntu.outputs.ip}} 'sudo add-apt-repository ppa:longsleep/golang-backports && sudo apt install -y golang'
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-      - name: Get and setup EDEN on packet
+      - name: Get and setup EDEN on ubuntu packet server
         run: |
           ssh root@${{steps.ubuntu.outputs.ip}} 'sudo rm -rf ~/eden'
           ssh root@${{steps.ubuntu.outputs.ip}} 'git clone https://github.com/lf-edge/eden.git && cd eden && git checkout '"$GITHUB_SHA"
@@ -71,7 +71,7 @@ jobs:
           ssh root@${{steps.ubuntu.outputs.ip}} 'cd eden && ./eden start'
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-      - name: Create EVE on packet
+      - name: Create EVE server on packet hosting
         id: eve
         run: |
           device_id=$(ssh root@${{steps.ubuntu.outputs.ip}} 'cd eden && export PACKET_TOKEN='"$PACKET_TOKEN"' && ./shell-scripts/packet/create-eve.sh'" ${{ matrix.conf_eve_server }} -p $PACKET_PROJECT"' -ns eve-gh-action')

--- a/.github/workflows/eden_packet_arm.yml
+++ b/.github/workflows/eden_packet_arm.yml
@@ -1,0 +1,116 @@
+---
+name: EdenPacketARM
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: [master]
+# yamllint disable rule:line-length
+jobs:
+  integration:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        conf_eden_server: ["-l dfw2 -c c2.large.arm"]
+        conf_eve_server: ["-l dfw2 -c c2.large.arm"]
+        hv: ["kvm"]
+    steps:
+      - name: Setup packages
+        run: |
+          sudo rm -rf /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/microsoft-prod.list.save
+          sudo add-apt-repository ppa:longsleep/golang-backports
+          sudo apt install -y golang jq expect
+      - name: Get eden
+        uses: actions/checkout@v2
+      - name: Create ubuntu on packet hosting
+        id: ubuntu
+        run: |
+          packet_ubuntu_id=$(./shell-scripts/packet/create.sh ${{ matrix.conf_eden_server }} -p "$PACKET_PROJECT" -ns gh-action -os ubuntu_18_04)
+          packet_ubuntu_ip=$(./shell-scripts/packet/wait-eth0.sh $packet_ubuntu_id 100)
+          echo "Packet server ID: ${packet_ubuntu_id}"
+          echo "Packet server IP: ${packet_ubuntu_ip}"
+          echo "::set-output name=id::$packet_ubuntu_id"
+          echo "::set-output name=ip::$packet_ubuntu_ip"
+          echo "Waiting for the deployment to complete"
+          ./shell-scripts/packet/wait-provisioning.sh $packet_ubuntu_id
+          sleep 100
+        env:
+          PACKET_TOKEN: ${{ secrets.PACKET_TOKEN }}
+          PACKET_PROJECT: ${{ secrets.PACKET_PROJECT }}
+      - name: Create ssh key
+        run: |
+          mkdir -p ~/.ssh/keys/
+          echo "$SSH_PRIVATE_KEY" > "$SSH_KEY_PATH"
+          sudo chmod 600 "$SSH_KEY_PATH"
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ./shell-scripts/packet/ssh-add.sh "$SSH_KEY_PATH" "$SSH_PASSPHRASE"
+          ssh-keyscan -H ${{steps.ubuntu.outputs.ip}} > ~/.ssh/known_hosts
+        env:
+          SSH_PRIVATE_KEY: ${{secrets.PACKET_SSH_KEY}}
+          SSH_PASSPHRASE: ${{secrets.PACKET_SSH_PASSPHRASE}}
+          SSH_KEY_PATH: ${{ github.workspace }}/../private.key
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      - name: Install Dependencies to packet EDEN server
+        run: |
+          ssh root@${{steps.ubuntu.outputs.ip}} 'sudo apt-get update && sudo apt-get remove docker docker-engine docker.io containerd runc'
+          ssh root@${{steps.ubuntu.outputs.ip}} 'sudo apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release'
+          ssh root@${{steps.ubuntu.outputs.ip}} 'curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --no-tty --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg'
+          ssh root@${{steps.ubuntu.outputs.ip}} 'echo "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null'
+          ssh root@${{steps.ubuntu.outputs.ip}} 'sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io'
+          ssh root@${{steps.ubuntu.outputs.ip}} 'sudo apt-get install -y jq make git expect qemu binfmt-support qemu-user-static qemu-utils qemu-system-x86 qemu-system-aarch64'
+          ssh root@${{steps.ubuntu.outputs.ip}} 'sudo add-apt-repository ppa:longsleep/golang-backports && sudo apt install -y golang'
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      - name: Get and setup EDEN on packet
+        run: |
+          ssh root@${{steps.ubuntu.outputs.ip}} 'sudo rm -rf ~/eden'
+          ssh root@${{steps.ubuntu.outputs.ip}} 'git clone https://github.com/lf-edge/eden.git && cd eden && git checkout '"$GITHUB_SHA"
+          ssh root@${{steps.ubuntu.outputs.ip}} 'cd eden && make clean && make build && make build-tests'
+          ssh root@${{steps.ubuntu.outputs.ip}} 'cd eden && ./eden config add --devmodel=general --arch=arm64'
+          ssh root@${{steps.ubuntu.outputs.ip}} 'cd eden && ./eden config set default --key eve.hv --value='"${{ matrix.hv }}"
+          ssh root@${{steps.ubuntu.outputs.ip}} 'cd eden && ./eden setup -v debug --netboot=true'
+          ssh root@${{steps.ubuntu.outputs.ip}} 'cd eden && ./eden start'
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      - name: Create EVE on packet
+        id: eve
+        run: |
+          device_id=$(ssh root@${{steps.ubuntu.outputs.ip}} 'cd eden && export PACKET_TOKEN='"$PACKET_TOKEN"' && ./shell-scripts/packet/create-eve.sh'" ${{ matrix.conf_eve_server }} -p $PACKET_PROJECT"' -ns eve-gh-action')
+          device_ip=$(ssh root@${{steps.ubuntu.outputs.ip}} 'cd eden && export PACKET_TOKEN='"$PACKET_TOKEN"' && ./shell-scripts/packet/wait-eth0.sh '"$device_id"' 200')
+          echo "Packet EVE ID: $device_id"
+          echo "Packet EVE IP: $device_ip"
+          echo "::set-output name=id::$device_id"
+          echo "Waiting for the deployment to complete"
+          ssh root@${{steps.ubuntu.outputs.ip}} 'cd eden && export PACKET_TOKEN='"$PACKET_TOKEN"' && ./shell-scripts/packet/wait-provisioning.sh '"$device_id"
+          sleep 100
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+          PACKET_TOKEN: ${{ secrets.PACKET_TOKEN }}
+          PACKET_PROJECT: ${{ secrets.PACKET_PROJECT }}
+      - name: Onboard EVE and run test
+        run: |
+          ssh root@${{steps.ubuntu.outputs.ip}} 'cd eden && ./eden eve onboard'
+          ssh root@${{steps.ubuntu.outputs.ip}} 'cd eden && EDEN_TEST=gcp EDEN_TEST_REGISTRY=n ./eden test tests/workflow -v debug'
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      - name: Collect logs
+        if: ${{ always() }}
+        run: |
+          ssh root@${{steps.ubuntu.outputs.ip}} 'cd eden && ./eden log --format json' > trace.log
+          ssh root@${{steps.ubuntu.outputs.ip}} 'cd eden && ./eden info' > info.log
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      - name: Terminate packet servers
+        if: ${{ always() }}
+        run: |
+          ./shell-scripts/packet/delete.sh ${{steps.ubuntu.outputs.id}}
+          ./shell-scripts/packet/delete.sh ${{steps.eve.outputs.id}}
+        env:
+          PACKET_TOKEN: ${{ secrets.PACKET_TOKEN }}
+      - name: Store raw test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: eden-packet${{ matrix.conf_eden_server }}---eve-packet${{ matrix.conf_eve_server }}-${{ matrix.hv }}
+          path: |
+            ${{ github.workspace }}/trace.log
+            ${{ github.workspace }}/info.log

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ endif
 $(LOCALBIN): $(BINDIR) cmd/*.go pkg/*/*.go pkg/*/*/*.go
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -ldflags "-s -w" -o $@ .
 	mkdir -p dist/scripts/shell
-	cp shell-scripts/* dist/scripts/shell/
+	cp -r shell-scripts/* dist/scripts/shell/
 
 $(BIN): $(LOCALBIN)
 	ln -sf $(BIN)-$(OS)-$(ARCH) $(BINDIR)/$@

--- a/shell-scripts/packet/create-eve.sh
+++ b/shell-scripts/packet/create-eve.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+EDEN_DIR=$SCRIPT_DIR/../../
+
+function eden_get_ipxe_cfg_url() {
+  if ! [ -f "$EDEN_DIR"/dist/default-images/eve/tftp/ipxe.efi.cfg ]; then
+    exit 1
+  fi
+
+  set_url_str=$(< "$EDEN_DIR"/dist/default-images/eve/tftp/ipxe.efi.cfg grep "set url")
+  echo "${set_url_str/"set url "/""}ipxe.efi.cfg"
+}
+
+ipxe_cfg_url=$(eden_get_ipxe_cfg_url)
+if [ -z "$ipxe_cfg_url" ]; then
+  fail "First, configure eden for network boot"
+fi
+
+"$SCRIPT_DIR"/create.sh "$@" -os custom_ipxe -ipxe "$ipxe_cfg_url"

--- a/shell-scripts/packet/create.sh
+++ b/shell-scripts/packet/create.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+while true; do
+   case "$1" in
+      -l*) #shellcheck disable=SC2039
+          location="${1/-l/}"
+          if [ -z "$location" ]; then
+             location="$2"
+             shift
+          fi
+          shift
+          ;;
+      -c*) #shellcheck disable=SC2039
+          server_conf="${1/-c/}"
+          if [ -z "$server_conf" ]; then
+             server_conf="$2"
+             shift
+          fi
+          shift
+          ;;
+       -p*) #shellcheck disable=SC2039
+          project="${1/-p/}"
+          if [ -z "$project" ]; then
+             project="$2"
+             shift
+          fi
+          shift
+          ;;
+       -ns*) #shellcheck disable=SC2039
+          name_suffix="${1/-ns/}"
+          if [ -z "$name_suffix" ]; then
+             name_suffix="$2"
+             shift
+          fi
+          shift
+          ;;
+       -os*) #shellcheck disable=SC2039
+          os="${1/-os/}"
+          if [ -z "$os" ]; then
+             os="$2"
+             shift
+          fi
+          shift
+          ;;
+      -ipxe*) #shellcheck disable=SC2039
+          ipxe_cfg_url="${1/-ipxe/}"
+          if [ -z "$ipxe_cfg_url" ]; then
+             ipxe_cfg_url="$2"
+             shift
+          fi
+          shift
+          ;;
+       *) break
+          ;;
+   esac
+done
+
+function fail() { echo "ERROR: packet: $*" 1>&2; echo "00000000-0000-0000-0000-000000000000"; exit 1; }
+
+help_text=$(cat << __EOT__
+Usage: create.sh -l <location> -c <server configuration> -p <packet project id> -os <packet os> [OPTIONS]
+
+OPTIONS:
+   -ns <string>
+      Name suffix for packet server.
+   -ipxe <string>
+      Url to ipxe cfg. Setup only if os param - custom_ipxe.
+
+Create packet server with name eden-<name suffix>-<location>-<conf>. Returns the id of the created packet server to the stdout or 00000000-0000-0000-0000-000000000000
+as server id on create fail.
+------------------------------------------------------------------------------------------------------
+__EOT__
+)
+
+function packet-cli() {
+   if [ -e "$HOME"/go/bin/packet-cli ]; then
+     "$HOME"/go/bin/packet-cli "$@"
+   else
+      "$GOPATH"/bin/packet-cli "$@"
+   fi
+}
+
+function packet_cli_create_device() {
+  counter_create=${1:-0}
+  packet_id=$(packet-cli -j device create -f "$location" \
+        -H eden-"$name_suffix"-"$location"-"$server_conf" \
+        -P "$server_conf" -p "$project" \
+        -o "$os" "$ipxe" | \
+        jq -r '.["id"]?')
+  if echo "$packet_id" | grep -q "null" || [ -z "$packet_id" ]; then
+    if [ "$counter_create" -gt "10" ]; then
+      fail "packet-cli thrown an error while creating"
+    fi
+    sleep 10
+    packet_cli_create_device $((counter_create + 1))
+  else
+    echo "$packet_id"
+  fi
+}
+
+if [ -z "$location" ] || [ -z "$server_conf" ] || [ -z "$project" ] || [ -z "$os" ]; then
+  fail "$help_text"
+fi
+
+if [ "$PACKET_TOKEN" = "" ]; then
+  fail "PACKET_TOKEN is empty, please set token"
+fi;
+
+ipxe=""
+if [ -n "$ipxe_cfg_url" ]; then
+   if ! [ "$os" = "custom_ipxe" ]; then
+      fail "You can't setup -ipxe with $os"
+   fi
+   ipxe="-i $ipxe_cfg_url"
+fi
+
+"$SCRIPT_DIR"/tools/cli-prepare.sh
+packet_cli_create_device

--- a/shell-scripts/packet/delete.sh
+++ b/shell-scripts/packet/delete.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+device_id=$1
+
+fail() { echo -e "ERROR: packet: $*" 1>&2; exit 1; }
+
+help_text=$(cat << __EOT__
+Usage: delete.sh <packet server id>
+
+Delete packet server by id.
+__EOT__
+)
+
+function packet-cli() {
+   if [ -e "$HOME"/go/bin/packet-cli ]; then
+     "$HOME"/go/bin/packet-cli "$@"
+   else
+      "$GOPATH"/bin/packet-cli "$@"
+   fi
+}
+
+function packet_cli_terminate_device() {
+    packet-cli -j device delete -f -i "$device_id"
+}
+
+if [ -z "$device_id" ]; then
+  fail "$help_text"
+fi
+
+packet_cli_terminate_device

--- a/shell-scripts/packet/ssh-add.sh
+++ b/shell-scripts/packet/ssh-add.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/expect -f
+set key_file [lindex $argv 0]
+set passphrase [lindex $argv 1]
+spawn ssh-add $key_file
+expect "Enter passphrase for $key_file:"
+send "$passphrase\n";
+expect "Identity added: $key_file"
+interact

--- a/shell-scripts/packet/tools/cli-prepare.sh
+++ b/shell-scripts/packet/tools/cli-prepare.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+function packet_cli_get() {
+    if ! [ -e "$HOME"/go/bin/packet-cli ] && ! [ -e "$GOPATH"/bin/packet-cli ]; then
+        GO111MODULE=on go get github.com/packethost/packet-cli
+    fi
+}
+
+packet_cli_get

--- a/shell-scripts/packet/wait-eth0.sh
+++ b/shell-scripts/packet/wait-eth0.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+device_id=$1
+repeat_count=$2
+
+fail() { echo "ERROR: packet: $*" 1>&2; exit 1; }
+
+help_text=$(cat << __EOT__
+Usage: wait-eth0.sh <packet server id> <repeat count>
+
+Attempts to get the ip of first internet adapter, with the specified number of attempts.
+There is a 10 second break between attempts to get ip.
+
+Returns the ip of th packet server to the stdout or 0.0.0.0 on fail.
+__EOT__
+)
+
+function packet-cli() {
+   if [ -e "$HOME"/go/bin/packet-cli ]; then
+     "$HOME"/go/bin/packet-cli "$@"
+   else
+      "$GOPATH"/bin/packet-cli "$@"
+   fi
+}
+
+function packet_cli_get_ip() {
+    counter_ip=${1:-0}
+    packet_server_info=$(packet-cli -j device get -i "$device_id")
+    packet_ip=$(echo "$packet_server_info" | jq -r '.ip_addresses[0]."address"?')
+    if echo "$packet_ip" | grep -q "null" || [ -z "$packet_ip" ]; then
+        if [ "$counter_ip" -gt "$repeat_count" ]; then
+            echo "0.0.0.0"
+            exit 1
+        fi
+        sleep 10
+        packet_cli_get_ip $((counter_ip + 1))
+    else
+        echo "$packet_ip"
+    fi
+}
+
+if [ -z "$device_id" ]; then
+  fail "$help_text"
+fi
+
+packet_cli_get_ip

--- a/shell-scripts/packet/wait-provisioning.sh
+++ b/shell-scripts/packet/wait-provisioning.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+device_id=$1
+timeout=${2:-1800}
+
+fail() { echo "ERROR: packet: $*" 1>&2; exit 1; }
+
+help_text=$(cat << __EOT__
+Usage: wait-provisioning.sh <packet server id> <timeout>
+
+A script awaiting provisioning to complete.
+__EOT__
+)
+
+function packet-cli() {
+   if [ -e "$HOME"/go/bin/packet-cli ]; then
+     "$HOME"/go/bin/packet-cli "$@"
+   else
+      "$GOPATH"/bin/packet-cli "$@"
+   fi
+}
+
+function packet_cli_wait_provisioning() {
+    time=${1:-0}
+    packet_server_info=$(packet-cli -j device get -i "$device_id")
+    packet_state=$(echo "$packet_server_info" | jq -r '.state')
+    if echo "$packet_state" | grep -q "null" || [ -z "$packet_state" ] || echo "$packet_state" | grep -q "provisioning"; then
+        if [ "$time" -gt "$timeout" ]; then
+            exit 1
+        fi
+        sleep 10
+        packet_cli_wait_provisioning $((time + 14))
+    fi
+}
+
+if [ -z "$device_id" ]; then
+  fail "$help_text"
+fi
+
+packet_cli_wait_provisioning


### PR DESCRIPTION
A few words about work: 

There is a server hosting https://www.packet.com/ that has several servers that we support. These scripts will help us automate their testing with Github Actions.

## Enviroment params
For workflow and scripts to work successfully, you need to set the environment variables:

PACKET_SSH_KEY - private key for connecting via ssh to packet servers.
PACKET_SSH_PASSPHRASE - The password for the private key.
PACKET_TOKEN - Token for the Packet API.
PACKET_PROJECT - id(in GUID format) of the Packet project.

## Added files
In total, 5 scripts and 1 workflow were added.

1. create - Created packet hosted server with parameters: configuration, location, and operation system in packet format, returned packet device id to stdout.
2. create-eve.sh - Create packet hosted server with ipxe boot with link from EDEN. Can only be started after running ./eden setup --netboot=true, return device id to stdout.
3. wait-eth0.sh - Waiting for eth0 to initialize and return ip to stdout.
4. wait-provisioning.sh - waiting for provisioning complete.
5. cli-prepare.sh - download packet-cli if not exist.

## What software do I use in scripts
I am using:

- packet-cli (https://github.com/packethost/packet-cli)
- jq for parse json responses from packet-cli

## For test packet we need

To test packet in this case, you need 2 servers, 1 with EDEN, another with EVE, since we cannot configure the tunnel to the EVE server to the local EDEN, so we are forced to deploy EDEN on the external network.

## Example usage in manual mode

1. **Setup required env.**
2. **Create packet ubuntu server for EDEN.**
```
ubuntu_device_id=$(./shell-scripts/packet/create.sh -c c2.large.arm -l dfw2 -p $PACKET_PROJECT -os ubuntu_18_04)
timeout=1800
./shell-scripts/packet/wait-provisioning.sh $ubuntu_device_id $timeout
repeat_count=100
ubuntu_device_ip=$(./shell-scripts/packet/wait-eth0.sh $ubuntu_device_id $repeat_count)
```
3. **Go to packet ubuntu server via ssh and download eden, install dependencies and setup netboot.**

Install Docker [instruction](https://docs.docker.com/engine/install/ubuntu/).
Install Go.
```
sudo add-apt-repository ppa:longsleep/golang-backports && sudo apt install -y golang
```
Intsall Eden dependencies.
```
sudo apt-get install -y jq make git expect qemu binfmt-support qemu-user-static \
 qemu-utils qemu-system-x86 qemu-system-aarch64
```
Clone your eden repo and go to eden dir.
```
git clone <eden repo> -b <eden branch> && cd eden
```
```
make clean
make build
make build-tests
./eden config add --devmodel=general --arch="arm64"
./eden config set default --key eve.tag --value="6.5.0"
./eden config set default --key eve.hv --value="kvm"
./eden setup -v debug --netboot=true
```
Where arch=arm64 - EVE packet server arch
eve.tag --value="6.5.0" - version of eve.
eve.hv --value="kvm" - eve hypervisor.
4. **Setup required env in ssh ubuntu session.**
```
export PACKET_TOKEN=<your token>
export PACKET_PROJECT=<packet project id in GUID format>
```
5. **Create EVE on packet hosting.** We run this commands in ssh, until point 10, where we exit from the ssh session.
The following command will return the packet device id. 
If creation is not possible or passed with an error, it will return 00000000-0000-0000-0000-000000000000 as device id and exit with status code 1.
```
eve_device_id=$(./shell-scripts/packet/create-eve.sh -c c2.large.arm -l dfw2 -p $PACKET_PROJECT)
```
6. **Waiting for EVE packet server deployment.**
```
timeout=1800
./shell-scripts/packet/wait-provisioning.sh $eve_device_id $timeout
sleep 100
```
7. **Wait for eth0 initialized in EVE packet server.**
This command will wait for the raising of the network interface on the server and will give its IP. The number of repetitions is also indicated for the timeout, the interval is 10 seconds. If the IP has not yet been allocated, then it will return 0.0.0.0 and exit with status code 1, it is worth checking what happened. Used to delay the start of the eden and the onboarding.
```
repeat_count=100
eve_device_ip=$(./shell-scripts/packet/wait-eth0.sh $eve_device_id $repeat_count)
```
7. **EDEN start and EVE onboard**
```
./eden start
./eden eve onboard
```
8. **Run EDEN tests.**
Test packet like GCP. But without registry, since there is a limitation of its work in the external network.
```
EDEN_TEST=gcp EDEN_TEST_REGISTRY=n ./eden test tests/workflow -v debug
```
9. **Terminate EVE.**
```
./shell-scripts/packet/delete.sh $eve_device_id
```
10. **Exit from ssh ubuntu session and terminate ubuntu.**
```
exit
./shell-scripts/packet/delete.sh $ubuntu_device_id
```
Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>