### PR TITLE
Tests cleanup and non-accel flag adjust

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -52,9 +52,9 @@ const (
 	DefaultRegistryPort         = 5050
 
 	//tags, versions, repos
-	DefaultEVETag               = "0.0.0-master-e77d8e56" // DefaultEVETag tag for EVE image
+	DefaultEVETag               = "0.0.0-master-7ab56bde" // DefaultEVETag tag for EVE image
 	DefaultAdamTag              = "0.0.39"
-	DefaultRedisTag             = "6"
+	DefaultRedisTag             = "7"
 	DefaultRegistryTag          = "2.7"
 	DefaultProcTag              = "83cfe07"
 	DefaultImage                = "library/alpine"
@@ -115,10 +115,10 @@ const (
 
 	DefaultQemuAccelDarwin     = "-machine q35,accel=hvf -cpu kvm64,kvmclock=off "
 	DefaultQemuAccelLinuxAmd64 = "-machine q35,accel=kvm,dump-guest-core=off,kernel-irqchip=split -cpu host,invtsc=on,kvmclock=off -device intel-iommu,intremap=on,caching-mode=on,aw-bits=48 "
-	DefaultQemulAmd64          = "-machine q35 --cpu SandyBridge "
+	DefaultQemuAmd64           = "-machine q35,smm=on --cpu SandyBridge "
 
 	DefaultQemuAccelArm64 = "-machine virt,accel=kvm,usb=off,dump-guest-core=off -cpu host "
-	DefaultQemulArm64     = "-machine virt,virtualization=true -cpu cortex-a57 "
+	DefaultQemuArm64      = "-machine virt,virtualization=true -cpu cortex-a57 "
 
 	DefaultAppSubnet        = "10.11.12.0/24"
 	DefaultHostOnlyNotation = "host-only-acl"

--- a/pkg/eden/qemu.go
+++ b/pkg/eden/qemu.go
@@ -63,14 +63,14 @@ func StartEVEQemu(qemuARCH, qemuOS, eveImageFile, qemuSMBIOSSerial string, eveTe
 				qemuOptions += defaults.DefaultQemuAccelLinuxAmd64
 			}
 		} else {
-			qemuOptions += defaults.DefaultQemulAmd64
+			qemuOptions += defaults.DefaultQemuAmd64
 		}
 	case "arm64":
 		qemuCommand = "qemu-system-aarch64"
 		if qemuAccel {
 			qemuOptions += defaults.DefaultQemuAccelArm64
 		} else {
-			qemuOptions += defaults.DefaultQemulArm64
+			qemuOptions += defaults.DefaultQemuArm64
 		}
 		netDev = "virtio-net-pci"
 		tpmDev = "tpm-tis-device"

--- a/tests/eclient/testdata/acl.txt
+++ b/tests/eclient/testdata/acl.txt
@@ -38,7 +38,7 @@ eden pod deploy -n curl-acl1 --memory=512MB docker://lfedge/eden-eclient:d9eb23f
 # Second app is only allowed to access $long_domain and $fake_domain.
 eden pod deploy -n curl-acl2 --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p 2224:22 --networks={{$network_name}} --acl={{$network_name}}:{{$long_domain}} --acl={{$network_name}}:{{$fake_domain}}:allow --acl={{$network_name}}:ieee.org:drop
 
-test eden.app.test -test.v -timewait 10m RUNNING curl-acl1 curl-acl2
+test eden.app.test -test.v -timewait 15m RUNNING curl-acl1 curl-acl2
 
 exec -t 10m bash wait_ssh.sh 2223
 exec -t 10m bash wait_ssh.sh 2224

--- a/tests/eclient/testdata/air-gapped-switch.txt
+++ b/tests/eclient/testdata/air-gapped-switch.txt
@@ -26,14 +26,14 @@ message 'Creating networks: local indirect and air-gapped switch direct'
 eden network create 10.11.12.0/24 -n indirect
 eden network create --type switch --uplink none -n direct
 
-test eden.network.test -test.v -timewait 10m ACTIVATED indirect direct
+test eden.network.test -test.v -timewait 20m ACTIVATED indirect direct
 
 message 'Starting applications'
 eden pod deploy -v debug -n eclient1 docker://lfedge/eden-eclient:d9eb23f -p {{template "port1"}}:22 --networks=indirect --networks=direct:{{template "mac1"}} --memory=512MB
 eden pod deploy -v debug -n eclient2 docker://lfedge/eden-eclient:d9eb23f -p {{template "port2"}}:22 --networks=indirect --networks=direct:{{template "mac2"}} --memory=512MB
 
 message 'Waiting for running state'
-test eden.app.test -test.v -timewait 20m RUNNING eclient1 eclient2
+test eden.app.test -test.v -timewait 15m RUNNING eclient1 eclient2
 
 message 'Checking accessibility'
 exec -t 5m bash wait_ssh.sh {{template "port1"}} {{template "port2"}}

--- a/tests/eclient/testdata/app_local_info.txt
+++ b/tests/eclient/testdata/app_local_info.txt
@@ -53,7 +53,7 @@ stdout 'local-manager'
 ! stderr .
 
 # STEP 2: Deploy the second app
-eden pod deploy -n app1 --memory=512MB docker://lfedge/eden-eclient:9455582 -p {{template "app_port"}}:22 --networks={{template "network"}}
+eden pod deploy -n app1 --memory=512MB docker://lfedge/eden-eclient:afaa332 -p {{template "app_port"}}:22 --networks={{template "network"}}
 test eden.app.test -test.v -timewait 10m RUNNING app1
 
 # Wait for ssh access
@@ -206,7 +206,13 @@ CMD="${3:-COMMAND_UNSPECIFIED}"
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 HOST=$($EDEN eve ip)
 CONFIG="{\"displayname\": \"$DN\", \"timestamp\": $TIMESTAMP, \"command\": \"$CMD\"}"
-echo "$CONFIG" | {{template "ssh"}}$HOST -p {{template "mngr_port"}} 'cat > {{template "app_cmd_file"}}'
+
+while true; do
+    echo "$CONFIG" | {{template "ssh"}}$HOST -p {{template "mngr_port"}} 'cat > {{template "app_cmd_file"}}'
+    APP_CMD_FILE_CONTENT="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "cat {{template "app_cmd_file"}}")"
+    echo "$APP_CMD_FILE_CONTENT" | grep "$CMD" && break
+    sleep 1
+done
 
 -- wait-for-app-state.sh --
 APP="${1}"

--- a/tests/eclient/testdata/dev_local_info.txt
+++ b/tests/eclient/testdata/dev_local_info.txt
@@ -52,7 +52,7 @@ exec -t 10m bash get-devinfo-status.sh
 ! stderr .
 
 # STEP 2: Deploy the second app
-eden pod deploy -n app1 --memory=512MB docker://lfedge/eden-eclient:9455582 -p {{template "app_port"}}:22 --networks={{template "network"}}
+eden pod deploy -n app1 --memory=512MB docker://lfedge/eden-eclient:99d7f62 -p {{template "app_port"}}:22 --networks={{template "network"}}
 test eden.app.test -test.v -timewait 10m RUNNING app1
 
 # Wait for ssh access
@@ -85,7 +85,7 @@ exec -t 1m bash eden-pod-ps.sh local-manager
 eden controller edge-node reboot
 
 # STEP 5.1: Wait for ssh access
-test eden.app.test -test.v -timewait 20m RUNNING app1
+test eden.app.test -test.v -timewait 20m RUNNING app1 local-manager
 exec -t 10m bash wait-ssh.sh {{template "app_port"}}
 
 # STEP 5.2: Start local manager application
@@ -243,7 +243,13 @@ EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "ede
 HOST=$($EDEN eve ip)
 CONFIG="{\"command\": \"$CMD\"}"
 echo "$CONFIG"
-echo "$CONFIG" | {{template "ssh"}}$HOST -p {{template "mngr_port"}} 'cat > {{template "dev_cmd_file"}}'
+
+while true; do
+    echo "$CONFIG" | {{template "ssh"}}$HOST -p {{template "mngr_port"}} 'cat > {{template "dev_cmd_file"}}'
+    DEV_CMD_FILE_CONTENT="$({{template "ssh"}}$HOST -p {{template "mngr_port"}} "cat {{template "dev_cmd_file"}}")"
+    echo "$DEV_CMD_FILE_CONTENT" | grep "$CMD" && break
+    sleep 1
+done
 
 -- wait-for-dev-state.sh --
 EXPSTATE="${1}"

--- a/tests/eclient/testdata/mount.txt
+++ b/tests/eclient/testdata/mount.txt
@@ -11,12 +11,12 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 1 reboot limit
 ! test eden.reboot.test -test.v -timewait 60m -reboot=0 -count=1 &
 
-eden pod deploy -n eclient-mount --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p {{$port}}:22 --mount=src=docker://nginx:1.20.0,dst=/tst --mount=src={{EdenConfig "eden.tests"}}/eclient/testdata,dst=/dir
+eden pod deploy -n eclient-mount --memory=512MB docker://lfedge/eden-eclient:d9eb23f -p {{$port}}:22 --mount=src=docker://hello-world:linux,dst=/tst --mount=src={{EdenConfig "eden.tests"}}/eclient/testdata,dst=/dir
 
 test eden.app.test -test.v -timewait 21m RUNNING eclient-mount
 
 exec -t 5m bash ssh.sh /tst
-stdout 'docker-entrypoint.sh'
+stdout 'hello'
 
 exec -t 5m bash ssh.sh /dir
 stdout 'mount.txt'
@@ -31,7 +31,7 @@ test eden.app.test -test.v -timewait 15m -check-new RUNNING eclient-mount
 
 # check old mount point
 exec -t 5m bash ssh.sh /tst
-! stdout 'docker-entrypoint.sh'
+! stdout 'hello'
 
 # mount onto another mount point
 eden volume attach eclient-mount_1_m_0 eclient-mount /dst
@@ -40,7 +40,7 @@ test eden.app.test -test.v -timewait 15m -check-new RUNNING eclient-mount
 
 # check new mount point
 exec -t 5m bash ssh.sh /dst
-stdout 'docker-entrypoint.sh'
+stdout 'hello'
 
 eden volume ls
 stdout '/dir'
@@ -50,6 +50,10 @@ stdout '/dst'
 eden pod delete eclient-mount
 
 test eden.app.test -test.v -timewait 10m - eclient-mount
+
+message 'Resetting of EVE'
+eden eve reset
+exec sleep 30
 
 -- eden-config.yml --
 {{/* Test's config. file */}}

--- a/tests/eclient/testdata/radio_silence.txt
+++ b/tests/eclient/testdata/radio_silence.txt
@@ -51,19 +51,19 @@ eden controller edge-node update --device profile_server_token={{template "token
 eden controller edge-node update --device local_profile_server=$app_ip:8888
 
 # STEP 1: Wait for radio status
-exec -t 1m bash get-radio-status.sh
+exec -t 2m bash get-radio-status.sh
 stdout 'radio-silence=false'
 ! stderr .
 
 # STEP 2: Enable Radio-silence
 exec -t 2m bash toggle-radio-silence.sh ON
-exec -t 1m bash get-radio-status.sh
+exec -t 2m bash get-radio-status.sh
 stdout 'radio-silence=true'
 ! stderr .
 
 # STEP 3: Disable Radio-silence mode
 exec -t 2m bash toggle-radio-silence.sh OFF
-exec -t 1m bash get-radio-status.sh
+exec -t 2m bash get-radio-status.sh
 stdout 'radio-silence=false'
 ! stderr .
 

--- a/tests/eclient/testdata/reboot_test.txt
+++ b/tests/eclient/testdata/reboot_test.txt
@@ -37,7 +37,7 @@ test eden.app.test -test.v -timewait 5m HALTED {{$app_name}}
 # simulate network outage
 eden eve link down
 # sleep without networks for 7 minutes
-exec sleep 7m
+exec sleep 420
 {{end}}
 
 # check info messages sent correct data in background

--- a/tests/eclient/testdata/shutdown_test.txt
+++ b/tests/eclient/testdata/shutdown_test.txt
@@ -1,4 +1,5 @@
 # Test for shutdown of all app instances of EVE
+# we inject network outage and check for entities to come after reboot for qemu and vbox
 
 {{$port := "2223"}}
 {{$network_name := "n1"}}
@@ -27,6 +28,9 @@ test eden.app.test -test.v -timewait 20m RUNNING {{$app_name}}
 # check for the ZDEVICE_STATE_PREPARING_POWEROFF state
 test eden.lim.test -test.v -timewait 5m -test.run TestInfo -out InfoContent.dinfo.state 'InfoContent.dinfo.state:ZDEVICE_STATE_PREPARING_POWEROFF' &
 
+# add small sleep to not miss rare PREPARING_POWEROFF state in the background
+exec sleep 10
+
 # send shutdown command
 eden controller edge-node shutdown
 
@@ -37,17 +41,31 @@ wait
 test eden.app.test -test.v -timewait 5m HALTED {{$app_name}} &
 
 # check for the ZDEVICE_STATE_PREPARED_POWEROFF state
-test eden.lim.test -test.v -timewait 5m -test.run TestInfo -out InfoContent.dinfo.state 'InfoContent.dinfo.state:ZDEVICE_STATE_PREPARED_POWEROFF' &
+test eden.lim.test -test.v -timewait 10m -test.run TestInfo -out InfoContent.dinfo.state 'InfoContent.dinfo.state:ZDEVICE_STATE_PREPARED_POWEROFF' &
 
 # wait for detectors
 wait
 
 # now reboot node to bring app back up
-test eden.reboot.test -test.v -timewait=10m -reboot=1 -count=1 &
+test eden.reboot.test -test.v -timewait=20m -reboot=1 -count=1 &
+
+{{$devmodel := EdenConfig "eve.devmodel"}}
+
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") }}
+# simulate network outage
+eden eve link down
+# sleep without networks for 7 minutes
+exec sleep 420
+{{end}}
 
 # check info messages sent correct data in background
 test eden.app.test -test.v -timewait 10m -check-new RUNNING {{$app_name}} &
 test eden.network.test -test.v -timewait 10m -check-new ACTIVATED {{$network_name}} &
+
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") }}
+# return networks
+eden eve link up
+{{end}}
 
 # wait for detectors
 wait

--- a/tests/eclient/testdata/userdata.txt
+++ b/tests/eclient/testdata/userdata.txt
@@ -19,7 +19,7 @@ eden pod deploy -n eclient --memory=512MB docker://lfedge/eden-eclient:d9eb23f -
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 
-exec sleep 10s
+exec sleep 10
 
 eden pod delete eclient
 

--- a/tests/escript/failScenario.txt
+++ b/tests/escript/failScenario.txt
@@ -1,23 +1,27 @@
 {{$reset := EdenGetEnv "EDEN_FAIL_RESET"}}
 
+{{$eden_root := EdenConfig "eden.root"}}
+{{$eden_bin_dist := EdenConfig "eden.bin-dist"}}
+{{$EDEN_DIST_BIN := (printf "%s/%s" $eden_root $eden_bin_dist) }}
+
 /bin/echo Default test fail scenario
 
 /bin/echo eden status
-eden status
+{{$EDEN_DIST_BIN}}/eden status
 /bin/echo eden pod ps
-eden pod ps
+{{$EDEN_DIST_BIN}}/eden pod ps
 /bin/echo eden network ls
-eden network ls
+{{$EDEN_DIST_BIN}}/eden network ls
 /bin/echo eden volume ls
-eden volume ls
+{{$EDEN_DIST_BIN}}/eden volume ls
 
 # stay for 10 seconds to keep additional logs
 /bin/sleep 10
 
 /bin/echo check fatal_stacks in logs
-eden log --format=json content:fatal_stacks
+{{$EDEN_DIST_BIN}}/eden log --format=json content:fatal_stacks
 
 {{ if (ne $reset "") }}
 /bin/echo EDEN's reset
-eden.escript.test -test.run TestEdenScripts/eden_reset -testdata {{EdenConfig "eden.root"}}/../tests/workflow/testdata/
+{{$EDEN_DIST_BIN}}/eden.escript.test -test.run TestEdenScripts/eden_reset -testdata {{EdenConfig "eden.root"}}/../tests/workflow/testdata/
 {{end}}

--- a/tests/escript/testdata/time.txt
+++ b/tests/escript/testdata/time.txt
@@ -1,4 +1,4 @@
-exec sleep 5s
-! exec -t 5s sleep 10s
-exec -t 10s sleep 5s
-exec sleep 15s
+exec sleep 5
+! exec -t 5s sleep 10
+exec -t 10s sleep 5
+exec sleep 15

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -178,15 +178,14 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/app_n
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/eclients
 {{end}}
 
-/bin/echo Eden Reboot test (34/{{$tests}})
-eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/reboot_test
-
-/bin/echo Eden Shutdown test (34.1/{{$tests}})
+/bin/echo Eden Shutdown test (34/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/shutdown_test
 
 {{ if ne $workflow "small" }}
+{{ if or (eq $workflow "large") (eq $workflow "gcp") }}
 /bin/echo Eden base OS update http (35/{{$tests}})
 eden.escript.test -testdata ../update_eve_image/testdata/ -test.run TestEdenScripts/update_eve_image_http
+{{end}}
 /bin/echo Eden base OS update oci (36/{{$tests}})
 eden.escript.test -testdata ../update_eve_image/testdata/ -test.run TestEdenScripts/update_eve_image_oci
 {{end}}


### PR DESCRIPTION
Reduce image used by mount test
Remove different eclient images from the same test
Move http image update test to gcp/large tests as a less complex and error-prone duplicate of image update from oci
Combine reboot and shutdown tests and remove reboot test from the workflow
Fixes to support Mac OS for tests