### PR TITLE
Check for abnormal reboots

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -49,7 +49,7 @@ const (
 	DefaultRegistryPort    = 5000
 
 	//tags, versions, repos
-	DefaultEVETag               = "0.0.0-master-6a8d5b60" //DefaultEVETag tag for EVE image
+	DefaultEVETag               = "0.0.0-master-f90326c0" //DefaultEVETag tag for EVE image
 	DefaultAdamTag              = "0.0.29"
 	DefaultRedisTag             = "6"
 	DefaultRegistryTag          = "2.7"

--- a/pkg/eden/qemu.go
+++ b/pkg/eden/qemu.go
@@ -47,7 +47,7 @@ func StartEVEQemu(qemuARCH, qemuOS, eveImageFile, qemuSMBIOSSerial string, eveTe
 		}
 		qemuOptions += fmt.Sprintf(",hostfwd=tcp::%d-:%d", origPort+offset, newPort+offset)
 	}
-	qemuOptions += fmt.Sprintf(" -device virtio-net-pci,netdev=eth%d ", 0)
+	qemuOptions += fmt.Sprintf(" -device e1000,netdev=eth%d ", 0)
 	offset += 10
 
 	qemuOptions += fmt.Sprintf("-netdev user,id=eth%d,net=%s,dhcpstart=%s,ipv6=off", 1, network, nets[0].SecondAddress)

--- a/tests/app/testdata/2dockers_test.txt
+++ b/tests/app/testdata/2dockers_test.txt
@@ -5,8 +5,8 @@
 
 eden -t 5s pod ps
 
-# Starting of reboot detector with a 3 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
+# Starting of reboot detector with a 1 reboots limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 # Run t1 docker
 eden -t 1m pod deploy -p 8027:80 docker://nginx -n t1 --memory 512MB

--- a/tests/docker/testdata/10dockers_test.txt
+++ b/tests/docker/testdata/10dockers_test.txt
@@ -1,11 +1,11 @@
-{{$test_opts := "-test.v -timewait 40m"}}
+{{$test_opts := "-test.v  -timewait=0"}}
 
 [!exec:curl] stop
 
 eden -t 1s pod ps
 
-# Starting of reboot detector with a 2 reboots limit
-! test eden.reboot.test {{$test_opts}} -reboot=0 -count=2 &
+# Starting of reboot detector with a 1 reboots limit
+! test eden.reboot.test {{$test_opts}} -reboot=0 -count=1 &
 
 # Run by docker's actor
 test eden.docker.test {{$test_opts}} -test.run TestDockerStart -name t1 -externalPort 8027 -memory 100M

--- a/tests/docker/testdata/2dockers_test.txt
+++ b/tests/docker/testdata/2dockers_test.txt
@@ -1,4 +1,4 @@
-{{$test_opts := "-test.v -timewait 20m"}}
+{{$test_opts := "-test.v -timewait=0"}}
 
 [!exec:curl] stop
 [!exec:cut] stop

--- a/tests/eclient/testdata/acl.txt
+++ b/tests/eclient/testdata/acl.txt
@@ -18,7 +18,7 @@
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 # Starting of reboot detector with a 1 reboot limit
-! test eden.reboot.test -test.v -timewait 40m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 message 'Resetting of EVE'
 eden eve reset

--- a/tests/eclient/testdata/air-gapped-switch.txt
+++ b/tests/eclient/testdata/air-gapped-switch.txt
@@ -15,8 +15,8 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with 2 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with 1 reboot limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 message 'Resetting of EVE'
 eden eve reset

--- a/tests/eclient/testdata/app_nonat.txt
+++ b/tests/eclient/testdata/app_nonat.txt
@@ -10,8 +10,8 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with 2 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with 1 reboot limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 message 'Resetting of EVE'
 eden eve reset

--- a/tests/eclient/testdata/disk.txt
+++ b/tests/eclient/testdata/disk.txt
@@ -9,8 +9,8 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with a 2 reboot limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 eden pod deploy -n eclient-disk --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{$port}}:22 --disks=file://{{EdenConfig "eden.root"}}/empty.qcow2
 

--- a/tests/eclient/testdata/eclient.txt
+++ b/tests/eclient/testdata/eclient.txt
@@ -9,8 +9,8 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with a 2 reboot limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{$port}}:22
 

--- a/tests/eclient/testdata/eclients.txt
+++ b/tests/eclient/testdata/eclients.txt
@@ -21,9 +21,9 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with a 2 reboot limit
-# Default time -- 30m
-! test eden.reboot.test -test.v -timewait {{if $time}}{{$time}}{{else}}30m{{end}} -reboot=0 -count=2 &
+# Starting of reboot detector with a 1 reboot limit
+# Default time -- infinite
+! test eden.reboot.test -test.v -timewait {{if $time}}{{$time}}{{else}}0{{end}} -reboot=0 -count=1 &
 
 # Default time -- 30m
 exec -t {{if $time}}{{$time}}{{else}}30m{{end}} bash ssh.sh

--- a/tests/eclient/testdata/host-only.txt
+++ b/tests/eclient/testdata/host-only.txt
@@ -11,7 +11,7 @@
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 # Starting of reboot detector with a 1 reboot limit
-! test eden.reboot.test -test.v -timewait 40m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 eden pod deploy -n ping-nw --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2223:22
 eden pod deploy -n ping-fw --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2224:22 --only-host=true

--- a/tests/eclient/testdata/maridb.txt
+++ b/tests/eclient/testdata/maridb.txt
@@ -12,8 +12,8 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with a 2 reboot limit
-#! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with a 1 reboot limit
+#! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22
 

--- a/tests/eclient/testdata/networking_light.txt
+++ b/tests/eclient/testdata/networking_light.txt
@@ -11,8 +11,8 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with a 2 reboot limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22
 #eden -t 20m pod logs eclient

--- a/tests/eclient/testdata/ngnix.txt
+++ b/tests/eclient/testdata/ngnix.txt
@@ -12,8 +12,8 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with a 2 reboot limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22
 

--- a/tests/eclient/testdata/nw_switch.txt
+++ b/tests/eclient/testdata/nw_switch.txt
@@ -10,8 +10,8 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with 2 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with 1 reboots limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 message 'Resetting of EVE'
 eden eve reset

--- a/tests/eclient/testdata/port_forward.txt
+++ b/tests/eclient/testdata/port_forward.txt
@@ -12,8 +12,8 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-# Starting of reboot detector with 2 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+# Starting of reboot detector with 1 reboots limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 message 'Resetting of EVE'
 eden eve reset

--- a/tests/eclient/testdata/port_switch.txt
+++ b/tests/eclient/testdata/port_switch.txt
@@ -4,7 +4,7 @@
 [!exec:sleep] stop
 
 # Starting of reboot detector with 2 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=2 &
 
 eden pod deploy -p 8027:80 docker://nginx -v debug -n nginx --memory=512MB
 

--- a/tests/eclient/testdata/profile.txt
+++ b/tests/eclient/testdata/profile.txt
@@ -12,7 +12,7 @@
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 # Starting of reboot detector with a 1 reboot limit
-! test eden.reboot.test -test.v -timewait 100m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 message 'Resetting of EVE'
 eden eve reset

--- a/tests/eclient/testdata/usb-pt_test.txt
+++ b/tests/eclient/testdata/usb-pt_test.txt
@@ -10,7 +10,7 @@
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 # Starting of reboot detector with a 2 reboot limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=2 &
 
 eden pod deploy -n n1 --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2223:22
 eden pod deploy -n n2 --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p 2224:22 --adapters USB2:2

--- a/tests/hardware_reboot/testdata/hardware_2usb_reboot.txt
+++ b/tests/hardware_reboot/testdata/hardware_2usb_reboot.txt
@@ -9,7 +9,7 @@
 [!exec:ssh] stop
 
 # Starting of reboot detector with a 2 reboot limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=2 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=2 &
 
 eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:83cfe07 -p {{template "port"}}:22 --adapters USB2:2 --adapters USB2:3
 

--- a/tests/hardware_reboot/testdata/hardware_audio_reboot.txt
+++ b/tests/hardware_reboot/testdata/hardware_audio_reboot.txt
@@ -8,7 +8,7 @@
 [!exec:ssh] stop
 
 # Starting of eve reboot detector with a 1 reboot limit
-! test eden.reboot.test -test.v -timewait 60m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 exec -t 20m bash deploy.sh {{template "port"}}
 test eden.app.test -test.v -timewait 30m RUNNING eclient

--- a/tests/network/testdata/network_test.txt
+++ b/tests/network/testdata/network_test.txt
@@ -1,7 +1,7 @@
 eden -t 10s network ls
 
 # Starting of reboot detector with a 1 reboot limit
-! test eden.reboot.test -test.v -timewait 20m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 # Create n1 network
 eden -t 1m network create 10.11.12.0/24 -n n1

--- a/tests/registry/testdata/registry_test.txt
+++ b/tests/registry/testdata/registry_test.txt
@@ -5,8 +5,8 @@
 
 eden -t 10s pod ps
 
-# Starting of reboot detector with a 3 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 # Upload image to registry
 eden -t 5m registry load nginx

--- a/tests/vnc/testdata/vnc_test.txt
+++ b/tests/vnc/testdata/vnc_test.txt
@@ -1,7 +1,7 @@
 {{$test_opts := "-test.v -name vnc-app"}}
 
 # Starting of reboot detector with a 1 reboot limit
-! test eden.reboot.test -test.v -timewait 45m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 #TestVNCVMStart checks if app processed by EVE, app in RUNNING state
 test eden.vnc.test {{$test_opts}} -timewait 15m -test.run TestVNCVMStart

--- a/tests/volume/testdata/volume_sftp.txt
+++ b/tests/volume/testdata/volume_sftp.txt
@@ -1,7 +1,7 @@
 eden -t 5s volume ls
 
 # Starting of reboot detector with a 1 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 # Create volume and force EVE to load it via SFTP
 eden -t 1m volume create -n v-qcow2-sftp file://{{EdenConfig "eden.root"}}/empty.qcow2 --format=qcow2 --disk-size=200M --sftp=true

--- a/tests/volume/testdata/volumes_test.txt
+++ b/tests/volume/testdata/volumes_test.txt
@@ -1,7 +1,7 @@
 eden -t 10s volume ls
 
 # Starting of reboot detector with a 1 reboots limit
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 # Create v1 volume
 eden -t 1m volume create -n v-docker docker://lfedge/eden-eclient:83cfe07 --disk-size=200M

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -3,7 +3,9 @@
 # EDEN_TEST env. var. -- flavour of test set: "small", "medium"(default) and "large"
 {{$workflow := EdenGetEnv "EDEN_TEST"}}
 # EDEN_TEST_SETUP env. var. -- "y"(default) performs the EDEN setup steps
-{{$setup := EdenGetEnv "EDEN_TEST_SETUP"}}
+{{$setup := "y"}}
+{{$setup_env := EdenGetEnv "EDEN_TEST_SETUP"}}
+{{if $setup_env}}{{$setup = $setup_env}}{{end}}
 # EDEN_TEST_STOP -- "y" stops EDEN after tests ("n" by default)
 {{$stop := EdenGetEnv "EDEN_TEST_STOP"}}
 # EDEN_TEST_USB_PT -- "y" enables USB Passthrough test (disabled by default).

--- a/tests/workflow/testdata/deploy_docker_eden.txt
+++ b/tests/workflow/testdata/deploy_docker_eden.txt
@@ -3,7 +3,7 @@
 [!exec:grep] stop
 
 # Fail if reboot
-! test eden.reboot.test -test.v -timewait 10m -reboot=0 -count=1 &
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 eden pod deploy -p 8028:80 docker://nginx
 stdout 'deploy pod .* with docker://nginx request sent'

--- a/tests/workflow/testdata/deploy_docker_test.txt
+++ b/tests/workflow/testdata/deploy_docker_test.txt
@@ -1,4 +1,4 @@
-{{$test_opts := "-test.v -timewait 10m"}}
+{{$test_opts := "-test.v  -timewait=0"}}
 
 # Starting of reboot detector with a 1 reboots limit
 ! test eden.reboot.test {{$test_opts}} -reboot=0 -count=1 &

--- a/tests/workflow/testdata/deploy_vm.txt
+++ b/tests/workflow/testdata/deploy_vm.txt
@@ -3,7 +3,7 @@
 exec uname
 ! stdout Darwin
 
-{{$test_opts := "-test.v -timewait 10m"}}
+{{$test_opts := "-test.v  -timewait=0"}}
 
 # Starting of reboot detector with a 1 reboots limit
 ! test eden.reboot.test {{$test_opts}} -reboot=0 -count=1 &


### PR DESCRIPTION
update EVE version
sync interface devices to be the same e1000
check for abnormal reboot and expand reboot waiting limit to the whole test
remove unneeded restart of EVE in integration test

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>