### PR TITLE
Add missing `working-directory` tag in `run-eden-test` action

### DIFF
--- a/.github/actions/run-eden-test/action.yml
+++ b/.github/actions/run-eden-test/action.yml
@@ -30,12 +30,14 @@ runs:
     - name: Collect info
       if: failure()
       uses: ./eden/.github/actions/collect-info
+      working-directory: "./eden"
     - name: Collect logs
       if: always()
       uses: ./eden/.github/actions/publish-logs
       with:
         file_system: ${{ inputs.file_system }}
         tpm_enabled: ${{ inputs.tpm_enabled }}
+      working-directory: "./eden"
     - name: Clean up after test
       if: always()
       run: |


### PR DESCRIPTION
Since we are using `test.yml` as reusable workflow in EVE we clone eden repository in EVE folder and it causes problems with working directories and building and executing binaries.

So we are using `working-directory:` and `path:` tags of GitHub actions with hard-coded `./eden` value to prevent any problems that might occur with resuing this workflow in EVE.