### PR TITLE
Test with eth passthrough and reboot

### DIFF
--- a/pkg/eden/qemu.go
+++ b/pkg/eden/qemu.go
@@ -64,7 +64,7 @@ func StartEVEQemu(qemuARCH, qemuOS, eveImageFile, qemuSMBIOSSerial string, eveTe
 		}
 		qemuOptions += fmt.Sprintf(",hostfwd=tcp::%d-:%d", origPort + offset, newPort + offset)
 	}
-	qemuOptions += fmt.Sprintf(" -device virtio-net-pci,netdev=eth%d ", 1)
+	qemuOptions += fmt.Sprintf(" -device e1000,netdev=eth%d ", 1)
 
 	if qemuOS == "" {
 		qemuOS = runtime.GOOS

--- a/pkg/expect/application.go
+++ b/pkg/expect/application.go
@@ -131,8 +131,12 @@ func (exp *AppExpectation) createAppInstanceConfig(img *config.Image, netInstanc
 	}
 	var adapters []*config.Adapter
 	for _, adapterName := range exp.appAdapters {
+		adapterType := evecommon.PhyIoType_PhyIoUSB
+		if strings.HasPrefix(adapterName, "eth") {
+			adapterType = evecommon.PhyIoType_PhyIoNetEth
+		}
 		adapters = append(adapters, &config.Adapter{
-			Type: evecommon.PhyIoType_PhyIoUSB,
+			Type: adapterType,
 			Name: adapterName,
 		})
 	}

--- a/pkg/models/common.go
+++ b/pkg/models/common.go
@@ -79,6 +79,7 @@ func generateSystemAdapters(ethCount, wifiCount uint) []*config.SystemAdapter {
 	}
 	return adapters
 }
+
 func generatePhysicalIOs(ethCount, wifiCount, usbCount uint) []*config.PhysicalIO {
 	var physicalIOs []*config.PhysicalIO
 	for i := uint(0); i < ethCount; i++ {
@@ -130,4 +131,25 @@ func generatePhysicalIOs(ethCount, wifiCount, usbCount uint) []*config.PhysicalI
 		}
 	}
 	return physicalIOs
+}
+
+// filterSystemAdapters filters out adapters for which the underlying network device was
+// either removed or disabled through devmodel file.
+func filterSystemAdapters(adapters []*config.SystemAdapter, physicalIOs []*config.PhysicalIO) []*config.SystemAdapter {
+	var filtered []*config.SystemAdapter
+	for _, adapter := range adapters {
+		for _, physicalIO := range physicalIOs {
+			if physicalIO.Ptype != evecommon.PhyIoType_PhyIoNetEth {
+				continue
+			}
+			if physicalIO.Logicallabel != adapter.Name {
+				continue
+			}
+			if physicalIO.Usage == evecommon.PhyIoMemberUsage_PhyIoUsageNone {
+				continue
+			}
+			filtered = append(filtered, adapter)
+		}
+	}
+	return filtered
 }

--- a/pkg/models/general.go
+++ b/pkg/models/general.go
@@ -70,6 +70,7 @@ func (ctx *DevModelGeneral) PhysicalIOs() []*config.PhysicalIO {
 //SetPhysicalIOs sets physicalIOs of devModel
 func (ctx *DevModelGeneral) SetPhysicalIOs(physicalIOs []*config.PhysicalIO){
 	ctx.physicalIOs = physicalIOs
+	ctx.adapters = filterSystemAdapters(ctx.adapters, ctx.physicalIOs)
 }
 
 //AdapterForSwitches returns adapterForSwitches of devModel

--- a/pkg/models/parallels.go
+++ b/pkg/models/parallels.go
@@ -66,6 +66,7 @@ func (ctx *DevModelParallels) PhysicalIOs() []*config.PhysicalIO {
 //SetPhysicalIOs sets physicalIOs of devModel
 func (ctx *DevModelParallels) SetPhysicalIOs(physicalIOs []*config.PhysicalIO){
 	ctx.physicalIOs = physicalIOs
+	ctx.adapters = filterSystemAdapters(ctx.adapters, ctx.physicalIOs)
 }
 
 //AdapterForSwitches returns adapterForSwitches of devModel

--- a/pkg/models/qemu.go
+++ b/pkg/models/qemu.go
@@ -64,6 +64,7 @@ func (ctx *DevModelQemu) PhysicalIOs() []*config.PhysicalIO {
 //SetPhysicalIOs sets physicalIOs of devModel
 func (ctx *DevModelQemu) SetPhysicalIOs(physicalIOs []*config.PhysicalIO){
 	ctx.physicalIOs = physicalIOs
+	ctx.adapters = filterSystemAdapters(ctx.adapters, ctx.physicalIOs)
 }
 
 //AdapterForSwitches returns adapterForSwitches of devModel

--- a/pkg/models/vbox.go
+++ b/pkg/models/vbox.go
@@ -67,6 +67,7 @@ func (ctx *DevModelVBox) PhysicalIOs() []*config.PhysicalIO {
 //SetPhysicalIOs sets physicalIOs of devModel
 func (ctx *DevModelVBox) SetPhysicalIOs(physicalIOs []*config.PhysicalIO){
 	ctx.physicalIOs = physicalIOs
+	ctx.adapters = filterSystemAdapters(ctx.adapters, ctx.physicalIOs)
 }
 
 //AdapterForSwitches returns adapterForSwitches of DevModelVBox

--- a/tests/escript/go-internal/testscript/testscript.go
+++ b/tests/escript/go-internal/testscript/testscript.go
@@ -449,7 +449,8 @@ Script:
 			continue
 		}
 
-		// Echo command to log.
+		// Echo command to log and stdout.
+		fmt.Printf("> %s\n", line)
 		fmt.Fprintf(&ts.log, "> %s\n", line)
 
 		// Command prefix [cond] means only run this command if cond is satisfied.

--- a/tests/hardware_reboot/eden.hardware_reboot.tests.txt
+++ b/tests/hardware_reboot/eden.hardware_reboot.tests.txt
@@ -1,4 +1,4 @@
 eden.escript.test -test.run TestEdenScripts/hardware_usb_reboot
 eden.escript.test -test.run TestEdenScripts/hardware_2usb_reboot
 eden.escript.test -test.run TestEdenScripts/hardware_audio_reboot
-
+eden.escript.test -test.run TestEdenScripts/hardware_eth_reboot

--- a/tests/hardware_reboot/testdata/hardware_eth_reboot.txt
+++ b/tests/hardware_reboot/testdata/hardware_eth_reboot.txt
@@ -1,0 +1,158 @@
+# Simple test of ETH passthrough functionality after reboot of a guest
+
+{{define "network"}}n1{{end}}
+{{define "port"}}2223{{end}}
+{{define "virtio_iface"}}enp3s0{{end}}
+{{define "passthrough_iface"}}enp4s0{{end}}
+{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{template "port"}} ubuntu@{{end}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+
+# Apply custom devmodel where usage of eth1 is PhyIoUsageNone and therefore it is available for passthrough.
+eden config set $EDEN_CONFIG --key eve.devmodelfile --value $WORK/devmodel.json
+
+# Re-generate device config
+message 'Resetting of EVE'
+eden eve reset
+
+# Make sure that if test fails mid-through, devmodelfile will be left unset.
+eden config set $EDEN_CONFIG --key eve.devmodelfile
+
+# Changes in physicalIO require reboot
+eden -t 2m eve stop
+! stderr .
+exec sleep 1m
+eden -t 2m eve start
+! stderr .
+
+# Deploy VM into network where only github.com is accessible
+eden network create 10.11.12.0/24 -n {{template "network"}}
+test eden.network.test -test.v -timewait 10m ACTIVATED {{template "network"}}
+exec -t 20m bash deploy.sh {{template "network"}} {{template "port"}}
+test eden.app.test -test.v -timewait 20m RUNNING app
+
+# Wait for VM to boot
+exec -t 20m bash ssh.sh
+stdout 'Ubuntu'
+
+# Check that passthrough interface is present and functional
+exec -t 20m bash check_passthrough.sh
+
+# reboot from guest
+exec -t 20m bash reboot.sh
+exec sleep 1m
+exec -t 20m bash ssh.sh
+stdout 'Ubuntu'
+
+# Re-check passthrough interface after reboot.
+# It also fails if there wasn't actually any reboot since the last check.
+exec -t 20m bash check_passthrough.sh
+
+# Cleanup - undeploy application
+eden pod delete app
+test eden.app.test -test.v -timewait 10m - app
+
+# Cleanup - remove network
+eden network delete {{template "network"}}
+test eden.network.test -test.v -timewait 10m - {{template "network"}}
+eden network ls
+! stdout '^{{template "network"}}\s'
+
+# Restore original devmodel (devmodelfile is already unset in the config)
+message 'Resetting of EVE'
+eden eve reset
+
+# Changes in physicalIO require reboot
+eden -t 2m eve stop
+! stderr .
+exec sleep 1m
+eden -t 2m eve start
+! stderr .
+
+-- deploy.sh --
+
+NETWORK=$1
+PORT=$2
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+IMG="https://cloud-images.ubuntu.com/releases/focal/release-20210510/ubuntu-20.04-server-cloudimg-amd64.img"
+PUB_KEY="$( cat {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa.pub )"
+$EDEN pod deploy -n app --networks=${NETWORK} --acl=${NETWORK}:github.com -p ${PORT}:22 --adapters eth1 --memory=1GB ${IMG} --metadata="#cloud-config\nssh_authorized_keys:\n - $PUB_KEY mykey@host"
+
+-- ssh.sh --
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for i in `seq 20`
+do
+ sleep 20
+ # Test SSH-access to VM
+ echo $i\) {{template "ssh"}}$HOST grep Ubuntu /etc/issue
+ {{template "ssh"}}$HOST grep Ubuntu /etc/issue && break
+done
+
+-- reboot.sh --
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+echo {{template "ssh"}}$HOST 'sudo shutdown -r +1 &>/dev/null &'
+{{template "ssh"}}$HOST 'sudo shutdown -r +1 &>/dev/null &'
+
+-- check_passthrough.sh --
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+CMDS="
+uptime -s;
+sudo lshw -class network;
+ip addr;
+! ls /tmp/passthrough-checked || exit;
+sudo sysctl -w net.ipv4.conf.all.rp_filter=0;
+sudo sysctl -w net.ipv4.conf.default.rp_filter=0;
+sudo dhclient {{template "passthrough_iface"}};
+sleep 20;
+ip addr;
+ping -c 5 -I {{template "virtio_iface"}} github.com || exit;
+ping -c 5 -I {{template "passthrough_iface"}} github.com || exit;
+! ping -c 5 -I {{template "virtio_iface"}} google.com || exit;
+ping -c 5 -I {{template "passthrough_iface"}} google.com || exit;
+touch /tmp/passthrough-checked
+"
+echo {{template "ssh"}}$HOST "$CMDS"
+{{template "ssh"}}$HOST "$CMDS"
+
+-- devmodel.json --
+
+{
+  "ioMemberList": [
+    {
+      "ztype": 1,
+      "phylabel": "eth0",
+      "phyaddrs": {
+        "Ifname": "eth0"
+      },
+      "logicallabel": "eth0",
+      "assigngrp": "eth0",
+      "usage": 2,
+      "usagePolicy": {
+        "freeUplink": true
+      }
+    },
+    {
+      "ztype": 1,
+      "phylabel": "eth1",
+      "phyaddrs": {
+        "Ifname": "eth1"
+      },
+      "logicallabel": "eth1",
+      "assigngrp": "eth1",
+      "usage": 0,
+      "usagePolicy": {
+        "freeUplink": true
+      }
+    }
+  ]
+}

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -10,6 +10,8 @@
 {{$usb_pt := EdenGetEnv "EDEN_TEST_USB_PT"}}
 # EDEN_TEST_AUDIO_PT -- "y" enables Audio Passthrough test (disabled by default).
 {{$audio_pt := EdenGetEnv "EDEN_TEST_AUDIO_PT"}}
+# EDEN_TEST_ETH_PT -- "y" enables Ethernet Passthrough test (disabled by default).
+{{$eth_pt := EdenGetEnv "EDEN_TEST_ETH_PT"}}
 # EDEN_TEST_REGISTRY env. var. -- "y"(default) performs the local EDEN registry test
 {{$registry := EdenGetEnv "EDEN_TEST_REGISTRY"}}
 
@@ -108,6 +110,10 @@ eden.escript.test -testdata ../hardware_reboot/testdata/ -test.run TestEdenScrip
 {{if (eq $audio_pt "y")}}
 /bin/echo Hardware reboot - Audio (22.1/{{$tests}})
 eden.escript.test -testdata ../hardware_reboot/testdata/ -test.run TestEdenScripts/hardware_audio_reboot
+{{end}}
+{{if (eq $eth_pt "y")}}
+/bin/echo Hardware reboot - Ethernet (22.2/{{$tests}})
+eden.escript.test -testdata ../hardware_reboot/testdata/ -test.run TestEdenScripts/hardware_eth_reboot
 {{end}}
 
 {{ if or (eq $workflow "large") (eq $workflow "gcp") }}


### PR DESCRIPTION
Alternative solution to: https://github.com/lf-edge/eden/pull/606 (which is incomplete)

Test deploys VM application with an additional passthrough ethernet interface. Key purpose is to verify that a reboot (`sudo shutdown -r +1`) from the guest doesn’t disrupt the set of assigned adapters. (We had bugs there in the past.) This test verifies that the application can communicate over the assigned passthrough Ethernet, and that it can not communicate via the NAT in EVE (due to the ACL blocking communication via network instance.)

Solution based on a custom devmodel file as [proposed here](https://github.com/lf-edge/eden/pull/606/files#r642512472).
`eth1` was switched from virtio to an emulated PCI NIC so that it is applicable for passthrough (this second interface is used only for testing purposes).

To run the test standalone (i.e. outside of the workflow), execute:
```
make clean && make build-tests
./eden config add default
./eden setup
source ~/.eden/activate.sh
./dist/bin/eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027
eden start
eden eve onboard
eden test tests/hardware_reboot -e hardware_eth_reboot -v debug
```

Also added `fmt.Printf("> %s\n", line)` to testscript as it is bothering me that I can't tell which command is currently running by a test that is being executed (locally or by github actions).

Signed-off-by: Milan Lenco <milan@zededa.com>