### PR TITLE
Reusable workflows for eden tests

### DIFF
--- a/.github/actions/publish-logs/action.yml
+++ b/.github/actions/publish-logs/action.yml
@@ -22,6 +22,7 @@ runs:
         cp dist/default-eve.log console.log || echo "no device log"
         docker logs eden_adam > adam.log 2>&1 || echo "no adam log"
       shell: bash
+      working-directory: "./eden"
     - name: Log counting
       if: ${{ always() }}
       run: |
@@ -42,16 +43,17 @@ runs:
         [ "$(jq length segfaults.log)" -gt 0 ] && echo "::warning::segfaults found, you can see them in Log counting->Segfaults section"
         echo "::endgroup::"
       shell: bash
+      working-directory: "./eden"
     - name: Store raw test results
       if: ${{ always() }}
       uses: actions/upload-artifact@v3
       with:
         name: eden-report-tpm-${{ inputs.tpm_enabled }}-${{ inputs.file_system }}
         path: |
-            ${{ github.workspace }}/eve-info.tar.gz # created by collect-info action
-            ${{ github.workspace }}/trace.log
-            ${{ github.workspace }}/info.log
-            ${{ github.workspace }}/metric.log
-            ${{ github.workspace }}/netstat.log
-            ${{ github.workspace }}/console.log
-            ${{ github.workspace }}/adam.log
+            ${{ github.workspace }}/eden/eve-info.tar.gz # created by collect-info action
+            ${{ github.workspace }}/eden/trace.log
+            ${{ github.workspace }}/eden/info.log
+            ${{ github.workspace }}/eden/metric.log
+            ${{ github.workspace }}/eden/netstat.log
+            ${{ github.workspace }}/eden/console.log
+            ${{ github.workspace }}/eden/adam.log

--- a/.github/actions/run-eden-test/action.yml
+++ b/.github/actions/run-eden-test/action.yml
@@ -11,30 +11,33 @@ inputs:
   suite:
     required: true
     type: string
+
 runs:
   using: 'composite'
   steps:
     - name: Setup Environment
-      uses: ./.github/actions/setup-environment
+      uses: ./eden/.github/actions/setup-environment
       with:
         file_system: ${{ inputs.file_system }}
         tpm_enabled: ${{ inputs.tpm_enabled }}
     - name: Run tests
       run: EDEN_TEST_STOP=n ./eden test ./tests/workflow -s ${{ inputs.suite }} -v debug
       shell: bash
+      working-directory: "./eden"
     - name: Collect info
       if: failure()
-      uses: ./.github/actions/collect-info
+      uses: ./eden/.github/actions/collect-info
     - name: Collect logs
       if: always()
-      uses: ./.github/actions/publish-logs
+      uses: ./eden/.github/actions/publish-logs
       with:
         file_system: ${{ inputs.file_system }}
         tpm_enabled: ${{ inputs.tpm_enabled }}
-    - name: Clean up after test 
+    - name: Clean up after test
       if: always()
       run: |
         ./eden stop
         make clean
         docker system prune -f -a
       shell: bash
+      working-directory: "./eden"

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -8,6 +8,7 @@ inputs:
   tpm_enabled:
     required: true
     type: bool
+
 runs:
   using: 'composite'
   steps:
@@ -23,10 +24,11 @@ runs:
               echo "$addr overlaps with test"; exit 1
             fi
         done
-        sudo df -h
+        df -h
         sudo swapoff -a
-        sudo free
+        free
       shell: bash
+      working-directory: "./eden"
     - name: Install Packages
       run: |
         sudo add-apt-repository ppa:stefanberger/swtpm-jammy
@@ -36,6 +38,7 @@ runs:
       run: |
         make build-tests
       shell: bash
+      working-directory: "./eden"
     - name: Configure
       run: |
         ./eden config add default
@@ -43,10 +46,12 @@ runs:
         ./eden config set default --key=eve.tpm --value=${{ inputs.tpm_enabled }}
         ./eden config set default --key=eve.cpu --value=2
       shell: bash
+      working-directory: "./eden"
     - name: Setup ext4
       if: inputs.file_system == 'ext4'
       run: ./eden setup -v debug
       shell: bash
+      working-directory: "./eden"
     - name: Setup zfs
       if: inputs.file_system == 'zfs'
       run: |
@@ -54,3 +59,4 @@ runs:
         ./eden config set default --key=eve.disk --value=4096
         ./eden setup -v debug --grub-options='set_global dom0_extra_args "$dom0_extra_args eve_install_zfs_with_raid_level "'
       shell: bash
+      working-directory: "./eden"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,12 @@
 ---
 name: Test
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  workflow_call:
 
 jobs:
-  smoke: 
+  smoke:
     continue-on-error: true
     strategy:
       matrix:
@@ -15,28 +17,34 @@ jobs:
     steps:
       - name: Get code
         uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.repository.full_name }}
+          path: "./eden"
       - name: Run Smoke tests
-        uses: ./.github/actions/run-eden-test
+        uses: ./eden/.github/actions/run-eden-test
         with:
           file_system: ${{ matrix.file_system }}
           tpm_enabled: ${{ matrix.tpm }}
           suite: "smoke.tests.txt"
 
-  networking: 
+  networking:
     name: Networking test suite
     needs: smoke
     runs-on: ubuntu-22.04
     steps:
       - name: Get code
         uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.repository.full_name }}
+          path: "./eden"
       - name: Run Networking tests
-        uses: ./.github/actions/run-eden-test
+        uses: ./eden/.github/actions/run-eden-test
         with:
           file_system: "ext4"
           tpm_enabled: true
           suite: "networking.tests.txt"
 
-  storage: 
+  storage:
     continue-on-error: true
     strategy:
       matrix:
@@ -47,8 +55,11 @@ jobs:
     steps:
       - name: Get code
         uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.repository.full_name }}
+          path: "./eden"
       - name: Run Storage tests
-        uses: ./.github/actions/run-eden-test
+        uses: ./eden/.github/actions/run-eden-test
         with:
           file_system: ${{ matrix.file_system }}
           tpm_enabled: true
@@ -61,8 +72,11 @@ jobs:
     steps:
       - name: Get code
         uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.repository.full_name }}
+          path: "./eden"
       - name: Run LPC LOC tests
-        uses: ./.github/actions/run-eden-test
+        uses: ./eden/.github/actions/run-eden-test
         with:
           file_system: "ext4"
           tpm_enabled: true
@@ -79,8 +93,11 @@ jobs:
     steps:
       - name: Get code
         uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.repository.full_name }}
+          path: "./eden"
       - name: Run EVE upgrade tests
-        uses: ./.github/actions/run-eden-test
+        uses: ./eden/.github/actions/run-eden-test
         with:
           file_system: ${{ matrix.file_system }}
           tpm_enabled: true
@@ -93,8 +110,11 @@ jobs:
     steps:
       - name: Get code
         uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.repository.full_name }}
+          path: "./eden"
       - name: Run User apps upgrade tests
-        uses: ./.github/actions/run-eden-test
+        uses: ./eden/.github/actions/run-eden-test
         with:
           file_system: "ext4"
           tpm_enabled: true


### PR DESCRIPTION
This PR will allow the [lf-edge/eve](https://github.com/lf-edge/eve/actions) to call the workflow from eden repo i.e re-usable workflow.

The configurations would be DRY and all the changes in eden can then be managed without having to copy them over to the eve.