### PR TITLE
Eden-SDN: fix allocation of network indexes

### DIFF
--- a/sdn/vm/cmd/sdnagent/agent.go
+++ b/sdn/vm/cmd/sdnagent/agent.go
@@ -214,27 +214,22 @@ func (a *agent) linkSubscribe(doneChan <-chan struct{}) chan netlink.LinkUpdate 
 }
 
 func (a *agent) allocNetworkIndexes() {
-	networkIndex := make(map[string]int)
-	// Keep previous indexes which are still needed.
-	for _, network := range a.netModel.Networks {
-		index, hasIndex := a.networkIndex[network.LogicalLabel]
-		if hasIndex {
-			networkIndex[network.LogicalLabel] = index
-		}
+	if a.networkIndex == nil {
+		a.networkIndex = make(map[string]int)
 	}
 	// Allocate new indexes where needed.
 	for _, network := range a.netModel.Networks {
-		index, hasIndex := networkIndex[network.LogicalLabel]
+		index, hasIndex := a.networkIndex[network.LogicalLabel]
 		if hasIndex {
+			// Keep already allocated index.
 			continue
 		}
 		index = 0
 		for a.isNetworkIndexUsed(index) {
 			index++
 		}
-		networkIndex[network.LogicalLabel] = index
+		a.networkIndex[network.LogicalLabel] = index
 	}
-	a.networkIndex = networkIndex
 }
 
 func (a *agent) isNetworkIndexUsed(index int) bool {


### PR DESCRIPTION
Every network is allocated a unique integer number, which is then used to generate internal per-network subnets, routing table numbers, etc. However, the previous implementation of `allocNetworkIndexes` was broken. Two different networks might have been given the same index. This bug is addressed by this commit.