### PR TITLE
use current context for ipxe files in eserver

### DIFF
--- a/cmd/edenSetup.go
+++ b/cmd/edenSetup.go
@@ -363,7 +363,7 @@ var setupCmd = &cobra.Command{
 					items, _ := ioutil.ReadDir(filepath.Dir(eveImageFile))
 					for _, item := range items {
 						if !item.IsDir() && item.Name() != "ipxe.efi.cfg" {
-							if _, err := eden.AddFileIntoEServer(server, filepath.Join(filepath.Dir(eveImageFile), item.Name())); err != nil {
+							if _, err := eden.AddFileIntoEServer(server, filepath.Join(filepath.Dir(eveImageFile), item.Name()), configName); err != nil {
 								log.Fatalf("AddFileIntoEServer: %s", err)
 							}
 						}
@@ -375,7 +375,7 @@ var setupCmd = &cobra.Command{
 					}
 					re := regexp.MustCompile("# set url .*")
 					ipxeFileReplaced := re.ReplaceAll(ipxeFileBytes,
-						[]byte(fmt.Sprintf("set url http://%s:%d/%s/", eServerIP, eserverPort, "eserver")))
+						[]byte(fmt.Sprintf("set url http://%s:%d/%s/%s/", eServerIP, eserverPort, "eserver", configName)))
 					if softserial != "" {
 						ipxeFileReplaced = []byte(strings.ReplaceAll(string(ipxeFileReplaced),
 							"eve_soft_serial=${mac:hexhyp}",
@@ -384,12 +384,13 @@ var setupCmd = &cobra.Command{
 					_ = os.MkdirAll(filepath.Join(filepath.Dir(eveImageFile), "tftp"), 0777)
 					ipxeConfigFile := filepath.Join(filepath.Dir(eveImageFile), "tftp", "ipxe.efi.cfg")
 					_ = ioutil.WriteFile(ipxeConfigFile, ipxeFileReplaced, 0777)
-					if _, err := eden.AddFileIntoEServer(server, ipxeConfigFile); err != nil {
+					i, err := eden.AddFileIntoEServer(server, ipxeConfigFile, configName)
+					if err != nil {
 						log.Fatalf("AddFileIntoEServer: %s", err)
 					}
 					log.Infof("download EVE done: %s", imageTag)
 					log.Infof("Please use %s to boot your EVE via ipxe", ipxeConfigFile)
-					log.Infof("ipxe.efi.cfg uploaded to eserver (http://%s:%s/eserver/ipxe.efi.cfg). Use it to boot your EVE via network", eServerIP, eServerPort)
+					log.Infof("ipxe.efi.cfg uploaded to eserver (http://%s:%s/%s). Use it to boot your EVE via network", eServerIP, eServerPort, i.FileName)
 					log.Infof("EVE already exists: %s", filepath.Dir(eveImageFile))
 				}
 			} else if installer {

--- a/docs/ipxe.md
+++ b/docs/ipxe.md
@@ -22,7 +22,7 @@ dhcp option [67 Bootfile-Name](https://tools.ietf.org/html/rfc2132#section-9.5) 
 
 You can also use `ipxe.efi.cfg` uploaded into eserver, link to which will also be inside
 output of setup command (something like
-`ipxe.efi.cfg uploaded to eserver (http://IP:8888/eserver/ipxe.efi.cfg).`).
+`ipxe.efi.cfg uploaded to eserver (http://IP:8888/eserver/default/ipxe.efi.cfg).`).
 
 You can start your device and wait for installation process of EVE. Next, you can run
 `eden start` and `eden eve onboard` as usual.
@@ -60,7 +60,7 @@ make build
 To boot EVE with iPXE you should run:
 
 ```console
-packet device create -f LOCATION -H NAME -i http://IP:8888/eserver/ipxe.efi.cfg -o custom_ipxe -P TYPE -p PROJECT_ID
+packet device create -f LOCATION -H NAME -i http://IP:8888/eserver/default/ipxe.efi.cfg -o custom_ipxe -P TYPE -p PROJECT_ID
 ```
 
 where:

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -69,7 +69,7 @@ const (
 
 	DefaultRedisPasswordFile = "redis.pass"
 
-	DefaultEServerTag          = "83cfe07"
+	DefaultEServerTag          = "4fd3d15"
 	DefaultEServerContainerRef = "lfedge/eden-http-server"
 
 	//DefaultRepeatCount is repeat count for requests

--- a/pkg/expect/file.go
+++ b/pkg/expect/file.go
@@ -24,7 +24,7 @@ func (exp *AppExpectation) createImageFile(id uuid.UUID, dsID string) *config.Im
 	status := server.EServerCheckStatus(filepath.Base(exp.appURL))
 	if !status.ISReady || status.Size != utils.GetFileSize(exp.appURL) || status.Sha256 != utils.SHA256SUM(exp.appURL) {
 		log.Infof("Start uploading into eserver of %s", exp.appLink)
-		status = server.EServerAddFile(exp.appURL)
+		status = server.EServerAddFile(exp.appURL, "")
 		if status.Error != "" {
 			log.Error(status.Error)
 		}

--- a/pkg/utils/networking.go
+++ b/pkg/utils/networking.go
@@ -205,7 +205,7 @@ func RepeatableAttempt(client *http.Client, req *http.Request) (response *http.R
 }
 
 //UploadFile send file in form
-func UploadFile(client *http.Client, url string, filePath string) (result *http.Response, err error) {
+func UploadFile(client *http.Client, url, filePath, prefix string) (result *http.Response, err error) {
 	body, writer := io.Pipe()
 
 	req, err := http.NewRequest(http.MethodPost, url, body)
@@ -218,10 +218,15 @@ func UploadFile(client *http.Client, url string, filePath string) (result *http.
 
 	errchan := make(chan error)
 
+	fileName := filepath.Base(filePath)
+	if prefix != "" {
+		fileName = fmt.Sprintf("%s/%s", prefix, fileName)
+	}
+
 	go func() {
 		defer writer.Close()
 		defer mwriter.Close()
-		w, err := mwriter.CreateFormFile("file", filepath.Base(filePath))
+		w, err := mwriter.CreateFormFile("file", fileName)
 		if err != nil {
 			errchan <- err
 			return


### PR DESCRIPTION
With this change we can use different ipxe files for EVEs in different context (non-default).