### PR TITLE
use actual value of the repo for the checkout 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Get code
         uses: actions/checkout@v3
         with:
-          repository: ${{ github.event.repository.full_name }}
+          repository: "lf-edge/eden"
           path: "./eden"
       - name: Run Smoke tests
         uses: ./eden/.github/actions/run-eden-test


### PR DESCRIPTION
`${{ github.event.repository.full_name }}` is not replaced by when the WF is called from another workflow. Use the actual value for the repo checkout for actions.