### PR TITLE
increase sleeps and timeouts in tests for rpi4

### DIFF
--- a/tests/eclient/testdata/acl.txt
+++ b/tests/eclient/testdata/acl.txt
@@ -22,7 +22,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 message 'Resetting of EVE'
 eden eve reset
-exec sleep 20
+exec sleep 30
 
 # use zededa.com IP address as a target for $fake_domain
 exec -t 10m bash dns_lookup.sh zededa.com

--- a/tests/eclient/testdata/air-gapped-switch.txt
+++ b/tests/eclient/testdata/air-gapped-switch.txt
@@ -20,7 +20,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 message 'Resetting of EVE'
 eden eve reset
-exec sleep 20
+exec sleep 30
 
 message 'Creating networks: local indirect and air-gapped switch direct'
 eden network create 10.11.12.0/24 -n indirect

--- a/tests/eclient/testdata/app_nonat.txt
+++ b/tests/eclient/testdata/app_nonat.txt
@@ -15,7 +15,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 message 'Resetting of EVE'
 eden eve reset
-exec sleep 20
+exec sleep 30
 
 message 'Creating networks'
 eden network create 10.11.12.0/24 -n indirect

--- a/tests/eclient/testdata/mount.txt
+++ b/tests/eclient/testdata/mount.txt
@@ -13,7 +13,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 eden pod deploy -n eclient-mount --memory=512MB docker://itmoeve/eclient:0.7 -p {{$port}}:22 --mount=src=docker://nginx:1.20.0,dst=/tst --mount=src={{EdenConfig "eden.tests"}}/eclient/testdata,dst=/dir
 
-test eden.app.test -test.v -timewait 20m RUNNING eclient-mount
+test eden.app.test -test.v -timewait 21m RUNNING eclient-mount
 
 exec -t 5m bash ssh.sh /tst
 stdout 'docker-entrypoint.sh'

--- a/tests/eclient/testdata/nw_switch.txt
+++ b/tests/eclient/testdata/nw_switch.txt
@@ -15,7 +15,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 message 'Resetting of EVE'
 eden eve reset
-exec sleep 20
+exec sleep 30
 
 message 'Creating networks'
 #exec sleep 5

--- a/tests/eclient/testdata/port_forward.txt
+++ b/tests/eclient/testdata/port_forward.txt
@@ -16,7 +16,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 message 'Resetting of EVE'
 eden eve reset
-exec sleep 20
+exec sleep 30
 
 ############################## TEST SCENARIO 1 ################################
 # Hairpin connectivity test between two apps connected to the same network instance
@@ -25,6 +25,7 @@ message 'SCENARIO 1: Creating networks'
 eden network create 10.11.12.0/24 -n n1
 
 test eden.network.test -test.v -timewait 10m ACTIVATED n1
+exec sleep 10
 
 message 'SCENARIO 1: Starting with both application attached to same network instance'
 eden pod deploy -v debug -n app1 docker://itmoeve/eclient:0.6 -p 2223:22 --networks=n1 --memory=512MB

--- a/tests/eclient/testdata/profile.txt
+++ b/tests/eclient/testdata/profile.txt
@@ -16,7 +16,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 message 'Resetting of EVE'
 eden eve reset
-exec sleep 20
+exec sleep 30
 
 # Define local-manager and two apps in different profiles
 # TBD: static ip in pod deploy

--- a/tests/network/testdata/network_test.txt
+++ b/tests/network/testdata/network_test.txt
@@ -1,4 +1,4 @@
-eden -t 5s network ls
+eden -t 10s network ls
 
 # Starting of reboot detector with a 1 reboot limit
 ! test eden.reboot.test -test.v -timewait 20m -reboot=0 -count=1 &

--- a/tests/registry/testdata/registry_test.txt
+++ b/tests/registry/testdata/registry_test.txt
@@ -3,7 +3,7 @@
 [!exec:cut] stop
 [!exec:grep] stop
 
-eden -t 5s pod ps
+eden -t 10s pod ps
 
 # Starting of reboot detector with a 3 reboots limit
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &

--- a/tests/volume/testdata/volumes_test.txt
+++ b/tests/volume/testdata/volumes_test.txt
@@ -1,4 +1,4 @@
-eden -t 5s volume ls
+eden -t 10s volume ls
 
 # Starting of reboot detector with a 1 reboots limit
 ! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &


### PR DESCRIPTION
When testing the EVE releases on Rpi4, i found floating test errors associated with small timeout values and small sleep values ​​in the tests. This PR fixes the problem.

Signed-off-by: Aleksandrov Dmitriy <goodmobiledevices@gmail.com>