### PR TITLE
expand memory for fsstress to 2G

### DIFF
--- a/tests/escript/failScenario.txt
+++ b/tests/escript/failScenario.txt
@@ -10,6 +10,10 @@ eden pod ps
 eden network ls
 /bin/echo eden volume ls
 eden volume ls
+
+# stay for 10 seconds to keep additional logs
+/bin/sleep 10
+
 /bin/echo check fatal_stacks in logs
 eden log --format=json content:fatal_stacks
 
@@ -17,6 +21,3 @@ eden log --format=json content:fatal_stacks
 /bin/echo EDEN's reset
 eden.escript.test -test.run TestEdenScripts/eden_reset -testdata {{EdenConfig "eden.root"}}/../tests/workflow/testdata/
 {{end}}
-
-# stay for 10 seconds to keep additional logs
-exec sleep 10

--- a/tests/fsstress/fsstress_test.go
+++ b/tests/fsstress/fsstress_test.go
@@ -34,7 +34,7 @@ var (
 	name       = flag.String("name", "", "Name of app, random if empty")
 	sshPort    = flag.Int("sshPort", 8028, "Port to publish ssh")
 	cpus       = flag.Uint("cpus", 2, "Cpu number for app")
-	memory     = flag.String("memory", "1G", "Memory for app")
+	memory     = flag.String("memory", "2G", "Memory for app")
 	scriptpath = flag.String("script_path", "", "Full path to the script that will be sent to the guest machine")
 	direct     = flag.Bool("direct", true, "Load image from url, not from eserver")
 	metadata   = flag.String("metadata", "#cloud-config\npassword: passw0rd\nchpasswd: { expire: False }\nssh_pwauth: True\n", "Metadata to pass into VM")


### PR DESCRIPTION
Seems we need more memory for app to run fsstress test.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>