### PR TITLE
3 small bug fixes

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -96,7 +96,7 @@ const (
 	DefaultMemory                = 4096
 	DefaultEVESerial             = "31415926"
 	NetDHCPID                    = "6822e35f-c1b8-43ca-b344-0bbc0ece8cf1"
-	NetNoDHCPID                  = "6822e35f-c1b8-43ca-b344-0bbc0ece8cf2"
+	NetDHCPID2                   = "6822e35f-c1b8-43ca-b344-0bbc0ece8cf2"
 	NetWiFiID                    = "6822e35f-c1b8-43ca-b344-0bbc0ece8cf3"
 	NetSwitch                    = "6822e35f-c1b8-43ca-b344-0bbc0ece8cf4"
 	DefaultTestProg              = "eden.escript.test"

--- a/pkg/eve/applications.go
+++ b/pkg/eve/applications.go
@@ -194,7 +194,7 @@ func (ctx *State) processApplicationsByInfo(im *info.ZInfoMsg) {
 				appStateObj.InternalIP = []string{}
 				appStateObj.macs = []string{}
 				for _, el := range im.GetAinfo().Network {
-					if len(im.GetAinfo().Network[0].IPAddrs) != 0 {
+					if len(el.IPAddrs) != 0 {
 						appStateObj.InternalIP = append(appStateObj.InternalIP, el.IPAddrs[0])
 						appStateObj.macs = append(appStateObj.macs, el.MacAddr)
 					}

--- a/pkg/models/common.go
+++ b/pkg/models/common.go
@@ -24,7 +24,7 @@ func generateNetworkConfigs(ethCount, wifiCount uint) []*config.NetworkConfig {
 		if ethCount > 1 {
 			networkConfigs = append(networkConfigs,
 				&config.NetworkConfig{
-					Id:   defaults.NetNoDHCPID,
+					Id:   defaults.NetDHCPID2,
 					Type: config.NetworkType_V4,
 					Ip: &config.Ipspec{
 						Dhcp:      config.DHCPType_Client,
@@ -76,7 +76,7 @@ func generateSystemAdapters(ethCount, wifiCount uint) []*config.SystemAdapter {
 			uplink = false
 		}
 		if i == 1 {
-			networkUUID = defaults.NetNoDHCPID
+			networkUUID = defaults.NetDHCPID2
 		}
 		if i == 2 {
 			networkUUID = defaults.NetSwitch

--- a/tests/eclient/testdata/nw_switch.txt
+++ b/tests/eclient/testdata/nw_switch.txt
@@ -34,7 +34,8 @@ eden pod deploy -v debug -n pong {{template "eclient_image"}} --networks=n1 --me
 message 'Waiting of running'
 test eden.app.test -test.v -timewait 20m RUNNING ping1 ping2 pong
 
-message 'Getting of "pong" IP'
+message 'Getting "pong" IP'
+exec sleep 5
 eden pod ps
 cp stdout pod_ps
 exec bash pong_ip.sh
@@ -52,6 +53,9 @@ stdout '100% packet loss'
 message 'Switching to 2nd network'
 eden pod modify pong --networks n2
 test eden.app.test -test.v -timewait 15m RUNNING pong
+
+message 'Getting new "pong" IP'
+exec sleep 5
 eden pod ps
 cp stdout pod_ps
 exec bash pong_ip.sh
@@ -67,6 +71,9 @@ stdout '0% packet loss'
 message 'Switching back to 1st network'
 eden pod modify pong --networks n1
 test eden.app.test -test.v -timewait 15m RUNNING pong
+
+message 'Getting new "pong" IP'
+exec sleep 5
 eden pod ps
 cp stdout pod_ps
 exec bash pong_ip.sh


### PR DESCRIPTION
1. In `nw_switch` test, do not assume that pod IP address is known as soon as it is reported as RUNNING
2. Avoid panic in `processApplicationsByInfo()` if the first pod interface does not have IP address reported yet but second does
3. `NetNoDHCPID` is not a good name for network which actually uses DHCP client