### PR TITLE
disable EdenEMH_ARM workflow

### DIFF
--- a/.github/workflows/eden_emh_arm.yml
+++ b/.github/workflows/eden_emh_arm.yml
@@ -2,7 +2,8 @@
 name: EdenEMH_ARM
 on:  # yamllint disable-line rule:truthy
   push:
-    branches: [master]
+    branches-ignore:
+      - '**'
 # yamllint disable rule:line-length
 jobs:
   integration:


### PR DESCRIPTION
Seems we do not have correct secrets for workflow and we need to disable it for now

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>