### PR TITLE
Move setup-gcloud to pinned version

### DIFF
--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           OVPN_FILE: ${{ secrets.OVPN_FILE }}
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0.5.0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - id: 'gcpauth'


### PR DESCRIPTION
We should move to pinned version of setup-gcloud to not hit errors in eden_gcp workflow