### PR TITLE
Add log info for test yml

### DIFF
--- a/.github/actions/collect-info/action.yml
+++ b/.github/actions/collect-info/action.yml
@@ -1,0 +1,19 @@
+name: 'Collect and store debug info'
+description: 'Collect debug info using EVE script executed via ssh and store downloaded tarball under the specified file name'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Collect info 
+      run: |
+        # Give EVE 5 minutes at most to enable ssh access (if tests failed early).
+        for i in $(seq 60); do ./eden eve ssh && break || sleep 5; done
+        ./eden sdn fwd eth0 22 --\
+          ssh -o StrictHostKeyChecking=no -p FWD_PORT -i ./dist/default-certs/id_rsa root@FWD_IP collect-info.sh &&\
+        ./eden sdn fwd eth0 22 --\
+          scp -o StrictHostKeyChecking=no -P FWD_PORT -i ./dist/default-certs/id_rsa root@FWD_IP:/persist/eve-info-* . &&\
+        # upload-artifact complains about colon in the file name
+        # make sure to update upload step if changing name
+        mv eve-info-* eve-info.tar.gz ||\
+        echo "failed to collect info"
+      shell: bash

--- a/.github/actions/publish-logs/action.yml
+++ b/.github/actions/publish-logs/action.yml
@@ -48,6 +48,7 @@ runs:
       with:
         name: eden-report-tpm-${{ inputs.tpm_enabled }}-${{ inputs.file_system }}
         path: |
+            ${{ github.workspace }}/eve-info.tar.gz # created by collect-info action
             ${{ github.workspace }}/trace.log
             ${{ github.workspace }}/info.log
             ${{ github.workspace }}/metric.log

--- a/.github/actions/run-eden-test/action.yml
+++ b/.github/actions/run-eden-test/action.yml
@@ -22,6 +22,9 @@ runs:
     - name: Run tests
       run: EDEN_TEST_STOP=n ./eden test ./tests/workflow -s ${{ inputs.suite }} -v debug
       shell: bash
+    - name: Collect info
+      if: failure()
+      uses: ./.github/actions/collect-info
     - name: Collect logs
       if: always()
       uses: ./.github/actions/publish-logs

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -4,6 +4,7 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches: [master]
 # yamllint disable rule:line-length
+
 jobs:
   check-secrets:
     runs-on: ubuntu-22.04
@@ -121,16 +122,7 @@ jobs:
           EDEN_TEST=gcp ./eden test tests/workflow -v debug
       - name: Collect info
         if: ${{ failure() }}
-        run: |
-          # Give EVE 5 minutes at most to enable ssh access (if tests failed early).
-          for i in $(seq 60); do ./eden eve ssh && break || sleep 5; done
-          ./eden sdn fwd eth0 22 --\
-            ssh -o StrictHostKeyChecking=no -p FWD_PORT -i ./dist/default-certs/id_rsa root@FWD_IP collect-info.sh &&\
-          ./eden sdn fwd eth0 22 --\
-            scp -o StrictHostKeyChecking=no -P FWD_PORT -i ./dist/default-certs/id_rsa root@FWD_IP:/persist/eve-info-* . &&\
-          # upload-artifact complains about colon in the file name
-          mv eve-info-* eve-info.tar.gz ||\
-          echo "failed to collect info"
+        uses: ./.github/actions/collect-info
       - name: Collect logs
         if: ${{ always() }}
         run: |


### PR DESCRIPTION
This PR improves #874.

It creates custom action for `Collect log` step and uses it in `eden_gcp.yml` and `test.yml`.
Reason why it's not changed in `eden.yml` is that we (hopefully) will be switching soon to `test.yml`