### PR TITLE
Add .idea and /eden to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 dist
 Config.in
 ./eden
+/eden
 
 # workflow flavours
 tests/workflow/workflow.default.txt

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ tests/workflow/workflow.default.txt
 tests/workflow/workflow.small.txt
 tests/workflow/workflow.large.txt
 
+#IDE
+.idea
+
 eve-config-dir/*
 
 export


### PR DESCRIPTION
Add missed /eden to .gitignore
Add .idea to .gitignore for Goland IDE

Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>