### PR TITLE
Split big eden workflow into 5 separate ones

### DIFF
--- a/tests/eclient/testdata/app_logs.txt
+++ b/tests/eclient/testdata/app_logs.txt
@@ -1,7 +1,8 @@
 # Test of App logs functionality
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
 
-eden pod deploy -n eclient --memory=512MB {{template "eclient_image"}}
+eden network create 10.11.12.0/24 -n n1
+eden pod deploy -n eclient --memory=512MB --networks=n1 {{template "eclient_image"}}
 
 # We run it in background as of logs and info are async
 test eden.app.test -test.v -timewait 15m RUNNING eclient &
@@ -29,8 +30,10 @@ stdout 'ubuntu-http-server'
 wait
 
 eden pod delete eclient
+eden network delete n1
 
 test eden.app.test -test.v -timewait 10m - eclient
+test eden.network.test -test.v -timewait 10m - n1
 
 -- eden-config.yml --
 {{/* Test's config. file */}}

--- a/tests/eclient/testdata/metadata.txt
+++ b/tests/eclient/testdata/metadata.txt
@@ -11,7 +11,8 @@
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
-eden pod deploy -n eclient --memory=512MB {{template "eclient_image"}} -p {{$port}}:22
+eden network create 10.11.12.0/24 -n n1
+eden pod deploy -n eclient --memory=512MB {{template "eclient_image"}} -p {{$port}}:22 --networks=n1 
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 
@@ -26,8 +27,10 @@ wait
 stdout '{"hello":"world"}'
 
 eden pod delete eclient
+eden network delete n1
 
 test eden.app.test -test.v -timewait 10m - eclient
+test eden.network.test -test.v -timewait 10m - n1
 
 -- eden-config.yml --
 {{/* Test's config. file */}}

--- a/tests/eclient/testdata/profile.txt
+++ b/tests/eclient/testdata/profile.txt
@@ -21,13 +21,15 @@ exec sleep 30
 
 # Define local-manager and two apps in different profiles
 # TBD: static ip in pod deploy
-eden pod deploy -n local-manager --memory=512MB {{template "eclient_image"}} -p 2223:22
+eden network create 10.11.12.0/24 -n n1
+
+eden pod deploy -n local-manager --memory=512MB {{template "eclient_image"}} -p 2223:22 --networks=n1
 
 test eden.app.test -test.v -timewait 10m RUNNING local-manager
 
-eden pod deploy -n app-profile-1 --memory=512MB {{template "eclient_image"}} --profile=profile-1
-eden pod deploy -n app-profile-2 --memory=512MB {{template "eclient_image"}} --profile=profile-2
-eden pod deploy -n app-profile-1-2 --memory=512MB {{template "eclient_image"}} --profile=profile-1 --profile=profile-2
+eden pod deploy -n app-profile-1 --memory=512MB {{template "eclient_image"}} --profile=profile-1 --networks=n1
+eden pod deploy -n app-profile-2 --memory=512MB {{template "eclient_image"}} --profile=profile-2 --networks=n1
+eden pod deploy -n app-profile-1-2 --memory=512MB {{template "eclient_image"}} --profile=profile-1 --profile=profile-2 --networks=n1
 
 # We have empty local_manager and empty default_profile, so apps should be in RUNNING state
 test eden.app.test -test.v -timewait 20m RUNNING app-profile-1 app-profile-2 app-profile-1-2 local-manager
@@ -126,8 +128,10 @@ eden pod delete app-profile-1
 eden pod delete app-profile-2
 eden pod delete app-profile-1-2
 eden pod delete local-manager
+eden network delete n1
 
 test eden.app.test -test.v -timewait 15m - app-profile-1 app-profile-2 app-profile-1-2 local-manager
+test eden.network.test -test.v -timewait 10m - n1
 
 -- wait_ssh.sh --
 

--- a/tests/eclient/testdata/userdata.txt
+++ b/tests/eclient/testdata/userdata.txt
@@ -16,15 +16,18 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 # Starting of reboot detector with a 1 reboot limit
 ! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
-eden pod deploy -n eclient --memory=512MB {{template "eclient_image"}} -p {{$port}}:22 --metadata={{$userdata_file}}
+eden network create 10.11.12.0/24 -n n1
+eden pod deploy -n eclient --memory=512MB --networks=n1 {{template "eclient_image"}} -p {{$port}}:22 --metadata={{$userdata_file}}
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 
 exec sleep 10
 
 eden pod delete eclient
+eden network delete n1
 
 test eden.app.test -test.v -timewait 10m - eclient
+test eden.network.test -test.v -timewait 10m - n1
 
 -- eden-config.yml --
 {{/* Test's config. file */}}

--- a/tests/workflow/eve-upgrade.tests.txt
+++ b/tests/workflow/eve-upgrade.tests.txt
@@ -1,0 +1,39 @@
+# Number of tests
+{{$tests := 6}}
+# EDEN_TEST_SETUP env. var. -- "y"(default) performs the EDEN setup steps
+{{$setup := "y"}}
+{{$setup_env := EdenGetEnv "EDEN_TEST_SETUP"}}
+{{if $setup_env}}{{$setup = $setup_env}}{{end}}
+# EDEN_TEST_STOP -- "y" stops EDEN after tests ("n" by default)
+{{$stop := EdenGetEnv "EDEN_TEST_STOP"}}
+# EDEN_TEST_REGISTRY env. var. -- "y"(default) performs the local EDEN registry test
+{{$registry := EdenGetEnv "EDEN_TEST_REGISTRY"}}
+
+{{$devmodel := EdenConfig "eve.devmodel"}}
+
+{{if (ne $setup "n")}}
+#./eden config add default
+/bin/echo Eden setup (1/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_setup
+#source ~/.eden/activate.sh
+{{end}}
+
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") (eq $devmodel "parallels") }}
+eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027 8028:8028 8029:8029 8030:8030 8031:8031
+{{end}}
+
+{{if (ne $setup "n")}}
+/bin/echo Eden start (2/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_start
+
+/bin/echo Eden onboard (3/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_onboard
+/bin/echo Eden template check (4/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/template_check
+{{end}}
+
+/bin/echo Eden base OS update http (5/{{$tests}})
+eden.escript.test -testdata ../update_eve_image/testdata/ -test.run TestEdenScripts/update_eve_image_http
+
+/bin/echo Eden base OS update oci (6/{{$tests}})
+eden.escript.test -testdata ../update_eve_image/testdata/ -test.run TestEdenScripts/update_eve_image_oci

--- a/tests/workflow/lpc-loc.tests.txt
+++ b/tests/workflow/lpc-loc.tests.txt
@@ -1,0 +1,46 @@
+# Number of tests
+{{$tests := 9}}
+# EDEN_TEST_SETUP env. var. -- "y"(default) performs the EDEN setup steps
+{{$setup := "y"}}
+{{$setup_env := EdenGetEnv "EDEN_TEST_SETUP"}}
+{{if $setup_env}}{{$setup = $setup_env}}{{end}}
+# EDEN_TEST_STOP -- "y" stops EDEN after tests ("n" by default)
+{{$stop := EdenGetEnv "EDEN_TEST_STOP"}}
+# EDEN_TEST_REGISTRY env. var. -- "y"(default) performs the local EDEN registry test
+{{$registry := EdenGetEnv "EDEN_TEST_REGISTRY"}}
+
+{{$devmodel := EdenConfig "eve.devmodel"}}
+
+{{if (ne $setup "n")}}
+#./eden config add default
+/bin/echo Eden setup (1/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_setup
+#source ~/.eden/activate.sh
+{{end}}
+
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") (eq $devmodel "parallels") }}
+eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027 8028:8028 8029:8029 8030:8030 8031:8031
+{{end}}
+
+{{if (ne $setup "n")}}
+/bin/echo Eden start (2/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_start
+
+/bin/echo Eden onboard (3/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_onboard
+/bin/echo Eden template check (4/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/template_check
+{{end}}
+
+/bin/echo Eden profile test (5/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/profile
+
+/bin/echo Eden test radio silence (6/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/radio_silence
+/bin/echo Eden test app info (7/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/app_local_info
+/bin/echo Eden test dev info (8/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/dev_local_info
+/bin/echo Eden location publish test (9/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/publish_location
+

--- a/tests/workflow/networking.tests.txt
+++ b/tests/workflow/networking.tests.txt
@@ -1,0 +1,67 @@
+# Number of tests
+{{$tests := 17}}
+k EDEN_TEST_SETUP env. var. -- "y"(default) performs the EDEN setup steps
+{{$setup := "y"}}
+{{$setup_env := EdenGetEnv "EDEN_TEST_SETUP"}}
+{{if $setup_env}}{{$setup = $setup_env}}{{end}}
+# EDEN_TEST_STOP -- "y" stops EDEN after tests ("n" by default)
+{{$stop := EdenGetEnv "EDEN_TEST_STOP"}}
+# EDEN_TEST_REGISTRY env. var. -- "y"(default) performs the local EDEN registry test
+{{$registry := EdenGetEnv "EDEN_TEST_REGISTRY"}}
+
+{{$devmodel := EdenConfig "eve.devmodel"}}
+
+{{if (ne $setup "n")}}
+#./eden config add default
+/bin/echo Eden setup (1/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_setup
+#source ~/.eden/activate.sh
+{{end}}
+
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") (eq $devmodel "parallels") }}
+eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027 8028:8028 8029:8029 8030:8030 8031:8031
+{{end}}
+
+{{if (ne $setup "n")}}
+/bin/echo Eden start (2/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_start
+
+/bin/echo Eden onboard (3/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_onboard
+/bin/echo Eden template check (4/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/template_check
+{{end}}
+
+/bin/echo Eden basic network test (5/{{$tests}})
+eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/network_test
+/bin/echo Eden basic VLAN test (6/{{$tests}})
+eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/switch_net_vlans
+/bin/echo Eden basic VLAN test (7/{{$tests}})
+eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/vlans_and_bonds
+
+/bin/echo Eden ACL to particular host (8/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/acl
+/bin/echo Eden Network light (9/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/networking_light
+
+/bin/echo Eden Networks switch (10/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/nw_switch
+/bin/echo Eden Network Ports switch (11/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_switch
+/bin/echo Eden Network portmap test (12/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_forward
+/bin/echo Eden test app info (13/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/app_dhcp
+
+/bin/echo Eden VNC (14/{{$tests}})
+eden.escript.test -testdata ../vnc/testdata/ -test.run TestEdenScripts/vnc_test
+
+/bin/echo Eden Networking via switch test (15/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/air-gapped-switch
+
+/bin/echo Eden Nginx (16/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/ngnix
+
+/bin/echo Verifying that we can use a switch network instance on a management port (17/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/app_nonat
+

--- a/tests/workflow/smoke.tests.txt
+++ b/tests/workflow/smoke.tests.txt
@@ -1,0 +1,79 @@
+# Number of tests
+{{$tests := 21}}
+# EDEN_TEST_SETUP env. var. -- "y"(default) performs the EDEN setup steps
+{{$setup := "y"}}
+{{$setup_env := EdenGetEnv "EDEN_TEST_SETUP"}}
+{{if $setup_env}}{{$setup = $setup_env}}{{end}}
+# EDEN_TEST_STOP -- "y" stops EDEN after tests ("n" by default)
+{{$stop := EdenGetEnv "EDEN_TEST_STOP"}}
+# EDEN_TEST_REGISTRY env. var. -- "y"(default) performs the local EDEN registry test
+{{$registry := EdenGetEnv "EDEN_TEST_REGISTRY"}}
+
+{{$devmodel := EdenConfig "eve.devmodel"}}
+
+{{if (ne $setup "n")}}
+#./eden config add default
+/bin/echo Eden setup (1/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_setup
+#source ~/.eden/activate.sh
+{{end}}
+
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") (eq $devmodel "parallels") }}
+eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027 8028:8028 8029:8029 8030:8030 8031:8031
+{{end}}
+
+{{if (ne $setup "n")}}
+/bin/echo Eden start (2/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_start
+/bin/echo Eden onboard (3/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_onboard
+/bin/echo Eden template check (4/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/template_check
+{{end}}
+
+{{if (ne $setup "y")}}
+# Just restart EVE if not using the SETUP steps
+# Is it QEMU?
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") (eq $devmodel "parallels") }}
+/bin/echo EVE restart (5/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eve_restart
+{{end}}
+{{end}}
+
+/bin/echo Eden Log test (6/{{$tests}})
+eden.escript.test -testdata ../lim/testdata/ -test.run TestEdenScripts/log_test
+/bin/echo Eden SSH test (7/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/ssh
+/bin/echo Eden Info test (8/{{$tests}})
+eden.escript.test -testdata ../lim/testdata/ -test.run TestEdenScripts/info_test
+/bin/echo Eden Metric test (9/{{$tests}})
+eden.escript.test -testdata ../lim/testdata/ -test.run TestEdenScripts/metric_test
+
+/bin/echo Escript args test (10/{{$tests}})
+eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/arg -args=test1=123,test2=456
+/bin/echo Escript template test (11/{{$tests}})
+eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/template
+/bin/echo Escript message test (12/{{$tests}})
+eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/message
+/bin/echo Escript nested scripts test (13/{{$tests}})
+eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/nested_scripts
+/bin/echo Escript time test (14/{{$tests}})
+eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/time
+/bin/echo Escript source test (15/{{$tests}})
+eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/source
+/bin/echo Escript fail scenario test (16/{{$tests}})
+eden.escript.test -testdata ../escript/testdata/ -test.run TestEdenScripts/fail_scenario
+
+/bin/echo Eden app metadata test (17/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/metadata
+/bin/echo Eden app userdata test (18/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/userdata
+/bin/echo Eden app log test (19/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/app_logs
+
+/bin/echo Eden Shutdown test (20/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/shutdown_test
+
+/bin/echo EVE reset (21/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_reset
+

--- a/tests/workflow/storage.tests.txt
+++ b/tests/workflow/storage.tests.txt
@@ -1,0 +1,56 @@
+# Number of tests
+{{$tests := 11}}
+# EDEN_TEST_SETUP env. var. -- "y"(default) performs the EDEN setup steps
+{{$setup := "y"}}
+{{$setup_env := EdenGetEnv "EDEN_TEST_SETUP"}}
+{{if $setup_env}}{{$setup = $setup_env}}{{end}}
+# EDEN_TEST_STOP -- "y" stops EDEN after tests ("n" by default)
+{{$stop := EdenGetEnv "EDEN_TEST_STOP"}}
+# EDEN_TEST_REGISTRY env. var. -- "y"(default) performs the local EDEN registry test
+{{$registry := EdenGetEnv "EDEN_TEST_REGISTRY"}}
+
+{{$devmodel := EdenConfig "eve.devmodel"}}
+
+{{if (ne $setup "n")}}
+#./eden config add default
+/bin/echo Eden setup (1/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_setup
+#source ~/.eden/activate.sh
+{{end}}
+
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") (eq $devmodel "parallels") }}
+eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027 8028:8028 8029:8029 8030:8030 8031:8031
+{{end}}
+
+{{if (ne $setup "n")}}
+/bin/echo Eden start (2/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_start
+
+/bin/echo Eden onboard (3/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_onboard
+
+/bin/echo Eden template check (4/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/template_check
+{{end}}
+
+/bin/echo Eden ZFS state and layout check (5/{{$tests}})
+eden.escript.test -testdata ../zfs/testdata/ -test.run TestEdenScripts/state_and_layout_check
+
+/bin/echo Eden basic volumes test (6/{{$tests}})
+eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/volumes_test
+
+/bin/echo Eden sftp volumes test (7/{{$tests}})
+eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/volume_sftp
+
+/bin/echo Eden test for local datastore volume (8/{{$tests}})
+eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/local_datastore
+
+/bin/echo Eden eclient with disk (9/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/disk
+
+/bin/echo Eden eclient with mounted volume (10/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/mount
+
+/bin/echo Eden registry (11/{{$tests}})
+eden.escript.test -testdata ../registry/testdata/ -test.run TestEdenScripts/registry_test
+

--- a/tests/workflow/user-apps.tests.txt
+++ b/tests/workflow/user-apps.tests.txt
@@ -1,0 +1,45 @@
+# Number of tests
+{{$tests := 8}}
+# EDEN_TEST_SETUP env. var. -- "y"(default) performs the EDEN setup steps
+{{$setup := "y"}}
+{{$setup_env := EdenGetEnv "EDEN_TEST_SETUP"}}
+{{if $setup_env}}{{$setup = $setup_env}}{{end}}
+# EDEN_TEST_STOP -- "y" stops EDEN after tests ("n" by default)
+{{$stop := EdenGetEnv "EDEN_TEST_STOP"}}
+# EDEN_TEST_REGISTRY env. var. -- "y"(default) performs the local EDEN registry test
+{{$registry := EdenGetEnv "EDEN_TEST_REGISTRY"}}
+
+{{$devmodel := EdenConfig "eve.devmodel"}}
+
+{{if (ne $setup "n")}}
+#./eden config add default
+/bin/echo Eden setup (1/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_setup
+#source ~/.eden/activate.sh
+{{end}}
+
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") (eq $devmodel "parallels") }}
+eden+ports.sh 2223:2223 2224:2224 5912:5902 5911:5901 8027:8027 8028:8028 8029:8029 8030:8030 8031:8031
+{{end}}
+
+{{if (ne $setup "n")}}
+/bin/echo Eden start (2/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_start
+
+/bin/echo Eden onboard (3/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/eden_onboard
+/bin/echo Eden template check (4/{{$tests}})
+eden.escript.test -test.run TestEdenScripts/template_check
+{{end}}
+
+/bin/echo Eden 2 dockers test (5/{{$tests}})
+eden.escript.test -testdata ../docker/testdata/ -test.run TestEdenScripts/2dockers_test
+
+/bin/echo Eden 2 dockers test with app state detector (6/{{$tests}})
+eden.escript.test -testdata ../app/testdata/ -test.run TestEdenScripts/2dockers_test
+
+/bin/echo Eden Mariadb (7/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/maridb
+
+/bin/echo Eden nodered (8/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/nodered


### PR DESCRIPTION
We split workflow tests into several ones to remove dependencies on build matrix and be able to run them in parallel to reduce testing time

Related to #863