### PR TITLE
fixes for fsstress test

### DIFF
--- a/pkg/projects/functions.go
+++ b/pkg/projects/functions.go
@@ -55,8 +55,13 @@ func SendCommandSSH(ip *string, port *int, user, password, command string, foreg
 				fmt.Printf("No ssh connections: %v", err)
 				return nil
 			}
-			session, _ := conn.NewSession()
+			session, err := conn.NewSession()
+			if err != nil {
+				fmt.Printf("Error creating session: %v", err)
+				return nil
+			}
 			if foreground {
+				defer conn.Close()
 				defer session.Close()
 				if err := session.Run(command); err != nil {
 					fmt.Println(err)
@@ -66,6 +71,7 @@ func SendCommandSSH(ip *string, port *int, user, password, command string, foreg
 				go func() {
 					_ = session.Run(command) //we cannot get answer for this command
 					session.Close()
+					conn.Close()
 				}()
 			}
 			for _, clb := range callbacks {

--- a/tests/fsstress/testdata/fsstress_test.txt
+++ b/tests/fsstress/testdata/fsstress_test.txt
@@ -3,7 +3,12 @@
 {{$env := EdenGetEnv "FSSTRESS_TIME"}}
 {{if $env}}{{$timewait = $env}}{{end}}
 
-{{$test_opts := "-test.v -name fsstress-app"}}
+{{$password := "passw0rd"}}
+
+{{$envpassword := EdenGetEnv "FSSTRESS_PASSWORD"}}
+{{if $envpassword}}{{$password = $envpassword}}{{end}}
+
+{{$test_opts := ( print "-test.v -name fsstress-app -password " $password)}}
 
 # Starting of reboot detector with a 1 reboot limit
 ! test eden.reboot.test -test.v -timewait {{$timewait}} -reboot=0 -count=1 &

--- a/tests/fsstress/testdata/run-script.sh
+++ b/tests/fsstress/testdata/run-script.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+# disable background updates
+sudo systemctl disable --now unattended-upgrades
 sudo apt-get update -y
 sudo apt-get install autoconf libtool fssync make coreutils pkg-config -y
 
 mkdir tests
 git clone https://github.com/linux-test-project/ltp.git
 cd ~/ltp && make autotools && ./configure && cd testcases/kernel/fs/fsstress && make
+nohup sudo sh -c "while true; do top -o %MEM -b -n 1 |head -n 30 >/dev/console; sleep 600; done" &>/dev/null </dev/null &
 nohup ./fsstress -d ~/tests -S -n 5 -p 100 -l 0 -s 1000 -v -c &>/dev/null </dev/null &


### PR DESCRIPTION
disable unattended-upgrades in fsstress vm, expand disk size and add memory output to console for debugging, add password variable to minimize hacking in case of public access.

fix closing of opened ssh connections (seems, it was the root cause of OOM issue inside VM).

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>