### PR TITLE
Fix stale error for volumes

### DIFF
--- a/tests/volume/testdata/volumes_test.txt
+++ b/tests/volume/testdata/volumes_test.txt
@@ -57,7 +57,7 @@ wait errorwait
 # delete old volume and check if app goes into running state
 eden -t 1m volume delete blank-vol-2
 test eden.vol.test -test.v -timewait 5m - blank-vol-2
-test eden.app.test -test.v -timewait 5m RUNNING eclient-mount
+test eden.app.test -test.v -timewait 15m RUNNING eclient-mount
 
 exec sleep 10
 


### PR DESCRIPTION
Seems we do not clean stale errors on volumes. And we should expand waiting for running state in volumes test as we want to wait for reboot of device in case of kernel crash.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>