### PR TITLE
wait for purging state

### DIFF
--- a/tests/eclient/testdata/nw_switch.txt
+++ b/tests/eclient/testdata/nw_switch.txt
@@ -50,8 +50,7 @@ stdout '100% packet loss'
 
 message 'Switching to 2st network'
 eden pod modify pong --networks n2
-test eden.app.test -test.v -timewait 5m PURGING pong
-test eden.app.test -test.v -timewait 10m RUNNING pong
+test eden.app.test -test.v -timewait 15m RUNNING pong
 eden pod ps
 cp stdout pod_ps
 exec bash pong_ip.sh
@@ -66,8 +65,7 @@ stdout '0% packet loss'
 
 message 'Switching back to 1st network'
 eden pod modify pong --networks n1
-test eden.app.test -test.v -timewait 5m PURGING pong
-test eden.app.test -test.v -timewait 10m RUNNING pong
+test eden.app.test -test.v -timewait 15m RUNNING pong
 eden pod ps
 cp stdout pod_ps
 exec bash pong_ip.sh


### PR DESCRIPTION
Seems, I broke nw_switch test in the old variant (due to eden.app.test now looks onto existing states before moving to the new ones), so we forced to add waiting for purging state into pod modify.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>