### PR TITLE
[WIP: DO NOT MERGE]: add swtpm support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,13 @@ ifeq ($(ESERVER_VERSION),)
 	ESERVER_VERSION = $(shell git describe --always)
 endif
 
+# SWTPM_TAG is the tag for swtpm image to build
+SWTPM_TAG ?= "lfedge/swtpm"
+# SWTPM_DIR is the directory with swtpm Dockerfile to build
+SWTPM_DIR=$(CURDIR)/swtpm
+# SWTPM_VERSION is the version of swtpm image to build - TODO: Move to docker environment?
+SWTPM_VERSION ?= "v0.7"
+
 # PROCESSING_TAG is the tag for processing image to build
 PROCESSING_TAG ?= "lfedge/eden-processing"
 # PROCESSING_DIR is the directory with processing Dockerfile to build
@@ -129,6 +136,10 @@ push-multi-arch-eserver:
 	@echo "Build and $(DOCKER_TARGET) eserver image $(ESERVER_TAG):$(ESERVER_VERSION)"
 	@docker buildx build --$(DOCKER_TARGET) --platform $(DOCKER_PLATFORM) --tag $(ESERVER_TAG):$(ESERVER_VERSION) $(ESERVER_DIR)
 
+push-multi-arch-swtpm:
+	@echo "Build and $(DOCKER_TARGET) swtpm image"
+	@docker buildx build --$(DOCKER_TARGET) --platform $(DOCKER_PLATFORM) --tag $(SWTPM_TAG):$(SWTPM_VERSION) $(SWTPM_DIR)
+
 push-multi-arch-eden:
 	@echo "Build and $(DOCKER_TARGET) eden image $(EDEN_TAG):$(EDEN_VERSION)"
 	@docker buildx build --$(DOCKER_TARGET) --platform $(DOCKER_PLATFORM) --tag $(EDEN_TAG):$(EDEN_VERSION) .
@@ -137,7 +148,7 @@ push-multi-arch-processing:
 	@echo "Build and $(DOCKER_TARGET) processing image $(PROCESSING_TAG):$(PROCESSING_VERSION)"
 	@docker buildx build --$(DOCKER_TARGET) --platform $(DOCKER_PLATFORM) --tag $(PROCESSING_TAG):$(PROCESSING_VERSION) $(PROCESSING_DIR)
 
-build-docker: push-multi-arch-processing push-multi-arch-eserver push-multi-arch-eden
+build-docker: push-multi-arch-processing push-multi-arch-eserver push-multi-arch-eden push-multi-arch-swtpm
 	make -C tests DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) DOCKER_TARGET=$(DOCKER_TARGET) DOCKER_PLATFORM=$(DOCKER_PLATFORM) build-docker
 
 tests-export: $(DIRECTORY_EXPORT) build-tests

--- a/cmd/edenStart.go
+++ b/cmd/edenStart.go
@@ -83,6 +83,12 @@ var startCmd = &cobra.Command{
 		} else {
 			log.Infof("Redis is running and accessible on port %d", redisPort)
 		}
+		if err := eden.StartSwtpm("latest"); err != nil {
+			log.Errorf("cannot start swtpm: %s", err)
+		} else {
+			log.Infof("swtpm is running and accessible via unix socket")
+		}
+
 		if !adamRemoteRedis {
 			adamRemoteRedisURL = ""
 		}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -56,6 +56,7 @@ const (
 	DefaultProcTag              = "83cfe07"
 	DefaultImage                = "library/alpine"
 	DefaultAdamContainerRef     = "lfedge/adam"
+	DefaultSwtpmContainerRef     = "lfedge/swtpm"
 	DefaultRedisContainerRef    = "redis"
 	DefaultRegistryContainerRef = "library/registry"
 	DefaultProcContainerRef     = "lfedge/eden-processing"
@@ -93,6 +94,7 @@ const (
 	DefaultControllerModePattern = `^(?P<Type>(file|proto|adam|zedcloud)):\/\/(?P<URL>.*)$`
 	DefaultPodLinkPattern        = `^(?P<TYPE>(oci|docker|http[s]{0,1}|file|directory)):\/\/(?P<TAG>[^:]+):*(?P<VERSION>.*)$`
 	DefaultRedisContainerName    = "eden_redis"
+	DefaultSwtpmContainerName    = "eden_swtpm"
 	DefaultAdamContainerName     = "eden_adam"
 	DefaultRegistryContainerName = "eden_registry"
 	DefaultEServerContainerName  = "eden_eserver"

--- a/pkg/eden/qemu.go
+++ b/pkg/eden/qemu.go
@@ -71,6 +71,8 @@ func StartEVEQemu(qemuARCH, qemuOS, eveImageFile, qemuSMBIOSSerial string, eveTe
 		qemuOptions += fmt.Sprintf(" -device e1000,netdev=eth%d ", 2)
 	}
 
+  qemuOptions += "-chardev socket,id=chrtpm,path=/tmp/swtpm-sock -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0 "
+
 	if qemuOS == "" {
 		qemuOS = runtime.GOOS
 	} else {

--- a/swtpm/Dockerfile
+++ b/swtpm/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine AS build
+
+RUN apk add git autoconf automake libtool gcc g++ openssl-dev build-base make socat gawk libtasn1-dev gnutls gnutls-utils gnutls-dev expect python3 libseccomp-dev json-glib-dev
+
+RUN git clone --branch=v0.9.1 --single-branch --depth=1 https://github.com/stefanberger/libtpms.git
+RUN cd libtpms                                  &&\
+    ./autogen.sh --prefix=/usr --libdir=/usr/lib --with-tpm2 --with-openssl &&\
+    make -j4                                    &&\
+    make install
+
+
+RUN git clone --branch=v0.7.0 --single-branch --depth=1 https://github.com/stefanberger/swtpm.git
+RUN cd swtpm                                                &&\
+    ./autogen.sh --prefix=/usr --libdir=/usr/lib --with-openssl --with-tss-user=root --with-tss-group=root &&\
+    make -j4                                                &&\
+    make install
+
+FROM alpine
+ENTRYPOINT ["/usr/bin/swtpm"]
+
+RUN apk add --no-cache libseccomp openssl
+
+COPY --from=build /usr /usr


### PR DESCRIPTION
Hi all,
I've started working on integrating [swtpm](https://github.com/stefanberger/swtpm/) into eden. The goal is to provide debugging/development support for TPMs in a virtualized setup.

swtpm is a TPM2.0 and 1.2 compliant TPM emulator based on [libtpm](https://github.com/stefanberger/libtpms)

This branch adds a Dockerfile for swtpm (```./swtpm/Dockerfile```) and the respective changes to the ```eden``` command.
When starting the eden setup, the QEMU-EVE instance will connect via a unix socket to the swtpm emulator running in a docker container.
For now, the container ```eden_swtpm``` will use ```/tmp``` as its working dir to store the TPM state and the unix socket that is used by the QEMU-EVE instance to communicate with the TPM. Note: QEMU does not support using tcp sockets to connect to the swtpm emulator, hence we have to use unix sockets.

I appreciate any comments! I'll focus on creating proper config options for this setup next.

**Usage**

Start eden:

```
make run
...
INFO[0000] Redis is running and accessible on port 6379                                                                               
DEBU[0000] Try to start container from image lfedge/swtpm:latest with command [socket --tpmstate dir=/swtpm --ctrl type=unixio,path=/s
wtpm/swtpm-sock --log level=20 --tpm2]                                                                                                
DEBU[0000] Try to create network eden_network                                                                                         
INFO[0001] started container: d889d5691e56a7156e9aedd6861833ba1afd9c598ac8d8132441fde3a7485207                                        
INFO[0001] swtpm is running and accessible via unix socket                                                                            
DEBU[0001] Try to start container from image lfedge/adam:0.0.32 with command [server --db-url redis://9v3w4IEo:9v3w4IEo@eden_redis:6379]
...
INFO[0003] Eserver is running and accesible on port 8888 
INFO[0003] Start EVE: qemu-system-x86_64 -display none -nodefaults -no-user-config -serial chardev:char0 -chardev socket,id=char0,port
=7777,host=localhost,server,nodelay,nowait,telnet,logfile=log -smbio
s type=1,serial=31415926 -monitor tcp:localhost:7788,server,nowait  -netdev user,id=eth0,net=192.168.0.0/24,dhcpstart=192.168.0.10,ipv
6=off,hostfwd=tcp::8028-:8028,hostfwd=tcp::2222-:22,hostfwd=tcp::5912-:5902,hostfwd=tcp::5911-:5901,hostfwd=tcp::8027-:8027 -device e1
000,netdev=eth0 -netdev user,id=eth1,net=192.168.0.0/24,dhcpstart=192.168.0.11,ipv6=off,hostfwd=tcp::5921-:5911,hostfwd=tcp::8037-:803
7,hostfwd=tcp::8038-:8038,hostfwd=tcp::2232-:32,hostfwd=tcp::5922-:5912 -device e1000,netdev=eth1 -chardev socket,id=chrtpm,path=/tmp/
swtpm-sock -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0 -machine q35,accel=kvm,dump-guest-core=off,kernel-irqch
ip=split -cpu host,invtsc=on,kvmclock=off -device intel-iommu,intremap=on,caching-mode=on,aw-bits=48 -drive file=...
...
INFO[0008] EVE is starting  
```
Onboard:
```
./eden eve onboard
INFO[0000] Adam waiting for EVE registration (0) of (20) 
INFO[0020] Adam waiting for EVE registration (1) of (20) 
...
INFO[0041] Received unexpected StatusCode(Bad Request): repeat request (0) of (20) 
INFO[0046] Received unexpected StatusCode(Bad Request): repeat request (1) of (20) 
INFO[0051] onboarded                                     
INFO[0051] device UUID: d68ebb0d-a22b-4aa9-904d-c82e69ba2455
```

Get Info should now include information on the TPM (`HSMInfo`)
```
./eden info
ztype: ZiDevice
devId: bfadc2fa-27c9-474e-a191-dc6d657ca72b
...
 HSMStatus:ENABLED  HSMInfo:"IBM-SW   TPM, FW Version 8217.4131.22.13878"  dataSecAtRestInfo:{status:DATASEC_AT_REST_ENABLED  info:"Fscrypt is enabled and active"}  
...
```

Inside EVE the TPM should be present at `/dev/tpm0`