### PR TITLE
Small fixes for unstable eden tests

### DIFF
--- a/tests/eclient/testdata/dev_local_info.txt
+++ b/tests/eclient/testdata/dev_local_info.txt
@@ -31,7 +31,7 @@ test eden.network.test -test.v -timewait 10m ACTIVATED {{template "network"}}
 
 # Deploy local-manager
 eden pod deploy -n local-manager --memory=512MB {{template "eclient_image"}} -p {{template "mngr_port"}}:22 --networks={{template "network"}}
-test eden.app.test -test.v -timewait 10m RUNNING local-manager
+test eden.app.test -test.v -timewait 15m RUNNING local-manager
 
 # Wait for ssh access
 exec -t 5m bash wait-ssh.sh {{template "mngr_port"}}
@@ -54,7 +54,7 @@ exec -t 10m bash get-devinfo-status.sh
 
 # STEP 2: Deploy the second app
 eden pod deploy -n app1 --memory=512MB {{template "eclient_image"}} -p {{template "app_port"}}:22 --networks={{template "network"}}
-test eden.app.test -test.v -timewait 10m RUNNING app1
+test eden.app.test -test.v -timewait 15m RUNNING app1
 
 # Wait for ssh access
 exec -t 5m bash wait-ssh.sh {{template "app_port"}}
@@ -123,9 +123,7 @@ exec -t 1m bash eden-pod-ps.sh local-manager
 ! stderr .
 
 # STEP 7: Check qemu process is gone aka powered off
-exec sleep 120
-eden eve status
-stdout 'EVE.*process not running'
+exec -t 5m bash wait-for-eve-to-stop.sh
 
 # STEP 8: Restart EVE; check apps come up
 message 'Restart EVE'
@@ -232,6 +230,16 @@ while true; do
     DEVINFO="$($EDEN sdn fwd eth0 {{template "mngr_port"}} -- {{template "ssh"}} "cat {{template "dev_info_status_file"}}")"
     echo "$DEVINFO" | grep "$EXPSTATE" && break
     sleep 1
+done
+
+-- wait-for-eve-to-stop.sh --
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+while true; do
+    STATUS="$($EDEN eve status)"
+    echo "$STATUS" | grep "EVE.*process not running" && break
+    sleep 3
 done
 
 -- eden-config.yml --

--- a/tests/eclient/testdata/networking_light.txt
+++ b/tests/eclient/testdata/networking_light.txt
@@ -43,7 +43,6 @@ exec sleep 10
 exec -t 1m bash setup_srv.sh
 exec sleep 10
 exec -t 1m bash run_srv.sh &
-exec sleep 10
 exec -t 1m bash run_client.sh
 exec sleep 10
 exec -t 1m bash get_result.sh
@@ -55,7 +54,6 @@ exec sleep 10
 exec -t 1m bash setup_srv.sh
 exec sleep 10
 exec -t 1m bash run_srv.sh &
-exec sleep 10
 exec -t 1m bash run_client.sh
 exec sleep 10
 exec -t 1m bash get_result.sh
@@ -103,6 +101,18 @@ $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} 'sh /tmp/server > /
 -- run_client.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 . ./env
+
+function check_server_port {
+    # get to server app via client app
+    listeners=$($EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} ssh -o StrictHostKeyChecking=no root@$ESERVER_IP netstat -tlpn)
+    echo "Current listeners: $listeners"
+    if echo "$listeners" | grep -q ":1234"; then
+        return 0
+    fi
+    return 1
+}
+
+until check_server_port; do sleep 3; done
 
 echo $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "echo {{$test_msg}} | nc -N $ESERVER_IP 1234"
 $EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "echo {{$test_msg}} | nc -N $ESERVER_IP 1234"

--- a/tests/eclient/testdata/profile.txt
+++ b/tests/eclient/testdata/profile.txt
@@ -40,7 +40,7 @@ eden controller edge-node update --device global_profile=profile-1
 
 # We set default_profile to profile-1, so app-profile-2 should be in HALTED state
 test eden.app.test -test.v -timewait 15m HALTED app-profile-2
-test eden.app.test -test.v -timewait 5m RUNNING app-profile-1 app-profile-1-2 local-manager
+test eden.app.test -test.v -timewait 15m RUNNING app-profile-1 app-profile-1-2 local-manager
 
 exec sleep 20
 
@@ -49,7 +49,7 @@ eden controller edge-node update --device global_profile=profile-2
 
 # We set default_profile to profile-2, so app-profile-1 should be in HALTED state
 test eden.app.test -test.v -timewait 15m HALTED app-profile-1
-test eden.app.test -test.v -timewait 5m RUNNING app-profile-2 app-profile-1-2 local-manager
+test eden.app.test -test.v -timewait 15m RUNNING app-profile-2 app-profile-1-2 local-manager
 
 # STEP 3: global_profile=profile-3
 
@@ -57,7 +57,7 @@ eden controller edge-node update --device global_profile=profile-3
 
 # We set default_profile to profile-3, so all apps against local-manager should be in HALTED state
 test eden.app.test -test.v -timewait 15m HALTED app-profile-1 app-profile-2 app-profile-1-2
-test eden.app.test -test.v -timewait 5m RUNNING local-manager
+test eden.app.test -test.v -timewait 15m RUNNING local-manager
 
 exec sleep 20
 
@@ -66,7 +66,7 @@ eden pod stop local-manager
 test eden.app.test -test.v -timewait 15m HALTED local-manager
 
 eden pod start local-manager
-test eden.app.test -test.v -timewait 5m RUNNING local-manager
+test eden.app.test -test.v -timewait 15m RUNNING local-manager
 
 # Wait for ssh access
 exec -t 5m bash wait_ssh.sh 2223
@@ -85,7 +85,7 @@ exec -t 1m bash local-manager-profile.sh 2223 profile-1
 
 # We set local_manager and use profile-1 in it, so app-profile-2 should be in HALTED state
 test eden.app.test -test.v -timewait 15m HALTED app-profile-2
-test eden.app.test -test.v -timewait 5m RUNNING app-profile-1 app-profile-1-2 local-manager
+test eden.app.test -test.v -timewait 15m RUNNING app-profile-1 app-profile-1-2 local-manager
 
 exec sleep 20
 
@@ -96,7 +96,7 @@ exec -t 1m bash local-manager-profile.sh 2223 profile-2
 
 # We set local_manager and use profile-2 in it, so app-profile-1 should be in HALTED state
 test eden.app.test -test.v -timewait 15m HALTED app-profile-1
-test eden.app.test -test.v -timewait 5m RUNNING app-profile-2 app-profile-1-2 local-manager
+test eden.app.test -test.v -timewait 15m RUNNING app-profile-2 app-profile-1-2 local-manager
 
 exec sleep 20
 
@@ -107,7 +107,7 @@ exec -t 1m bash local-manager-profile.sh 2223 profile-3
 
 # We set local_manager and use profile-3 in it, so all apps against local-manager should be in HALTED state
 test eden.app.test -test.v -timewait 15m HALTED app-profile-1 app-profile-2 app-profile-1-2
-test eden.app.test -test.v -timewait 5m RUNNING local-manager
+test eden.app.test -test.v -timewait 15m RUNNING local-manager
 
 exec sleep 20
 
@@ -118,7 +118,7 @@ eden controller edge-node update --device local_profile_server=""
 
 exec sleep 30
 # We have empty local_manager and empty default_profile, so apps should come back to RUNNING state now
-test eden.app.test -test.v -timewait 5m RUNNING app-profile-1 app-profile-2 app-profile-1-2 local-manager
+test eden.app.test -test.v -timewait 15m RUNNING app-profile-1 app-profile-2 app-profile-1-2 local-manager
 
 exec sleep 20
 

--- a/tests/reboot/reboot_test.go
+++ b/tests/reboot/reboot_test.go
@@ -51,7 +51,7 @@ func checkReboot(t *testing.T, edgeNode *device.Ctx) projects.ProcInfoFunc {
 		currentLastRebootTime := im.GetDinfo().LastRebootTime
 		if !proto.Equal(lastRebootTime, currentLastRebootTime) {
 			if im.GetDinfo().LastRebootReason == "" &&
-				lastRebootTime.AsTime().IsZero() {
+				currentLastRebootTime.AsTime().Unix() == 0 {
 				// device may not fill the info
 				return nil
 			}

--- a/tests/volume/testdata/volumes_test.txt
+++ b/tests/volume/testdata/volumes_test.txt
@@ -18,7 +18,7 @@ eden -t 1m volume create -n v-vhdx file://{{EdenConfig "eden.root"}}/empty.vhdx 
 stdout 'create volume v-vhdx with file://{{EdenConfig "eden.root"}}/empty.vhdx request sent'
 
 # Wait for ready
-test eden.vol.test -test.v -timewait 10m DELIVERED v-qcow2 v-docker v-qcow v-vmdk v-vhdx
+test eden.vol.test -test.v -timewait 15m DELIVERED v-qcow2 v-docker v-qcow v-vmdk v-vhdx
 
 # measure reported total space of persist
 exec -t 5m bash wait-and-get-half-total.sh
@@ -26,7 +26,7 @@ source .env
 
 # allocate volume with size of half total space
 eden -t 1m volume create -n blank-vol-1 blank --disk-size=$half_total
-test eden.vol.test -test.v -timewait 1m CREATED_VOLUME blank-vol-1
+test eden.vol.test -test.v -timewait 3m CREATED_VOLUME blank-vol-1
 
 # allocate background info check for volumeErr contains Remaining word
 test eden.lim.test -test.v -timewait 3m -test.run TestInfo -out InfoContent.vinfo 'InfoContent.vinfo.volumeErr:Remaining' 'InfoContent.vinfo.displayName:blank-vol-2' &errorwait&


### PR DESCRIPTION
Mostly just increasing timeouts where we often see EVE not being fast enough when run by slow Github runners.