### PR TITLE
wait for all domains in acl

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -40,6 +40,8 @@ jobs:
         run: |
           ./eden log --format json > trace.log || echo "no log"
           ./eden info > info.log || echo "no info"
+          ./eden metric > metric.log || echo "no metric"
+          ./eden netstat > netstat.log || echo "no netstat"
           cp dist/default-eve.log console.log || echo "no device log"
           docker logs eden_adam > adam.log 2>&1 || echo "no adam log"
       - name: Log counting
@@ -65,5 +67,7 @@ jobs:
           path: |
               ${{ github.workspace }}/trace.log
               ${{ github.workspace }}/info.log
+              ${{ github.workspace }}/metric.log
+              ${{ github.workspace }}/netstat.log
               ${{ github.workspace }}/console.log
               ${{ github.workspace }}/adam.log

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -82,9 +82,12 @@ jobs:
       - name: Collect logs
         if: ${{ always() }}
         run: |
-          ./eden log --format json > trace.log
-          ./eden info > info.log
-          ./eden utils gcp vm log --vm-name eve-eden-actions-${{ matrix.hv }}-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS" > console.log
+          ./eden log --format json > trace.log || echo "no log"
+          ./eden info > info.log || echo "no info"
+          ./eden metric > metric.log || echo "no metric"
+          ./eden netstat > netstat.log || echo "no netstat"
+          docker logs eden_adam > adam.log 2>&1 || echo "no adam log"
+          ./eden utils gcp vm log --vm-name eve-eden-actions-${{ matrix.hv }}-${{github.run_number}} -k "$GOOGLE_APPLICATION_CREDENTIALS" > console.log || echo "no device log"
       - name: Clean
         if: ${{ always() }}
         run: |
@@ -115,4 +118,7 @@ jobs:
           path: |
             ${{ github.workspace }}/trace.log
             ${{ github.workspace }}/info.log
+            ${{ github.workspace }}/adam.log
+            ${{ github.workspace }}/netstat.log
+            ${{ github.workspace }}/metric.log
             ${{ github.workspace }}/console.log

--- a/tests/eclient/testdata/acl.txt
+++ b/tests/eclient/testdata/acl.txt
@@ -64,12 +64,12 @@ stderr 'Connected to {{$long_domain}}'
 ! stderr 'Connected'
 
 # Wait for network packets information
-exec -t 10m bash wait_netstat.sh curl-acl1
+exec -t 20m bash wait_netstat.sh curl-acl1 google.com github.com {{$long_domain}} {{$fake_domain}}
 stdout 'google.com'
 stdout 'github.com'
 stdout '{{$long_domain}}'
 stdout '{{$fake_domain}}'
-exec -t 10m bash wait_netstat.sh curl-acl2
+exec -t 20m bash wait_netstat.sh curl-acl2 google.com github.com {{$long_domain}}
 stdout 'google.com'
 stdout 'github.com'
 stdout '{{$long_domain}}'
@@ -121,8 +121,11 @@ echo {{template "ssh"}}$HOST -p $1 curl -v --max-time 30 "$2"
 #!/bin/sh
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 
-echo "Waiting for flowlog results"
-until "$EDEN" pod logs --fields=netstat $1 | grep 'google.com'; do sleep 30; done
+echo "Waiting for netstat results"
+for p in ${@: 2}
+do
+  until "$EDEN" pod logs --fields=netstat $1 | grep $p; do sleep 30; done
+done
 "$EDEN" pod logs --fields=netstat $1
 
 -- eden-config.yml --


### PR DESCRIPTION
Seems, we can get netstat results [out of order](https://github.com/lf-edge/eden/runs/2677185310#step:11:3214) of request we make, so we should wait for all domains in wait_netstat.sh.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>