### PR TITLE
RoL: add command to retrieve device console logs from uart

### DIFF
--- a/cmd/edenRol.go
+++ b/cmd/edenRol.go
@@ -137,7 +137,7 @@ func rolInit() {
 	// rol -> rent
 	rolCmd.AddCommand(rolRentCmd)
 	rolRentCmd.PersistentFlags().StringVarP(&rolProjectID, "project-id", "p", "", "project id")
-	_ = rolRentCmd.MarkFlagRequired("project-id")
+	_ = rolRentCmd.MarkPersistentFlagRequired("project-id")
 	// rol -> rent -> create
 	createRentCmd.Flags().StringVarP(&rolRentName, "name", "n", "", "rent name")
 	createRentCmd.Flags().StringVar(&rolModel, "model", "", "device model")

--- a/cmd/edenRol.go
+++ b/cmd/edenRol.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"path"
+	"strings"
 )
 
 var (
@@ -17,8 +18,8 @@ var (
 	rolRentName     string
 	rolModel        string
 	rolManufacturer string
-	rolRentID		string
-	rolIPXEUrl		string
+	rolRentID       string
+	rolIPXEUrl      string
 )
 
 var rolCmd = &cobra.Command{
@@ -115,6 +116,23 @@ var closeRentCmd = &cobra.Command{
 	},
 }
 
+var getRentConsoleOutputCmd = &cobra.Command{
+	Use:   "console-output",
+	Short: "Get device console output",
+	Long:  `Get device console output from uart`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := rolgo.NewClient()
+		if err != nil {
+			log.Fatalf(err.Error())
+		}
+		consoleOutput, err := client.Rents.GetConsoleOutput(rolProjectID, rolRentID)
+		if err != nil {
+			log.Fatalf(err.Error())
+		}
+		fmt.Println(strings.Join(consoleOutput, "\n"))
+	},
+}
+
 func rolInit() {
 	// rol -> rent
 	rolCmd.AddCommand(rolRentCmd)
@@ -137,4 +155,8 @@ func rolInit() {
 	getRentCmd.Flags().StringVarP(&rolRentID, "id", "i", "", "rent id")
 	_ = getRentCmd.MarkFlagRequired("id")
 	rolRentCmd.AddCommand(getRentCmd)
+	// rol -> rent -> console-output
+	getRentConsoleOutputCmd.Flags().StringVarP(&rolRentID, "id", "i", "", "rent id")
+	_ = getRentConsoleOutputCmd.MarkFlagRequired("id")
+	rolRentCmd.AddCommand(getRentConsoleOutputCmd)
 }

--- a/docs/eve-platforms.md
+++ b/docs/eve-platforms.md
@@ -158,7 +158,8 @@ We can use this system for running tests on RPi4.
 3. Create device rent in RoL.
 4. Waiting for device will be ready.
 5. Onboard eve (use `eden eve onboard`)
-6. Close device rent in RoL.
+6. Get the logs from the UART console.
+7. Close device rent in RoL.
 
 Since the controller (Adam) runs on the Manager, and it needs to be accessible
 from the running EVE device, ensure that the Manager is accessible from your GCP
@@ -200,5 +201,8 @@ instance. This means that the Manager must be one of:
 
    `eden rol rent get -i "$rent_id" -p "$PROJECT_ID" | jq -r .machineState`
 5. Onboard eve (use `eden eve onboard`)
-6. When you no longer need the device, you need to close the rent.
+6. Let's get the logs from the UART console, so we can write them to a file for further analysis.
+
+   `eden rol rent console-output -i "$rent_id" -p "$PROJECT_ID" > uart.log`
+7. When you no longer need the device, you need to close the rent.
    `eden rol rent close -i "$rent_id" -p "$PROJECT_ID"`

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/lf-edge/eden
 go 1.16
 
 require (
-	github.com/Insei/rolgo v0.0.1
+	github.com/Insei/rolgo v0.0.2
 	github.com/amitbet/vncproxy v0.0.0-20200118084310-ea8f9b510913
 	github.com/bugsnag/bugsnag-go v1.5.3 // indirect
 	github.com/bugsnag/panicwrap v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,8 @@ github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
-github.com/Insei/rolgo v0.0.1 h1:ZVFoV89+xsueMfqVcVgskL3BP/qO7OYG+Yj0CcS5cr4=
-github.com/Insei/rolgo v0.0.1/go.mod h1:3JGeO13UEilalWLu/98Kd1mVMDGb2H7kS4Swf/WWWdw=
+github.com/Insei/rolgo v0.0.2 h1:Ph7FFRBGWeXs1qAXIGzqiji3gzEuJseRf27O74JOJ4Q=
+github.com/Insei/rolgo v0.0.2/go.mod h1:3JGeO13UEilalWLu/98Kd1mVMDGb2H7kS4Swf/WWWdw=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=


### PR DESCRIPTION
This feature is not stable due to some USB issues that occur when there is not enough power for the USB devices on the RPI4 that serves as the server for the current RoL. We connect 10 uart rs232 devices via usb hubs to RPi4 server with RoL. That's why sometimes, the logs will be empty.

Despite this problem, we can still get the logs, which will allow us to understand the situation with the RPi4 in more detail in case of problems during automatic testing.

