### PR TITLE
Adjust working directory in collect-info

### DIFF
--- a/.github/actions/collect-info/action.yml
+++ b/.github/actions/collect-info/action.yml
@@ -1,6 +1,9 @@
 name: 'Collect and store debug info'
 description: 'Collect debug info using EVE script executed via ssh or console and store downloaded tarball under the specified file name'
-
+inputs:
+  working-directory:
+    description: 'Working directory of action'
+    default: "./eden"
 runs:
   using: 'composite'
   steps:
@@ -11,4 +14,4 @@ runs:
         ./shell-scripts/collect-info-ssh.sh || ./shell-scripts/collect-info-console.sh 120
         cp dist/default-eve.log.backup dist/default-eve.log || true
       shell: bash
-      working-directory: "./eden"
+      working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -59,11 +59,9 @@ jobs:
         run: EDEN_TEST_STOP=n ./eden test ./tests/workflow -v debug
       - name: Collect info
         if: ${{ failure() }}
-        run: |
-          # Do not pollute console logs which are collected by publish-logs action.
-          cp dist/default-eve.log dist/default-eve.log.backup || true
-          ./shell-scripts/collect-info-ssh.sh || ./shell-scripts/collect-info-console.sh 120
-          cp dist/default-eve.log.backup dist/default-eve.log || true
+        uses: ./.github/actions/collect-info
+        with:
+          working-directory: ${{ github.workspace }}
       - name: Collect logs
         if: ${{ always() }}
         run: |

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -123,6 +123,8 @@ jobs:
       - name: Collect info
         if: ${{ failure() }}
         uses: ./.github/actions/collect-info
+        with:
+          working-directory: ${{ github.workspace }}
       - name: Collect logs
         if: ${{ always() }}
         run: |


### PR DESCRIPTION
I can see [problems](https://github.com/lf-edge/eden/actions/runs/6405609193/job/17388534621#step:18:31) in eden_gcp workflow where eden subdirectory does not exist. Let's use input variable to set working-directory aligned with our expectation.