### PR TITLE
pkg: defaults: Workaround to fix QEMU's MSR errors

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -123,7 +123,7 @@ const (
 	DefaultAdamLogLevel = "warning" //min level of logs sent from EVE to Adam
 
 	DefaultQemuAccelDarwin     = "-machine q35,accel=hvf -cpu kvm64,kvmclock=off "
-	DefaultQemuAccelLinuxAmd64 = "-machine q35,accel=kvm,dump-guest-core=off,kernel-irqchip=split -cpu host,invtsc=on,kvmclock=off -device intel-iommu,intremap=on,caching-mode=on,aw-bits=48 "
+	DefaultQemuAccelLinuxAmd64 = "-machine q35,accel=kvm,dump-guest-core=off,kernel-irqchip=split -cpu host,-vmx-true-ctls,-vmx-secondary-ctls,invtsc=on,kvmclock=off -device intel-iommu,intremap=on,caching-mode=on,aw-bits=48 "
 	DefaultQemuAmd64           = "-machine q35,smm=on --cpu SandyBridge "
 
 	DefaultQemuAccelArm64 = "-machine virt,accel=kvm,usb=off,dump-guest-core=off -cpu host "


### PR DESCRIPTION
A QEMU crash has being experienced for some combinations of newer kernels and QEMU versions on the host when running EVE from QEMU. QEMU crashes when trying to access VMX_PROCBASED_CTLS2 MSR register and VMs/Containers are not initialized:

error: failed to set MSR 0x48b to 0x137bff00000000

This commit provides a workaround while the proper fix is not provided.