### PR TITLE
Check that DNS flowstat entries are properly sorted between apps

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -49,7 +49,7 @@ const (
 	DefaultRegistryPort    = 5000
 
 	//tags, versions, repos
-	DefaultEVETag               = "0.0.0-master-87f2a9a8" //DefaultEVETag tag for EVE image
+	DefaultEVETag               = "6.8.0" //DefaultEVETag tag for EVE image
 	DefaultAdamTag              = "0.0.27"
 	DefaultRedisTag             = "6"
 	DefaultRegistryTag          = "2.7"

--- a/tests/eclient/testdata/acl.txt
+++ b/tests/eclient/testdata/acl.txt
@@ -62,15 +62,24 @@ stderr 'Connected to {{$long_domain}}'
 #stderr 'Connected to {{$fake_domain}}'
 ! exec -t 1m bash curl.sh 2224 github.com
 ! stderr 'Connected'
+! exec -t 1m bash curl.sh 2224 ieee.org
+! stderr 'Connected'
 ! exec -t 1m bash curl.sh 2224 google.com
 ! stderr 'Connected'
 
 # Wait for network packets information
-exec -t 20m bash wait_netstat.sh {{$network_name}} google.com github.com {{$long_domain}} {{$fake_domain}}
+exec -t 10m bash wait_netstat.sh curl-acl1 google.com github.com {{$long_domain}} {{$fake_domain}}
 stdout 'google.com'
 stdout 'github.com'
 stdout '{{$long_domain}}'
 stdout '{{$fake_domain}}'
+! stdout 'ieee.org'
+exec -t 10m bash wait_netstat.sh curl-acl2 google.com github.com {{$long_domain}} ieee.org
+stdout 'google.com'
+stdout 'github.com'
+stdout '{{$long_domain}}'
+! stdout '{{$fake_domain}}'
+stdout 'ieee.org'
 
 # Cleanup - undeploy applications
 eden pod delete curl-acl1
@@ -101,10 +110,10 @@ done
 -- dns_lookup.sh --
 
 # Performs DNS lookup for a given hostname and adds host_ip=<ip> into the .env file
-# The script uses 'getent' command to avoid dependencies on tools like 'host', 'dig', etc.
+# Uses dig command which is already included by most modern Linux systems and also macOS.
 # Usage: dns_lookup.sh <hostname>
 
-IP=$(getent hosts $1 | head -n 1 | cut -d ' ' -f 1)
+IP=$(dig +short $1)
 echo host_ip=$IP>>.env
 
 -- curl.sh --
@@ -122,9 +131,9 @@ EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "ede
 echo "Waiting for netstat results"
 for p in ${@: 2}
 do
-  until "$EDEN" network netstat $1 | grep $p; do sleep 30; done
+  until "$EDEN" pod logs --fields=netstat $1 | grep "$p"; do sleep 30; done
 done
-"$EDEN" network netstat $1
+"$EDEN" pod logs --fields=netstat $1
 
 -- eden-config.yml --
 {{/* Test's config file */}}


### PR DESCRIPTION
Extend ACL test to check that DNS flowlog records are properly sorted between applications residing on the same network.
There was a bug in EVE causing flowstat collection to incorrectly sort recorded DNS requests by application ID.
This bug was fixed by: https://github.com/lf-edge/eve/pull/2130

Signed-off-by: Milan Lenco <milan@zededa.com>