### PR TITLE
decrease timer.download.retry to run retry faster

### DIFF
--- a/pkg/controller/functions.go
+++ b/pkg/controller/functions.go
@@ -107,6 +107,7 @@ func (cloud *CloudCtx) OnBoardDev(node *device.Ctx) error {
 				node.SetConfigItem("timer.metric.interval", "10")
 				node.SetConfigItem("app.allow.vnc", "true")
 				node.SetConfigItem("newlog.allow.fastupload", "true")
+				node.SetConfigItem("timer.download.retry", "60")
 				log.Debugf("will apply devModel %s", node.GetDevModel())
 				deviceModel, err := models.GetDevModelByName(node.GetDevModel())
 				if err != nil {

--- a/tests/app/app_test.go
+++ b/tests/app/app_test.go
@@ -73,6 +73,7 @@ func checkAndAppendState(appName, state string) {
 			state:     state,
 			timestamp: time.Now(),
 		})
+		fmt.Println(utils.AddTimestamp(fmt.Sprintf("\tappName %s state changed to %s", appName, state)))
 	}
 }
 

--- a/tests/network/nw_test.go
+++ b/tests/network/nw_test.go
@@ -65,6 +65,7 @@ func checkNewLastState(netName, state string) bool {
 func checkAndAppendState(netName, state string) {
 	if checkNewLastState(netName, state) {
 		states[netName] = append(states[netName], nwState{state: state, timestamp: time.Now()})
+		fmt.Println(utils.AddTimestamp(fmt.Sprintf("\tnetName %s state changed to %s", netName, state)))
 	}
 }
 

--- a/tests/volume/vol_test.go
+++ b/tests/volume/vol_test.go
@@ -65,6 +65,7 @@ func checkNewLastState(volName, state string) bool {
 func checkAndAppendState(volName, state string) {
 	if checkNewLastState(volName, state) {
 		states[volName] = append(states[volName], volState{state: state, timestamp: time.Now()})
+		fmt.Println(utils.AddTimestamp(fmt.Sprintf("\tvolName %s state changed to %s", volName, state)))
 	}
 }
 


### PR DESCRIPTION
We can see connection timeouts errors and we have retry mechanism, but we need to decrease time to repeat to pass our time limits.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>