### PR TITLE
Use BuildJet runners for eden workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,16 @@ on:
     inputs:
       eve_image:
         type: string
+      runner:
+        type: string
+        default: buildjet-4vcpu-ubuntu-2204
   workflow_call:
     inputs:
       eve_image:
         type: string
+      runner:
+        type: string
+        default: buildjet-4vcpu-ubuntu-2204
 
 jobs:
   smoke:
@@ -19,7 +25,7 @@ jobs:
         file_system: ['ext4', 'zfs']
         tpm: [true, false]
     name: Smoke tests
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Get code
         uses: actions/checkout@v3
@@ -37,7 +43,7 @@ jobs:
   networking:
     name: Networking test suite
     needs: smoke
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Get code
         uses: actions/checkout@v3
@@ -59,7 +65,7 @@ jobs:
         file_system: ['ext4', 'zfs']
     name: Storage test suite
     needs: smoke
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Get code
         uses: actions/checkout@v3
@@ -77,7 +83,7 @@ jobs:
   lpc-loc:
     name: LPC LOC test suite
     needs: smoke
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Get code
         uses: actions/checkout@v3
@@ -99,7 +105,7 @@ jobs:
         file_system: ['ext4', 'zfs']
     name: EVE upgrade test suite
     needs: smoke
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Get code
         uses: actions/checkout@v3
@@ -117,7 +123,7 @@ jobs:
   user-apps:
     name: User apps test suite
     needs: smoke
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Get code
         uses: actions/checkout@v3

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,0 +1,7 @@
+# Github Actions
+
+Eden is a part of testing infrastructure of EVE and it's integrated in EVE CI/CD pipelines. EVE uses [test.yml](https://github.com/lf-edge/eden/blob/master/.github/workflows/test.yml) reusable workflow to run eden tests against specific EVE version in PR.
+Eden reusable workflows are running using [BuildJet](https://buildjet.com/for-github-actions) runners provided by LF-EDGE. They provide both Arm and x86_64 architectures.
+Currently we are provided with 4vCPU/16GBs of RAM and 8vCPU/32GBs of RAM runners. Maximum CPUs running in parallel is 64 for x86_64, that means with 4vCPUs we can have 16 jobs running in parallel.
+In case one wants to run eden workflows locally in their own fork, `runner` and `repo` input variables for reusable workflow should be specified.
+


### PR DESCRIPTION
This commit changes runners of composite `test.yml` workflow to BuildJet runners. They are more powerful and cheaper that the ones provided by GitHub.

In case somebody would want to run these workflows in their local fork runner and repository to pull eden code from has been parametrized

Note that this workflow is used by EVE repository.

Switching to BuildJet runners and using new workflow should reduce time to run tests from 6 hours to approx. 1.5 hours.

Documentation is available at `docs/github-actions.md`

However, there are still some tests failing which needs further investigation