### PR TITLE
minor fix in the actions syntax for the Collect info task

### DIFF
--- a/.github/actions/collect-info/action.yml
+++ b/.github/actions/collect-info/action.yml
@@ -4,7 +4,7 @@ description: 'Collect debug info using EVE script executed via ssh and store dow
 runs:
   using: 'composite'
   steps:
-    - name: Collect info 
+    - name: Collect info
       run: |
         # Give EVE 5 minutes at most to enable ssh access (if tests failed early).
         for i in $(seq 60); do ./eden eve ssh && break || sleep 5; done
@@ -17,3 +17,4 @@ runs:
         mv eve-info-* eve-info.tar.gz ||\
         echo "failed to collect info"
       shell: bash
+      working-directory: "./eden"

--- a/.github/actions/run-eden-test/action.yml
+++ b/.github/actions/run-eden-test/action.yml
@@ -30,14 +30,12 @@ runs:
     - name: Collect info
       if: failure()
       uses: ./eden/.github/actions/collect-info
-      working-directory: "./eden"
     - name: Collect logs
       if: always()
       uses: ./eden/.github/actions/publish-logs
       with:
         file_system: ${{ inputs.file_system }}
         tpm_enabled: ${{ inputs.tpm_enabled }}
-      working-directory: "./eden"
     - name: Clean up after test
       if: always()
       run: |


### PR DESCRIPTION
` working-directory: "./eden"` is supported with/by the `run` command of github. Moved the definition of  `working-directory: "./eden"` to the collect-info action file.