### PR TITLE
Use proto format on Adam side

### DIFF
--- a/pkg/controller/adam/adam.go
+++ b/pkg/controller/adam/adam.go
@@ -27,6 +27,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	mimeProto     = "application/x-proto-binary"
+	mimeTextPlain = "text/plain"
+	mimeJSON      = "application/json"
+)
+
 //Ctx stores controller settings
 type Ctx struct {
 	dir               string
@@ -170,30 +176,30 @@ func (adam *Ctx) Register(device *device.Ctx) error {
 		log.Printf("error encoding json: %v", err)
 		return err
 	}
-	return adam.postObj("/admin/onboard", body, "application/json")
+	return adam.postObj("/admin/onboard", body, mimeJSON)
 }
 
 //DeviceList return device list
 func (adam *Ctx) DeviceList(filter types.DeviceStateFilter) (out []string, err error) {
 	if filter == types.RegisteredDeviceFilter || filter == types.AllDevicesFilter {
-		return adam.getList("/admin/device")
+		return adam.getList("/admin/device", mimeJSON)
 	}
 	return []string{}, nil
 }
 
 //ConfigSet set config for devID
 func (adam *Ctx) ConfigSet(devUUID uuid.UUID, devConfig []byte) (err error) {
-	return adam.putObj(path.Join("/admin/device", devUUID.String(), "config"), devConfig)
+	return adam.putObj(path.Join("/admin/device", devUUID.String(), "config"), devConfig, mimeProto)
 }
 
 //ConfigGet get config for devID
 func (adam *Ctx) ConfigGet(devUUID uuid.UUID) (out string, err error) {
-	return adam.getObj(path.Join("/admin/device", devUUID.String(), "config"))
+	return adam.getObj(path.Join("/admin/device", devUUID.String(), "config"), mimeProto)
 }
 
 //CertsGet get attest certs for devID
 func (adam *Ctx) CertsGet(devUUID uuid.UUID) (out string, err error) {
-	return adam.getObj(path.Join("/admin/device", devUUID.String(), "certs"))
+	return adam.getObj(path.Join("/admin/device", devUUID.String(), "certs"), mimeJSON)
 }
 
 //RequestLastCallback check request by pattern from existence files with callback
@@ -277,7 +283,7 @@ func (adam *Ctx) DeviceRemove(devUUID uuid.UUID) (err error) {
 //DeviceGetOnboard get device onboardUUID for devUUID
 func (adam *Ctx) DeviceGetOnboard(devUUID uuid.UUID) (onboardUUID uuid.UUID, err error) {
 	var devCert types.DeviceCert
-	devInfo, err := adam.getObj(path.Join("/admin/device", devUUID.String()))
+	devInfo, err := adam.getObj(path.Join("/admin/device", devUUID.String()), mimeJSON)
 	if err != nil {
 		return uuid.Nil, err
 	}
@@ -337,7 +343,7 @@ func (adam *Ctx) DeviceGetByOnboardUUID(onboardUUID string) (devUUID uuid.UUID, 
 
 //GetDeviceCert gets deviceCert contains certificates and serial
 func (adam *Ctx) GetDeviceCert(device *device.Ctx) (deviceCert *types.DeviceCert, err error) {
-	devInfo, err := adam.getObj(path.Join("/admin/device", device.GetID().String()))
+	devInfo, err := adam.getObj(path.Join("/admin/device", device.GetID().String()), mimeJSON)
 	if err != nil {
 		return nil, err
 	}
@@ -354,7 +360,7 @@ func (adam *Ctx) UploadDeviceCert(deviceCert types.DeviceCert) error {
 	if err != nil {
 		return err
 	}
-	return adam.postObj("/admin/device", body, "text/plain")
+	return adam.postObj("/admin/device", body, mimeTextPlain)
 }
 
 //SetDeviceOptions sets options for provided devUUID
@@ -363,12 +369,12 @@ func (adam *Ctx) SetDeviceOptions(devUUID uuid.UUID, options *types.DeviceOption
 	if err != nil {
 		return err
 	}
-	return adam.putObj(path.Join("/admin/device", devUUID.String(), "options"), body)
+	return adam.putObj(path.Join("/admin/device", devUUID.String(), "options"), body, mimeJSON)
 }
 
 //GetDeviceOptions returns DeviceOptions for provided devUUID
 func (adam *Ctx) GetDeviceOptions(devUUID uuid.UUID) (*types.DeviceOptions, error) {
-	devInfo, err := adam.getObj(path.Join("/admin/device", devUUID.String(), "options"))
+	devInfo, err := adam.getObj(path.Join("/admin/device", devUUID.String(), "options"), mimeJSON)
 	if err != nil {
 		return nil, err
 	}
@@ -385,12 +391,12 @@ func (adam *Ctx) SetGlobalOptions(options *types.GlobalOptions) error {
 	if err != nil {
 		return err
 	}
-	return adam.putObj("/admin/options", body)
+	return adam.putObj("/admin/options", body, mimeJSON)
 }
 
 //GetGlobalOptions returns global options from controller
 func (adam *Ctx) GetGlobalOptions() (*types.GlobalOptions, error) {
-	devInfo, err := adam.getObj("/admin/options")
+	devInfo, err := adam.getObj("/admin/options", mimeJSON)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/adam/httpclient.go
+++ b/pkg/controller/adam/httpclient.go
@@ -61,7 +61,7 @@ func (adam *Ctx) deleteObj(path string) (err error) {
 	return nil
 }
 
-func (adam *Ctx) getObj(path string) (out string, err error) {
+func (adam *Ctx) getObj(path string, acceptMime string) (out string, err error) {
 	u, err := utils.ResolveURL(adam.url, path)
 	if err != nil {
 		log.Printf("error constructing URL: %v", err)
@@ -71,6 +71,9 @@ func (adam *Ctx) getObj(path string) (out string, err error) {
 	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
 		log.Fatalf("unable to create new http request: %v", err)
+	}
+	if acceptMime != "" {
+		req.Header.Set("Accept", acceptMime)
 	}
 
 	response, err := utils.RepeatableAttempt(client, req)
@@ -85,7 +88,7 @@ func (adam *Ctx) getObj(path string) (out string, err error) {
 	return string(buf), nil
 }
 
-func (adam *Ctx) getList(path string) (out []string, err error) {
+func (adam *Ctx) getList(path string, acceptMime string) (out []string, err error) {
 	u, err := utils.ResolveURL(adam.url, path)
 	if err != nil {
 		log.Printf("error constructing URL: %v", err)
@@ -95,6 +98,9 @@ func (adam *Ctx) getList(path string) (out []string, err error) {
 	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
 		log.Fatalf("unable to create new http request: %v", err)
+	}
+	if acceptMime != "" {
+		req.Header.Set("Accept", acceptMime)
 	}
 
 	response, err := utils.RepeatableAttempt(client, req)
@@ -129,7 +135,7 @@ func (adam *Ctx) postObj(path string, obj []byte, mimeType string) (err error) {
 	return nil
 }
 
-func (adam *Ctx) putObj(path string, obj []byte) (err error) {
+func (adam *Ctx) putObj(path string, obj []byte, mimeType string) (err error) {
 	u, err := utils.ResolveURL(adam.url, path)
 	if err != nil {
 		log.Printf("error constructing URL: %v", err)
@@ -140,6 +146,7 @@ func (adam *Ctx) putObj(path string, obj []byte) (err error) {
 	if err != nil {
 		log.Fatalf("unable to create new http request: %v", err)
 	}
+	req.Header.Set("Content-Type", mimeType)
 	_, err = utils.RepeatableAttempt(client, req)
 	if err != nil {
 		log.Fatalf("unable to send request: %v", err)

--- a/pkg/controller/cloud.go
+++ b/pkg/controller/cloud.go
@@ -56,7 +56,7 @@ type Cloud interface {
 	AddVolume(volumeConfig *config.Volume) error
 	RemoveVolume(id string) error
 	ListVolume() []*config.Volume
-	GetConfigBytes(dev *device.Ctx, pretty bool) ([]byte, error)
+	GetConfigBytes(dev *device.Ctx, jsonFormat bool) ([]byte, error)
 	GetDeviceCurrent() (dev *device.Ctx, err error)
 	ConfigSync(dev *device.Ctx) (err error)
 	ConfigParse(config *config.EdgeDevConfig) (dev *device.Ctx, err error)

--- a/pkg/controller/device.go
+++ b/pkg/controller/device.go
@@ -16,7 +16,7 @@ import (
 	"github.com/lf-edge/eve/api/go/config"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
-	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 //StateUpdate refresh state file
@@ -289,7 +289,7 @@ func (cloud *CloudCtx) processDev(id uuid.UUID, state device.EdgeNodeState) {
 		log.Fatalf("ConfigGet error: %s", err)
 	}
 	var deviceConfig config.EdgeDevConfig
-	err = protojson.Unmarshal([]byte(configString), &deviceConfig)
+	err = proto.Unmarshal([]byte(configString), &deviceConfig)
 	if err != nil {
 		log.Fatalf("unmarshal error: %s", err)
 	}
@@ -453,7 +453,7 @@ func (cloud *CloudCtx) checkDriveDs(drive *config.Drive, dataStores []*config.Da
 
 // GetConfigBytes generate json representation of device config
 //nolint:cyclop,maintidx
-func (cloud *CloudCtx) GetConfigBytes(dev *device.Ctx, pretty bool) ([]byte, error) {
+func (cloud *CloudCtx) GetConfigBytes(dev *device.Ctx, jsonFormat bool) ([]byte, error) {
 	var contentTrees []*config.ContentTree
 	var volumes []*config.Volume
 	var baseOSConfigs []*config.BaseOSConfig
@@ -661,8 +661,8 @@ volumeLoop:
 		ProfileServerToken: dev.GetProfileServerToken(),
 		Disks:              disksConfig,
 	}
-	if pretty {
+	if jsonFormat {
 		return json.MarshalIndent(devConfig, "", "    ")
 	}
-	return json.Marshal(devConfig)
+	return proto.Marshal(devConfig)
 }

--- a/pkg/controller/eflowlog/eflowlog.go
+++ b/pkg/controller/eflowlog/eflowlog.go
@@ -17,7 +17,7 @@ import (
 	"github.com/lf-edge/eve/api/go/flowlog"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
-	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 //FlowLogCheckerMode is FlowLogExist, FlowLogNew and FlowLogAny
@@ -38,7 +38,7 @@ const (
 //ParseFullLogEntry unmarshal FlowMessage
 func ParseFullLogEntry(data []byte) (*flowlog.FlowMessage, error) {
 	var lb flowlog.FlowMessage
-	err := protojson.Unmarshal(data, &lb)
+	err := proto.Unmarshal(data, &lb)
 	return &lb, err
 }
 

--- a/pkg/controller/einfo/einfo.go
+++ b/pkg/controller/einfo/einfo.go
@@ -16,6 +16,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 //HandlerFunc must process info.ZInfoMsg and return true to exit
@@ -29,7 +30,7 @@ type QHandlerFunc func(im *info.ZInfoMsg, query map[string]string) bool
 //ParseZInfoMsg unmarshal ZInfoMsg
 func ParseZInfoMsg(data []byte) (ZInfoMsg *info.ZInfoMsg, err error) {
 	var zi info.ZInfoMsg
-	err = protojson.Unmarshal(data, &zi)
+	err = proto.Unmarshal(data, &zi)
 	return &zi, err
 }
 

--- a/pkg/controller/emetric/emetric.go
+++ b/pkg/controller/emetric/emetric.go
@@ -16,6 +16,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 //MetricCheckerMode is MetricExist, MetricNew and MetricAny
@@ -36,7 +37,7 @@ const (
 //ParseMetricsBundle unmarshal LogBundle
 func ParseMetricsBundle(data []byte) (logBundle *metrics.ZMetricMsg, err error) {
 	var lb metrics.ZMetricMsg
-	err = protojson.Unmarshal(data, &lb)
+	err = proto.Unmarshal(data, &lb)
 	return &lb, err
 }
 

--- a/pkg/controller/functions.go
+++ b/pkg/controller/functions.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"crypto/sha1"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -21,6 +20,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/pbkdf2"
 	"golang.org/x/term"
+	"google.golang.org/protobuf/proto"
 )
 
 //CloudPrepare is for init controller connection and obtain device list
@@ -179,7 +179,7 @@ func (cloud *CloudCtx) OnBoardDev(node *device.Ctx) error {
 //VersionIncrement use []byte with config.EdgeDevConfig and increment config version
 func VersionIncrement(configOld []byte) ([]byte, error) {
 	var deviceConfig config.EdgeDevConfig
-	if err := json.Unmarshal(configOld, &deviceConfig); err != nil {
+	if err := proto.Unmarshal(configOld, &deviceConfig); err != nil {
 		return nil, fmt.Errorf("unmarshal error: %s", err)
 	}
 	existingID := deviceConfig.Id
@@ -208,5 +208,5 @@ func VersionIncrement(configOld []byte) ([]byte, error) {
 		}
 	}
 	log.Debugf("VersionIncrement %d->%s", oldVersion, deviceConfig.Id.Version)
-	return json.Marshal(&deviceConfig)
+	return proto.Marshal(&deviceConfig)
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -54,7 +54,7 @@ const (
 
 	//tags, versions, repos
 	DefaultEVETag               = "9.2.0" // DefaultEVETag tag for EVE image
-	DefaultAdamTag              = "0.0.42"
+	DefaultAdamTag              = "0.0.43"
 	DefaultRedisTag             = "7"
 	DefaultRegistryTag          = "2.7"
 	DefaultProcTag              = "83cfe07"


### PR DESCRIPTION
This PR enables using of proto format on controller side.
Using proto we will be able to not depend on updates of EVE's API on Adam side and keep the same version of Adam before some kind of global update (e.g. another endpoint implementation).