### PR TITLE
remove container after execution

### DIFF
--- a/pkg/utils/container.go
+++ b/pkg/utils/container.go
@@ -575,8 +575,10 @@ func RunDockerCommand(image string, command string, volumeMap map[string]string)
 	}
 	defer out.Close()
 	b, err := ioutil.ReadAll(out)
-	if err == nil {
-		return string(b), nil
+
+	if err := cli.ContainerRemove(ctx, resp.ID, types.ContainerRemoveOptions{RemoveVolumes: true}); err != nil {
+		log.Errorf("ContainerRemove error: %s", err)
 	}
-	return "", err
+
+	return string(b), err
 }


### PR DESCRIPTION
remove container after execution to reduce storage usage

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>