### PR TITLE
stringify the fields inside the attr field which were int and  boolean

### DIFF
--- a/models/template_l1_APU-2.json
+++ b/models/template_l1_APU-2.json
@@ -6,9 +6,9 @@
     "memory": "4G",
     "storage": "56G",
     "Cpus": "4",
-    "hsm": 0,
-    "leds": 3,
-    "watchdog": true
+    "hsm": "0",
+    "leds": "3",
+    "watchdog": "true"
   },
   "logo": {
     "logo_front": "/workspace/spec/logo_front_APU-2.png",

--- a/models/template_l1_Dell-Edge-Gateway-3001.json
+++ b/models/template_l1_Dell-Edge-Gateway-3001.json
@@ -4,9 +4,9 @@
     "memory": "4G",
     "storage": "32G",
     "Cpus": "4",
-    "hsm": 2,
-    "leds": 1,
-    "watchdog": true
+    "hsm": "2",
+    "leds": "1",
+    "watchdog": "true"
   },
   "logo": {
     "logo_back": "/workspace/spec/logo_back_Edge-Gateway-3001.png",

--- a/models/template_l1_Nexcom-B116.json
+++ b/models/template_l1_Nexcom-B116.json
@@ -6,9 +6,9 @@
     "memory": "1G",
     "storage": "18G",
     "Cpus": "6",
-    "watchdog": true,
-    "hsm": 0,
-    "leds": 1
+    "watchdog": "true",
+    "hsm": "0",
+    "leds": "1"
   },
   "logo": {
     "logo_back":"/workspace/spec/logo_back_Nexcom-B116.png",

--- a/models/template_l1_Rockwell-1756CMS1B1.json
+++ b/models/template_l1_Rockwell-1756CMS1B1.json
@@ -22,7 +22,7 @@
       },
       "logicallabel": "eth0",
       "cost": 0,
-      "usagePolicy": {
+      "usagePolicy": {}
     },
     {
       "ztype": 1,

--- a/models/template_l1_SIMATIC-IPC127E.json
+++ b/models/template_l1_SIMATIC-IPC127E.json
@@ -4,9 +4,9 @@
     "memory": "4G",
     "storage": "32G",
     "Cpus": "4",
-    "hsm": 1,
-    "leds": 3,
-    "watchdog": true
+    "hsm": "1",
+    "leds": "3",
+    "watchdog": "true"
   },"logo": {
     "logo_back": "/workspace/spec/logo_back_SIMATIC-IPC127E.png",
     "logo_front": "/workspace/spec/logo_front_SIMATIC-IPC127E.png"

--- a/models/template_l1_SYS-E100-9APP-wwan.json
+++ b/models/template_l1_SYS-E100-9APP-wwan.json
@@ -4,9 +4,9 @@
     "memory": "8G",
     "storage": "500G",
     "Cpus": "4",
-    "hsm": 2,
-    "leds": 0,
-    "watchdog": true
+    "hsm": "2",
+    "leds": "0",
+    "watchdog": "true"
   },
   "logo": {
     "logo_back": "/workspace/spec/logo_back_SYSE100-9APP.png",

--- a/models/template_l1_UNO-220.json
+++ b/models/template_l1_UNO-220.json
@@ -6,9 +6,9 @@
     "memory": "8G",
     "storage": "32G",
     "Cpus": "4",
-    "watchdog": true,
-    "hsm": 1,
-    "leds": 1
+    "watchdog": "true",
+    "hsm": "1",
+    "leds": "1"
   },
   "logo": {
     "logo_back":"/workspace/spec/logo_back_UNO-220.png",

--- a/models/template_l1_UNO-2372G.json
+++ b/models/template_l1_UNO-2372G.json
@@ -59,7 +59,7 @@
       "ztype": 6,
       "phylabel": "wwan0",
       "assigngrp": "USB0-3",
-      "usagePolicy": null
+      "usagePolicy": {}
     },
     {
       "ztype": 2,

--- a/models/template_l1_UNO-420.json
+++ b/models/template_l1_UNO-420.json
@@ -59,7 +59,7 @@
       "ztype": 6,
       "phylabel": "wwan0",
       "assigngrp": "USB",
-      "usagePolicy": null
+      "usagePolicy": {}
     },
     {
       "ztype": 2,

--- a/models/template_l1_UP-APL01.json
+++ b/models/template_l1_UP-APL01.json
@@ -6,9 +6,9 @@
     "memory": "2G",
     "storage": "32G",
     "Cpus": "2",
-    "hsm": 2,
-    "leds": 4,
-    "watchdog": true
+    "hsm": "2",
+    "leds": "4",
+    "watchdog": "true"
   },
   "logo": {
     "logo_back": "/workspace/spec/logo_back_UP-APL01.png",

--- a/models/template_l1_kontron.json
+++ b/models/template_l1_kontron.json
@@ -44,7 +44,7 @@
       "ztype": 6,
       "phylabel": "wwan0",
       "assigngrp": "USB",
-      "usagePolicy": null
+      "usagePolicy": {}
     },
     {
       "usage": 1,
@@ -54,7 +54,7 @@
       "ztype": 6,
       "phylabel": "wwan1",
       "assigngrp": "USB",
-      "usagePolicy": null
+      "usagePolicy": {}
     },
     {
       "ztype": 7,

--- a/models/template_l1_rpi4.json
+++ b/models/template_l1_rpi4.json
@@ -6,9 +6,9 @@
     "memory": "4G",
     "storage": "16G",
     "Cpus": "4",
-    "hsm": 0,
-    "leds": 1,
-    "watchdog": true
+    "hsm": "0",
+    "leds": "1",
+    "watchdog": "true"
     },
     "logo": {
         "logo_front": "/workspace/spec/logo_front_RPi4.png"


### PR DESCRIPTION
stringify the fields inside the attr field which were int and  boolean, since unmarshalling of these fields were resulting in errors

`json: cannot unmarshal number into Go value of type string`
few 'usagePolicy' was set to {} which was set to null

Signed-off-by: chethan-zededa <chethan@zededa.com>