### PR TITLE
Test for switch network instance VLANs

### DIFF
--- a/cmd/podModify.go
+++ b/cmd/podModify.go
@@ -78,6 +78,11 @@ var podModifyCmd = &cobra.Command{
 					opts = append(opts, expect.WithPortsPublish(portPublishCombined))
 				}
 				opts = append(opts, expect.WithACL(processAcls(acl)))
+				vlansParsed, err := processVLANs(vlans)
+				if err != nil {
+					log.Fatal(err)
+				}
+				opts = append(opts, expect.WithVLANs(vlansParsed))
 				opts = append(opts, expect.WithOldApp(appName))
 				expectation := expect.AppExpectationFromURL(ctrl, dev, defaults.DefaultDummyExpect, appName, opts...)
 				appInstanceConfig := expectation.Application()
@@ -139,4 +144,6 @@ func podModifyInit() {
 	podModifyCmd.Flags().StringSliceVar(&acl, "acl", nil, `Allow access only to defined hosts/ips/subnets
 You can set acl for particular network in format '<network_name:acl>'
 To remove acls you can set empty line '<network_name>:'`)
+	podModifyCmd.Flags().StringSliceVar(&vlans, "vlan", nil, `Connect application to the (switch) network over an access port assigned to the given VLAN.
+You can set access VLAN ID (VID) for a particular network in the format '<network_name:VID>'`)
 }

--- a/pkg/expect/application.go
+++ b/pkg/expect/application.go
@@ -118,10 +118,11 @@ func (exp *AppExpectation) createAppInstanceConfig(img *config.Image, netInstanc
 			log.Fatalf("broken network instance pointer: %v", k)
 		}
 		bundle.appInstanceConfig.Interfaces = append(bundle.appInstanceConfig.Interfaces, &config.NetworkAdapter{
-			Name:       "default",
-			NetworkId:  ni.Uuidandversion.Uuid,
-			Acls:       exp.getAcls(k),
-			MacAddress: k.mac,
+			Name:         "default",
+			NetworkId:    ni.Uuidandversion.Uuid,
+			Acls:         exp.getAcls(k),
+			MacAddress:   k.mac,
+			AccessVlanId: exp.getAccessVID(k),
 		})
 	}
 	if exp.vncDisplay != 0 {

--- a/pkg/expect/expectation.go
+++ b/pkg/expect/expectation.go
@@ -70,6 +70,7 @@ type AppExpectation struct {
 
 	disks []string
 	acl   map[string][]string // networkInstanceName -> acls
+	vlans map[string]int // networkInstanceName -> VID
 
 	openStackMetadata bool
 	profiles          []string

--- a/pkg/expect/networkInstance.go
+++ b/pkg/expect/networkInstance.go
@@ -218,3 +218,12 @@ func (exp *AppExpectation) getAcls(ni *NetInstanceExpectation) []*config.ACE {
 	}
 	return acls
 }
+
+// getAccessVID returns Access VLAN ID to assign to the interface between the app
+// and the given network instance.
+func (exp *AppExpectation) getAccessVID(ni *NetInstanceExpectation) uint32 {
+	if exp.vlans == nil {
+		return 0
+	}
+	return uint32(exp.vlans[ni.name])
+}

--- a/pkg/expect/options.go
+++ b/pkg/expect/options.go
@@ -201,6 +201,13 @@ func WithACL(acl map[string][]string) ExpectationOption {
 	}
 }
 
+//WithVLANs sets access VLAN IDs for application interfaces
+func WithVLANs(vlans map[string]int) ExpectationOption {
+	return func(expectation *AppExpectation) {
+		expectation.vlans = vlans
+	}
+}
+
 //WithRegistry sets registry to use (remote/local)
 func WithRegistry(registry string) ExpectationOption {
 	return func(expectation *AppExpectation) {

--- a/tests/escript/escript_test.go
+++ b/tests/escript/escript_test.go
@@ -1,6 +1,7 @@
 package escript
 
 import (
+	"errors"
 	"flag"
 	log "github.com/sirupsen/logrus"
 	"os"
@@ -35,9 +36,21 @@ func TestEdenScripts(t *testing.T) {
 
 	log.Info("testData directory: ", *testData)
 	testscript.Run(t, testscript.Params{
-		Dir:   *testData,
-		Flags: flagsParsed,
+		Dir:       *testData,
+		Flags:     flagsParsed,
+		Condition: customConditions,
 	})
+}
+
+// Function adds additional condition(s) for testscripts:
+// - [env:<env-variable>] is satisfied if the environment variable has a non-empty string value assigned.
+func customConditions(ts *testscript.TestScript, cond string) (bool, error) {
+	if strings.HasPrefix(cond, "env:") {
+		env := cond[len("env:"):]
+		env = strings.TrimSpace(env)
+		return ts.Getenv(env) != "", nil
+	}
+	return false, errors.New("unknown condition")
 }
 
 func TestMain(m *testing.M) {

--- a/tests/escript/go-internal/testscript/testscript.go
+++ b/tests/escript/go-internal/testscript/testscript.go
@@ -122,7 +122,7 @@ type Params struct {
 	// Condition is called, if not nil, to determine whether a particular
 	// condition is true. It's called only for conditions not in the
 	// standard set, and may be nil.
-	Condition func(cond string) (bool, error)
+	Condition func(ts *TestScript, cond string) (bool, error)
 
 	// Cmds holds a map of commands available to the script.
 	// It will only be consulted for commands not part of the standard set.
@@ -580,7 +580,7 @@ func (ts *TestScript) condition(cond string) (bool, error) {
 			return ok, nil
 		}
 		if ts.params.Condition != nil {
-			return ts.params.Condition(cond)
+			return ts.params.Condition(ts, cond)
 		}
 		ts.Fatalf("unknown condition %q", cond)
 		panic("unreachable")

--- a/tests/network/Makefile
+++ b/tests/network/Makefile
@@ -17,7 +17,7 @@ OS ?= $(HOSTOS)
 # IMAGE_TAG is the tag for image to build
 IMAGE_TAG ?= itmoeve/docker-test
 # IMAGE_VERSION is the version of image to build
-IMAGE_VERSION ?= 1.2
+IMAGE_VERSION ?= 1.3
 # IMAGE_DIR is the directory with image Dockerfile to build
 IMAGE_DIR=$(CURDIR)/image
 

--- a/tests/network/eden.network.tests.txt
+++ b/tests/network/eden.network.tests.txt
@@ -1,1 +1,3 @@
 eden.escript.test -test.run TestEdenScripts/test_networking -test.timeout 40m
+
+eden.escript.test -test.run TestEdenScripts/vlans -test.timeout 40m

--- a/tests/network/image/Dockerfile
+++ b/tests/network/image/Dockerfile
@@ -2,17 +2,20 @@ FROM debian:buster-slim
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \
   supervisor=3.3.5-1 \
-  curl=7.64.0-4+deb10u1 \
+  curl=7.64.0-4+deb10u2 \
   dhcpcd5=7.1.0-2 \
-  nginx=1.14.2-2+deb10u3 \
-  net-tools=1.60+git20180626.aebd88e-1 && \
+  nginx=1.14.2-2+deb10u4 \
+  net-tools=1.60+git20180626.aebd88e-1 \
+  dnsmasq=2.80-1+deb10u1 \
+  iproute2=4.20.0-2+deb10u1 && \
   rm -rf /var/lib/apt/lists/*
 
+RUN mkdir /app/
 COPY supervisord.conf /etc/supervisord.conf
-COPY entrypoint.sh /entrypoint.sh
-COPY dhcpcd.conf /dhcpcd.conf
-RUN chmod a+x /entrypoint.sh
+COPY entrypoint.sh /app/entrypoint.sh
+COPY dhcpcd.conf /etc/dhcpcd.conf
+RUN chmod a+x /app/entrypoint.sh
 
 EXPOSE 80
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/tests/network/image/supervisord.conf
+++ b/tests/network/image/supervisord.conf
@@ -26,7 +26,7 @@ stopsignal=KILL
 stopasgroup=true
 
 [program:dhcpcd]
-command=/sbin/dhcpcd --nobackground -f /dhcpcd.conf
+command=/sbin/dhcpcd --nobackground -f /etc/dhcpcd.conf
 autostart=true
 autorestart=true
 numprocs=1

--- a/tests/network/testdata/vlans.txt
+++ b/tests/network/testdata/vlans.txt
@@ -1,0 +1,202 @@
+[!exec:bash] stop
+[!exec:grep] stop
+[!exec:cut] stop
+[!exec:curl] stop
+[!exec:sleep] stop
+
+# This test deploys 5 applications in total.
+# Four of those applications run the same curl and nginx services as used in "test_networking.txt".
+# All applications are connected to a NATed local network (10.1.0.0/24), used for access to HTTP endpoints from outside
+# through port-maps, but also to an air-gaped switch network split into multiple VLANs (10.2.<vid>.0/24):
+#  - app1 and app2 are connected to VLAN 100
+#  - app3 is connected to VLAN 200
+#  - app4 has initially no VLANs configured, later it is moved to VLAN 100
+#
+# The fifth application provides DHCP services separately for VLANs 100, 200 and for applications outside VLANs:
+#  - VLAN 100 uses IP range 10.2.100.0/24
+#  - VLAN 200 uses IP range 10.2.200.0/24
+#  - application interfaces without VLAN assignment get IP addresses from the range 10.2.0.0/24
+
+# The application providing DHCP services for multiple VLANs requires netadmin capabilities, otherwise
+# it is not permitted to create VLAN sub-interfaces. For security reasons, EVE does not allow to grant these
+# capabilities to native containers, therefore it is required to deploy apps as VMs-in-Containers for this test to pass.
+exec -t 2m bash check_vm_support.sh
+source .env
+[!env:with_hw_virt] skip 'Missing HW-assisted virtualization capability'
+
+# TODO: push into the itmoeve repository
+{{$image := "docker://milan4zededa/docker-test:1.3"}}
+
+# string to use as the testing sequence
+{{$test_data := "TEST_SEQUENCE"}}
+
+# create networks for the test
+eden network create 10.1.0.0/24 -n nat
+eden network create --type switch --uplink none -n switch
+test eden.network.test -test.v -timewait 10m ACTIVATED nat
+test eden.network.test -test.v -timewait 10m ACTIVATED switch
+
+# Deploy DHCP server
+eden pod deploy -n dhcp-server --memory=512MB --networks=nat --networks=switch -p 8027:80 --mount=src={{EdenConfig "eden.tests"}}/network/testdata/vlans/dhcp-server,dst=/app {{$image}}
+test eden.app.test -test.v -timewait 10m RUNNING dhcp-server
+exec -t 2m bash wait_and_get_ifconfig.sh dhcp-server 8027
+stdout '10.2.100.1  netmask 255.255.255.0'
+stdout '10.2.200.1  netmask 255.255.255.0'
+
+# Deploy app1 and connect it to VLAN 100
+eden pod deploy -n app1 --memory=512MB --networks=nat --networks=switch -p 8028:80 --vlan=switch:100 --metadata='url={{$test_data}}' {{$image}}
+test eden.app.test -test.v -timewait 10m RUNNING app1
+exec -t 5m bash wait_and_get_ip.sh app1 8028
+grep 'app1_ip=10.2.100.\d+' .env
+source .env
+
+# Deploy app2 and connect it to VLAN 100
+eden pod deploy -n app2 --memory=512MB --networks=nat --networks=switch -p 8029:80 --vlan=switch:100 --metadata="url=http://${app1_ip}/user-data.html" {{$image}}
+test eden.app.test -test.v -timewait 10m RUNNING app2
+exec -t 5m bash wait_and_get_ip.sh app2 8029
+grep 'app2_ip=10.2.100.\d+' .env
+source .env
+
+# Wait for app2 to obtain test_data from app1
+exec -t 5m bash wait_and_get_recv_data.sh app2 8029
+stdout '{{$test_data}}'
+
+# Deploy app3 and connect it to VLAN 200
+eden pod deploy -n app3 --memory=512MB --networks=nat --networks=switch -p 8030:80 --vlan=switch:200 --metadata="url=http://${app1_ip}/user-data.html" {{$image}}
+test eden.app.test -test.v -timewait 10m RUNNING app3
+exec -t 5m bash wait_and_get_ip.sh app3 8030
+grep 'app3_ip=10.2.200.\d+' .env
+source .env
+
+# app3 will try to obtain test_data from app1, but it should fail because they are in different VLANs
+exec -t 5m bash wait_and_get_recv_data.sh app3 8030
+! stdout '{{$test_data}}'
+
+# Deploy app4 outside of VLANs
+eden pod deploy -n app4 --memory=512MB --networks=nat --networks=switch -p 8031:80 --metadata="url=http://${app1_ip}/user-data.html" {{$image}}
+test eden.app.test -test.v -timewait 10m RUNNING app4
+exec -t 5m bash wait_and_get_ip.sh app4 8031
+grep 'app4_ip=10.2.0.\d+' .env
+source .env
+
+# app4 will try to obtain test_data from app1, but it should fail because app1 is inside VLAN while app4 is not
+exec -t 5m bash wait_and_get_recv_data.sh app4 8031
+! stdout '{{$test_data}}'
+
+# Modify app4 and move it to the VLAN 100
+eden pod modify app4 --networks=nat --networks=switch -p 8031:80 --vlan=switch:100
+exec sleep 15
+test eden.app.test -test.v -timewait 10m RUNNING app4
+exec -t 5m bash wait_and_get_ip.sh app4 8031
+grep 'app4_ip=10.2.100.\d+' .env
+source .env
+
+# app4 should now be able to obtain test_data from app1
+exec -t 5m bash wait_and_get_recv_data.sh app4 8031
+stdout '{{$test_data}}'
+
+# Cleanup - undeploy applications
+eden pod delete dhcp-server
+eden pod delete app1
+eden pod delete app2
+eden pod delete app3
+eden pod delete app4
+test eden.app.test -test.v -timewait 10m - dhcp-server app1 app2 app3 app4
+eden pod ps
+! stdout 'dhcp-server'
+! stdout 'app[1-4]'
+
+# Cleanup - remove networks
+eden network delete nat
+eden network delete switch
+test eden.network.test -test.v -timewait 10m - nat switch
+eden network ls
+! stdout 'nat'
+! stdout 'switch'
+
+-- check_vm_support.sh --
+#!/bin/sh
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+:>.env
+while true;
+do
+    virt=$($EDEN info --out InfoContent.dinfo.Capabilities.HWAssistedVirtualization | tail -n 1)
+    if [ -z "$virt" ]; then
+        sleep 3
+        continue
+    fi
+    [ "$virt" == "true" ] && echo "with_hw_virt=true" >>.env
+    break
+done
+
+-- wait_and_get_ifconfig.sh --
+#!/bin/sh
+
+APP=$1
+PORT=$2
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+address=http://${HOST}:${PORT}/ifconfig.html
+until curl -m 10 $address | grep -q LOOPBACK; do sleep 3; done
+curl -m 10 $address
+
+-- wait_and_get_ip.sh --
+#!/bin/sh
+
+APP=$1
+PORT=$2
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+function get_ip {
+    address=http://${HOST}:${PORT}/ifconfig.html
+    ifconfig=$(curl -m 10 $address) || return 1
+    if [ -z "$ifconfig" ]; then
+        return 1
+    fi
+    interfaces=$(echo "$ifconfig" | grep "^\w" | grep -v LOOPBACK | cut -d: -f1)
+    eth1=$(echo "$interfaces" | awk 'NR==2')
+    IP=$(echo "$ifconfig" | grep "^${eth1}: " -A 1 | awk '/inet / {print $2}' | cut -d"/" -f1)
+    if [ ! -z "$IP" ]; then
+        echo "IP address of $APP is: $IP"
+        echo "${APP}_ip=$IP" >.env
+        return 0
+    fi
+    return 1
+}
+
+until get_ip; do sleep 3; done
+
+-- wait_and_get_recv_data.sh --
+#!/bin/sh
+
+APP=$1
+PORT=$2
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+address=http://${HOST}:${PORT}/received-data.html
+
+# wait at most 1 minute for received-data.html to be available
+for i in `seq 12`
+do
+    sleep 5
+    recv_data=$(curl -m 10 $address)
+    if [ ! -z "$recv_data" ]; then
+        break
+    fi
+done
+curl -m 10 $address
+
+-- eden-config.yml --
+{{/* Test's config file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/network/testdata/vlans/dhcp-server/entrypoint.sh
+++ b/tests/network/testdata/vlans/dhcp-server/entrypoint.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+interfaces=$(ifconfig | grep "^\w" | grep -v LOOPBACK | cut -d: -f1)
+eth1=$(echo "$interfaces" | awk 'NR==2')
+
+ip addr add 10.2.0.1/24 dev "${eth1}"
+
+# Configure VLAN sub-interfaces
+ip link add link "${eth1}" name "${eth1}.100" type vlan id 100
+ip link set dev "${eth1}.100" up
+ip addr add 10.2.100.1/24 dev "${eth1}.100"
+
+ip link add link "${eth1}" name "${eth1}.200" type vlan id 200
+ip link set dev "${eth1}.200" up
+ip addr add 10.2.200.1/24 dev "${eth1}.200"
+
+# DHCP server for apps without VLANs
+cat <<EOF > /etc/dnsmasq.conf
+bind-interfaces
+except-interface=lo
+dhcp-leasefile=/run/dnsmasq.leases
+interface=${eth1}
+dhcp-range=10.2.0.2,10.2.0.254,60m
+EOF
+
+# DHCP server for VLAN 100
+cat <<EOF > /etc/dnsmasq.100.conf
+bind-interfaces
+except-interface=lo
+dhcp-leasefile=/run/dnsmasq.100.leases
+interface=${eth1}.100
+dhcp-range=10.2.100.2,10.2.100.254,60m
+EOF
+
+# DHCP server for VLAN 200
+cat <<EOF > /etc/dnsmasq.200.conf
+bind-interfaces
+except-interface=lo
+dhcp-leasefile=/run/dnsmasq.200.leases
+interface=${eth1}.200
+dhcp-range=10.2.200.2,10.2.200.254,60m
+EOF
+
+cat <<EOF > /etc/supervisord.conf
+[supervisord]
+nodaemon=true
+
+[program:dnsmasq]
+command=dnsmasq -d -b -C /etc/dnsmasq.conf
+
+[program:dnsmasq.100]
+command=dnsmasq -d -b -C /etc/dnsmasq.100.conf
+
+[program:dnsmasq.200]
+command=dnsmasq -d -b -C /etc/dnsmasq.200.conf
+
+[program:nginx]
+command=nginx -g "daemon off;"
+autorestart=true
+stopsignal=KILL
+stopasgroup=true
+
+[program:ip]
+command=/bin/sh -c "while true; do sleep 5; ifconfig>/var/www/html/ifconfig.html; done"
+autorestart=true
+stopsignal=KILL
+stopasgroup=true
+EOF
+
+exec /usr/bin/supervisord -c /etc/supervisord.conf

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -32,7 +32,7 @@ qemu+usb.sh
 qemu+audio.sh
 {{end}}
 {{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") (eq $devmodel "parallels") }}
-eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027
+eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027 8028:8028 8029:8029 8030:8030 8031:8031
 {{end}}
 
 {{if (ne $setup "n")}}
@@ -79,6 +79,8 @@ eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/fail_
 
 /bin/echo Eden basic network test (16/{{$tests}})
 eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/network_test
+/bin/echo Eden basic VLAN test (16.1/{{$tests}})
+eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/vlans
 /bin/echo Eden basic volumes test (17.1/{{$tests}})
 eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/volumes_test
 /bin/echo Eden sftp volumes test (17.2/{{$tests}})


### PR DESCRIPTION
Test deploys multiple applications into a single switch network sliced using VLANs. It also deploys an app providing DHCP services separately for every VLAN. Then it checks if IP address allocations are as expected and that only applications inside the same VLAN are able to talk to each other.

To run the test standalone (i.e. outside of the workflow), execute:
```
 export EDEN_FAIL_RESET=y
 make clean && make build-tests
 ./eden config add default
 ./eden config set default --key eve.log-level --value debug
 ./eden setup
 ./dist/bin/eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027 8028:8028 8029:8029 8030:8030 8031:8031
 ./eden start
 ./eden eve onboard
 ./eden test tests/network -e vlans -v debug
```

Note: test depends on the DHCP-server app being able to create VLAN sub-interfaces, which requires NETADMIN capabilities.
For security reasons, EVE does not allow to grant these capabilities to native containers, and so it is required to deploy the app as a VM-in-Container. Without hardware assisted virtualization the test is therefore automatically skipped (it will not be included in the integration check, but will run after merge on GCP).

Signed-off-by: Milan Lenco <milan@zededa.com>