### PR TITLE
Test quick replace of network instances

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -7,7 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-//directories and files
+// directories and files
 const (
 	DefaultDist             = "dist"             //root directory
 	DefaultImageDist        = "images"           //directory for images inside dist
@@ -36,7 +36,7 @@ const (
 	DefaultTestArgsEnv = "EDEN_TEST_ARGS" //default env for test arguments
 )
 
-//domains, ips, ports
+// domains, ips, ports
 const (
 	DefaultDomain               = "mydomain.adam"
 	DefaultIP                   = "192.168.0.1"
@@ -53,7 +53,7 @@ const (
 	DefaultRegistryPort         = 5050
 
 	//tags, versions, repos
-	DefaultEVETag               = "9.2.0" // DefaultEVETag tag for EVE image
+	DefaultEVETag               = "10.4.0" // DefaultEVETag tag for EVE image
 	DefaultAdamTag              = "0.0.43"
 	DefaultRedisTag             = "7"
 	DefaultRegistryTag          = "2.7"

--- a/pkg/eve/networks.go
+++ b/pkg/eve/networks.go
@@ -13,7 +13,7 @@ import (
 	"github.com/lf-edge/eve/api/go/metrics"
 )
 
-//NetInstState stores state of network instance
+// NetInstState stores state of network instance
 type NetInstState struct {
 	Name        string
 	UUID        string
@@ -78,11 +78,17 @@ func (ctx *State) processNetworksByInfo(im *info.ZInfoMsg) {
 
 		if len(im.GetNiinfo().GetNetworkErr()) > 0 {
 			netInstStateObj.EveState = fmt.Sprintf("%s ERRORS: %s", im.GetNiinfo().GetState().String(), im.GetNiinfo().GetNetworkErr())
+		} else if !netInstStateObj.Activated {
+			netInstStateObj.EveState = "NOT_ACTIVATED"
 		} else {
-			if im.GetNiinfo().State == info.ZNetworkInstanceState_ZNETINST_STATE_ONLINE || netInstStateObj.Activated {
+			switch im.GetNiinfo().State {
+			case info.ZNetworkInstanceState_ZNETINST_STATE_INIT:
+				netInstStateObj.EveState = "INIT"
+			case info.ZNetworkInstanceState_ZNETINST_STATE_ONLINE:
+				// netInstStateObj.Activated is true
 				netInstStateObj.EveState = "ACTIVATED"
-			} else {
-				netInstStateObj.EveState = "NOT_ACTIVATED"
+			case info.ZNetworkInstanceState_ZNETINST_STATE_ERROR:
+				netInstStateObj.EveState = "ERROR"
 			}
 		}
 		// XXX Guard against old EVE which doesn't send state
@@ -114,7 +120,7 @@ func (ctx *State) processNetworksByMetric(msg *metrics.ZMetricMsg) {
 	}
 }
 
-//NetList prints networks
+// NetList prints networks
 func (ctx *State) NetList() error {
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 0, 8, 1, '\t', 0)

--- a/tests/network/testdata/network_replace_test.txt
+++ b/tests/network/testdata/network_replace_test.txt
@@ -1,0 +1,66 @@
+eden -t 10s network ls
+
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
+
+# Create n1 network
+eden -t 1m network create 10.11.12.0/24 -n n1
+test eden.network.test -test.v -timewait 10m ACTIVATED n1
+
+# Quickly replace n1 with n2 so that EVE sees them swapped in one EdgeDevConfig.
+# This is interesting to test, because some internally (inside EVE) allocated numbers
+# and generated config will be reused and could cause conflicts if not properly
+# implemented.
+eden -t 1m network delete n1
+eden -t 1m network create 10.11.13.0/24 -n n2
+test eden.network.test -test.v -timewait 2m - n1
+test eden.network.test -test.v -timewait 2m ACTIVATED n2
+
+# Replace network instance while reusing the same subnet.
+eden -t 1m network delete n2
+eden -t 1m network create 10.11.13.0/24 -n n3
+test eden.network.test -test.v -timewait 2m - n2
+test eden.network.test -test.v -timewait 2m ACTIVATED n3
+
+# Replace one network instance with two (one of them will reuse the subnet).
+eden -t 1m network delete n3
+eden -t 1m network create 10.11.12.0/24 -n n4
+eden -t 1m network create 10.11.13.0/24 -n n5
+test eden.network.test -test.v -timewait 2m - n3
+test eden.network.test -test.v -timewait 2m ACTIVATED n4
+test eden.network.test -test.v -timewait 2m ACTIVATED n5
+
+# Move subnet from one network instance to another.
+exec -t 1m bash replace-subnet.sh n4 10.11.12 10.11.14
+eden -t 1m network create 10.11.12.0/24 -n n6 # subnet originally used by n4
+test eden.network.test -test.v -timewait 2m ACTIVATED n6
+test eden.network.test -test.v -timewait 2m ACTIVATED n4
+
+# Cleanup.
+eden -t 1m network delete n4
+eden -t 1m network delete n5
+eden -t 1m network delete n6
+test eden.network.test -test.v -timewait 2m - n4
+test eden.network.test -test.v -timewait 2m - n5
+test eden.network.test -test.v -timewait 2m - n6
+
+# Test's config. file
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- replace-subnet.sh --
+# There isn't dedicated CLI command to modify subnet of existing NI,
+# therefore we need to modify JSON-formatted edge config using jq.
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+$EDEN controller edge-node get-config --file eve-prev.cfg
+jq '.networkInstances |= map(if .displayname == "'$1'" then .ip |= tostring else . end)' < eve-prev.cfg |\
+  sed 's/'$2'/'$3'/g' |\
+    jq '.networkInstances |= map(if .displayname == "'$1'" then .ip |= fromjson else . end)' > eve-new.cfg
+$EDEN controller edge-node set-config --file eve-new.cfg

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -88,6 +88,8 @@ eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/netwo
 eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/switch_net_vlans
 /bin/echo Eden basic VLAN test (16.2/{{$tests}})
 eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/vlans_and_bonds
+/bin/echo Eden test replaced network instances (16.3/{{$tests}})
+eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/network_replace_test
 /bin/echo Eden basic volumes test (17.1/{{$tests}})
 eden.escript.test -testdata ../volume/testdata/ -test.run TestEdenScripts/volumes_test
 /bin/echo Eden sftp volumes test (17.2/{{$tests}})

--- a/tests/workflow/networking.tests.txt
+++ b/tests/workflow/networking.tests.txt
@@ -1,5 +1,5 @@
 # Number of tests
-{{$tests := 17}}
+{{$tests := 18}}
 # EDEN_TEST_SETUP env. var. -- "y"(default) performs the EDEN setup steps
 {{$setup := "y"}}
 {{$setup_env := EdenGetEnv "EDEN_TEST_SETUP"}}
@@ -65,3 +65,5 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/ngnix
 /bin/echo Verifying that we can use a switch network instance on a management port (17/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/app_nonat
 
+/bin/echo Testing quick replace of network instances (18/{{$tests}})
+eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/network_replace_test


### PR DESCRIPTION
This new test quickly replaces one network instance with another of the same type, so that EVE sees them swapped in one EdgeDevConfig. This is interesting to test, because some internally (inside EVE) allocated numbers and generated config will be reused and could cause conflicts if not properly implemented.

The test is expected to succeed with EVE version >= 10.4.0
In older versions there were either bugs (after zedrouter refactoring) or the code was not robust enough to handle these scenarios (before refactoring).

As part of this commit, the reported network instance status was fixed to recognize an in-progress and not yet completed initialization of a network instance. With this, eden will be able to detect if EVE is stuck creating or modifying NI.