### PR TITLE
Eden-SDN: implement network firewall + make tproxy a standalone endpoint

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -53,7 +53,7 @@ const (
 	DefaultRegistryPort         = 5050
 
 	//tags, versions, repos
-	DefaultEVETag               = "0.0.0-master-072272e8" // DefaultEVETag tag for EVE image
+	DefaultEVETag               = "0.0.0-master-1c8a8a4f" // DefaultEVETag tag for EVE image
 	DefaultAdamTag              = "0.0.41"
 	DefaultRedisTag             = "7"
 	DefaultRegistryTag          = "2.7"

--- a/sdn/examples/tproxy/README.md
+++ b/sdn/examples/tproxy/README.md
@@ -3,11 +3,11 @@
 Network model for this example is described by [network-model.json](./network-model.json).
 Notice that EVE is connected into a single network (logical label `network0`), with 
 transparent proxying enabled. As a result, every HTTP/HTTPS request sent from the device
-will get transparently redirected into a proxy. The proxy performs MITM proxying for all
-destinations (including the Adam controller), except for the `zededa.com` destination
-(which is only added as an example and not really accessed by the device) - see `proxyRules`
-configured for `transparentProxy`.
-Both the device and the proxy use the same DNS server `my-dns-server`. In fact, for ever
+will get transparently redirected into a proxy (logical label `my-tproxy`). The proxy
+performs MITM proxying for all destinations (including the Adam controller), except for
+the `zededa.com` destination (which is only added as an example and not really accessed
+by the device) - see `proxyRules` configured for `transparentProxy`.
+Both the device and the proxy use the same DNS server `my-dns-server`. In fact, for every
 HTTP/HTTPS request, the destination address will be translated twice - first by the device
 (which is made redundant by the redirection) and then by the proxy.
 
@@ -167,8 +167,6 @@ make clean && make build-tests
 Note that traffic coming out from EVE VM will go through the SDN VM (where it will be proxied),
 then it will be S-NATed on the exit from the VM, continue into the host networking and out
 into the Internet towards the zedcloud.
-
-
 
 [DPC]: https://github.com/lf-edge/eve/blob/8.10/pkg/pillar/types/zedroutertypes.go#L473-L487
 [override-template]: https://github.com/lf-edge/eve/blob/8.10/conf/DevicePortConfig/override.json.template

--- a/sdn/examples/tproxy/network-model.json
+++ b/sdn/examples/tproxy/network-model.json
@@ -26,23 +26,10 @@
         "domainName": "sdn",
         "privateDNS": ["my-dns-server"]
       },
-      "transparentProxy": {
-        "caCertPEM": "-----BEGIN CERTIFICATE-----\nMIIDVTCCAj2gAwIBAgIUPGtlx1k08RmWd9RxiCKTXYnAUkIwDQYJKoZIhvcNAQEL\nBQAwOjETMBEGA1UEAwwKemVkZWRhLmNvbTELMAkGA1UEBhMCVVMxFjAUBgNVBAcM\nDVNhbiBGcmFuY2lzY28wHhcNMjIwOTA3MTcwMDE0WhcNMzIwNjA2MTcwMDE0WjA6\nMRMwEQYDVQQDDAp6ZWRlZGEuY29tMQswCQYDVQQGEwJVUzEWMBQGA1UEBwwNU2Fu\nIEZyYW5jaXNjbzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALQsi7IG\nM8KApujL71MJXbuPQNn/g+RItQeehaFRcqcCcpFW4k1YveMNdf5HReKlAfufFtaa\nIF368t33UlleblopLM8m8r9Ev1sSJOS1yYgU1HABjyw54LXBqT4tAf0xjlRaLn4L\nQBUAS0TTywTppGXtNwXpxqdDuQdigNskqzEFaGI52IQezfGt7L2CeeJ/YJNcbImR\neCXMPwTatUHLLE29Qv8GQQfy7TpCXdXVLvQAyfZJi7lY7DjPqBab5ocnVTRcEpKz\nFwH2+KTokQkU1UF614IveRF3ZOqqmrQvy1AdSvekFLIz2uP7xsfy3I3HNQcPJ4DI\n5vNzBaE/hF5xK40CAwEAAaNTMFEwHQYDVR0OBBYEFPxOB5cxsf89x6KdFSTTFV2L\nwta1MB8GA1UdIwQYMBaAFPxOB5cxsf89x6KdFSTTFV2Lwta1MA8GA1UdEwEB/wQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAFXqCJuq4ifMw3Hre7+X23q25jOb1nzd\n8qs+1Tij8osUC5ekD21x/k9g+xHvacoJIOzsAmpAPSnwXKMnvVdAeX6Scg1Bvejj\nTdXfNEJ7jcvDROUNjlWYjwiY+7ahDkj56nahwGjjUQdgCCzRiSYPOq6N1tRkn97a\ni6+jB8DnTSDnv5j8xiPDbWJ+nv2O1NNsoHS91UrTqkVXxNItrCdPPh21hzrTJxs4\noSf4wbaF5n3E2cPpSAaXBEyxBdXAqUCIhP0q9/pgBTYuJ+eW467u4xWqUVi4iBtN\nwVfYelYC2v03Rn433kv624oJDQ7MM5bDUv3nqPtkUys0ARwxs8tQCgg=\n-----END CERTIFICATE-----",
-        "caKeyPEM": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC0LIuyBjPCgKbo\ny+9TCV27j0DZ/4PkSLUHnoWhUXKnAnKRVuJNWL3jDXX+R0XipQH7nxbWmiBd+vLd\n91JZXm5aKSzPJvK/RL9bEiTktcmIFNRwAY8sOeC1wak+LQH9MY5UWi5+C0AVAEtE\n08sE6aRl7TcF6canQ7kHYoDbJKsxBWhiOdiEHs3xrey9gnnif2CTXGyJkXglzD8E\n2rVByyxNvUL/BkEH8u06Ql3V1S70AMn2SYu5WOw4z6gWm+aHJ1U0XBKSsxcB9vik\n6JEJFNVBeteCL3kRd2Tqqpq0L8tQHUr3pBSyM9rj+8bH8tyNxzUHDyeAyObzcwWh\nP4RecSuNAgMBAAECggEAazt75Pd2BNQHAtSlWplfdQq8gUJm4A452BAL3kgYYbe+\nMiwwwfIICcNwL2eB+3NTq8syj4TpsKVzuJHDLDdcnEKXTa8TmKy06uHwnUJocJpd\nGVCEQsErsWFSdhPZdDTzTdbihtfxSs6C/bLDyOe5lYRKVDWfqttOm0uP/11imehq\n5CbnirPJF80i7SSR3ft743SbE9NMXy7IYlGZ9NDUaKcPVhH+oxEB81DodnIxk7BD\nIiPa44m2XyCbDFWY9gmKGCr838tG8DG9at4SldG18JwobJsjFgOTJTIrPZEd8aUS\nWx21YITEzQG4RMp3/RvNNiWNgvqSPuuoov5qS0O8TQKBgQDkm5RRQGAr2f4Giodr\n+CaSrOdTB2wGTS/w5xKktkOa/0ZVW4QOgKu04bSp8BJ88JvOfwdX8WuAqa+4ZQa1\nd76Ya0nGotY125ZQ5RYgKaaFaWUJy/CAquet7cr7mbGWYhGbngL1qWQMkxcZlJnL\nZSR83c8oSUMNIsA2ZXnjh1+iBwKBgQDJw0mcpnrvOgf5MP7NSjiAMrt+YgRCcx2D\nKPIZuxn6t0N9+HRnQC5EN3twSXp5HE2XjPn8jG1xl345E/Ev2t3vzbe8iabzcEne\nw9/6Wqd5ENmk/Qib3T2RZshl1zymSRdSVZexcjd9f1nmsq1JyhEk5s4ZsIkk5U0Z\n/3SM6NrQywKBgFaFm6j02HFAXChVndN7Y/33esWt9XCdHhvrGN9GLGgpXZFIxb5H\nbLVVB2+Z8SVgW1fYNAtQ0AMuNddwRQ3BeF1vnciUMMbJiSaszab2nJO5xAflK+1G\nwdDOQxjenpvwGgHv1+bqaXdo5EFGQL7+VMT9nj39HGeIU39DANLglY1ZAoGBALrU\n4sJzix0hoKaJTzmsg/t6fxJ+EzGxRV/iN6XKEzmOIKpyut+tl+pFckG9WPLzWYp/\n2jGZm/L29MRICixlQOTBm2W0FewRS+ZDfZFoBvLdvpzATwt96HhPNDzR/fCBeF4e\nslR3zpigqBAv3rWYrx17uNgjGCwZRbdQTY36Rj3XAoGAOKrgsJkWPNV08Sw9DX6R\nSyODv0NpdCKlGcDZX/LZc/imic0eCUww64ZqPFHHdRkIEj3cVtSTryqfXPFheVxB\nJA/5Rtu/UAatNxhUwA3NT1WJewBsTQyds75Vwz0TBvqr0VWEi5GbxlZReLu7v5gj\nrt3dAPD3c4Szs8PbWB9pGso=\n-----END PRIVATE KEY-----",
-        "proxyRules": [
-          {
-            "reqHost": "zededa.com",
-            "action": "reject"
-          },
-          {
-            "action": "mitm"
-          }
-        ],
-        "privateDNS": ["my-dns-server"]
-      },
+      "transparentProxy": "my-tproxy",
       "router": {
         "outsideReachability": true,
-        "reachableEndpoints": ["my-client", "my-dns-server"]
+        "reachableEndpoints": ["my-client", "my-dns-server", "my-tproxy"]
       }
     }
   ],
@@ -71,6 +58,26 @@
           "1.1.1.1",
           "8.8.8.8"
         ]
+      }
+    ],
+    "transparentProxies": [
+      {
+        "logicalLabel": "my-tproxy",
+        "fqdn": "tproxy.sdn",
+        "subnet": "10.17.17.0/24",
+        "ip": "10.17.17.10",
+        "caCertPEM": "-----BEGIN CERTIFICATE-----\nMIIDVTCCAj2gAwIBAgIUPGtlx1k08RmWd9RxiCKTXYnAUkIwDQYJKoZIhvcNAQEL\nBQAwOjETMBEGA1UEAwwKemVkZWRhLmNvbTELMAkGA1UEBhMCVVMxFjAUBgNVBAcM\nDVNhbiBGcmFuY2lzY28wHhcNMjIwOTA3MTcwMDE0WhcNMzIwNjA2MTcwMDE0WjA6\nMRMwEQYDVQQDDAp6ZWRlZGEuY29tMQswCQYDVQQGEwJVUzEWMBQGA1UEBwwNU2Fu\nIEZyYW5jaXNjbzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALQsi7IG\nM8KApujL71MJXbuPQNn/g+RItQeehaFRcqcCcpFW4k1YveMNdf5HReKlAfufFtaa\nIF368t33UlleblopLM8m8r9Ev1sSJOS1yYgU1HABjyw54LXBqT4tAf0xjlRaLn4L\nQBUAS0TTywTppGXtNwXpxqdDuQdigNskqzEFaGI52IQezfGt7L2CeeJ/YJNcbImR\neCXMPwTatUHLLE29Qv8GQQfy7TpCXdXVLvQAyfZJi7lY7DjPqBab5ocnVTRcEpKz\nFwH2+KTokQkU1UF614IveRF3ZOqqmrQvy1AdSvekFLIz2uP7xsfy3I3HNQcPJ4DI\n5vNzBaE/hF5xK40CAwEAAaNTMFEwHQYDVR0OBBYEFPxOB5cxsf89x6KdFSTTFV2L\nwta1MB8GA1UdIwQYMBaAFPxOB5cxsf89x6KdFSTTFV2Lwta1MA8GA1UdEwEB/wQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAFXqCJuq4ifMw3Hre7+X23q25jOb1nzd\n8qs+1Tij8osUC5ekD21x/k9g+xHvacoJIOzsAmpAPSnwXKMnvVdAeX6Scg1Bvejj\nTdXfNEJ7jcvDROUNjlWYjwiY+7ahDkj56nahwGjjUQdgCCzRiSYPOq6N1tRkn97a\ni6+jB8DnTSDnv5j8xiPDbWJ+nv2O1NNsoHS91UrTqkVXxNItrCdPPh21hzrTJxs4\noSf4wbaF5n3E2cPpSAaXBEyxBdXAqUCIhP0q9/pgBTYuJ+eW467u4xWqUVi4iBtN\nwVfYelYC2v03Rn433kv624oJDQ7MM5bDUv3nqPtkUys0ARwxs8tQCgg=\n-----END CERTIFICATE-----",
+        "caKeyPEM": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC0LIuyBjPCgKbo\ny+9TCV27j0DZ/4PkSLUHnoWhUXKnAnKRVuJNWL3jDXX+R0XipQH7nxbWmiBd+vLd\n91JZXm5aKSzPJvK/RL9bEiTktcmIFNRwAY8sOeC1wak+LQH9MY5UWi5+C0AVAEtE\n08sE6aRl7TcF6canQ7kHYoDbJKsxBWhiOdiEHs3xrey9gnnif2CTXGyJkXglzD8E\n2rVByyxNvUL/BkEH8u06Ql3V1S70AMn2SYu5WOw4z6gWm+aHJ1U0XBKSsxcB9vik\n6JEJFNVBeteCL3kRd2Tqqpq0L8tQHUr3pBSyM9rj+8bH8tyNxzUHDyeAyObzcwWh\nP4RecSuNAgMBAAECggEAazt75Pd2BNQHAtSlWplfdQq8gUJm4A452BAL3kgYYbe+\nMiwwwfIICcNwL2eB+3NTq8syj4TpsKVzuJHDLDdcnEKXTa8TmKy06uHwnUJocJpd\nGVCEQsErsWFSdhPZdDTzTdbihtfxSs6C/bLDyOe5lYRKVDWfqttOm0uP/11imehq\n5CbnirPJF80i7SSR3ft743SbE9NMXy7IYlGZ9NDUaKcPVhH+oxEB81DodnIxk7BD\nIiPa44m2XyCbDFWY9gmKGCr838tG8DG9at4SldG18JwobJsjFgOTJTIrPZEd8aUS\nWx21YITEzQG4RMp3/RvNNiWNgvqSPuuoov5qS0O8TQKBgQDkm5RRQGAr2f4Giodr\n+CaSrOdTB2wGTS/w5xKktkOa/0ZVW4QOgKu04bSp8BJ88JvOfwdX8WuAqa+4ZQa1\nd76Ya0nGotY125ZQ5RYgKaaFaWUJy/CAquet7cr7mbGWYhGbngL1qWQMkxcZlJnL\nZSR83c8oSUMNIsA2ZXnjh1+iBwKBgQDJw0mcpnrvOgf5MP7NSjiAMrt+YgRCcx2D\nKPIZuxn6t0N9+HRnQC5EN3twSXp5HE2XjPn8jG1xl345E/Ev2t3vzbe8iabzcEne\nw9/6Wqd5ENmk/Qib3T2RZshl1zymSRdSVZexcjd9f1nmsq1JyhEk5s4ZsIkk5U0Z\n/3SM6NrQywKBgFaFm6j02HFAXChVndN7Y/33esWt9XCdHhvrGN9GLGgpXZFIxb5H\nbLVVB2+Z8SVgW1fYNAtQ0AMuNddwRQ3BeF1vnciUMMbJiSaszab2nJO5xAflK+1G\nwdDOQxjenpvwGgHv1+bqaXdo5EFGQL7+VMT9nj39HGeIU39DANLglY1ZAoGBALrU\n4sJzix0hoKaJTzmsg/t6fxJ+EzGxRV/iN6XKEzmOIKpyut+tl+pFckG9WPLzWYp/\n2jGZm/L29MRICixlQOTBm2W0FewRS+ZDfZFoBvLdvpzATwt96HhPNDzR/fCBeF4e\nslR3zpigqBAv3rWYrx17uNgjGCwZRbdQTY36Rj3XAoGAOKrgsJkWPNV08Sw9DX6R\nSyODv0NpdCKlGcDZX/LZc/imic0eCUww64ZqPFHHdRkIEj3cVtSTryqfXPFheVxB\nJA/5Rtu/UAatNxhUwA3NT1WJewBsTQyds75Vwz0TBvqr0VWEi5GbxlZReLu7v5gj\nrt3dAPD3c4Szs8PbWB9pGso=\n-----END PRIVATE KEY-----",
+        "proxyRules": [
+          {
+            "reqHost": "zededa.com",
+            "action": "reject"
+          },
+          {
+            "action": "mitm"
+          }
+        ],
+        "privateDNS": ["my-dns-server"]
       }
     ]
   }

--- a/sdn/vm/api/endpoints.go
+++ b/sdn/vm/api/endpoints.go
@@ -22,9 +22,39 @@ type Endpoints struct {
 	// Consider using together with NetworkModel.Firewall, configured to block HTTP(s)
 	// traffic that tries to bypass a proxy.
 	ExplicitProxies []ExplicitProxy `json:"explicitProxies,omitempty"`
+	// TransparentProxies are proxying both HTTP and HTTPS traffic transparently.
+	TransparentProxies []TransparentProxy `json:"transparentProxies,omitempty"`
 	// NetbootServers : HTTP/TFTP servers providing artifacts needed to boot EVE OS
 	// over a network (using netboot/PXE + iPXE).
 	NetbootServers []NetbootServer `json:"netbootServers,omitempty"`
+}
+
+// GetAll : returns all endpoints as one list.
+// Returned list items are of type Endpoint, which is a common struct embedded
+// inside each endpoint.
+func (eps Endpoints) GetAll() (all []Endpoint) {
+	for _, client := range eps.Clients {
+		all = append(all, client.Endpoint)
+	}
+	for _, dnsSrv := range eps.DNSServers {
+		all = append(all, dnsSrv.Endpoint)
+	}
+	for _, ntpSrv := range eps.NTPServers {
+		all = append(all, ntpSrv.Endpoint)
+	}
+	for _, httpSrv := range eps.HTTPServers {
+		all = append(all, httpSrv.Endpoint)
+	}
+	for _, exProxy := range eps.ExplicitProxies {
+		all = append(all, exProxy.Endpoint)
+	}
+	for _, tProxy := range eps.TransparentProxies {
+		all = append(all, tProxy.Endpoint)
+	}
+	for _, netBootSrv := range eps.NetbootServers {
+		all = append(all, netBootSrv.Endpoint)
+	}
+	return all
 }
 
 // Endpoint simulates "remote" client or a server.
@@ -252,12 +282,71 @@ func (e ExplicitProxy) ReferencesFromItem() []LogicalLabelRef {
 	return refs
 }
 
+// Proxy can be either transparent or configured explicitly.
+type Proxy struct {
+	// DNSClientConfig : DNS configuration to be applied for the proxy.
+	DNSClientConfig
+	// CertPEM : Proxy certificate of the certificate authority in the PEM format.
+	// Proxy will use CA cert to sign certificate that it generates for itself.
+	// EVE should be configured to trust CA certificate.
+	// Not needed if proxy is just forwarding all flows (i.e. not terminating TLS).
+	CACertPEM string `json:"caCertPEM"`
+	// CAKeyPEM : Proxy key of the certificate authority in the PEM format.
+	// Proxy will use CA cert to sign certificate that it generates for itself.
+	// EVE should be configured to trust CA certificate.
+	// Not needed if proxy is just forwarding all flows (i.e. not terminating TLS).
+	CAKeyPEM string `json:"caKeyPEM"`
+	// ProxyRules : a set of rules that decides what to do with proxied traffic.
+	// By default (no rules defined), proxy will just forward all the flows.
+	ProxyRules []ProxyRule `json:"proxyRules"`
+}
+
+// ProxyRule : rule used by a proxy, which, if matches a given flow, decides what
+// to do with it.
+type ProxyRule struct {
+	// ReqHost : host from HTTP request header (or from the SNI value in the TLS ClientHello)
+	// to match this rule with (e.g. "google.com").
+	// Empty ReqHost should be used with the default rule (put one at most).
+	ReqHost string `json:"reqHost"`
+	// Action to take.
+	Action ProxyAction `json:"action"`
+}
+
 // UserCredentials : User credentials for an explicit proxy.
 type UserCredentials struct {
 	// Username
 	Username string `json:"username"`
 	// Password
 	Password string `json:"password"`
+}
+
+// TransparentProxy is a proxy that both HTTP and HTTPS traffic is forwarded through
+// transparently.
+type TransparentProxy struct {
+	// Endpoint configuration.
+	Endpoint
+	// Proxy configuration (common to transparent and explicit proxies).
+	Proxy
+}
+
+// ItemCategory categorizes the item within Endpoints.
+func (e TransparentProxy) ItemCategory() string {
+	return "transparent-proxy"
+}
+
+// ReferencesFromItem lists references to private DNS servers (if there are any).
+func (e TransparentProxy) ReferencesFromItem() []LogicalLabelRef {
+	refs := make([]LogicalLabelRef, 0, len(e.PrivateDNS))
+	for _, dns := range e.PrivateDNS {
+		refs = append(refs, LogicalLabelRef{
+			ItemType:         Endpoint{}.ItemType(),
+			ItemCategory:     DNSServer{}.ItemCategory(),
+			ItemLogicalLabel: dns,
+			// Avoids duplicate DNS servers within the same transparent proxy.
+			RefKey: "transparent-proxy-" + e.LogicalLabel,
+		})
+	}
+	return refs
 }
 
 // NetbootServer provides HTTP and TFTP server endpoints, serving all artifacts
@@ -319,6 +408,51 @@ type NetbootArtifact struct {
 	// If enabled, this file is then announced to netboot clients using DHCP
 	// option 67 (59 in DHCPv6).
 	Entrypoint bool `json:"entrypoint"`
+}
+
+// ProxyAction : proxy action.
+type ProxyAction uint8
+
+const (
+	// PxForward : just forward proxied traffic.
+	PxForward ProxyAction = iota
+	// PxReject : reject (block) proxied traffic.
+	PxReject
+	// PxMITM : act as a man-in-the-middle (split TLS tunnel in two).
+	PxMITM
+)
+
+// ProxyActionToString : convert ProxyAction to string representation used in JSON.
+var ProxyActionToString = map[ProxyAction]string{
+	PxForward: "forward",
+	PxReject:  "reject",
+	PxMITM:    "mitm",
+}
+
+// ProxyActionToID : get ProxyAction from a string representation.
+var ProxyActionToID = map[string]ProxyAction{
+	"":        PxForward, // default value
+	"forward": PxForward,
+	"reject":  PxReject,
+	"mitm":    PxMITM,
+}
+
+// MarshalJSON marshals the enum as a quoted json string.
+func (s ProxyAction) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(`"`)
+	buffer.WriteString(ProxyActionToString[s])
+	buffer.WriteString(`"`)
+	return buffer.Bytes(), nil
+}
+
+// UnmarshalJSON un-marshals a quoted json string to the enum value.
+func (s *ProxyAction) UnmarshalJSON(b []byte) error {
+	var j string
+	if err := json.Unmarshal(b, &j); err != nil {
+		return err
+	}
+	*s = ProxyActionToID[j]
+	return nil
 }
 
 // ProxyListenProto : protocol used to listen for incoming requests for proxying.

--- a/sdn/vm/pkg/configitems/dhcpClient.go
+++ b/sdn/vm/pkg/configitems/dhcpClient.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	dhcpcdBinary       = "/sbin/dhcpcd"
-	dhcpcdStartTimeout = 3 * time.Second
+	dhcpcdStartTimeout = 5 * time.Second
 	dhcpcdStopTimeout  = 30 * time.Second
 )
 
@@ -199,7 +199,7 @@ func (c *DhcpClientConfigurator) Delete(ctx context.Context, item depgraph.Item)
 }
 
 func dhcpcdPidFile(ifName string) string {
-	return fmt.Sprintf("/run/dhcpcd-%s.pid", ifName)
+	return fmt.Sprintf("/run/%s.pid", ifName)
 }
 
 func isDhcpcdRunning(ifName string) bool {

--- a/sdn/vm/pkg/configitems/iptables.go
+++ b/sdn/vm/pkg/configitems/iptables.go
@@ -22,6 +22,8 @@ type IptablesChain struct {
 	// We could probably extract this from IptablesRule.Args, but let's keep things
 	// simple and not dive into the iptables semantics too much.
 	RefersChains []string
+	// RefersVeths : names of VETH interfaces referred from rules.
+	RefersVeths []string
 	// PreCreated : a custom chain which already exists (as empty).
 	PreCreated bool
 }
@@ -90,6 +92,15 @@ func (ch IptablesChain) Dependencies() (deps []depgraph.Dependency) {
 				Table:        ch.Table,
 				ForIPv6:      ch.ForIPv6,
 			}),
+		})
+	}
+	for _, referredVeth := range ch.RefersVeths {
+		deps = append(deps, depgraph.Dependency{
+			RequiredItem: depgraph.ItemRef{
+				ItemType: VethTypename,
+				ItemName: referredVeth,
+			},
+			Description: "veth interface must exist",
 		})
 	}
 	deps = append(deps, depgraph.Dependency{


### PR DESCRIPTION
Also included is an update of the default EVE version to include: https://github.com/lf-edge/eve/pull/2897
This is needed for the SDN example `sdn/examples/proxy-auto-discovery` to work correctly.

Signed-off-by: Milan Lenco <milan@zededa.com>