### PR TITLE
Test port-map recovery after network outage

### DIFF
--- a/cmd/edenStart.go
+++ b/cmd/edenStart.go
@@ -67,6 +67,7 @@ var startCmd = &cobra.Command{
 			qemuAccel = viper.GetBool("eve.accel")
 			qemuSMBIOSSerial = viper.GetString("eve.serial")
 			qemuConfigFile = utils.ResolveAbsPath(viper.GetString("eve.qemu-config"))
+			qemuMonitorPort = viper.GetInt("eve.qemu-monitor-port")
 			evePidFile = utils.ResolveAbsPath(viper.GetString("eve.pid"))
 			eveLogFile = utils.ResolveAbsPath(viper.GetString("eve.log"))
 			eveRemote = viper.GetBool("eve.remote")
@@ -116,7 +117,8 @@ var startCmd = &cobra.Command{
 				log.Infof("EVE is starting in Virtual Box")
 			}
 		} else {
-			if err := eden.StartEVEQemu(qemuARCH, qemuOS, eveImageFile, qemuSMBIOSSerial, eveTelnetPort, hostFwd, qemuAccel, qemuConfigFile, eveLogFile, evePidFile, false); err != nil {
+			if err := eden.StartEVEQemu(qemuARCH, qemuOS, eveImageFile, qemuSMBIOSSerial, eveTelnetPort, qemuMonitorPort,
+				hostFwd, qemuAccel, qemuConfigFile, eveLogFile, evePidFile, false); err != nil {
 				log.Errorf("cannot start eve: %s", err)
 			} else {
 				log.Infof("EVE is starting")
@@ -179,6 +181,7 @@ func startInit() {
 	startCmd.Flags().BoolVarP(&qemuAccel, "eve-accel", "", true, "use acceleration")
 	startCmd.Flags().StringVarP(&qemuSMBIOSSerial, "eve-serial", "", defaults.DefaultEVESerial, "SMBIOS serial")
 	startCmd.Flags().StringVarP(&qemuConfigFile, "qemu-config", "", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultQemuFileToSave), "config file to use")
+	startCmd.Flags().IntVarP(&qemuMonitorPort, "qemu-monitor-port", "", defaults.DefaultQemuMonitorPort, "Port for access to QEMU monitor")
 	startCmd.Flags().StringVarP(&evePidFile, "eve-pid", "", filepath.Join(currentPath, defaults.DefaultDist, "eve.pid"), "file for save EVE pid")
 	startCmd.Flags().StringVarP(&eveLogFile, "eve-log", "", filepath.Join(currentPath, defaults.DefaultDist, "eve.log"), "file for save EVE log")
 	startCmd.Flags().StringVarP(&eveImageFile, "image-file", "", "", "path to image drive, overrides default setting")

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -35,17 +35,18 @@ const (
 
 //domains, ips, ports
 const (
-	DefaultDomain       = "mydomain.adam"
-	DefaultIP           = "192.168.0.1"
-	DefaultEVEIP        = "192.168.1.2"
-	DefaultEserverPort  = 8888
-	DefaultTelnetPort   = 7777
-	DefaultSSHPort      = 2222
-	DefaultEVEHost      = "127.0.0.1"
-	DefaultRedisHost    = "localhost"
-	DefaultRedisPort    = 6379
-	DefaultAdamPort     = 3333
-	DefaultRegistryPort = 5000
+	DefaultDomain          = "mydomain.adam"
+	DefaultIP              = "192.168.0.1"
+	DefaultEVEIP           = "192.168.1.2"
+	DefaultEserverPort     = 8888
+	DefaultTelnetPort      = 7777
+	DefaultQemuMonitorPort = 7788
+	DefaultSSHPort         = 2222
+	DefaultEVEHost         = "127.0.0.1"
+	DefaultRedisHost       = "localhost"
+	DefaultRedisPort       = 6379
+	DefaultAdamPort        = 3333
+	DefaultRegistryPort    = 5000
 
 	//tags, versions, repos
 	DefaultEVETag               = "6.6.0" //DefaultEVETag tag for EVE image
@@ -197,30 +198,31 @@ var (
 		"registry.port": "registry-port",
 		"registry.dist": "registry-dist",
 
-		"eve.arch":         "eve-arch",
-		"eve.os":           "eve-os",
-		"eve.accel":        "eve-accel",
-		"eve.hv":           "eve-hv",
-		"eve.serial":       "eve-serial",
-		"eve.pid":          "eve-pid",
-		"eve.log":          "eve-log",
-		"eve.firmware":     "eve-firmware",
-		"eve.repo":         "eve-repo",
-		"eve.registry":     "eve-registry",
-		"eve.tag":          "eve-tag",
-		"eve.uefi-tag":     "eve-uefi-tag",
-		"eve.hostfwd":      "eve-hostfwd",
-		"eve.dist":         "eve-dist",
-		"eve.base-dist":    "eve-base-dist",
-		"eve.qemu-config":  "qemu-config",
-		"eve.uuid":         "uuid",
-		"eve.image-file":   "image-file",
-		"eve.dtb-part":     "dtb-part",
-		"eve.config-part":  "config-part",
-		"eve.base-version": "os-version",
-		"eve.devmodel":     "devmodel",
-		"eve.devmodelfile": "devmodel-file",
-		"eve.telnet-port":  "eve-telnet-port",
+		"eve.arch":              "eve-arch",
+		"eve.os":                "eve-os",
+		"eve.accel":             "eve-accel",
+		"eve.hv":                "eve-hv",
+		"eve.serial":            "eve-serial",
+		"eve.pid":               "eve-pid",
+		"eve.log":               "eve-log",
+		"eve.firmware":          "eve-firmware",
+		"eve.repo":              "eve-repo",
+		"eve.registry":          "eve-registry",
+		"eve.tag":               "eve-tag",
+		"eve.uefi-tag":          "eve-uefi-tag",
+		"eve.hostfwd":           "eve-hostfwd",
+		"eve.dist":              "eve-dist",
+		"eve.base-dist":         "eve-base-dist",
+		"eve.qemu-config":       "qemu-config",
+		"eve.uuid":              "uuid",
+		"eve.image-file":        "image-file",
+		"eve.dtb-part":          "dtb-part",
+		"eve.config-part":       "config-part",
+		"eve.base-version":      "os-version",
+		"eve.devmodel":          "devmodel",
+		"eve.devmodelfile":      "devmodel-file",
+		"eve.telnet-port":       "eve-telnet-port",
+		"eve.qemu-monitor-port": "qemu-monitor-port",
 
 		"eden.images.dist":   "image-dist",
 		"eden.images.docker": "docker-yml",

--- a/pkg/defaults/templates.go
+++ b/pkg/defaults/templates.go
@@ -140,6 +140,9 @@ eve:
     #ssid for wifi
     ssid: '{{parse "eve.ssid"}}'
 
+    #port for QEMU Monitor
+    qemu-monitor-port: {{parse "eve.qemu-monitor-port"}}
+
 eden:
     #root directory of eden
     root: '{{parse "eden.root"}}'

--- a/pkg/eden/eden.go
+++ b/pkg/eden/eden.go
@@ -27,6 +27,12 @@ import (
 	"github.com/spf13/viper"
 )
 
+//LinkState of an EVE uplink interface.
+type LinkState struct {
+	InterfaceName string
+	IsUP          bool
+}
+
 //StartRedis function run redis in docker with mounted redisPath:/data
 //if redisForce is set, it recreates container
 func StartRedis(redisPort int, redisPath string, redisForce bool, redisTag string) (err error) {

--- a/pkg/eden/qemu.go
+++ b/pkg/eden/qemu.go
@@ -1,7 +1,11 @@
 package eden
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
+	"net"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -12,12 +16,16 @@ import (
 )
 
 //StartEVEQemu function run EVE in qemu
-func StartEVEQemu(qemuARCH, qemuOS, eveImageFile, qemuSMBIOSSerial string, eveTelnetPort int, qemuHostFwd map[string]string, qemuAccel bool, qemuConfigFile, logFile string, pidFile string, foregroud bool) (err error) {
+func StartEVEQemu(qemuARCH, qemuOS, eveImageFile, qemuSMBIOSSerial string, eveTelnetPort, qemuMonitorPort int, qemuHostFwd map[string]string,
+	qemuAccel bool, qemuConfigFile, logFile, pidFile string, foregroud bool) (err error) {
 	qemuCommand := ""
 	qemuOptions := "-display none -nodefaults -no-user-config "
 	qemuOptions += fmt.Sprintf("-serial chardev:char0 -chardev socket,id=char0,port=%d,host=localhost,server,nodelay,nowait,telnet,logfile=%s ", eveTelnetPort, logFile)
 	if qemuSMBIOSSerial != "" {
 		qemuOptions += fmt.Sprintf("-smbios type=1,serial=%s ", qemuSMBIOSSerial)
+	}
+	if qemuMonitorPort != 0 {
+		qemuOptions += fmt.Sprintf("-monitor tcp:localhost:%d,server,nowait  ", qemuMonitorPort)
 	}
 	nets, err := utils.GetSubnetsNotUsed(1)
 	if err != nil {
@@ -119,4 +127,101 @@ func StopEVEQemu(pidFile string) (err error) {
 //StatusEVEQemu function get status of EVE
 func StatusEVEQemu(pidFile string) (status string, err error) {
 	return utils.StatusCommandWithPid(pidFile)
+}
+
+//SetLinkStateQemu changes the link state of the given interface.
+//If interface name is undefined, the function changes the link state of every uplink interface.
+func SetLinkStateQemu(qemuMonitorPort int, ifName string, up bool) error {
+	if ifName == "" {
+		if err := setLinkStateQemu(qemuMonitorPort, "eth0", up); err != nil {
+			return err
+		}
+		if err := setLinkStateQemu(qemuMonitorPort, "eth1", up); err != nil {
+			return err
+		}
+		return nil
+	}
+	return setLinkStateQemu(qemuMonitorPort, ifName, up)
+}
+
+func setLinkStateQemu(qemuMonitorPort int, ifName string, up bool) error {
+	tcpAddr, _ := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", qemuMonitorPort))
+	conn, err := net.DialTCP("tcp", nil, tcpAddr)
+	if err != nil {
+		return err
+	}
+	linkState := "on"
+	if !up {
+		linkState = "off"
+	}
+	cmd := fmt.Sprintf("set_link %s %s", ifName, linkState)
+	_, err = conn.Write([]byte(cmd + "\n"))
+	if err == nil {
+		err = conn.CloseWrite()
+	}
+	if err != nil {
+		return fmt.Errorf("failed to send '%s' command to qemu: %v", cmd, err)
+	}
+	scanner := bufio.NewScanner(conn)
+	for scanner.Scan() {
+		// read output from the QEMU monitor command prompt
+		line := scanner.Text()
+		if strings.HasPrefix(line, "QEMU") || strings.HasPrefix(line, "(qemu)") {
+			continue
+		}
+		// anything else must be an error message
+		return errors.New(line)
+	}
+	if scanner.Err() != nil {
+		return fmt.Errorf("failed to read response from QEMU monitor: %v", scanner.Err())
+	}
+	return nil
+}
+
+//GetLinkStateQemu returns the link state of the interface.
+//If interface name is undefined, link state of all interfaces is returned.
+func GetLinkStateQemu(qemuMonitorPort int, ifName string) (linkStates []LinkState, err error) {
+	// Unfortunately QEMU Monitor doesn't provide command to obtain
+	// the current link state of interfaces.
+	// All we can do is to traverse through the command history,
+	// find the last invocation of set_link command for every interface and assume
+	// that it succeeded.
+	var linkStateMap = map[string]bool{"eth0": true, "eth1": true} // initial state
+	tcpAddr, _ := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", qemuMonitorPort))
+	conn, err := net.DialTCP("tcp", nil, tcpAddr)
+	if err != nil {
+		return nil, err
+	}
+	cmd := "info history"
+	_, err = conn.Write([]byte(cmd + "\n"))
+	if err == nil {
+		err = conn.CloseWrite()
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to send '%s' command to qemu: %v", cmd, err)
+	}
+	scanner := bufio.NewScanner(conn)
+	setLinkCmdReg := regexp.MustCompile("'set_link (\\S+) (on|off)'")
+	for scanner.Scan() {
+		// read output from the QEMU monitor command prompt
+		line := scanner.Text()
+		match := setLinkCmdReg.FindStringSubmatch(line)
+		if len(match) == 3 {
+			nicName := match[1]
+			isUp := match[2] == "on"
+			if _, knownNic := linkStateMap[nicName]; knownNic {
+				linkStateMap[nicName] = isUp
+			}
+		}
+	}
+	if scanner.Err() != nil {
+		return nil, fmt.Errorf("failed to read response from QEMU monitor: %v", scanner.Err())
+	}
+	for nicName, isUP := range linkStateMap {
+		if ifName != "" && ifName != nicName {
+			continue
+		}
+		linkStates = append(linkStates, LinkState{InterfaceName: nicName, IsUP: isUP})
+	}
+	return linkStates, nil
 }

--- a/pkg/eden/qemu.go
+++ b/pkg/eden/qemu.go
@@ -136,10 +136,7 @@ func SetLinkStateQemu(qemuMonitorPort int, ifName string, up bool) error {
 		if err := setLinkStateQemu(qemuMonitorPort, "eth0", up); err != nil {
 			return err
 		}
-		if err := setLinkStateQemu(qemuMonitorPort, "eth1", up); err != nil {
-			return err
-		}
-		return nil
+		return setLinkStateQemu(qemuMonitorPort, "eth1", up)
 	}
 	return setLinkStateQemu(qemuMonitorPort, ifName, up)
 }
@@ -201,7 +198,7 @@ func GetLinkStateQemu(qemuMonitorPort int, ifName string) (linkStates []LinkStat
 		return nil, fmt.Errorf("failed to send '%s' command to qemu: %v", cmd, err)
 	}
 	scanner := bufio.NewScanner(conn)
-	setLinkCmdReg := regexp.MustCompile("'set_link (\\S+) (on|off)'")
+	setLinkCmdReg := regexp.MustCompile(`'set_link (\S+) (on|off)'`)
 	for scanner.Scan() {
 		// read output from the QEMU monitor command prompt
 		line := scanner.Text()

--- a/pkg/eden/vbox.go
+++ b/pkg/eden/vbox.go
@@ -259,10 +259,7 @@ func SetLinkStateVbox(vmName, ifName string, up bool) error {
 		if err := setLinkStateVbox(vmName, "eth0", up); err != nil {
 			return err
 		}
-		if err := setLinkStateVbox(vmName, "eth1", up); err != nil {
-			return err
-		}
-		return nil
+		return setLinkStateVbox(vmName, "eth1", up)
 	}
 	return setLinkStateVbox(vmName, ifName, up)
 }

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -388,6 +388,8 @@ func generateConfigFileFromTemplate(filePath string, templateString string, cont
 			return defaults.DefaultTelnetPort
 		case "eve.ssid":
 			return ""
+		case "eve.qemu-monitor-port":
+			return defaults.DefaultQemuMonitorPort
 
 		case "eden.root":
 			return filepath.Join(currentPath, defaults.DefaultDist)

--- a/tests/eclient/testdata/port_forward.txt
+++ b/tests/eclient/testdata/port_forward.txt
@@ -1,6 +1,7 @@
 # Tests for port forward connectivity between applications
 
 {{$test_msg := "Port forward tests"}}
+{{$devmodel := EdenConfig "eve.devmodel"}}
 {{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
 
 [!exec:bash] stop
@@ -43,6 +44,20 @@ exec sleep 20
 exec -t 1m bash test_connectivity.sh 2223 2224
 stdout 'Ubuntu'
 
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") }}
+message 'SCENARIO 1: Simulating network outage'
+eden eve link down
+# keep link down long enough for EVE to notice and un-configure port maps
+exec sleep 60
+! exec -t 1m bash check_ssh.sh 2223 2224
+eden eve link up
+# give EVE some time to recover (largely depends on the DHCP server)
+exec sleep 20
+exec -t 5m bash wait_ssh.sh 2223 2224
+exec -t 1m bash test_connectivity.sh 2223 2224
+stdout 'Ubuntu'
+{{end}}
+
 message 'SCENARIO 1: Resource cleaning'
 eden pod delete app1
 eden pod delete app2
@@ -64,7 +79,6 @@ eden network ls
 # get different IP addresses from the same subnet with DHCP.
 
 {{$osruntime := EdenOSRuntime}}
-{{$devmodel := EdenConfig "eve.devmodel"}}
 {{$allowSlirpRouting := EdenCheckSlirpSupportRouting}}
 
 {{if (eq $osruntime "linux")}}
@@ -90,6 +104,18 @@ cp stdout eve_status
 
 message 'SCENARIO 2: Testing port map connectivity between apps'
 exec sleep 20
+exec -t 1m bash test_connectivity.sh 2234 2223
+stdout 'Ubuntu'
+
+message 'SCENARIO 2: Simulating network outage'
+eden eve link down
+# keep link down long enough for EVE to notice and un-configure port maps
+exec sleep 60
+! exec -t 1m bash check_ssh.sh 2223 2234
+eden eve link up
+# give EVE some time to recover (largely depends on the DHCP server)
+exec sleep 20
+exec -t 5m bash wait_ssh.sh 2223 2234
 exec -t 1m bash test_connectivity.sh 2234 2223
 stdout 'Ubuntu'
 
@@ -126,6 +152,16 @@ do
     echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
     {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
   done
+done
+
+-- check_ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+for p in $*
+do
+  echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
+  {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue || exit
 done
 
 -- test_connectivity.sh --


### PR DESCRIPTION
This PR consists of two commits:

The first one adds a new eden command `eden eve link up|down|status`, which allows to manage the link status of EVE's uplink interfaces. This is currently only supported for `QEMU` and `VBOX` device models.
For `QEMU` the command uses `set_link` command provided by [the QEMU Monitor ](https://qemu-project.gitlab.io/qemu/system/monitor.html). With VirtualBox, it is possible to (dis)connect cable to/from interface using `VBoxManage controlvm setlinkstate`.

Examples of the command usage:

- Print link status of all interface:
```
$ ./eden eve link status
INTERFACE	LINK
eth0		UP
eth1		UP
```
- Disconnect all interfaces:
```
$ ./eden eve link down
INFO[0000] Link state of EVE interfaces after update:   
INTERFACE	LINK
eth0		DOWN
eth1		DOWN
```
- (Re)Connect all interfaces:
```
$ ./eden eve link up
INFO[0000] Link state of EVE interfaces after update:   
INTERFACE	LINK
eth0		UP
eth1		UP
```
- Disconnect a specific interface:
```
$ ./eden eve link down -i eth0
INFO[0000] Link state of EVE interfaces after update:   
INTERFACE	LINK
eth0		DOWN
eth1		UP
```
- (Re)Connect a specific interface:
```
$ ./eden eve link up -i eth0
INFO[0000] Link state of EVE interfaces after update:   
INTERFACE	LINK
eth0		UP
eth1		UP
```

The second commit adds network outage scenario into the `eclient/port_forward` test. This should be tested because when the link of a mgmt interface goes down, zedrouter unconfigures all the iptables rules created for port maps. When the link is back up, the port maps should be recreated (this didn't work and was fixed only recently). 
The network outage is simulated using the newly added eden command described above.