### PR TITLE
Small fixes for custom-installer after the refactor

### DIFF
--- a/pkg/eden/qemu.go
+++ b/pkg/eden/qemu.go
@@ -19,7 +19,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-//StartSWTPM starts swtpm process and use stateDir as state, log, pid and socket location
+// StartSWTPM starts swtpm process and use stateDir as state, log, pid and socket location
 func StartSWTPM(stateDir string) error {
 	if err := os.MkdirAll(stateDir, 0777); err != nil {
 		return err
@@ -34,14 +34,14 @@ func StartSWTPM(stateDir string) error {
 	return nil
 }
 
-//StopSWTPM stops swtpm process using pid from stateDir
+// StopSWTPM stops swtpm process using pid from stateDir
 func StopSWTPM(stateDir string) error {
 	command := "swtpm"
 	pidFile := filepath.Join(stateDir, fmt.Sprintf("%s.pid", command))
 	return utils.StopCommandWithPid(pidFile)
 }
 
-//StartEVEQemu function run EVE in qemu
+// StartEVEQemu function run EVE in qemu
 func StartEVEQemu(qemuARCH, qemuOS, eveImageFile, imageFormat string, isInstaller bool,
 	qemuSMBIOSSerial string, eveTelnetPort, qemuMonitorPort, netDevBasePort int,
 	qemuHostFwd map[string]string, qemuAccel bool, qemuConfigFile, logFile, pidFile string,
@@ -160,6 +160,9 @@ func StartEVEQemu(qemuARCH, qemuOS, eveImageFile, imageFormat string, isInstalle
 		installerOptions := consoleOpts + qemuOptions
 		installerOptions += fmt.Sprintf("-drive file=%s,format=%s ",
 			eveImageFile, imageFormat)
+		if qemuConfigFile != "" {
+			installerOptions += fmt.Sprintf("-readconfig %s ", qemuConfigFile)
+		}
 		log.Infof("Start EVE installer: %s %s", qemuCommand, installerOptions)
 		if err := utils.RunCommandForeground(qemuCommand, strings.Fields(installerOptions)...); err != nil {
 			return fmt.Errorf("StartEVEQemu: %s", err)
@@ -199,17 +202,17 @@ func StartEVEQemu(qemuARCH, qemuOS, eveImageFile, imageFormat string, isInstalle
 	return nil
 }
 
-//StopEVEQemu function stop EVE
+// StopEVEQemu function stop EVE
 func StopEVEQemu(pidFile string) (err error) {
 	return utils.StopCommandWithPid(pidFile)
 }
 
-//StatusEVEQemu function get status of EVE
+// StatusEVEQemu function get status of EVE
 func StatusEVEQemu(pidFile string) (status string, err error) {
 	return utils.StatusCommandWithPid(pidFile)
 }
 
-//SetLinkStateQemu changes the link state of the given interface.
+// SetLinkStateQemu changes the link state of the given interface.
 func SetLinkStateQemu(qemuMonitorPort int, ifName string, up bool) error {
 	tcpAddr, _ := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", qemuMonitorPort))
 	conn, err := net.DialTCP("tcp", nil, tcpAddr)
@@ -244,7 +247,7 @@ func SetLinkStateQemu(qemuMonitorPort int, ifName string, up bool) error {
 	return nil
 }
 
-//GetLinkStatesQemu returns link states for the given set of EVE interfaces.
+// GetLinkStatesQemu returns link states for the given set of EVE interfaces.
 func GetLinkStatesQemu(qemuMonitorPort int, ifNames []string) (linkStates []edensdn.LinkState, err error) {
 	// Unfortunately QEMU Monitor doesn't provide command to obtain
 	// the current link state of interfaces.

--- a/pkg/openevec/config.go
+++ b/pkg/openevec/config.go
@@ -80,7 +80,7 @@ type AdamConfig struct {
 
 type CustomInstallerConfig struct {
 	Path   string `mapstructure:"path" resolvepath:""`
-	Format string `mapstructure:"path"`
+	Format string `mapstructure:"format"`
 }
 
 type QemuConfig struct {

--- a/pkg/openevec/start.go
+++ b/pkg/openevec/start.go
@@ -71,20 +71,26 @@ func StartEServer(cfg EdenSetupArgs) error {
 
 func StartEden(cfg *EdenSetupArgs, vmName string) error {
 
-	if err := StartRedis(*cfg); err != nil {
-		return fmt.Errorf("cannot start redis %w", err)
-	}
+	// Note that custom installer only works with zedcloud controller.
+	// FIXME: ZedControlURL is not set for 'eden start' command.
+	useZedcloud := cfg.Eve.CustomInstaller.Path != "" || cfg.Runtime.ZedControlURL != ""
 
-	if err := StartAdam(*cfg); err != nil {
-		return fmt.Errorf("cannot start adam %w", err)
-	}
+	if !useZedcloud {
+		if err := StartRedis(*cfg); err != nil {
+			return fmt.Errorf("cannot start redis %w", err)
+		}
 
-	if err := StartRegistry(*cfg); err != nil {
-		return fmt.Errorf("cannot start registry %w", err)
-	}
+		if err := StartAdam(*cfg); err != nil {
+			return fmt.Errorf("cannot start adam %w", err)
+		}
 
-	if err := StartEServer(*cfg); err != nil {
-		return fmt.Errorf("cannot start adam %w", err)
+		if err := StartRegistry(*cfg); err != nil {
+			return fmt.Errorf("cannot start registry %w", err)
+		}
+
+		if err := StartEServer(*cfg); err != nil {
+			return fmt.Errorf("cannot start adam %w", err)
+		}
 	}
 
 	if cfg.Eve.Remote {

--- a/sdn/examples/tproxy/README.md
+++ b/sdn/examples/tproxy/README.md
@@ -161,7 +161,7 @@ make clean && make build-tests
 ./eden config set default --key eve.custom-installer.path --value "$(pwd)/installer.raw"
 ./eden config set default --key eve.custom-installer.format --value raw
 ./eden setup
-./eden start --sdn-network-model $(pwd)/sdn/examples/explicit-proxy/network-model.json
+./eden start --sdn-network-model $(pwd)/sdn/examples/tproxy/network-model.json
 ```
 
 Note that traffic coming out from EVE VM will go through the SDN VM (where it will be proxied),


### PR DESCRIPTION
I noticed that `--zedcontrol` option is also broken (not only `eden setup` but also `eden start` should now know about it). We can think of some solution and fix it in another PR.

Signed-off-by: Milan Lenco <milan@zededa.com>