### PR TITLE
eclient: implement Radio API endpoint

### DIFF
--- a/tests/eclient/image/pkg/go.mod
+++ b/tests/eclient/image/pkg/go.mod
@@ -3,6 +3,6 @@ module github.com/lf-edge/eden/tests/eclient/image/pgk
 go 1.14
 
 require (
-	github.com/lf-edge/eve/api/go v0.0.0-20210527213129-76adc960648b
+	github.com/lf-edge/eve/api/go v0.0.0-20211016001156-aff9b55f0bc8
 	google.golang.org/protobuf v1.26.0
 )

--- a/tests/eclient/image/pkg/go.sum
+++ b/tests/eclient/image/pkg/go.sum
@@ -1,9 +1,10 @@
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.5.0 h1:LUVKkCeviFUMKqHa4tXIIij/lbhnMbP7Fn5wKdKkRh4=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/lf-edge/eve/api/go v0.0.0-20210527213129-76adc960648b h1:gcIFEtX6FW0yDhHTwh6zJLIhOsc/2lCSt9DIMSBEzvI=
-github.com/lf-edge/eve/api/go v0.0.0-20210527213129-76adc960648b/go.mod h1:DuAv0PyTTzmd3n25iHJ/Hx2SrbON4hf3I0oXfnUH4d8=
+github.com/lf-edge/eve/api/go v0.0.0-20211016001156-aff9b55f0bc8 h1:L+pcWEDw6lVoT0VJeZCA/YLXBGUQc3/bmUl+XEQNrbQ=
+github.com/lf-edge/eve/api/go v0.0.0-20211016001156-aff9b55f0bc8/go.mod h1:DuAv0PyTTzmd3n25iHJ/Hx2SrbON4hf3I0oXfnUH4d8=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/tests/eclient/image/pkg/main.go
+++ b/tests/eclient/image/pkg/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
+	"time"
 
 	"github.com/lf-edge/eve/api/go/profile"
 	"google.golang.org/protobuf/proto"
@@ -17,22 +20,46 @@ const (
 )
 
 var (
-	profileFile = flag.String("file", "/mnt/profile", "File with current profile")
-	token       = flag.String("token", "", "Token of profile server")
+	profileFile = flag.String("profile", "/mnt/profile",
+		"File with current profile")
+	radioSilenceCfgFile = flag.String("radio-silence", "/mnt/radio-silence",
+		"File with the requested radio-silence state ('OFF'/'ON' or '0'/'1')")
+	radioSilenceCounterFile = flag.String("radio-silence-counter", "/mnt/radio-silence-counter",
+		"File contains the number of radio-silence state changes (ON/OFF switches) already performed")
+	radioStatusFile = flag.String("radio-status", "/mnt/radio-status.json",
+		"Periodically updated JSON file with the current radio status")
+	token = flag.String("token", "", "Token of profile server")
+)
+
+var (
+	radioSilenceIsChanging bool
+	radioSilenceCounter    int
+	radioSilenceMTime      time.Time
 )
 
 func main() {
 	flag.Parse()
 	http.HandleFunc("/api/v1/local_profile", localProfile)
+	http.HandleFunc("/api/v1/radio", radio)
 	fmt.Println(http.ListenAndServe(":8888", nil))
 }
 
-func localProfile(w http.ResponseWriter, _ *http.Request) {
+func localProfile(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		errStr := fmt.Sprintf("Unexpected method: %s", r.Method)
+		fmt.Println(errStr)
+		http.Error(w, errStr, http.StatusMethodNotAllowed)
+		return
+	}
 	profileFromFile, err := ioutil.ReadFile(*profileFile)
 	if err != nil {
 		errStr := fmt.Sprintf("ReadFile: %s", err)
 		fmt.Println(errStr)
-		http.Error(w, errStr, http.StatusInternalServerError)
+		if os.IsNotExist(err) {
+			http.Error(w, errStr, http.StatusNotFound)
+		} else {
+			http.Error(w, errStr, http.StatusInternalServerError)
+		}
 		return
 	}
 	localProfileObject := &profile.LocalProfile{
@@ -50,5 +77,102 @@ func localProfile(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write(data); err != nil {
 		fmt.Printf("Failed to write: %s\n", err)
+	}
+}
+
+func radio(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		errStr := fmt.Sprintf("Unexpected method: %s", r.Method)
+		fmt.Println(errStr)
+		http.Error(w, errStr, http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Publish received radio status into the file.
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		errStr := fmt.Sprintf("Failed to read request body: %v", err)
+		fmt.Println(errStr)
+		http.Error(w, errStr, http.StatusBadRequest)
+		return
+	}
+	radioStatus := &profile.RadioStatus{}
+	err = proto.Unmarshal(body, radioStatus)
+	if err != nil {
+		errStr := fmt.Sprintf("Failed to unmarshal request body: %v", err)
+		fmt.Println(errStr)
+		http.Error(w, errStr, http.StatusBadRequest)
+		return
+	}
+	data, err := json.Marshal(radioStatus)
+	if err != nil {
+		errStr := fmt.Sprintf("Marshal: %s", err)
+		fmt.Println(errStr)
+		http.Error(w, errStr, http.StatusInternalServerError)
+		return
+	}
+	err = ioutil.WriteFile(*radioStatusFile, data, 0644)
+	if err != nil {
+		errStr := fmt.Sprintf("WriteFile: %s", err)
+		fmt.Println(errStr)
+		http.Error(w, errStr, http.StatusInternalServerError)
+		return
+	}
+
+	// Update radio-silence-counter file.
+	if radioSilenceIsChanging {
+		// radio-silence was switched ON or OFF
+		radioSilenceCounter++
+		data := []byte(fmt.Sprintf("%d", radioSilenceCounter))
+		err := ioutil.WriteFile(*radioSilenceCounterFile, data, 0644)
+		if err != nil {
+			errStr := fmt.Sprintf("WriteFile: %s", err)
+			fmt.Println(errStr)
+		}
+		radioSilenceIsChanging = false
+	}
+
+	// If the requested radio-silence state has changed, send it in the response.
+	info, err := os.Stat(*radioSilenceCfgFile)
+	if err != nil {
+		errStr := fmt.Sprintf("Stat: %s", err)
+		fmt.Println(errStr)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if info.ModTime().Equal(radioSilenceMTime) {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	radioSilenceMTime = info.ModTime()
+	data, err = ioutil.ReadFile(*radioSilenceCfgFile)
+	if err != nil {
+		errStr := fmt.Sprintf("ReadFile: %s", err)
+		fmt.Println(errStr)
+		if os.IsNotExist(err) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.Error(w, errStr, http.StatusInternalServerError)
+		return
+	}
+	radioSilenceConfig := strings.ToLower(strings.TrimSpace(string(data)))
+	radioConfig := &profile.RadioConfig{
+		RadioSilence: radioSilenceConfig == "on" || radioSilenceConfig == "1",
+		ServerToken:  *token,
+	}
+	data, err = proto.Marshal(radioConfig)
+	if err != nil {
+		errStr := fmt.Sprintf("Marshal: %s", err)
+		fmt.Println(errStr)
+		http.Error(w, errStr, http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set(contentType, mimeProto)
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(data); err != nil {
+		fmt.Printf("Failed to write: %s\n", err)
+	} else {
+		radioSilenceIsChanging = radioStatus.RadioSilence != radioConfig.RadioSilence
 	}
 }


### PR DESCRIPTION
Added implementation of the [Radio API endpoint](https://github.com/lf-edge/eve/blob/master/api/PROFILE.md#radio) into the `local_manager` app from the `eclient` image. This will allow to test the [Radio-Silence feature](https://wiki.lfedge.org/display/EVE/EVE+Airplane+Mode) of EVE.

Signed-off-by: Milan Lenco <milan@zededa.com>