### PR TITLE
Fix ifconfig parsing

### DIFF
--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -62,12 +62,12 @@ jobs:
         env:
           OVPN_FILE: ${{ secrets.OVPN_FILE }}
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0.5.0
+        uses: google-github-actions/setup-gcloud@v0.6.0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - id: 'gcpauth'
         name: Auth to Google Cloud SDK
-        uses: google-github-actions/auth@v0.4.1
+        uses: google-github-actions/auth@v0.8.2
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           credentials_json: ${{ secrets.GCP_SA_KEY }}

--- a/tests/eclient/testdata/app_dhcp.txt
+++ b/tests/eclient/testdata/app_dhcp.txt
@@ -113,10 +113,10 @@ function get_ip {
     if [ -z "$ifconfig" ]; then
         return 1
     fi
-    interfaces=$(echo "$ifconfig" | grep "^\w" | grep -v LOOPBACK | cut -d: -f1)
+    interfaces=$(echo "$ifconfig" | grep "^\w" | grep -iv LOOPBACK | cut -d' ' -f1 | cut -d':' -f1)
     eth1=$(echo "$interfaces" | awk 'NR==2')
-    IP=$(echo "$ifconfig" | grep "^${eth1}: " -A 1 | awk '/inet / {print $2}')
-    MAC=$(echo "$ifconfig" | grep "^${eth1}: " -A 2 | awk '/ether / {print $2}')
+    IP=$(echo "$ifconfig" | grep "^${eth1}" -A 1 | grep 'inet ' | sed 's/addr://' | awk '/inet / {print $2}')
+    MAC=$(echo "$ifconfig" | grep "^${eth1}" -A 3 | sed 's/^.*HWaddr/ether/' | awk '/ether / {print $2}' | awk -F' ' '{print tolower($NF)}')
     if [ ! -z "$IP" ]; then
         echo "IP address of $APP is: $IP"
         echo "${APP}_ip=$IP" >.env

--- a/tests/network/testdata/vlans_and_bonds.txt
+++ b/tests/network/testdata/vlans_and_bonds.txt
@@ -204,9 +204,9 @@ function get_ip {
     if [ -z "$ifconfig" ]; then
         return 1
     fi
-    interfaces=$(echo "$ifconfig" | grep "^\w" | grep -v LOOPBACK | cut -d: -f1)
+    interfaces=$(echo "$ifconfig" | grep "^\w" | grep -iv LOOPBACK | cut -d' ' -f1 | cut -d':' -f 1)
     eth1=$(echo "$interfaces" | awk 'NR==2')
-    IP=$(echo "$ifconfig" | grep "^${eth1}: " -A 1 | awk '/inet / {print $2}' | cut -d"/" -f1)
+    IP=$(echo "$ifconfig" | grep "^${eth1}" -A 1 | grep 'inet ' | sed 's/addr://' | awk '/inet / {print $2}')
     if [ ! -z "$IP" ]; then
         echo "IP address of $APP is: $IP"
         echo "${APP}_ip=$IP" >.env


### PR DESCRIPTION
With updating of eclient image I can see different format of ifconfig
output. Let's parse both of them.

Old one:
```
nbu1x1.1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 10.11.12.2  netmask 255.255.255.255  broadcast 10.11.12.255
        inet6 fe80::216:3eff:fe00:101  prefixlen 64  scopeid 0x20<link>
        ether 00:16:3e:00:01:01  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```
New one:
```
nbu1x1.1  Link encap:Ethernet  HWaddr 00:16:3E:00:01:01  
          inet addr:10.11.12.2  Bcast:10.11.12.255  Mask:255.255.255.255
          inet6 addr: fe80::216:3eff:fe00:101/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:239 errors:0 dropped:0 overruns:0 frame:0
          TX packets:204 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:52178 (50.9 KiB)  TX bytes:47656 (46.5 KiB)
```
