### PR TITLE
check for non-init state for old versions of EVE

### DIFF
--- a/pkg/eve/networks.go
+++ b/pkg/eve/networks.go
@@ -88,6 +88,7 @@ func (ctx *State) processNetworksByInfo(im *info.ZInfoMsg) {
 		// XXX Guard against old EVE which doesn't send state
 		// sends INIT state when deleting network instance
 		if !netInstStateObj.Activated &&
+			im.GetNiinfo().State != info.ZNetworkInstanceState_ZNETINST_STATE_INIT &&
 			netInstStateObj.AdamState == "NOT_IN_CONFIG" {
 			netInstStateObj.deleted = true
 		}


### PR DESCRIPTION
Check for non-init state in special workaround for old versions of EVE. In newest version (7.0+) we use activated=false and state=init as an intermediate [state](https://github.com/lf-edge/eve/blob/797f5b34716dfb3c7383693992b5508b0d8aba20/pkg/pillar/cmd/zedagent/handlenetworkinstance.go#L97), so we cannot use this state as indication for deleted networks.