### PR TITLE
Add the --pin-cpus option.

### DIFF
--- a/cmd/edenPod.go
+++ b/cmd/edenPod.go
@@ -119,6 +119,7 @@ You can set access VLAN ID (VID) for a particular network in the format '<networ
 	podDeployCmd.Flags().BoolVar(&cfg.Runtime.OpenStackMetadata, "openstack-metadata", false, "Use OpenStack metadata for VM")
 	podDeployCmd.Flags().StringVar(&cfg.Runtime.DatastoreOverride, "datastoreOverride", "", "Override datastore path for disks (when we use different URL for Eden and EVE or for local datastore)")
 	podDeployCmd.Flags().Uint32Var(&cfg.Runtime.StartDelay, "start-delay", 0, "The amount of time (in seconds) that EVE waits (after boot finish) before starting application")
+	podDeployCmd.Flags().BoolVar(&cfg.Runtime.PinCpus, "pin-cpus", false, "Pin the CPUs used by the pod")
 
 	return podDeployCmd
 }

--- a/pkg/expect/application.go
+++ b/pkg/expect/application.go
@@ -46,6 +46,7 @@ func (exp *AppExpectation) createAppInstanceConfig(img *config.Image, netInstanc
 	default:
 		return nil, fmt.Errorf("not supported appType")
 	}
+	bundle.appInstanceConfig.Fixedresources.PinCpu = exp.pinCpus
 	bundle.appInstanceConfig.StartDelayInSeconds = exp.startDelay
 	for _, d := range exp.disks {
 		mountPoint := ""

--- a/pkg/expect/expectation.go
+++ b/pkg/expect/expectation.go
@@ -85,6 +85,7 @@ type AppExpectation struct {
 	profiles          []string
 	datastoreOverride string
 	startDelay        uint32
+	pinCpus           bool
 }
 
 //use provided appLink to try predict format of volume

--- a/pkg/expect/options.go
+++ b/pkg/expect/options.go
@@ -277,3 +277,11 @@ func WithStartDelay(startDelay uint32) ExpectationOption {
 		expectation.startDelay = startDelay
 	}
 }
+
+// WithPinCpus set pin-cpus option
+func WithPinCpus(pinCpus bool) ExpectationOption {
+	return func(expectation *AppExpectation) {
+		expectation.pinCpus = pinCpus
+
+	}
+}

--- a/pkg/openevec/config.go
+++ b/pkg/openevec/config.go
@@ -184,6 +184,7 @@ type RuntimeConfig struct {
 	AppMemory         string   `cobraflag:"memory"`
 	VolumeType        string   `cobraflag:"volume-type"`
 	AppCpus           uint32   `cobraflag:"cpus"`
+	PinCpus           bool     `cobraflag:"pin-cpus"`
 	ImageFormat       string   `cobraflag:"format"`
 	ACL               []string `cobraflag:"acl"`
 	VLANs             []string `cobraflag:"vlan"`

--- a/pkg/openevec/pod.go
+++ b/pkg/openevec/pod.go
@@ -138,6 +138,7 @@ func PodDeploy(appLink string, cfg *EdenSetupArgs) error {
 	opts = append(opts, expect.WithProfiles(cfg.Runtime.Profiles))
 	opts = append(opts, expect.WithDatastoreOverride(cfg.Runtime.DatastoreOverride))
 	opts = append(opts, expect.WithStartDelay(cfg.Runtime.StartDelay))
+	opts = append(opts, expect.WithPinCpus(cfg.Runtime.PinCpus))
 	expectation := expect.AppExpectationFromURL(ctrl, dev, appLink, cfg.Runtime.PodName, opts...)
 	appInstanceConfig := expectation.Application()
 	dev.SetApplicationInstanceConfig(append(dev.GetApplicationInstances(), appInstanceConfig.Uuidandversion.Uuid))


### PR DESCRIPTION
The option is used during the pod deploy. The option cannot be changed after the pod is already running.

Usage would be: ./eden pod deploy --pin-cpus OPTIONS

Signed-off-by: Nikolay Martyanov <ohmspectator@gmail.com>