### PR TITLE
Adjust volumes_test timeouts

### DIFF
--- a/tests/volume/testdata/volumes_test.txt
+++ b/tests/volume/testdata/volumes_test.txt
@@ -63,8 +63,8 @@ exec sleep 10
 
 # check purging of app with large volume
 eden pod purge eclient-mount
-test eden.app.test -test.v -timewait 5m PURGING eclient-mount
-test eden.app.test -test.v -timewait 5m RUNNING eclient-mount
+test eden.app.test -test.v -timewait 2m PURGING eclient-mount
+test eden.app.test -test.v -timewait 10m RUNNING eclient-mount
 
 exec sleep 10
 


### PR DESCRIPTION
Seems 5m may be not enough to tear down the app, recreate the volume and start app again.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>