### PR TITLE
Adjust tests to reduce load

### DIFF
--- a/pkg/controller/functions.go
+++ b/pkg/controller/functions.go
@@ -103,7 +103,7 @@ func (cloud *CloudCtx) OnBoardDev(node *device.Ctx) error {
 			node.SetRemote(cloud.vars.EveRemote)
 			node.SetRemoteAddr(cloud.vars.EveRemoteAddr)
 			if !alreadyRegistered { //new node
-				node.SetConfigItem("timer.config.interval", "5")
+				node.SetConfigItem("timer.config.interval", "10")
 				node.SetConfigItem("timer.location.app.interval", "10")
 				node.SetConfigItem("timer.location.cloud.interval", "300")
 				node.SetConfigItem("app.allow.vnc", "true")

--- a/tests/eclient/testdata/dhcp-server/entrypoint.sh
+++ b/tests/eclient/testdata/dhcp-server/entrypoint.sh
@@ -15,12 +15,4 @@ interface=${eth0}
 dhcp-range=10.11.13.2,10.11.13.254,60m
 EOF
 
-cat <<EOF > /etc/supervisord.conf
-[supervisord]
-nodaemon=true
-
-[program:dnsmasq]
-command=dnsmasq -d -b -C /etc/dnsmasq.conf
-EOF
-
-exec /usr/bin/supervisord -c /etc/supervisord.conf
+exec dnsmasq -d -b -C /etc/dnsmasq.conf

--- a/tests/network/testdata/switch_net_vlans.txt
+++ b/tests/network/testdata/switch_net_vlans.txt
@@ -24,6 +24,10 @@ exec -t 2m bash check_vm_support.sh
 source .env
 [!env:with_hw_virt] skip 'Missing HW-assisted virtualization capability'
 
+
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
+
 {{$image := "docker://lfedge/eden-docker-test:83cfe07"}}
 
 # string to use as the testing sequence
@@ -60,6 +64,9 @@ source .env
 exec -t 5m bash wait_and_get_recv_data.sh app2 8029
 stdout '{{$test_data}}'
 
+eden pod delete app2
+test eden.app.test -test.v -timewait 10m - app2
+
 # Deploy app3 and connect it to VLAN 200
 eden pod deploy -n app3 --memory=448MB --networks=nat --networks=switch -p 8030:80 --vlan=switch:200 --metadata="url=http://${app1_ip}/user-data.html" {{$image}}
 test eden.app.test -test.v -timewait 10m RUNNING app3
@@ -70,6 +77,9 @@ source .env
 # app3 will try to obtain test_data from app1, but it should fail because they are in different VLANs
 exec -t 5m bash wait_and_get_recv_data.sh app3 8030
 ! stdout '{{$test_data}}'
+
+eden pod delete app3
+test eden.app.test -test.v -timewait 10m - app3
 
 # Deploy app4 outside of VLANs
 eden pod deploy -n app4 --memory=448MB --networks=nat --networks=switch -p 8031:80 --metadata="url=http://${app1_ip}/user-data.html" {{$image}}
@@ -85,7 +95,7 @@ exec -t 5m bash wait_and_get_recv_data.sh app4 8031
 # Modify app4 and move it to the VLAN 100
 eden pod modify app4 --networks=nat --networks=switch -p 8031:80 --vlan=switch:100
 exec sleep 15
-test eden.app.test -test.v -timewait 10m RUNNING app4
+test eden.app.test -test.v -timewait 15m RUNNING app4
 exec -t 5m bash wait_and_get_ip.sh app4 8031
 grep 'app4_ip=10.2.100.\d+' .env
 source .env
@@ -97,10 +107,8 @@ stdout '{{$test_data}}'
 # Cleanup - undeploy applications
 eden pod delete dhcp-server
 eden pod delete app1
-eden pod delete app2
-eden pod delete app3
 eden pod delete app4
-test eden.app.test -test.v -timewait 10m - dhcp-server app1 app2 app3 app4
+test eden.app.test -test.v -timewait 10m - dhcp-server app1 app4
 eden pod ps
 ! stdout 'dhcp-server'
 ! stdout 'app[1-4]'

--- a/tests/network/testdata/vlans/dhcp-server/entrypoint.sh
+++ b/tests/network/testdata/vlans/dhcp-server/entrypoint.sh
@@ -14,31 +14,14 @@ ip link add link "${eth1}" name "${eth1}.200" type vlan id 200
 ip link set dev "${eth1}.200" up
 ip addr add 10.2.200.1/24 dev "${eth1}.200"
 
-# DHCP server for apps without VLANs
+# DHCP server for apps
 cat <<EOF > /etc/dnsmasq.conf
 bind-interfaces
 except-interface=lo
 dhcp-leasefile=/run/dnsmasq.leases
-interface=${eth1}
-dhcp-range=10.2.0.2,10.2.0.254,60m
-EOF
-
-# DHCP server for VLAN 100
-cat <<EOF > /etc/dnsmasq.100.conf
-bind-interfaces
-except-interface=lo
-dhcp-leasefile=/run/dnsmasq.100.leases
-interface=${eth1}.100
-dhcp-range=10.2.100.2,10.2.100.254,60m
-EOF
-
-# DHCP server for VLAN 200
-cat <<EOF > /etc/dnsmasq.200.conf
-bind-interfaces
-except-interface=lo
-dhcp-leasefile=/run/dnsmasq.200.leases
-interface=${eth1}.200
-dhcp-range=10.2.200.2,10.2.200.254,60m
+dhcp-range=${eth1},10.2.0.2,10.2.0.254,60m
+dhcp-range=${eth1}.100,10.2.100.2,10.2.100.254,60m
+dhcp-range=${eth1}.200,10.2.200.2,10.2.200.254,60m
 EOF
 
 cat <<EOF > /etc/supervisord.conf
@@ -47,24 +30,27 @@ nodaemon=true
 
 [program:dnsmasq]
 command=dnsmasq -d -b -C /etc/dnsmasq.conf
-
-[program:dnsmasq.100]
-command=dnsmasq -d -b -C /etc/dnsmasq.100.conf
-
-[program:dnsmasq.200]
-command=dnsmasq -d -b -C /etc/dnsmasq.200.conf
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
 
 [program:nginx]
 command=nginx -g "daemon off;"
 autorestart=true
 stopsignal=KILL
 stopasgroup=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
 
 [program:ip]
 command=/bin/sh -c "while true; do sleep 5; ifconfig>/var/www/html/ifconfig.html; done"
 autorestart=true
 stopsignal=KILL
 stopasgroup=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
 EOF
 
 exec /usr/bin/supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
We can refactor switch_net_vlans test to use less apps and to not run
multiple dnsmasq in time. Also we can slightly increase config interval.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>