### PR TITLE
gic max version to boot on newer arm64 hosts

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -126,8 +126,8 @@ const (
 	DefaultQemuAccelLinuxAmd64 = "-machine q35,accel=kvm,dump-guest-core=off,kernel-irqchip=split -cpu host,-vmx-true-ctls,-vmx-secondary-ctls,invtsc=on,kvmclock=off -device intel-iommu,intremap=on,caching-mode=on,aw-bits=48 "
 	DefaultQemuAmd64           = "-machine q35,smm=on --cpu SandyBridge "
 
-	DefaultQemuAccelArm64 = "-machine virt,accel=kvm,usb=off,dump-guest-core=off -cpu host "
-	DefaultQemuArm64      = "-machine virt,virtualization=true -cpu cortex-a57 "
+	DefaultQemuAccelArm64 = "-machine virt,accel=kvm,usb=off,dump-guest-core=off,gic-version=max -cpu host "
+	DefaultQemuArm64      = "-machine virt,virtualization=true,gic-version=max -cpu cortex-a57 "
 
 	DefaultAppSubnet        = "10.11.12.0/24"
 	DefaultHostOnlyNotation = "host-only-acl"


### PR DESCRIPTION
I can see problems while running on arm64 hosts with acceleration. Seems we should align gic version with the host one. According to [docs](https://www.qemu.org/docs/master/system/arm/virt.html?highlight=gic%20version), `max` is the best option here.