### PR TITLE
add avahi-daemon and nginx to eclient image

### DIFF
--- a/tests/eclient/image/Dockerfile
+++ b/tests/eclient/image/Dockerfile
@@ -29,33 +29,35 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   openssh-server \
   jq \
   setserial \
+  avahi-daemon \
+  nginx-light \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN mkdir /var/run/sshd
-RUN echo 'root:adam&eve' | chpasswd
-RUN sed -i 's/#*PermitRootLogin prohibit-password/PermitRootLogin yes/g' /etc/ssh/sshd_config
-
-# SSH login fix. Otherwise user is kicked off after login
-RUN sed -i 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' /etc/pam.d/sshd
+RUN mkdir /var/run/sshd && \
+    echo 'root:adam&eve' | chpasswd && \
+    sed -i 's/#*PermitRootLogin prohibit-password/PermitRootLogin yes/g' /etc/ssh/sshd_config && \
+    sed -i 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' /etc/pam.d/sshd
 
 ENV NOTVISIBLE="in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
 
-RUN mkdir -p /root/.ssh/
-RUN mkdir -p /mnt
-RUN touch /mnt/profile
 COPY cert/id_rsa* /root/.ssh/
 COPY cert/id_rsa.pub /root/.ssh/authorized_keys
-RUN chown root:root /root/.ssh/
-RUN chmod 600 /root/.ssh/id_rsa*
+
+RUN mkdir -p /mnt && \
+    touch /mnt/profile && \
+    chown root:root /root/.ssh/ && \
+    chmod 600 /root/.ssh/id_rsa*
 COPY portmap_test.sh /root/portmap_test.sh
 COPY get_eve_ip.sh /root/get_eve_ip.sh
 COPY entrypoint.sh /entrypoint.sh
-COPY reboot /sbin/
-COPY halt /sbin
+COPY avahi.http.service /etc/avahi/services/http.service
+COPY reboot /sbin/reboot
+COPY halt /sbin/halt
 COPY --from=build /out/local_manager /root/
 
 EXPOSE 22
+EXPOSE 80
 CMD ["/entrypoint.sh"]

--- a/tests/eclient/image/avahi.http.service
+++ b/tests/eclient/image/avahi.http.service
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--*-nxml-*-->
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+   <name replace-wildcards="yes">%h</name>
+   <service>
+      <type>_http._tcp</type>
+      <port>80</port>
+   </service>
+</service-group>

--- a/tests/eclient/image/entrypoint.sh
+++ b/tests/eclient/image/entrypoint.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
 
+# configurable with envs
+if [ -z "$AVAHI_HOST_NAME" ]; then AVAHI_HOST_NAME=ubuntu-http-server; fi
+if [ -z "$AVAHI_DOMAIN_NAME" ]; then AVAHI_DOMAIN_NAME=local; fi
+
+sed -i "s/^#host-name=.*/host-name=$AVAHI_HOST_NAME/" /etc/avahi/avahi-daemon.conf
+sed -i "s/^host-name=.*/host-name=$AVAHI_HOST_NAME/" /etc/avahi/avahi-daemon.conf
+sed -i "s/^#domain-name=.*/domain-name=$AVAHI_DOMAIN_NAME/" /etc/avahi/avahi-daemon.conf
+sed -i "s/^domain-name=.*/domain-name=$AVAHI_DOMAIN_NAME/" /etc/avahi/avahi-daemon.conf
+sed -i 's/^publish-workstation=no/publish-workstation=yes/' /etc/avahi/avahi-daemon.conf
+sed -i 's/^use-ipv6=yes/use-ipv6=no/' /etc/avahi/avahi-daemon.conf
+
+service dbus start
+service avahi-daemon start
+service nginx start
+
 mkdir -p /run/sshd
 /usr/sbin/sshd -D


### PR DESCRIPTION
Add avahi-daemon and nginx to eclient image to support mDNS and be ready for local-datastore test

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>