### PR TITLE
Increased timeout for local_datastore test

### DIFF
--- a/tests/eclient/testdata/air-gapped-switch.txt
+++ b/tests/eclient/testdata/air-gapped-switch.txt
@@ -33,7 +33,7 @@ eden pod deploy -v debug -n eclient1 docker://lfedge/eden-eclient:83cfe07 -p {{t
 eden pod deploy -v debug -n eclient2 docker://lfedge/eden-eclient:83cfe07 -p {{template "port2"}}:22 --networks=indirect --networks=direct:{{template "mac2"}} --memory=512MB
 
 message 'Waiting for running state'
-test eden.app.test -test.v -timewait 10m RUNNING eclient1 eclient2
+test eden.app.test -test.v -timewait 20m RUNNING eclient1 eclient2
 
 message 'Checking accessibility'
 exec -t 5m bash wait_ssh.sh {{template "port1"}} {{template "port2"}}

--- a/tests/volume/testdata/local_datastore.txt
+++ b/tests/volume/testdata/local_datastore.txt
@@ -19,7 +19,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:4558d83 -p {{$port}}:22
 
-test eden.app.test -test.v -timewait 15m RUNNING eclient
+test eden.app.test -test.v -timewait 20m RUNNING eclient
 
 exec -t 5m bash ssh.sh
 stdout 'Ubuntu'


### PR DESCRIPTION
https://github.com/lf-edge/eve/runs/3822932851?check_suite_focus=true 
Timeout in 15 min is not enough to deploy the app. 

Signed-off-by: Ruslan Dautov <dautov2@gmail.com>