### PR TITLE
port 5000 is not usable on Mac OS Monterey, move registry to 5050

### DIFF
--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -49,7 +49,7 @@ var startRegistryCmd = &cobra.Command{
 		if err := eden.StartRegistry(registryPort, registryTag, registryDist); err != nil {
 			log.Errorf("cannot start registry: %s", err)
 		} else {
-			log.Infof("registry is running and accessible on port %d", adamPort)
+			log.Infof("registry is running and accessible on port %d", registryPort)
 		}
 	},
 }

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -194,7 +194,7 @@ You can modify behavior with `--volume-type` flag:
 
 ### Docker Image from Local Registry
 
-eden starts a local registry image, running on the localhost at port `5000`
+eden starts a local registry image, running on the localhost at port `5050`
 (configurable). You can start a docker image from that registry by
 passing it the `--registry=local` option. The default for `--registry`
 is the hostname given by the registry. For example,

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -46,7 +46,7 @@ const (
 	DefaultRedisHost       = "localhost"
 	DefaultRedisPort       = 6379
 	DefaultAdamPort        = 3333
-	DefaultRegistryPort    = 5000
+	DefaultRegistryPort    = 5050
 
 	//tags, versions, repos
 	DefaultEVETag               = "0.0.0-master-6b6fa8fe" //DefaultEVETag tag for EVE image


### PR DESCRIPTION
port 5000 is not usable on Mac OS Monterey, move registry to 5050

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>