### PR TITLE
use tty to have consistent output from container

### DIFF
--- a/pkg/utils/container.go
+++ b/pkg/utils/container.go
@@ -546,7 +546,7 @@ func RunDockerCommand(image string, command string, volumeMap map[string]string)
 	resp, err := cli.ContainerCreate(ctx, &container.Config{
 		Image: image,
 		Cmd:   strings.Fields(command),
-		Tty:   false,
+		Tty:   true,
 	}, &container.HostConfig{
 		Mounts: mounts,
 	},


### PR DESCRIPTION
Seems we should use tty to have consistent [output](https://github.com/moby/moby/blob/master/client/container_logs.go#L19-L21) from container.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>