### PR TITLE
Update EVE-OS version to 9.2.0

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -53,7 +53,7 @@ const (
 	DefaultRegistryPort         = 5050
 
 	//tags, versions, repos
-	DefaultEVETag               = "0.0.0-master-1c8a8a4f" // DefaultEVETag tag for EVE image
+	DefaultEVETag               = "9.2.0" // DefaultEVETag tag for EVE image
 	DefaultAdamTag              = "0.0.42"
 	DefaultRedisTag             = "7"
 	DefaultRegistryTag          = "2.7"


### PR DESCRIPTION
Update EVE-OS version to 9.2.0

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>