### PR TITLE
stay inside failScenario to keep additional logs

### DIFF
--- a/tests/escript/failScenario.txt
+++ b/tests/escript/failScenario.txt
@@ -17,3 +17,6 @@ eden log --format=json content:fatal_stacks
 /bin/echo EDEN's reset
 eden.escript.test -test.run TestEdenScripts/eden_reset -testdata {{EdenConfig "eden.root"}}/../tests/workflow/testdata/
 {{end}}
+
+# stay for 10 seconds to keep additional logs
+exec sleep 10


### PR DESCRIPTION
In case of failure we exit immediately. In this case we may have situations when we have not all logs comes to Adam.
In this PR I add sleep for 10 seconds inside failScenario to keep additional logs.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>