### PR TITLE
Add local profile server devinfo test

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,7 +21,7 @@ OS ?= $(HOSTOS)
 WORKDIR ?= $(CURDIR)/../dist
 
 gotestsum:
-	go get gotest.tools/gotestsum
+	go get -d gotest.tools/gotestsum
 
 #test: $(TESTS:=_test)
 test: gotestsum

--- a/tests/eclient/testdata/dev_local_info.txt
+++ b/tests/eclient/testdata/dev_local_info.txt
@@ -1,0 +1,258 @@
+# Test dev local info
+
+{{define "mngr_port"}}8027{{end}}
+{{define "app_port"}}8028{{end}}
+{{define "token"}}server_token_123{{end}}
+{{define "app_info_status_file"}}/mnt/app-info-status.json{{end}}
+{{define "dev_info_status_file"}}/mnt/dev-info-status.json{{end}}
+{{define "dev_cmd_file"}}/mnt/dev-command.json{{end}}
+{{define "network"}}n1{{end}}
+{{define "ssh"}}ssh -q -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@{{end}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+[!exec:chmod] stop
+[!exec:jq] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
+
+# Starting of reboot detector with a 3 reboot limit since we reboot twice
+! test eden.reboot.test -test.v -timewait 100m -reboot=0 -count=3 &
+
+message 'Resetting of EVE'
+eden eve reset
+exec sleep 30
+
+# Create n1 network
+eden -t 1m network create 10.11.12.0/24 -n {{template "network"}}
+test eden.network.test -test.v -timewait 10m ACTIVATED {{template "network"}}
+
+# Deploy local-manager
+eden pod deploy -n local-manager --memory=512MB docker://lfedge/eden-eclient:99d7f62 -p {{template "mngr_port"}}:22 --networks={{template "network"}}
+test eden.app.test -test.v -timewait 10m RUNNING local-manager
+
+# Wait for ssh access
+exec -t 5m bash wait-ssh.sh {{template "mngr_port"}}
+
+# Start local manager application
+exec -t 1m bash local-manager-start.sh
+
+# Obtain local-manager IP address
+exec -t 2m bash get-app-ip.sh local-manager
+source .env
+
+# Configure local server
+eden controller edge-node update --device profile_server_token={{template "token"}}
+eden controller edge-node update --device local_profile_server=$app_ip:8888
+
+# STEP 1: Wait for devinfo status
+exec sleep 30
+exec -t 10m bash get-devinfo-status.sh
+! stderr .
+
+# STEP 2: Deploy the second app
+eden pod deploy -n app1 --memory=512MB docker://lfedge/eden-eclient:9455582 -p {{template "app_port"}}:22 --networks={{template "network"}}
+test eden.app.test -test.v -timewait 10m RUNNING app1
+
+# Wait for ssh access
+exec -t 5m bash wait-ssh.sh {{template "app_port"}}
+
+# STEP 3: Wait for devinfo status reporting ONLINE
+exec -t 10m bash wait-for-dev-state.sh ONLINE
+! stderr .
+
+# STEP 4: Request for shutdown. Check that app1 stops before local_manager
+exec -t 1m bash put-devinfo-cmd.sh COMMAND_SHUTDOWN &
+exec -t 5m bash wait-for-dev-state.sh SHUTTING_DOWN
+! stderr .
+# Could it already have HALTED? Match HALTING or HALTED
+exec -t 5m bash wait-for-app-state.sh app1 HALT
+! stderr .
+exec -t 1m bash get-appinfo-status.sh local-manager
+stdout 'RUNNING'
+! stderr .
+exec -t 5m bash wait-for-app-state.sh app1 HALTED
+! stderr .
+
+# Did local-manager halt? Can't check by asking local-manager
+exec -t 1m bash eden-pod-ps.sh local-manager
+! stdout 'RUNNING'
+! stderr .
+
+# STEP 5: test reboot via controller bringing them back up
+# send reboot command without wait
+eden controller edge-node reboot
+
+# STEP 5.1: Wait for ssh access
+exec -t 40m bash wait-ssh.sh {{template "app_port"}}
+
+# STEP 5.2: Start local manager application
+exec -t 1m bash local-manager-start.sh
+
+# STEP 5.3: Wait for devinfo status reporting ONLINE
+exec sleep 30
+exec -t 10m bash wait-for-dev-state.sh ONLINE
+! stderr .
+
+# STEP 5.4: Check apps are back
+exec -t 20m bash wait-for-app-state.sh local-manager RUNNING
+! stderr .
+exec -t 20m bash wait-for-app-state.sh app1 RUNNING
+! stderr .
+
+# We can run the rest of the test only with qemu right now to properly
+# handle start of EVE after poweroff.
+{{$devmodel := EdenConfig "eve.devmodel"}}
+{{if not (eq $devmodel "ZedVirtual-4G")}}
+eden eve reset
+skip 'The rest of the test is supported only on QEMU'
+{{end}}
+
+# STEP 6: Request for poweroff. Check that app1 stops before local_manager
+exec -t 1m bash put-devinfo-cmd.sh COMMAND_SHUTDOWN_POWEROFF &
+exec -t 5m bash wait-for-dev-state.sh POWERING_OFF
+! stderr .
+# Could it already have HALTED? Match HALTING or HALTED
+exec -t 5m bash wait-for-app-state.sh app1 HALT
+! stderr .
+exec -t 1m bash get-appinfo-status.sh local-manager
+stdout 'RUNNING'
+! stderr .
+exec -t 5m bash wait-for-app-state.sh app1 HALTED
+! stderr .
+
+# Did local-manager halt? Can't check by asking local-manager
+exec -t 1m bash eden-pod-ps.sh local-manager
+! stdout 'RUNNING'
+! stderr .
+
+# STEP 7: Check qemu process is gone aka powered off
+exec sleep 120
+eden eve status
+stdout 'process not running'
+
+# STEP 8: Restart EVE; check apps come up
+message 'Restart EVE'
+eden eve start
+exec sleep 30
+
+# STEP 8.1: Wait for ssh access
+exec -t 40m bash wait-ssh.sh {{template "app_port"}}
+
+# STEP 9: Remove the second app
+eden pod delete app1
+test eden.app.test -test.v -timewait 15m - app1
+
+# STEP 10: Undeploy local-manager
+eden pod delete local-manager
+test eden.app.test -test.v -timewait 15m - local-manager
+eden network delete {{template "network"}}
+test eden.network.test -test.v -timewait 10m - {{template "network"}}
+
+-- wait-ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for p in $*
+do
+  for i in `seq 20`
+  do
+    sleep 20
+    # Test SSH-access to container
+    echo {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue
+    {{template "ssh"}}$HOST -p $p grep -q Ubuntu /etc/issue && break
+  done
+done
+
+-- local-manager-start.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+ARGS="--token={{template "token"}}"
+{{template "ssh"}}$HOST -p {{template "mngr_port"}} "/root/local_manager $ARGS &>/dev/null &"
+
+-- get-app-ip.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+IP=$($EDEN pod ps | grep $1 | awk '{print $4}' | cut -d ":" -f 1)
+echo app_ip=$IP>>.env
+
+-- eden-pod-ps.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+line=$($EDEN pod ps | grep $1)
+echo line
+
+-- get-appinfo-status.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+APP="$1"
+CMDS="
+until test -f {{template "app_info_status_file"}}; do sleep 5; done
+sleep 2
+cat {{template "app_info_status_file"}}
+"
+
+OUTPUT="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "$CMDS")"
+if [ -n "$APP" ]; then
+    echo "$OUTPUT" | jq --arg APP "$APP" '.appsInfo[] | select(.name==$APP)'
+else
+    echo "$OUTPUT"
+fi
+
+-- wait-for-app-state.sh --
+APP="${1}"
+EXPSTATE="${2}"
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+while true; do
+    APPINFO="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "cat {{template "app_info_status_file"}}")"
+    APPINFO="$(echo "$APPINFO" | jq --arg APP "$APP" '.appsInfo[] | select(.name==$APP)')"
+    echo "$APPINFO" | grep "$EXPSTATE" && break
+    sleep 1
+done
+
+-- get-devinfo-status.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+CMDS="
+until test -f {{template "dev_info_status_file"}}; do sleep 5; done
+sleep 2
+cat {{template "dev_info_status_file"}}
+"
+
+OUTPUT="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "$CMDS")"
+echo "$OUTPUT"
+
+OUTPUT="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "$CMDS")"
+echo "$OUTPUT"
+
+-- put-devinfo-cmd.sh --
+CMD="${1:-COMMAND_UNSPECIFIED}"
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+CONFIG="{\"command\": \"$CMD\"}"
+echo "$CONFIG"
+echo "$CONFIG" | {{template "ssh"}}$HOST -p {{template "mngr_port"}} 'cat > {{template "dev_cmd_file"}}'
+
+-- wait-for-dev-state.sh --
+EXPSTATE="${1}"
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+
+while true; do
+    DEVINFO="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "cat {{template "dev_info_status_file"}}")"
+    echo "$DEVINFO" | grep "$EXPSTATE" && break
+    sleep 1
+done
+
+-- eden-config.yml --
+{{/* Test's config file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/eclient/testdata/shutdown_test.txt
+++ b/tests/eclient/testdata/shutdown_test.txt
@@ -1,0 +1,73 @@
+# Test for shutdown of all app instances of EVE
+
+{{$port := "2223"}}
+{{$network_name := "n1"}}
+{{$app_name := "eclient"}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+[!exec:chmod] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
+
+# Create n1 network
+eden -t 1m network create 10.11.12.0/24 -n {{$network_name}}
+
+# Wait for run
+test eden.network.test -test.v -timewait 10m ACTIVATED {{$network_name}}
+
+eden pod deploy -n {{$app_name}} --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p {{$port}}:22 --networks={{$network_name}}
+
+test eden.app.test -test.v -timewait 20m RUNNING {{$app_name}}
+
+# exec -t 5m bash ssh.sh
+# stdout 'Ubuntu'
+
+# send shutdown command
+eden controller edge-node shutdown
+
+# wait for HALTED state which indicates that we are shutting down
+test eden.app.test -test.v -timewait 5m HALTED {{$app_name}}
+# XXX can we check for the SHUTTING_DOWN state? Need check on ZDeviceState
+
+# now reboot node to bring app back up
+test eden.reboot.test -test.v -timewait=10m -reboot=1 -count=1 &
+
+# check info messages sent correct data in background
+test eden.app.test -test.v -timewait 10m -check-new RUNNING {{$app_name}} &
+test eden.network.test -test.v -timewait 10m -check-new ACTIVATED {{$network_name}} &
+
+# wait for detectors
+wait
+
+# check ssh access to app after reboot
+# exec -t 5m bash ssh.sh
+# stdout 'Ubuntu'
+
+eden pod delete {{$app_name}}
+test eden.app.test -test.v -timewait 10m - {{$app_name}}
+
+eden network delete {{$network_name}}
+test eden.network.test -test.v -timewait 10m - {{$network_name}}
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+HOST=$($EDEN eve ip)
+for i in `seq 20`
+do
+sleep 20
+# Test SSH-access to container
+echo $i\) ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue
+ssh -o ConnectTimeout=10 -oStrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -p {{$port}} root@$HOST grep Ubuntu /etc/issue && break
+done

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -176,6 +176,9 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/eclie
 /bin/echo Eden Reboot test (34/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/reboot_test
 
+/bin/echo Eden Shutdown test (34.1/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/shutdown_test
+
 {{ if ne $workflow "small" }}
 /bin/echo Eden base OS update http (35/{{$tests}})
 eden.escript.test -testdata ../update_eve_image/testdata/ -test.run TestEdenScripts/update_eve_image_http

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -120,6 +120,8 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/radio
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/app_local_info
 /bin/echo Eden test app info (21.6/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/app_dhcp
+/bin/echo Eden test dev info (21.7/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/dev_local_info
 /bin/echo Eden location publish test (21.7/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/publish_location
 


### PR DESCRIPTION
Tests for shutdown and shutdown_poweroff in the Local Profile Server DevInfo API while checking that an app
instance running a local profile server is shut down last.

Separate commit for a test for shutdown from controller.

Depends on the implementation in https://github.com/lf-edge/eve/pull/2610