### PR TITLE
Small changes to trigger publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
 ---
-name: Publish
+name: Publish DockerHub
 # yamllint disable-line rule:truthy
 on:
   push:


### PR DESCRIPTION
We changed the dockerHub env key to be able to push images.

Signed-off-by: Ruslan Dautov <87017043+ruslan-zededa@users.noreply.github.com>