### PR TITLE
Fix application adapter name

### DIFF
--- a/cmd/edenStart.go
+++ b/cmd/edenStart.go
@@ -21,7 +21,7 @@ func newStartCmd(configName, verbosity *string) *cobra.Command {
 		Long:              `Start harness.`,
 		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.StartEden(cfg, vmName, tapInterface, zedControlURL); err != nil {
+			if err := openevec.StartEden(cfg, vmName, zedControlURL, tapInterface); err != nil {
 				log.Fatalf("Start eden failed: %s", err)
 			}
 		},


### PR DESCRIPTION
Previously, eden would use "default" for every application adapter name. However, EVE API requires that in the scope of an application, each network adapter should be assigned a unique name.

Additionally, there was a small bug in "eden start" that made the command to fail if EVE was configured to run against zedcloud.