### PR TITLE
setting eve.tag and eve.registry for eden tests for PR's build

### DIFF
--- a/.github/actions/run-eden-test/action.yml
+++ b/.github/actions/run-eden-test/action.yml
@@ -11,7 +11,7 @@ inputs:
   suite:
     required: true
     type: string
-  eve_tag:
+  eve_image:
     type: string
 
 runs:
@@ -22,7 +22,7 @@ runs:
       with:
         file_system: ${{ inputs.file_system }}
         tpm_enabled: ${{ inputs.tpm_enabled }}
-        eve_tag: ${{ inputs.eve_tag }}
+        eve_image: ${{ inputs.eve_image }}
     - name: Run tests
       run: EDEN_TEST_STOP=n ./eden test ./tests/workflow -s ${{ inputs.suite }} -v debug
       shell: bash

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -8,7 +8,7 @@ inputs:
   tpm_enabled:
     required: true
     type: bool
-  eve_tag:
+  eve_image:
     type: string
 
 runs:
@@ -50,9 +50,13 @@ runs:
       shell: bash
       working-directory: "./eden"
     - name: Setup eve version
-      if: "${{ inputs.eve_tag != '' }}"
+      if: ${{ inputs.eve_image != '' }} and contains(${{ inputs.eve_image }}, ":" )
       run: |
-        ./eden config set default --key eve.tag --value=${{ inputs.eve_tag }}
+        image=${{ inputs.eve_image }}
+        eve_pr_registry=$(echo "$image" |  cut -d ':' -f 1)
+        eve_pr=$(echo "$image" |  cut -d ':' -f 2 | cut -d "-" -f1)
+        ./eden config set default --key=eve.registry --value="$eve_pr_registry"
+        ./eden config set default --key=eve.tag --value="$eve_pr"
       shell: bash
       working-directory: "./eden"
     - name: Setup ext4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,11 @@ name: Test
 on:
   workflow_dispatch:
     inputs:
-      eve_tag:
+      eve_image:
         type: string
   workflow_call:
     inputs:
-      eve_tag:
+      eve_image:
         type: string
 
 jobs:
@@ -32,7 +32,7 @@ jobs:
           file_system: ${{ matrix.file_system }}
           tpm_enabled: ${{ matrix.tpm }}
           suite: "smoke.tests.txt"
-          eve_tag:  ${{ inputs.eve_tag }}
+          eve_image:  ${{ inputs.eve_image }}
 
   networking:
     name: Networking test suite
@@ -42,7 +42,7 @@ jobs:
       - name: Get code
         uses: actions/checkout@v3
         with:
-          repository: ${{ github.event.repository.full_name }}
+          repository: "lf-edge/eden"
           path: "./eden"
       - name: Run Networking tests
         uses: ./eden/.github/actions/run-eden-test
@@ -50,7 +50,7 @@ jobs:
           file_system: "ext4"
           tpm_enabled: true
           suite: "networking.tests.txt"
-          eve_tag:   ${{ inputs.eve_tag }}
+          eve_image:   ${{ inputs.eve_image }}
 
   storage:
     continue-on-error: true
@@ -64,7 +64,7 @@ jobs:
       - name: Get code
         uses: actions/checkout@v3
         with:
-          repository: ${{ github.event.repository.full_name }}
+          repository: "lf-edge/eden"
           path: "./eden"
       - name: Run Storage tests
         uses: ./eden/.github/actions/run-eden-test
@@ -72,7 +72,7 @@ jobs:
           file_system: ${{ matrix.file_system }}
           tpm_enabled: true
           suite: "storage.tests.txt"
-          eve_tag: ${{ inputs.eve_tag }}
+          eve_image: ${{ inputs.eve_image }}
 
   lpc-loc:
     name: LPC LOC test suite
@@ -82,7 +82,7 @@ jobs:
       - name: Get code
         uses: actions/checkout@v3
         with:
-          repository: ${{ github.event.repository.full_name }}
+          repository: "lf-edge/eden"
           path: "./eden"
       - name: Run LPC LOC tests
         uses: ./eden/.github/actions/run-eden-test
@@ -90,7 +90,7 @@ jobs:
           file_system: "ext4"
           tpm_enabled: true
           suite: "lpc-loc.tests.txt"
-          eve_tag: ${{ inputs.eve_tag }}
+          eve_image: ${{ inputs.eve_image }}
 
   eve-upgrade:
     continue-on-error: true
@@ -104,7 +104,7 @@ jobs:
       - name: Get code
         uses: actions/checkout@v3
         with:
-          repository: ${{ github.event.repository.full_name }}
+          repository: "lf-edge/eden"
           path: "./eden"
       - name: Run EVE upgrade tests
         uses: ./eden/.github/actions/run-eden-test
@@ -112,7 +112,7 @@ jobs:
           file_system: ${{ matrix.file_system }}
           tpm_enabled: true
           suite: "eve-upgrade.tests.txt"
-          eve_tag: ${{ inputs.eve_tag }}
+          eve_image: ${{ inputs.eve_image }}
 
   user-apps:
     name: User apps test suite
@@ -122,7 +122,7 @@ jobs:
       - name: Get code
         uses: actions/checkout@v3
         with:
-          repository: ${{ github.event.repository.full_name }}
+          repository: "lf-edge/eden"
           path: "./eden"
       - name: Run User apps upgrade tests
         uses: ./eden/.github/actions/run-eden-test
@@ -130,5 +130,5 @@ jobs:
           file_system: "ext4"
           tpm_enabled: true
           suite: "user-apps.tests.txt"
-          eve_tag: ${{ inputs.eve_tag }}
+          eve_image: ${{ inputs.eve_image }}
 


### PR DESCRIPTION
A different repository is used for the eve PRs after they have been built. Although this value is present in the tag that Eve passes, we still need to extract the necessary data. Using the fundamental shell commands, this PR will retrieve the necessary data.