### PR TITLE
fix eclient image

### DIFF
--- a/tests/eclient/image/files/entrypoint.sh
+++ b/tests/eclient/image/files/entrypoint.sh
@@ -14,7 +14,8 @@ sed -i "s/^domain-name=.*/domain-name=$AVAHI_DOMAIN_NAME/" /etc/avahi/avahi-daem
 sed -i 's/^publish-workstation=no/publish-workstation=yes/' /etc/avahi/avahi-daemon.conf
 sed -i 's/^use-ipv6=yes/use-ipv6=no/' /etc/avahi/avahi-daemon.conf
 
-# we must re-generate them now on every boot for no-hyper mode
+# we must re-generate them now on every boot
+rm -rf /run/*
 mkdir -p /run/sshd
 mkdir -p /run/nginx
 


### PR DESCRIPTION
Recreation of run directory on every boot in eclient to be compatible with accelerated and non-accelerated versions.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>