### PR TITLE
Extend eclient/local_manager to support app commands

### DIFF
--- a/tests/eclient/image/pkg/go.mod
+++ b/tests/eclient/image/pkg/go.mod
@@ -3,6 +3,6 @@ module github.com/lf-edge/eden/tests/eclient/image/pgk
 go 1.14
 
 require (
-	github.com/lf-edge/eve/api/go v0.0.0-20220125064314-55e8c30d0b76
+	github.com/lf-edge/eve/api/go v0.0.0-20220204033926-a6b0df482c02
 	google.golang.org/protobuf v1.26.0
 )

--- a/tests/eclient/image/pkg/go.sum
+++ b/tests/eclient/image/pkg/go.sum
@@ -3,8 +3,8 @@ github.com/golang/protobuf v1.5.0 h1:LUVKkCeviFUMKqHa4tXIIij/lbhnMbP7Fn5wKdKkRh4
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/lf-edge/eve/api/go v0.0.0-20220125064314-55e8c30d0b76 h1:4gpJAEi6eLe1kBh28noCrR48YAtCUT8XkoCjuUpJO9k=
-github.com/lf-edge/eve/api/go v0.0.0-20220125064314-55e8c30d0b76/go.mod h1:DuAv0PyTTzmd3n25iHJ/Hx2SrbON4hf3I0oXfnUH4d8=
+github.com/lf-edge/eve/api/go v0.0.0-20220204033926-a6b0df482c02 h1:as36I7nJr9K415Dwm/fZukqJUwJ4pBCfg7Gz3V6pAeI=
+github.com/lf-edge/eve/api/go v0.0.0-20220204033926-a6b0df482c02/go.mod h1:DuAv0PyTTzmd3n25iHJ/Hx2SrbON4hf3I0oXfnUH4d8=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=


### PR DESCRIPTION
This will be then used by app_local_info test (https://github.com/lf-edge/eden/pull/744).

Signed-off-by: Milan Lenco <milan@zededa.com>