### PR TITLE
[WIP] add Equinix Metal Host(emh) cmd and change workflow

### DIFF
--- a/cmd/edenEmh.go
+++ b/cmd/edenEmh.go
@@ -1,0 +1,237 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/lf-edge/eden/pkg/linuxkit"
+	"github.com/lf-edge/eden/pkg/utils"
+	"github.com/spf13/viper"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"encoding/json"
+)
+
+var (
+	emhProjectID		string
+	emhPortName			string
+	emhPlan				string
+	emhPortID			string
+	emhNetworkID		string
+	emhDeviceID			string
+	emhFacility			string
+	emhOS				string
+	emhIpxeURL			string
+	emhEVETag			string
+	emhPrefixDeviceName	string
+)
+
+var emhCmd = &cobra.Command{
+	Use:   "emh",
+	Short: `Manage devices in Equinix Metal Hosting`,
+	Long:  `Manage devices in Equinix Metal Hosting
+			(you need to provide a api key, set it by export PACKET_AUTH_TOKEN=<your's token'>)`,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if err := rootCmd.PersistentPreRunE(cmd, args); err != nil {
+			return err
+		}
+		assignCobraToViper(cmd)
+
+		viperLoaded, err := utils.LoadConfigFile(configFile)
+
+		if viperLoaded && err == nil {
+			emhEVETag = viper.GetString("eve.tag") //use variable from config
+		}
+		return nil
+	},
+}
+
+var emhDeviceCmd = &cobra.Command{
+	Use:   "device",
+	Short: `Manage devices in EMH`,
+}
+
+var emhDevicePortCmd = &cobra.Command{
+	Use:   "port",
+	Short: `Read eth ports configurations on EMH switches per device`,
+}
+
+var emhPortCmd = &cobra.Command{
+	Use:   "port",
+	Short: `Manage ethernet ports configurations on EMH switches`,
+}
+
+var emhCreateDevice = &cobra.Command{
+	Use:   "create",
+	Short: "Create device in EMH",
+	Long:  `Create device in Equinix Metal Hosting`,
+	Run: func(cmd *cobra.Command, args []string) {
+		emhClient, err := linuxkit.NewEMHClient()
+		if err != nil {
+			log.Fatalf("Unable to connect to EMH: %v", err)
+		}
+		device, err := emhClient.CreateDevice(emhProjectID, emhPrefixDeviceName + "test-eden-eve-" + emhEVETag + "-" + emhFacility, emhFacility, emhPlan, emhOS, emhIpxeURL)
+		if err != nil {
+			log.Fatalf("Unable to create device in EMH: %v", err)
+		}
+		deviceJSON, err := json.Marshal(device)
+		if err != nil {
+			log.Fatalf("Failed get device as json: %v", err)
+		}
+		fmt.Println(string(deviceJSON))
+	},
+}
+
+var emhGetDevice = &cobra.Command{
+	Use:   "get",
+	Short: "Get device details",
+	Long:  `Get device details`,
+	Run: func(cmd *cobra.Command, args []string) {
+		emhClient, err := linuxkit.NewEMHClient()
+		if err != nil {
+			log.Fatalf("Unable to connect to EMH: %v", err)
+		}
+		device, err := emhClient.GetDevice(emhDeviceID)
+		if err != nil {
+			log.Fatalf("Unable to get device: %v", err)
+		}
+		deviceJSON, err := json.Marshal(device)
+		if err != nil {
+			log.Fatalf("Failed get device as json: %v", err)
+		}
+		fmt.Println(string(deviceJSON))
+	},
+}
+
+var emhDeleteDevice = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete device",
+	Run: func(cmd *cobra.Command, args []string) {
+		emhClient, err := linuxkit.NewEMHClient()
+		if err != nil {
+			log.Fatalf("Unable to connect to EMH: %v", err)
+		}
+		err = emhClient.DeleteDevice(emhDeviceID)
+		if err != nil {
+			log.Fatalf("Unable to delete device: %v", err)
+		}
+	},
+}
+
+var emhGetDevicePort = &cobra.Command{
+	Use:   "get",
+	Short: "Get device network port",
+	Long:  `Get device network port`,
+	Run: func(cmd *cobra.Command, args []string) {
+		emhClient, err := linuxkit.NewEMHClient()
+		if err != nil {
+			log.Fatalf("Unable to connect to EMH: %v", err)
+		}
+		port, err := emhClient.GetDevicePortByName(emhDeviceID, emhPortName)
+		if err != nil {
+			log.Fatalf(err.Error())
+		}
+		portJSON, err := json.Marshal(port)
+		if err != nil {
+			log.Fatalf("Failed get port as json: %v", err)
+		}
+		fmt.Println(string(portJSON))
+	},
+}
+
+var emhAssignPort = &cobra.Command{
+	Use:   "assign",
+	Short: "Add a VLAN to a port",
+	Long:  `Add a VLAN to a port`,
+	Run: func(cmd *cobra.Command, args []string) {
+		emhClient, err := linuxkit.NewEMHClient()
+		if err != nil {
+			log.Fatalf("Unable to connect to EMH: %v", err)
+		}
+		err = emhClient.AssignPort(emhPortID, emhNetworkID)
+		if err != nil {
+			log.Fatalf(err.Error())
+		}
+	},
+}
+
+var emhDisbondPort = &cobra.Command{
+	Use:   "disbond",
+	Short: "Disable bonding for port",
+	Long:  `Disable bonding for port`,
+	Run: func(cmd *cobra.Command, args []string) {
+		emhClient, err := linuxkit.NewEMHClient()
+		if err != nil {
+			log.Fatalf("Unable to connect to EMH: %v", err)
+		}
+		err = emhClient.DisbondPort(emhPortID)
+		if err != nil {
+			log.Fatalf(err.Error())
+		}
+	},
+}
+
+var emhAssignPortNative = &cobra.Command{
+	Use:   "assign-native",
+	Short: "Assign a virtual network to the port as a \"native VLAN\"",
+	Long:  `Assign a virtual network to the port as a "native VLAN"`,
+	Run: func(cmd *cobra.Command, args []string) {
+		emhClient, err := linuxkit.NewEMHClient()
+		if err != nil {
+			log.Fatalf("Unable to connect to EMH: %v", err)
+		}
+		err = emhClient.AssignNativePort(emhPortID, emhNetworkID)
+		if err != nil {
+			log.Fatalf(err.Error())
+		}
+	},
+}
+
+func emhInit() {
+	// device
+	emhCmd.AddCommand(emhDeviceCmd)
+	// device -> create
+	emhDeviceCmd.AddCommand(emhCreateDevice)
+	emhCreateDevice.Flags().StringVarP(&emhProjectID, "project-id", "p", "", "project id")
+	emhCreateDevice.Flags().StringVarP(&emhFacility, "facility","f", "", "facility code")
+	emhCreateDevice.Flags().StringVarP(&emhPrefixDeviceName, "name-prefix","n", "", "device name prefix")
+	emhCreateDevice.Flags().StringVarP(&emhOS, "operating-system", "o", "", "operation system")
+	emhCreateDevice.Flags().StringVarP(&emhIpxeURL, "ipxe","i", "", "ipxe cfg url")
+	emhCreateDevice.Flags().StringVarP(&emhPlan, "plan", "P", "", "plan (configuration)")
+	_ = emhCreateDevice.MarkFlagRequired("project-id")
+	_ = emhCreateDevice.MarkFlagRequired("facility")
+	_ = emhCreateDevice.MarkFlagRequired("plan")
+	_ = emhCreateDevice.MarkFlagRequired("operating-system")
+	// device -> get
+	emhDeviceCmd.AddCommand(emhGetDevice)
+	emhGetDevice.Flags().StringVarP(&emhDeviceID, "device-id","i", "", "device id")
+	_ = emhGetDevice.MarkFlagRequired("device-id")
+	// device -> delete
+	emhDeviceCmd.AddCommand(emhDeleteDevice)
+	emhDeleteDevice.Flags().StringVarP(&emhDeviceID, "device-id","i", "", "device id")
+	_ = emhGetDevice.MarkFlagRequired("device-id")
+	// device -> port
+	emhDeviceCmd.AddCommand(emhDevicePortCmd)
+	// device -> port -> get
+	emhDevicePortCmd.AddCommand(emhGetDevicePort)
+	emhGetDevicePort.Flags().StringVarP(&emhDeviceID, "device-id","i", "", "device id")
+	emhGetDevicePort.Flags().StringVarP(&emhPortName, "port-name","p", "", "device port name")
+	_ = emhGetDevicePort.MarkFlagRequired("device-id")
+	_ = emhGetDevicePort.MarkFlagRequired("port-name")
+	// port
+	emhCmd.AddCommand(emhPortCmd)
+	// port -> assign
+	emhPortCmd.AddCommand(emhAssignPort)
+	emhAssignPort.Flags().StringVarP(&emhPortID, "port-id", "i", "", "port id")
+	emhAssignPort.Flags().StringVarP(&emhPortName, "network-id", "n", "", "network id")
+	_ = emhAssignPort.MarkFlagRequired("port-id")
+	_ = emhAssignPort.MarkFlagRequired("network-id")
+	// port -> disbond
+	emhPortCmd.AddCommand(emhDisbondPort)
+	emhDisbondPort.Flags().StringVarP(&emhPortID,"port-id", "i", "", "port id")
+	_ = emhAssignPort.MarkFlagRequired("port-id")
+	// port -> assign-native
+	emhPortCmd.AddCommand(emhAssignPortNative)
+	emhAssignPortNative.Flags().StringVarP(&emhPortID, "port-id", "i", "", "port id")
+	emhAssignPortNative.Flags().StringVarP(&emhPortName, "network-id", "n", "", "network id")
+	_ = emhAssignPortNative.MarkFlagRequired("port-id")
+	_ = emhAssignPortNative.MarkFlagRequired("network-id")
+}

--- a/cmd/edenUtils.go
+++ b/cmd/edenUtils.go
@@ -98,6 +98,8 @@ func utilsInit() {
 	certsInit()
 	utilsCmd.AddCommand(gcpCmd)
 	gcpInit()
+	utilsCmd.AddCommand(emhCmd)
+	emhInit()
 	utilsCmd.AddCommand(sdInfoEveCmd)
 	debugInit()
 	utilsCmd.AddCommand(debugCmd)

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/nerd2/gexto v0.0.0-20190529073929-39468ec063f6
 	github.com/onsi/gomega v1.10.0 // indirect
 	github.com/opencontainers/selinux v1.7.0 // indirect
+	github.com/packethost/packngo v0.15.0 // indirect
 	github.com/pelletier/go-toml v1.9.0 // indirect
 	github.com/prometheus/client_golang v1.8.0 // indirect
 	github.com/prometheus/common v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -595,6 +595,8 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
+github.com/packethost/packngo v0.15.0 h1:nyiVHJAhQdt37Vf141vvm83niZHRKbBs9FmFB+QRgd4=
+github.com/packethost/packngo v0.15.0/go.mod h1:YrtUNN9IRjjqN6zK+cy2IYoi3EjHfoWTWxJkI1I1Vk0=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
@@ -805,6 +807,7 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200420201142-3c4aac89819a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/pkg/linuxkit/emh.go
+++ b/pkg/linuxkit/emh.go
@@ -1,0 +1,88 @@
+package linuxkit
+
+import (
+	"fmt"
+	"github.com/packethost/packngo"
+	log "github.com/sirupsen/logrus"
+)
+// EMHClient contains interfaces for communication with EMH
+type EMHClient struct {
+	devices packngo.DeviceService
+	ports packngo.PortService
+}
+
+// NewEMHClient creates a new EMH client
+func NewEMHClient() (*EMHClient, error) {
+	log.Debugf("Connecting to EMH")
+	var emhClient *EMHClient
+	client, err := packngo.NewClient()
+	if err != nil {
+		return emhClient, fmt.Errorf(err.Error())
+	}
+	emhClient = &EMHClient{
+		devices: client.Devices,
+		ports: client.Ports,
+	}
+	return emhClient, nil
+}
+
+// CreateDevice create a device in EMH
+func (emh EMHClient) CreateDevice(projectID, hostname, facility, plan, operatingSystem, ipxeURL string) (*packngo.Device, error) {
+	var facilityArgs []string
+	if facility != "" {
+		facilityArgs = append(facilityArgs, facility)
+	}
+
+	request := &packngo.DeviceCreateRequest{
+		Hostname: hostname,
+		Facility: facilityArgs,
+		OS: operatingSystem,
+		ProjectID: projectID,
+		IPXEScriptURL: ipxeURL,
+		Plan: plan,
+		BillingCycle: "hourly",
+	}
+
+	device, _, err := emh.devices.Create(request)
+	return device, err
+}
+
+// GetDevice Getting a device
+func (emh EMHClient) GetDevice(deviceID string) (*packngo.Device, error) {
+	device,_, err := emh.devices.Get(deviceID, nil)
+	return device, err
+}
+
+// DeleteDevice deletes a device
+func (emh EMHClient) DeleteDevice(deviceID string) error {
+	_, err := emh.devices.Delete(deviceID, true)
+	return err
+}
+
+// GetDevicePortByName Getting a device port by name
+func (emh EMHClient) GetDevicePortByName(deviceID, portName string) (*packngo.Port, error) {
+	device,_, err := emh.devices.Get(deviceID, nil)
+	if err != nil {
+		return nil, err
+	}
+	port, err := device.GetPortByName(portName)
+	return port, err
+}
+
+// DisbondPort disables bonding for one port
+func (emh EMHClient) DisbondPort(portID string) error {
+	_, _, err := emh.ports.Disbond(portID, false)
+	return err
+}
+
+// AssignPort adds a VLAN to a port
+func (emh EMHClient) AssignPort(portID, vlanID string) error {
+	_, _, err := emh.ports.Assign(portID, vlanID)
+	return err
+}
+
+// AssignNativePort assigns a virtual network to the port as a "native VLAN"
+func (emh EMHClient) AssignNativePort(portID, vlanID string) error {
+	_, _, err := emh.ports.AssignNative(portID, vlanID)
+	return err
+}


### PR DESCRIPTION
When discussing [PR in EVE](https://github.com/lf-edge/eve/pull/2103), we decided we wanted to see a VPN tunnel from the GH actions server to the EVE packet hosted server.

All servers in the packet hosting have at least 2 network ports. They are combined into bond0. I failed to get both ports out of bond0 and I failed with eth0 alone. Therefore, I do not touch the configuration of the eth0 port, and only disconnect eth1 from bond0. 
With the eth1 port, we can do whatever we want and this does not affect the work.
After manual tests, I was able to merge 2 servers into 1 virtual network using eth1 on both servers.
After success, I decided to check the [official cli](https://github.com/packethost/packet-cli) for managing packet hosting, but unfortunately I found that there is no functional for managing network ports. For this reason I had to write a cli in eden to be able to manage ports and devices.

- [x] Create wirtual network in Equinix Metal Hosting for vpn connections.
- [x] Create OpenVPN server.
- [x] Create DHCP server in Virtual network.
- [x] EMH cmd cli
- [ ] workflow

OpenVPN server and DHCP server run on the same server. On this server, the eth1 port is disconnected from bond0 and a native vlan for VPN connections is set on this port. This port is connected by a bridge with an adapter in which all VPN clients are connected.

For vpn clients, addresses are allocated from 192.168.8.128 to 192.168.8.200.
For DHCP clients addresses are allocated from 192.168.8.10 to 192.168.8.127.


Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>