### PR TITLE
show segfaults in workflow results and make timestamps readable

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -60,6 +60,10 @@ jobs:
           echo "::group::Error log function filename duplicates"
           echo "$(jq -s 'map(select(.severity | contains("err")))|group_by(.filename)|map(select(length>10))|map({"source": .[0].source, "filename": .[0].filename, "function": .[0].function, "content": [.[].content], "total":length})|sort_by(.total)| reverse[]' trace.log)"
           echo "::endgroup::"
+          echo "::group::Segfaults"
+          echo "$(jq -s 'map(select(.content | contains("segfault at")))' trace.log)"|tee segfaults.log
+          [ "$(jq length segfaults.log)" -gt 0 ] && echo "::warning::segfaults found, you can see them in Log counting->Segfaults section"
+          echo "::endgroup::"
       - name: Store raw test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -110,6 +110,10 @@ jobs:
           echo "::group::Error log function filename duplicates"
           echo "$(jq -s 'map(select(.severity | contains("err")))|group_by(.filename)|map(select(length>10))|map({"source": .[0].source, "filename": .[0].filename, "function": .[0].function, "content": [.[].content], "total":length})|sort_by(.total)| reverse[]' trace.log)"
           echo "::endgroup::"
+          echo "::group::Segfaults"
+          echo "$(jq -s 'map(select(.content | contains("segfault at")))' trace.log)"|tee segfaults.log
+          [ "$(jq length segfaults.log)" -gt 0 ] && echo "::warning::segfaults found, you can see them in Log counting->Segfaults section"
+          echo "::endgroup::"
       - name: Store raw test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/pkg/controller/eapps/eappslog.go
+++ b/pkg/controller/eapps/eappslog.go
@@ -3,7 +3,6 @@
 package eapps
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"reflect"
@@ -92,15 +91,18 @@ func HandleFactory(format LogFormat, once bool) HandlerFunc {
 func LogPrn(le *logs.LogEntry, format LogFormat) {
 	switch format {
 	case LogJSON:
-		enc := json.NewEncoder(os.Stdout)
-		_ = enc.Encode(le)
+		b, err := protojson.Marshal(le)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(b)
 	case LogLines:
 		fmt.Println("source:", le.Source)
 		fmt.Println("severity:", le.Severity)
 		fmt.Println("content:", strings.TrimSpace(le.Content))
 		fmt.Println("filename:", le.Filename)
 		fmt.Println("function:", le.Function)
-		fmt.Println("timestamp:", le.Timestamp)
+		fmt.Println("timestamp:", le.Timestamp.AsTime())
 		fmt.Println("iid:", le.Iid)
 		fmt.Println()
 	default:

--- a/pkg/controller/einfo/einfo.go
+++ b/pkg/controller/einfo/einfo.go
@@ -49,7 +49,7 @@ func InfoPrn(im *info.ZInfoMsg) {
 	if im.GetNiinfo() != nil {
 		fmt.Println("niinfo:", im.GetNiinfo())
 	}
-	fmt.Println("atTimeStamp:", im.GetAtTimeStamp())
+	fmt.Println("atTimeStamp:", im.GetAtTimeStamp().AsTime())
 	fmt.Println()
 }
 
@@ -60,7 +60,7 @@ func ZInfoPrn(im *info.ZInfoMsg, ds []*ZInfoMsgInterface) {
 	for i, d := range ds {
 		fmt.Printf("[%d]: %s\n", i, *d)
 	}
-	fmt.Println("atTimeStamp:", im.GetAtTimeStamp())
+	fmt.Println("atTimeStamp:", im.GetAtTimeStamp().AsTime())
 	fmt.Println()
 }
 

--- a/pkg/controller/elog/elog.go
+++ b/pkg/controller/elog/elog.go
@@ -3,7 +3,6 @@
 package elog
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"reflect"
@@ -117,15 +116,18 @@ func HandleFactory(format LogFormat, once bool) HandlerFunc {
 func LogPrn(le *FullLogEntry, format LogFormat) {
 	switch format {
 	case LogJSON:
-		enc := json.NewEncoder(os.Stdout)
-		_ = enc.Encode(le)
+		b, err := protojson.Marshal(le)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(string(b))
 	case LogLines:
 		fmt.Println("source:", le.Source)
 		fmt.Println("severity:", le.Severity)
 		fmt.Println("content:", strings.TrimSpace(le.Content))
 		fmt.Println("filename:", le.Filename)
 		fmt.Println("function:", le.Function)
-		fmt.Println("timestamp:", le.Timestamp)
+		fmt.Println("timestamp:", le.Timestamp.AsTime())
 		fmt.Println("iid:", le.Iid)
 		fmt.Println()
 	default:


### PR DESCRIPTION
show segfaults in workflow results and make timestamps readable

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>