### PR TITLE
Fix "controller edge-node set-config" command

### DIFF
--- a/pkg/openevec/edgeNode.go
+++ b/pkg/openevec/edgeNode.go
@@ -20,6 +20,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 func EdgeNodeReboot(controllerMode string) error {
@@ -301,7 +302,7 @@ func EdgeNodeSetConfig(fileWithConfig string) error {
 		return fmt.Errorf("cannot unmarshal config: %w", err)
 	}
 	// Adam expects json type
-	cfg, err := json.Marshal(&dConfig)
+	cfg, err := proto.Marshal(&dConfig)
 	if err != nil {
 		return fmt.Errorf("cannot marshal config: %w", err)
 	}


### PR DESCRIPTION
In [pkg/controller/adam/adam.go](https://github.com/lf-edge/eden/blob/master/pkg/controller/adam/adam.go), method [ConfigSet](https://github.com/lf-edge/eden/blob/master/pkg/controller/adam/adam.go#L190-L193), we have recently changed content type to `application/x-proto-binary`, yet [EdgeNodeSetConfig](https://github.com/lf-edge/eden/blob/master/pkg/openevec/edgeNode.go#L303-L307) remained unchanged and still submits the configuration in JSON.