### PR TITLE
sdn,client: use the authentication identity files only for the ssh

### DIFF
--- a/pkg/edensdn/client.go
+++ b/pkg/edensdn/client.go
@@ -171,7 +171,7 @@ func (client *SdnClient) sshArgs(extra ...string) (sshArgs []string) {
 	if client.SSHKeyPath == "" {
 		log.Fatal("SDN client with undefined SSHKeyPath")
 	}
-	allArgs := fmt.Sprintf("-o ConnectTimeout=5 -o StrictHostKeyChecking=no "+
+	allArgs := fmt.Sprintf("-o IdentitiesOnly=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no "+
 		"-i %s -p %d root@localhost", client.SSHKeyPath, client.SSHPort)
 	return append(strings.Fields(allArgs), extra...)
 }

--- a/pkg/openevec/sdn.go
+++ b/pkg/openevec/sdn.go
@@ -15,13 +15,13 @@ import (
 )
 
 func SdnForwardSSHToEve(commandToRun string, cfg *EdenSetupArgs) error {
-	arguments := fmt.Sprintf("-o ConnectTimeout=5 -o StrictHostKeyChecking=no -i %s "+
+	arguments := fmt.Sprintf("-o IdentitiesOnly=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no -i %s "+
 		"-p FWD_PORT root@FWD_IP %s", sdnSSSHKeyPrivate(cfg.Eden.SSHKey), commandToRun)
 	return SdnForwardCmd("", "eth0", 22, "ssh", cfg, strings.Fields(arguments)...)
 }
 
 func SdnForwardSCPFromEve(remoteFilePath, localFilePath string, cfg *EdenSetupArgs) error {
-	arguments := fmt.Sprintf("-o ConnectTimeout=5 -o StrictHostKeyChecking=no -i %s "+
+	arguments := fmt.Sprintf("-o IdentitiesOnly=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no -i %s "+
 		"-P FWD_PORT root@FWD_IP:%s %s", sdnSSSHKeyPrivate(cfg.Eden.SSHKey), remoteFilePath, localFilePath)
 	return SdnForwardCmd("", "eth0", 22, "scp", cfg, strings.Fields(arguments)...)
 }


### PR DESCRIPTION
By default SSH tries to access the server with all the keys from the ~/.ssh folder, and the identity will be the last one in the list. This behavior leads to the following error:

    ERRO[0000] Failed to get EVE IP address: get-eve-ip.sh failed: Received disconnect from 127.0.0.1 port 6622:2: Too many authentication failures

if there are number of keys in the ~/.ssh folder is greater than 'MaxAuthTries' SSH server configuration option, which is set to 6 by default.

сс: @milan-zededa 
cc: @uncleDecart 