### PR TITLE
Add StopSDN call lost during refactoring

### DIFF
--- a/pkg/openevec/eve.go
+++ b/pkg/openevec/eve.go
@@ -210,6 +210,7 @@ func StopEve(vmName string, cfg *EdenSetupArgs) error {
 			}
 		}
 	}
+	eden.StopSDN(cfg.Eve.DevModel, cfg.Sdn.PidFile)
 	return nil
 }
 


### PR DESCRIPTION
As most functions have moved to `openevec` package, `StopEve()` accidentally lost call to `StopSDN()`, which stops SDN VM if it is running.
@uncleDecart, I noticed that `StopEVE()` is duplicated and still exists also outside of `openevec`: https://github.com/lf-edge/eden/blob/master/pkg/eden/eden.go#L896-L926