### PR TITLE
[MERGING TO TEST BRANCH] Use BuildJet runners for eden workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         file_system: ['ext4', 'zfs']
         tpm: [true, false]
     name: Smoke tests
-    runs-on: ubuntu-22.04
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Get code
         uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
   networking:
     name: Networking test suite
     needs: smoke
-    runs-on: ubuntu-22.04
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Get code
         uses: actions/checkout@v3
@@ -59,7 +59,7 @@ jobs:
         file_system: ['ext4', 'zfs']
     name: Storage test suite
     needs: smoke
-    runs-on: ubuntu-22.04
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Get code
         uses: actions/checkout@v3
@@ -77,7 +77,7 @@ jobs:
   lpc-loc:
     name: LPC LOC test suite
     needs: smoke
-    runs-on: ubuntu-22.04
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Get code
         uses: actions/checkout@v3
@@ -99,7 +99,7 @@ jobs:
         file_system: ['ext4', 'zfs']
     name: EVE upgrade test suite
     needs: smoke
-    runs-on: ubuntu-22.04
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Get code
         uses: actions/checkout@v3
@@ -117,7 +117,7 @@ jobs:
   user-apps:
     name: User apps test suite
     needs: smoke
-    runs-on: ubuntu-22.04
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Get code
         uses: actions/checkout@v3


### PR DESCRIPTION
This commit changes runners of composite `test.yml` workflow to BuildJet runners. They are more powerful and cheaper that the ones provided by GitHub.

Note that this workflow is used by EVE repository.

Switching to BuildJet runners and using new workflow should reduce time to run tests from 6 hours to approx. 1.5 hours.

However, there are still some tests failing which needs further investigation.

Why [MERGING TO TEST BRANCH]: LF-edge is still setting up billing process for BuildJet, we will merge this once it's done. Right now we can try it out and see if it's working by running action manually. Next step would be to check if changing workflow runners changes them while using composite workflow. 

Checklist:
- [] Eden workflow dispatched manually runs on BuildJet successfully*
- [] EVE runs `test.yml` workflow and it uses BuildJet runners

* some tests are still failing