### PR TITLE
Fix typo in publish-logs action

### DIFF
--- a/.github/actions/publish-logs/action.yml
+++ b/.github/actions/publish-logs/action.yml
@@ -4,7 +4,7 @@ description: 'Collect, process and publish logs from Eden'
 inputs:
   file_system:
     required: true
-    type string
+    type: string
   tpm_enabled:
     required: true
     type: bool


### PR DESCRIPTION
In `inputs` section `file_system` `type`
definition missed colon