### PR TITLE
Use cirros image to speedup local_datastore test

### DIFF
--- a/pkg/defaults/images.go
+++ b/pkg/defaults/images.go
@@ -32,4 +32,12 @@ var ImageStore = map[string]*ImageOptions{
 		Size:   562692096,
 		Sha256: "1b5b3fe616e1eea4176049d434a360344a7d471f799e151190f21b0a27f0b424",
 	},
+	"http://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img": {
+		Size:   16300544,
+		Sha256: "932fcae93574e242dc3d772d5235061747dfe537668443a1f0567d893614b464",
+	},
+	"http://download.cirros-cloud.net/0.5.2/cirros-0.5.2-aarch64-disk.img": {
+		Size:   16872448,
+		Sha256: "889c1117647b3b16cfc47957931c6573bf8e755fc9098fdcad13727b6c9f2629",
+	},
 }

--- a/tests/volume/testdata/local_datastore.txt
+++ b/tests/volume/testdata/local_datastore.txt
@@ -1,10 +1,12 @@
 # Test for deploying app from local datastore https://wiki.lfedge.org/display/EVE/Local+DataStore+with+ZeroConfig
 
 {{$port := "2223"}}
-{{$eve_arch := EdenConfig "eve.arch"}}
-{{$image_dir := "releases/groovy/release-20210108"}}
-{{$image_path := printf "%s/ubuntu-20.10-server-cloudimg-%s.img" $image_dir $eve_arch}}
-{{$image_url := printf "https://cloud-images.ubuntu.com/%s" $image_path}}
+{{$arch := EdenConfig "eve.arch"}}
+{{if (eq $arch "amd64")}}{{$arch = "x86_64"}}{{end}}
+{{if (eq $arch "arm64")}}{{$arch = "aarch64"}}{{end}}
+{{$image_dir := "0.5.2"}}
+{{$image_path := printf "%s/cirros-0.5.2-%s-disk.img" $image_dir $arch}}
+{{$image_url := printf "http://download.cirros-cloud.net/%s" $image_path}}
 {{$datastore := "http://ubuntu-http-server.local"}}
 
 [!exec:bash] stop


### PR DESCRIPTION
We can speed up local datastore test using image with less size