### PR TITLE
Makefile: Make the tests target to depend on build-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ $(BINDIR):
 $(DIRECTORY_EXPORT):
 	mkdir -p $@
 
-test: build
+test: build-tests
 	make -C tests TESTS="$(TESTS)" DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) test
 
 # create empty drives to use as additional volumes


### PR DESCRIPTION
In order to run the tests target, we need to have the
test binaries built. Let's update that target to do
that beforehand.

This prevents situations where newcomers scratch their
heads on why the tests target fails and it doesn't seem
to imply any side-effects.

Signed-off-by: Lucas Meneghel Rodrigues <lucas@zededa.com>