### PR TITLE
Use firmware blobs from EVE-OS image

### DIFF
--- a/cmd/downloader.go
+++ b/cmd/downloader.go
@@ -14,10 +14,9 @@ import (
 )
 
 var (
-	eveArch    string
-	eveTag     string
-	eveUefiTag string
-	outputDir  string
+	eveArch   string
+	eveTag    string
+	outputDir string
 )
 
 var downloaderCmd = &cobra.Command{
@@ -36,7 +35,6 @@ var downloadEVECmd = &cobra.Command{
 		if viperLoaded {
 			eveRegistry = viper.GetString("eve.registry")
 			eveTag = viper.GetString("eve.tag")
-			eveUefiTag = viper.GetString("eve.uefi-tag")
 			eveArch = viper.GetString("eve.arch")
 			eveHV = viper.GetString("eve.hv")
 			adamDist = utils.ResolveAbsPath(viper.GetString("adam.dist"))
@@ -63,15 +61,8 @@ var downloadEVECmd = &cobra.Command{
 		if err := utils.DownloadEveLive(eveDesc, eveImageFile); err != nil {
 			log.Fatal(err)
 		}
-		if format == "qcow2" {
-			uefiDesc := utils.UEFIDescription{
-				Registry: eveRegistry,
-				Tag:      eveUefiTag,
-				Arch:     eveArch,
-			}
-			if err := utils.DownloadUEFI(uefiDesc, filepath.Dir(eveImageFile)); err != nil {
-				log.Fatal(err)
-			}
+		if err := utils.DownloadUEFI(eveDesc, filepath.Dir(eveImageFile)); err != nil {
+			log.Fatal(err)
 		}
 		log.Infof(model.DiskReadyMessage(), eveImageFile)
 		fmt.Println(eveImageFile)
@@ -119,7 +110,6 @@ var downloadEVERootFSCmd = &cobra.Command{
 func downloaderInit() {
 	downloaderCmd.AddCommand(downloadEVECmd)
 	downloadEVECmd.Flags().StringVarP(&eveTag, "eve-tag", "", defaults.DefaultEVETag, "tag to download eve")
-	downloadEVECmd.Flags().StringVarP(&eveUefiTag, "eve-uefi-tag", "", defaults.DefaultEVETag, "tag to download eve UEFI")
 	downloadEVECmd.Flags().StringVarP(&eveArch, "eve-arch", "", runtime.GOARCH, "arch of EVE")
 	downloadEVECmd.Flags().StringVarP(&eveHV, "eve-hv", "", defaults.DefaultEVEHV, "HV of EVE (kvm or xen)")
 	downloadEVECmd.Flags().StringVarP(&eveImageFile, "image-file", "i", "", "path for image drive")

--- a/docs/eve-images.md
+++ b/docs/eve-images.md
@@ -218,37 +218,6 @@ eden setup
 eden now will use the above container image to generate and configure
 the live disk image.
 
-#### Changing UEFI
-
-eden uses separate tags for `eve` and `eve-uefi`. This means that you can
-set the tag just for `eve`, while it will continue to use the default
-for `eve-uefi`. This helps with a development cycle where you are changing
-`eve`, but do not want to make changes to or rebuild `eve-uefi`.
-
-On the other hand, you can make changes to `eve-uefi`, in addition to or
-independent of `eve`.
-
-To run eden setup to use just a specific `eve-uefi` image, or both `eve` and `eve-uefi`:
-
-```sh
-eden setup --eve-uefi-tag <uefi-tag>
-eden setup --eve-tag <tag> --eve-uefi-tag <uefi-tag>
-```
-
-Continuing the above example:
-
-```sh
-eden setup --eve-uefi-tag eve-uefi-special
-eden setup --eve-tag 0.0.0-testbranch-b6a6d6fd --eve-uefi-tag eve-uefi-special
-```
-
-Or you can save it, by setting it in the file:
-
-```console
-eden config set default --key eve.uefi-tag --value eve-uefi-special
-eden setup
-```
-
 ### Live Image
 
 To generate the live image:

--- a/docs/eve-platforms.md
+++ b/docs/eve-platforms.md
@@ -8,11 +8,6 @@ build or deploy EVE, or run `eden` commands, with additional considerations.
 EVE uses virtualization; to run in VM-based environments, including most cloud
 instances, see [virtual EVE](./virtual-eve.md).
 
-## arm64
-
-When running on arm64, including Raspberry Pi 4, you may need to specify the
-UEFI build explicitly to eden, via `eve setup --eve-uefi-tag`.
-
 ## VirtualBox support
 
 Eden can be used with VirtualBox.

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -236,7 +236,6 @@ var (
 		"eve.repo":         "eve-repo",
 		"eve.registry":     "eve-registry",
 		"eve.tag":          "eve-tag",
-		"eve.uefi-tag":     "eve-uefi-tag",
 		"eve.hostfwd":      "eve-hostfwd",
 		"eve.dist":         "eve-dist",
 		"eve.base-dist":    "eve-base-dist",

--- a/pkg/utils/downloaders.go
+++ b/pkg/utils/downloaders.go
@@ -52,30 +52,6 @@ func (desc EVEDescription) Version() (string, error) {
 	return fmt.Sprintf("%s-%s-%s", desc.Tag, desc.HV, desc.Arch), nil
 }
 
-// UEFIDescription provides information about UEFI to download
-type UEFIDescription struct {
-	Registry string
-	Tag      string
-	Arch     string
-}
-
-// image extracts image tag from UEFIDescription
-func (desc UEFIDescription) image(latest bool) (string, error) {
-	if desc.Registry == "" {
-		desc.Registry = defaults.DefaultEveRegistry
-	}
-	if latest {
-		return fmt.Sprintf("%s-uefi:latest-%s", defaults.DefaultEveRegistry, desc.Arch), nil
-	}
-	if desc.Tag == "" {
-		return "", fmt.Errorf("tag not present")
-	}
-	if desc.Arch == "" {
-		return "", fmt.Errorf("arch not present")
-	}
-	return fmt.Sprintf("%s-uefi:%s-%s", desc.Registry, desc.Tag, desc.Arch), nil
-}
-
 //DownloadEveInstaller pulls EVE installer image from docker
 func DownloadEveInstaller(eve EVEDescription, outputFile string) (err error) {
 	image, err := eve.Image()
@@ -92,24 +68,17 @@ func DownloadEveInstaller(eve EVEDescription, outputFile string) (err error) {
 	return nil
 }
 
-func DownloadUEFI(uefi UEFIDescription, outputDir string) (err error) {
-	efiImage, err := uefi.image(false) //download OVMF
+// DownloadUEFI downloads and extracts uefi from EVE-OS image
+func DownloadUEFI(eve EVEDescription, outputDir string) (err error) {
+	image, err := eve.Image()
 	if err != nil {
 		return err
 	}
-	if err := PullImage(efiImage); err != nil {
-		log.Infof("cannot pull %s", efiImage)
-		efiImage, err = uefi.image(true) //try with latest version of OVMF
-		if err != nil {
-			return err
-		}
-		log.Infof("will retry with %s", efiImage)
-		if err := PullImage(efiImage); err != nil {
-			return fmt.Errorf("ImagePull (%s): %s", efiImage, err)
-		}
+	if err := PullImage(image); err != nil {
+		return fmt.Errorf("ImagePull (%s): %s", image, err)
 	}
-	if err := SaveImageAndExtract(efiImage, outputDir, ""); err != nil {
-		return fmt.Errorf("SaveImage: %s", err)
+	if err := SaveImageAndExtract(image, outputDir, "/bits/firmware"); err != nil {
+		return fmt.Errorf("SaveImageAndExtract: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Having separate uefi image to extract files from is not fit the approach
 of testing all blobs from the current EVE-OS image. We use different
 tags for eve-uefi image and cannot pull last image during testing.
 Let's use files bundled into EVE-OS image.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>