### PR TITLE
Fix acl test to handle multiple IPs from dig

### DIFF
--- a/cmd/edenNetwork.go
+++ b/cmd/edenNetwork.go
@@ -206,5 +206,5 @@ func networkInit() {
 	networkCreateCmd.Flags().StringVar(&networkType, "type", "local", "Type of network: local or switch")
 	networkCreateCmd.Flags().StringVarP(&networkName, "name", "n", "", "Name of network (empty for auto generation)")
 	networkCreateCmd.Flags().StringVarP(&uplinkAdapter, "uplink", "u", "eth0", "Name of uplink adapter, set to 'none' to not use uplink")
-	networkCreateCmd.Flags().StringSliceVarP(&staticDNSEntries, "static-dns-entries", "s", []string{}, "List of static DNS entries in format HOSTNAME:IP_ADDR,IP_ADDR,...")
+	networkCreateCmd.Flags().StringArrayVarP(&staticDNSEntries, "static-dns-entries", "s", []string{}, "List of static DNS entries in format HOSTNAME:IP_ADDR,IP_ADDR,...")
 }

--- a/tests/eclient/testdata/acl.txt
+++ b/tests/eclient/testdata/acl.txt
@@ -116,10 +116,11 @@ done
 -- dns_lookup.sh --
 
 # Performs DNS lookup for a given hostname and adds host_ip=<ip> into the .env file
+# If query returns several IPs they will be joined into one line with comma separator
 # Uses dig command which is already included by most modern Linux systems and also macOS.
 # Usage: dns_lookup.sh <hostname>
 
-IP=$(dig +short $1)
+IP=$(dig +short $1 | paste -sd "," -)
 echo host_ip=$IP>>.env
 
 -- curl.sh --


### PR DESCRIPTION
Dig command may return several IPs to properly handle them during creation of network we should join lines from output into one with comma separator.

Also we should replace StringSliceVarP with StringArrayVarP to properly handle commas.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>