### PR TITLE
When Eden-SDN was added, EthLoops were removed

### DIFF
--- a/cmd/edenStart.go
+++ b/cmd/edenStart.go
@@ -63,7 +63,6 @@ func newStartCmd(configName, verbosity *string) *cobra.Command {
 	startCmd.Flags().StringVarP(&cfg.Eve.Log, "eve-log", "", filepath.Join(currentPath, defaults.DefaultDist, "eve.log"), "file for save EVE log")
 	startCmd.Flags().StringVarP(&cfg.Eve.ImageFile, "image-file", "", cfg.Eve.ImageFile, "path to image drive, overrides default setting")
 	startCmd.Flags().StringVarP(&cfg.Runtime.TapInterface, "with-tap", "", "", "use tap interface in QEMU as the third")
-	startCmd.Flags().IntVarP(&cfg.Runtime.EthLoops, "with-eth-loops", "", 0, "add one or more ethernet loops (requires custom device model)")
 	startCmd.Flags().StringVarP(&cfg.Runtime.VmName, "vmname", "", defaults.DefaultVBoxVMName, "vbox vmname required to create vm")
 
 	startCmd.Flags().StringVarP(&cfg.Eve.UsbNetConfFile, "eve-usbnetconf-file", "", "", "path to device network config (aka usb.json) applied in runtime using a USB stick")

--- a/cmd/eve.go
+++ b/cmd/eve.go
@@ -87,7 +87,6 @@ func newStartEveCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 	startEveCmd.Flags().IntVarP(&cfg.Eve.QemuCpus, "cpus", "", defaults.DefaultCpus, "vbox cpus")
 	startEveCmd.Flags().IntVarP(&cfg.Eve.QemuMemory, "memory", "", defaults.DefaultMemory, "vbox memory size (MB)")
 	startEveCmd.Flags().StringVarP(&cfg.Runtime.TapInterface, "with-tap", "", "", "use tap interface in QEMU as the third")
-	startEveCmd.Flags().IntVarP(&cfg.Runtime.EthLoops, "with-eth-loops", "", 0, "add one or more ethernet loops (requires custom device model)")
 
 	return startEveCmd
 }

--- a/pkg/openevec/config.go
+++ b/pkg/openevec/config.go
@@ -201,7 +201,6 @@ type RuntimeConfig struct {
 	Host              string   `cobraflag:"eve-host"`
 	SshPort           int      `cobraflag:"eve-ssh-port"`
 	TapInterface      string   `cobraflag:"with-tap"`
-	EthLoops          int      `cobraflag:"with-eth-loops"`
 }
 
 type PacketConfig struct {


### PR DESCRIPTION
These ethernet loops were just a weird hack to implement `vlans_and_bonds` test. With Eden-SDN, this test can be rewritten and done properly (TBD, for now it is skipped).

Signed-off-by: Milan Lenco <milan@zededa.com>