### PR TITLE
Test ACEs with the Drop action

### DIFF
--- a/cmd/podModify.go
+++ b/cmd/podModify.go
@@ -141,9 +141,11 @@ func podModifyInit() {
 	podModifyCmd.Flags().StringSliceVarP(&portPublish, "publish", "p", nil, "Ports to publish in format EXTERNAL_PORT:INTERNAL_PORT")
 	podModifyCmd.Flags().BoolVar(&aclOnlyHost, "only-host", false, "Allow access only to host and external networks")
 	podModifyCmd.Flags().StringSliceVar(&podNetworks, "networks", nil, "Networks to connect to app (ports will be mapped to first network). May have <name:[MAC address]> notation.")
-	podModifyCmd.Flags().StringSliceVar(&acl, "acl", nil, `Allow access only to defined hosts/ips/subnets
-You can set acl for particular network in format '<network_name:acl>'
-To remove acls you can set empty line '<network_name>:'`)
+	podModifyCmd.Flags().StringSliceVar(&acl, "acl", nil, `Allow access only to defined hosts/ips/subnets.
+Without explicitly configured ACLs, all traffic is allowed.
+You can set ACL for a particular network in format '<network_name[:endpoint[:action]]>', where 'action' is either 'allow' (default) or 'drop'.
+With ACLs configured, endpoints not matched by any rule are blocked.
+To block all traffic define ACL with no endpoints: '<network_name>:'`)
 	podModifyCmd.Flags().StringSliceVar(&vlans, "vlan", nil, `Connect application to the (switch) network over an access port assigned to the given VLAN.
 You can set access VLAN ID (VID) for a particular network in the format '<network_name:VID>'`)
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -49,7 +49,7 @@ const (
 	DefaultRegistryPort    = 5000
 
 	//tags, versions, repos
-	DefaultEVETag               = "0.0.0-master-c1e7b2f6" //DefaultEVETag tag for EVE image
+	DefaultEVETag               = "0.0.0-master-07dba8cb" //DefaultEVETag tag for EVE image
 	DefaultAdamTag              = "0.0.28"
 	DefaultRedisTag             = "6"
 	DefaultRegistryTag          = "2.7"

--- a/pkg/expect/expectation.go
+++ b/pkg/expect/expectation.go
@@ -29,6 +29,15 @@ var (
 	directoryApp appType = 5 //for application with files from directory
 )
 
+//ACE is an access control entry (a single entry of ACL).
+type ACE struct {
+	Endpoint string
+	Drop     bool
+}
+
+//ACLs is a map of access control lists assigned to network instances.
+type ACLs map[string][]ACE // network instance -> ACL (list of ACEs)
+
 //AppExpectation is description of app, expected to run on EVE
 type AppExpectation struct {
 	ctrl        controller.Cloud
@@ -69,7 +78,7 @@ type AppExpectation struct {
 	sftpLoad       bool
 
 	disks []string
-	acl   map[string][]string // networkInstanceName -> acls
+	acl   ACLs
 	vlans map[string]int // networkInstanceName -> VID
 
 	openStackMetadata bool

--- a/pkg/expect/options.go
+++ b/pkg/expect/options.go
@@ -195,7 +195,7 @@ func WithVolumeType(volumesType VolumeType) ExpectationOption {
 }
 
 //WithACL sets access only for defined hosts
-func WithACL(acl map[string][]string) ExpectationOption {
+func WithACL(acl ACLs) ExpectationOption {
 	return func(expectation *AppExpectation) {
 		expectation.acl = acl
 	}

--- a/tests/eclient/testdata/acl.txt
+++ b/tests/eclient/testdata/acl.txt
@@ -34,9 +34,9 @@ eden network create 10.11.12.0/24 -n {{$network_name}} -s {{$fake_domain}}:$host
 test eden.network.test -test.v -timewait 10m ACTIVATED {{$network_name}}
 
 # First app is only allowed to access github.com and $long_domain.
-eden pod deploy -n curl-acl1 --memory=512MB docker://itmoeve/eclient:0.4 -p 2223:22 --networks={{$network_name}} --acl={{$network_name}}:github.com --acl={{$network_name}}:{{$long_domain}}
+eden pod deploy -n curl-acl1 --memory=512MB docker://itmoeve/eclient:0.4 -p 2223:22 --networks={{$network_name}} --acl={{$network_name}}:github.com --acl={{$network_name}}:{{$long_domain}}:allow --acl={{$network_name}}:google.com:drop
 # Second app is only allowed to access $long_domain and $fake_domain.
-eden pod deploy -n curl-acl2 --memory=512MB docker://itmoeve/eclient:0.4 -p 2224:22 --networks={{$network_name}} --acl={{$network_name}}:{{$long_domain}} --acl={{$network_name}}:{{$fake_domain}}
+eden pod deploy -n curl-acl2 --memory=512MB docker://itmoeve/eclient:0.4 -p 2224:22 --networks={{$network_name}} --acl={{$network_name}}:{{$long_domain}} --acl={{$network_name}}:{{$fake_domain}}:allow --acl={{$network_name}}:ieee.org:drop
 
 test eden.app.test -test.v -timewait 10m RUNNING curl-acl1 curl-acl2
 

--- a/tests/eclient/testdata/port_forward.txt
+++ b/tests/eclient/testdata/port_forward.txt
@@ -8,6 +8,7 @@
 [!exec:sleep] stop
 [!exec:ssh] stop
 [!exec:chmod] stop
+[!exec:timeout] stop
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
@@ -150,8 +151,8 @@ do
   do
     sleep 20
     # Test SSH-access to container
-    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
-    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
+    echo timeout 10s {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
+    timeout 10s {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
   done
 done
 


### PR DESCRIPTION
PR adds support to define ACEs with the drop action and extends the `acl` test. Currently, the "Drop" action is not properly implemented by EVE (it behaves as "Allow").
Bug fix is provided by this PR: https://github.com/lf-edge/eve/pull/2184
Until the fix is merged and the eden is updated to test EVE with a tag recent enough to include the fix, this PR will keep failing and should not be merged, hence marking as Draft.

Also fixed is an occasional failure of the `port_forward` test. After a network outage (which is being exercised by that test), EVE is recovering some network configuration which was removed when the link went down. This for example includes iptables rules for portmaps. If eden tries to ssh too soon, it may actually get stucked, even if run with `ConnectTimeout=10`. This is probably because the timeout only applies to connection establishment, but not to subsequent communication, which apparently may get stuck if DNAT rules are being reinstalled at the same time. Using`timeout` command to limit the execution time of the `ssh` process as a whole is a completely reliable alternative.

Signed-off-by: Milan Lenco <milan@zededa.com>