### PR TITLE
GitHub Actions: use report_name instead of variables in publish-logs

### DIFF
--- a/.github/actions/publish-logs/action.yml
+++ b/.github/actions/publish-logs/action.yml
@@ -2,12 +2,9 @@ name: 'Collect, count and publish logs'
 description: 'Collect, process and publish logs from Eden'
 
 inputs:
-  file_system:
+  report_name:
     required: true
     type: string
-  tpm_enabled:
-    required: true
-    type: bool
 
 runs:
   using: 'composite'
@@ -48,7 +45,7 @@ runs:
       if: ${{ always() }}
       uses: actions/upload-artifact@v3
       with:
-        name: eden-report-tpm-${{ inputs.tpm_enabled }}-${{ inputs.file_system }}
+        name: ${{ inputs.report_name }}
         path: |
             ${{ github.workspace }}/eden/eve-info.tar.gz # created by collect-info action
             ${{ github.workspace }}/eden/trace.log

--- a/.github/actions/run-eden-test/action.yml
+++ b/.github/actions/run-eden-test/action.yml
@@ -34,8 +34,7 @@ runs:
       if: always()
       uses: ./eden/.github/actions/publish-logs
       with:
-        file_system: ${{ inputs.file_system }}
-        tpm_enabled: ${{ inputs.tpm_enabled }}
+        report_name: eden-report-${{ inputs.suite }}-tpm-${{ inputs.tpm_enabled }}-${{ inputs.file_system }}
     - name: Clean up after test
       if: always()
       run: |


### PR DESCRIPTION
Previous implementation did not use test suite name in publishing logs, therefore for 11 different workflows we got only 4 artifacts, new implimentation uses report_name parameter in publish-logs action which makes it more flexible to set up any report name user wants and makes it more clear how it forms in `run-eden-test` action. And, of course, it adds test suite name now

cc: @milan-zededa @yash-zededa 

Please approve: @deitch @eriknordmark 