### PR TITLE
use latest uefi with arch

### DIFF
--- a/pkg/utils/downloaders.go
+++ b/pkg/utils/downloaders.go
@@ -65,7 +65,7 @@ func (desc UEFIDescription) image(latest bool) (string, error) {
 		desc.Registry = defaults.DefaultEveRegistry
 	}
 	if latest {
-		return fmt.Sprintf("%s-uefi", desc.Registry), nil
+		return fmt.Sprintf("%s-uefi:latest-%s", defaults.DefaultEveRegistry, desc.Arch), nil
 	}
 	if desc.Tag == "" {
 		return "", fmt.Errorf("tag not present")


### PR DESCRIPTION
we should use arch in our latest uefi image to use it for another arch