### PR TITLE
update eve-alpine and fix arm64 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:6.2.0 as build
+FROM lfedge/eve-alpine:6.6.0 as build
 ENV BUILD_PKGS go make qemu-img
 RUN eve-alpine-deploy.sh
 

--- a/eserver/Dockerfile
+++ b/eserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:6.2.0 AS build
+FROM lfedge/eve-alpine:6.6.0 AS build
 ENV BUILD_PKGS go git openssh-keygen
 RUN eve-alpine-deploy.sh
 
@@ -16,7 +16,6 @@ RUN go mod download
 COPY . /eserver/src
 
 ARG GOOS=linux
-ARG GOARCH=amd64
 
 RUN go build -ldflags "-s -w" -o /eserver/bin/eserver main.go
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -52,7 +52,7 @@ const (
 	DefaultAdamTag              = "0.0.25"
 	DefaultRedisTag             = "6"
 	DefaultRegistryTag          = "2.7"
-	DefaultProcTag              = "1.2"
+	DefaultProcTag              = "1.3"
 	DefaultImage                = "library/alpine"
 	DefaultAdamContainerRef     = "lfedge/adam"
 	DefaultRedisContainerRef    = "redis"
@@ -68,7 +68,7 @@ const (
 
 	DefaultRedisPasswordFile = "redis.pass"
 
-	DefaultEServerTag          = "1.4"
+	DefaultEServerTag          = "1.5"
 	DefaultEServerContainerRef = "lfedge/eden-http-server"
 
 	//DefaultRepeatCount is repeat count for requests

--- a/processing/Dockerfile
+++ b/processing/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:8a53b741d47f42752db30dd896c3467433bac152 as build
+FROM lfedge/eve-alpine:6.6.0 as build
 ENV BUILD_PKGS perl git gawk
 RUN eve-alpine-deploy.sh
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -17,8 +17,11 @@ OS ?= $(HOSTOS)
 
 WORKDIR ?= $(CURDIR)/../dist
 
+gotestsum:
+	go get gotest.tools/gotestsum
+
 #test: $(TESTS:=_test)
-test:
+test: gotestsum
 	gotestsum --jsonfile $(WORKDIR)/results.json --junitfile $(WORKDIR)/results.xml --raw-command -- go tool test2json -t ../eden test workflow -v debug
 
 build: $(TESTS:=_build)


### PR DESCRIPTION
Update and sync eve-alpine. 
Fix arm64 build of eserver.
Move gotestsum to the place where it is expected

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>