### PR TITLE
Refactor openevec to base actions on top of type and fix multiple configs

### DIFF
--- a/.github/workflows/eden_setup.yml
+++ b/.github/workflows/eden_setup.yml
@@ -5,7 +5,7 @@ on:  # yamllint disable-line rule:truthy
     branches: [master]
 
 jobs:
-  setup:
+  build:
     runs-on: ubuntu-22.04
     steps:
       - name: setup
@@ -29,19 +29,41 @@ jobs:
         run: |
           make LINUXKIT_TARGET=build DOCKER_PLATFORM=linux/arm64 build-docker
           make LINUXKIT_TARGET=build DOCKER_PLATFORM=linux/amd64 build-docker
-      - name: cleanup
+  setup:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: setup
         run: |
-          rm -fr ~/.linuxkit
-          docker system prune --all --force --volumes
+          sudo apt update
+          sudo apt install -y qemu-utils qemu-user-static qemu-system-x86 jq swtpm
+      - name: host info
+        run: |
+          ip a
+      - name: get eden
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
       - name: build eden
         run: |
           make clean
           make build-tests
       - name: run
         run: |
+          # check separate (non-default) config
           ./eden config add setup
+          ./eden config set setup --key=eve.accel --value=false
           ./eden --config setup setup
+          ./eden --config setup start
+          ./eden --config setup eve onboard
+          ./eden --config setup info
           ./eden --config setup clean
+
           ./eden config add setup --arch=arm64
           ./eden --config setup setup
           ./eden --config setup clean

--- a/cmd/adam.go
+++ b/cmd/adam.go
@@ -39,7 +39,7 @@ func newStartAdamCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Short: "start adam",
 		Long:  `Start adam.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.AdamStart(cfg); err != nil {
+			if err := openEVEC.AdamStart(); err != nil {
 				log.Fatalf("Adam start failed: %s", err)
 			}
 		},

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -60,7 +60,7 @@ func newDebugStartEveCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 			if _, err := os.Stat(cfg.Eden.SSHKey); !os.IsNotExist(err) {
 				commandToRun := fmt.Sprintf("perf record %s -o %s", perfOptions, perfLocation)
 				commandToRun = fmt.Sprintf("sh -c 'nohup %s > /dev/null 2>&1 &'", commandToRun)
-				if err = openevec.SdnForwardSSHToEve(commandToRun, cfg); err != nil {
+				if err = openEVEC.SdnForwardSSHToEve(commandToRun); err != nil {
 					log.Fatal(err)
 				}
 			} else {
@@ -94,7 +94,7 @@ func newDebugStopEveCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			if _, err := os.Stat(eveSSHKey); !os.IsNotExist(err) {
 				commandToRun := "killall -SIGINT perf"
-				if err = openevec.SdnForwardSSHToEve(commandToRun, cfg); err != nil {
+				if err = openEVEC.SdnForwardSSHToEve(commandToRun); err != nil {
 					log.Fatal(err)
 				}
 			} else {
@@ -132,10 +132,10 @@ func newDebugSaveEveCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 			tmpFile := fmt.Sprintf("%s.tmp", absPath)
 			if _, err := os.Stat(eveSSHKey); !os.IsNotExist(err) {
 				commandToRun := fmt.Sprintf("perf script -i %s > %s", perfLocation, defaults.DefaultPerfScriptEVELocation)
-				if err = openevec.SdnForwardSSHToEve(commandToRun, cfg); err != nil {
+				if err = openEVEC.SdnForwardSSHToEve(commandToRun); err != nil {
 					log.Fatal(err)
 				}
-				err = openevec.SdnForwardSCPFromEve(defaults.DefaultPerfScriptEVELocation, tmpFile, cfg)
+				err = openEVEC.SdnForwardSCPFromEve(defaults.DefaultPerfScriptEVELocation, tmpFile)
 				if err != nil {
 					log.Fatal(err)
 				}
@@ -189,10 +189,10 @@ func newDebugHardwareEveCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 					commandToRun = "lshw -short"
 				}
 				commandToRun += ">" + hwLocation
-				if err = openevec.SdnForwardSSHToEve(commandToRun, cfg); err != nil {
+				if err = openEVEC.SdnForwardSSHToEve(commandToRun); err != nil {
 					log.Fatal(err)
 				}
-				if err = openevec.SdnForwardSCPFromEve(hwLocation, absPath, cfg); err != nil {
+				if err = openEVEC.SdnForwardSCPFromEve(hwLocation, absPath); err != nil {
 					log.Fatal(err)
 				}
 			}

--- a/cmd/disks.go
+++ b/cmd/disks.go
@@ -36,7 +36,7 @@ func newDisksLayoutCmd() *cobra.Command {
 		Short: "Get disks layout",
 		Long:  `Get disks layout`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if layout, err := openevec.GetDisksLayout(); err != nil {
+			if layout, err := openEVEC.GetDisksLayout(); err != nil {
 				log.Fatal(err)
 			} else {
 				fmt.Println(layout)
@@ -54,7 +54,7 @@ func newSetDisksLayoutCmd() *cobra.Command {
 		Short: "Set disks layout",
 		Long:  `Set disks layout`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.SetDiskLayout(dc); err != nil {
+			if err := openEVEC.SetDiskLayout(dc); err != nil {
 				log.Fatal(err)
 			}
 		},

--- a/cmd/downloader.go
+++ b/cmd/downloader.go
@@ -81,7 +81,7 @@ func newDownloadEVECmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Short: "download eve live image from docker",
 		Long:  `Download eve live image from docker.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.DownloadEve(cfg); err != nil {
+			if err := openEVEC.DownloadEve(); err != nil {
 				log.Fatal(err)
 			}
 		},

--- a/cmd/edenClean.go
+++ b/cmd/edenClean.go
@@ -22,7 +22,7 @@ func newCleanCmd(configName, verbosity *string) *cobra.Command {
 		Long:              `Clean harness.`,
 		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.EdenClean(*cfg, *configName, configDist, vmName, currentContext); err != nil {
+			if err := openEVEC.EdenClean(*configName, configDist, vmName, currentContext); err != nil {
 				log.Fatalf("Setup eden failed: %s", err)
 			}
 		},

--- a/cmd/edenController.go
+++ b/cmd/edenController.go
@@ -59,7 +59,7 @@ func newEdgeNodeReboot(controllerMode string) *cobra.Command {
 		Short: "reboot EVE instance",
 		Long:  `reboot EVE instance.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.EdgeNodeReboot(controllerMode); err != nil {
+			if err := openEVEC.EdgeNodeReboot(controllerMode); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -73,7 +73,7 @@ func newEdgeNodeEVEImageUpdateRetry(controllerMode string) *cobra.Command {
 		Short: "retry update of EVE image",
 		Long:  `Update EVE image retry.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.EdgeNodeEVEImageUpdateRetry(controllerMode); err != nil {
+			if err := openEVEC.EdgeNodeEVEImageUpdateRetry(controllerMode); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -87,7 +87,7 @@ func newEdgeNodeShutdown(controllerMode string) *cobra.Command {
 		Short: "shutdown EVE app instances",
 		Long:  `shutdown EVE app instances.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.EdgeNodeShutdown(controllerMode); err != nil {
+			if err := openEVEC.EdgeNodeShutdown(controllerMode); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -107,7 +107,7 @@ func newEdgeNodeEVEImageUpdate(controllerMode string, cfg *openevec.EdenSetupArg
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			baseOSImage := args[0]
-			if err := openevec.EdgeNodeEVEImageUpdate(baseOSImage, baseOSVersion, registry, controllerMode, baseOSImageActivate, baseOSVDrive); err != nil {
+			if err := openEVEC.EdgeNodeEVEImageUpdate(baseOSImage, baseOSVersion, registry, controllerMode, baseOSImageActivate, baseOSVDrive); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -131,7 +131,7 @@ func newEdgeNodeEVEImageRemove(controllerMode string, cfg *openevec.EdenSetupArg
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			baseOSImage := args[0]
-			if err := openevec.EdgeNodeEVEImageRemove(controllerMode, baseOSVersion, baseOSImage, cfg.Eden.Dist); err != nil {
+			if err := openEVEC.EdgeNodeEVEImageRemove(controllerMode, baseOSVersion, baseOSImage, cfg.Eden.Dist); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -150,7 +150,7 @@ func newEdgeNodeUpdate(controllerMode string) *cobra.Command {
 		Short: "update EVE config",
 		Long:  `Update EVE config.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.EdgeNodeUpdate(controllerMode, deviceItems, configItems); err != nil {
+			if err := openEVEC.EdgeNodeUpdate(controllerMode, deviceItems, configItems); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -174,7 +174,7 @@ func newEdgeNodeGetOptions(controllerMode string) *cobra.Command {
 		Short: "fetch EVE options",
 		Long:  `Fetch EVE options.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.EdgeNodeGetOptions(controllerMode, fileWithConfig); err != nil {
+			if err := openEVEC.EdgeNodeGetOptions(controllerMode, fileWithConfig); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -193,7 +193,7 @@ func newEdgeNodeSetOptions(controllerMode string) *cobra.Command {
 		Short: "set EVE options",
 		Long:  `Set EVE options.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.EdgeNodeSetOptions(controllerMode, fileWithConfig); err != nil {
+			if err := openEVEC.EdgeNodeSetOptions(controllerMode, fileWithConfig); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -212,7 +212,7 @@ func newControllerGetOptions() *cobra.Command {
 		Short: "fetch controller options",
 		Long:  `Fetch controller options.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.ControllerGetOptions(fileWithConfig); err != nil {
+			if err := openEVEC.ControllerGetOptions(fileWithConfig); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -231,7 +231,7 @@ func newControllerSetOptions() *cobra.Command {
 		Short: "set controller options",
 		Long:  `Set controller options.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.ControllerSetOptions(fileWithConfig); err != nil {
+			if err := openEVEC.ControllerSetOptions(fileWithConfig); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -250,7 +250,7 @@ func newEdgeNodeGetConfig(controllerMode string) *cobra.Command {
 		Short: "fetch EVE config",
 		Long:  `Fetch EVE config.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.EdgeNodeGetConfig(controllerMode, fileWithConfig); err != nil {
+			if err := openEVEC.EdgeNodeGetConfig(controllerMode, fileWithConfig); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -269,7 +269,7 @@ func newEdgeNodeSetConfig() *cobra.Command {
 		Short: "set EVE config",
 		Long:  `Set EVE config.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.EdgeNodeSetConfig(fileWithConfig); err != nil {
+			if err := openEVEC.EdgeNodeSetConfig(fileWithConfig); err != nil {
 				log.Fatal(err)
 			}
 		},

--- a/cmd/edenGcp.go
+++ b/cmd/edenGcp.go
@@ -40,7 +40,7 @@ func newGcpImageDelete(gcpKey, gcpProjectName *string) *cobra.Command {
 		Use:   "delete",
 		Short: "delete image from gcp",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.GcpImageDelete(*gcpKey, *gcpProjectName, gcpImageName, gcpBucketName); err != nil {
+			if err := openEVEC.GcpImageDelete(*gcpKey, *gcpProjectName, gcpImageName, gcpBucketName); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -81,7 +81,7 @@ func newGcpImageUploadCmd(cfg *openevec.EdenSetupArgs, gcpKey, gcpProjectName *s
 		Use:   "upload",
 		Short: "upload image to gcp",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := openevec.GcpImageUpload(*gcpKey, *gcpProjectName, gcpImageName, gcpBucketName, cfg.Eve.ImageFile, cfg.Eve.TPM)
+			err := openEVEC.GcpImageUpload(*gcpKey, *gcpProjectName, gcpImageName, gcpBucketName, cfg.Eve.ImageFile, cfg.Eve.TPM)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -127,7 +127,7 @@ func newGcpRunCmd(cfg *openevec.EdenSetupArgs, gcpKey, gcpProjectName *string) *
 		Use:   "run",
 		Short: "run vm in gcp",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := openevec.GcpRun(*gcpKey, *gcpProjectName, gcpImageName, gcpVMName, gcpZone, gcpMachineType, cfg.Eve.TPM, cfg.Eve.Disks, cfg.Eve.ImageSizeMB)
+			err := openEVEC.GcpRun(*gcpKey, *gcpProjectName, gcpImageName, gcpVMName, gcpZone, gcpMachineType, cfg.Eve.TPM, cfg.Eve.Disks, cfg.Eve.ImageSizeMB)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -150,7 +150,7 @@ func newGcpDeleteCmd(gcpKey, gcpProjectName *string) *cobra.Command {
 		Use:   "delete",
 		Short: "delete vm from gcp",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := openevec.GcpDelete(*gcpKey, *gcpProjectName, gcpVMName, gcpZone)
+			err := openEVEC.GcpDelete(*gcpKey, *gcpProjectName, gcpVMName, gcpZone)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/edenNetwork.go
+++ b/cmd/edenNetwork.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"github.com/lf-edge/eden/pkg/controller/types"
-	"github.com/lf-edge/eden/pkg/openevec"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/thediveo/enumflag"
@@ -37,7 +36,7 @@ func newNetworkLsCmd() *cobra.Command {
 		Use:   "ls",
 		Short: "List networks",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.NetworkLs(outputFormat); err != nil {
+			if err := openEVEC.NetworkLs(outputFormat); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -57,7 +56,7 @@ func newNetworkDeleteCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			niName := args[0]
-			if err := openevec.NetworkDelete(niName); err != nil {
+			if err := openEVEC.NetworkDelete(niName); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -76,7 +75,7 @@ func newNetworkNetstatCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			niName := args[0]
-			if err := openevec.NetworkNetstat(niName, outputFormat, outputTail); err != nil {
+			if err := openEVEC.NetworkNetstat(niName, outputFormat, outputTail); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -105,7 +104,7 @@ func newNetworkCreateCmd() *cobra.Command {
 			if len(args) == 1 {
 				subnet = args[0]
 			}
-			if err := openevec.NetworkCreate(subnet, networkType, networkName, uplinkAdapter, staticDNSEntries); err != nil {
+			if err := openEVEC.NetworkCreate(subnet, networkType, networkName, uplinkAdapter, staticDNSEntries); err != nil {
 				log.Fatal(err)
 			}
 		},

--- a/cmd/edenPacket.go
+++ b/cmd/edenPacket.go
@@ -53,7 +53,7 @@ func newPacketRunCmd(cfg *openevec.EdenSetupArgs, packetKey, packetProjectName *
 		Use:   "run",
 		Short: "run vm in packet",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := openevec.PacketRun(*packetKey, *packetProjectName, packetVMName, packetZone, packetMachineType, packetIPXEUrl, cfg)
+			err := openEVEC.PacketRun(*packetKey, *packetProjectName, packetVMName, packetZone, packetMachineType, packetIPXEUrl)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -75,7 +75,7 @@ func newPacketDeleteCmd(packetKey, packetProjectName *string) *cobra.Command {
 		Use:   "delete",
 		Short: "delete vm from packet",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.PacketDelete(*packetKey, *packetProjectName, packetVMName); err != nil {
+			if err := openEVEC.PacketDelete(*packetKey, *packetProjectName, packetVMName); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -93,7 +93,7 @@ func newPacketGetIPCmd(packetKey, packetProjectName *string) *cobra.Command {
 		Use:   "get-ip",
 		Short: "print IP of VM in packet",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.PacketGetIP(*packetKey, *packetProjectName, packetVMName); err != nil {
+			if err := openEVEC.PacketGetIP(*packetKey, *packetProjectName, packetVMName); err != nil {
 				log.Fatal(err)
 			}
 		},

--- a/cmd/edenPod.go
+++ b/cmd/edenPod.go
@@ -57,7 +57,7 @@ func newPodPublishCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			appName := args[0]
-			if err := openevec.PodPublish(appName, kernelFile, initrdFile, rootFile, formatStr, arch, local, disks, cfg); err != nil {
+			if err := openEVEC.PodPublish(appName, kernelFile, initrdFile, rootFile, formatStr, arch, local, disks); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -84,7 +84,7 @@ func newPodDeployCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			appLink := args[0]
-			if err := openevec.PodDeploy(appLink, pc, cfg); err != nil {
+			if err := openEVEC.PodDeploy(appLink, pc, cfg); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -132,7 +132,7 @@ func newPodPsCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Use:   "ps",
 		Short: "List pods",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.PodPs(cfg, outputFormat); err != nil {
+			if err := openEVEC.PodPs(outputFormat); err != nil {
 				log.Fatalf("EVE pod deploy failed: %s", err)
 			}
 		},
@@ -152,7 +152,7 @@ func newPodStopCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			appName := args[0]
-			if err := openevec.PodStop(appName); err != nil {
+			if err := openEVEC.PodStop(appName); err != nil {
 				log.Fatalf("EVE pod stop failed: %s", err)
 			}
 		},
@@ -171,7 +171,7 @@ func newPodPurgeCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			appName := args[0]
 			explicitVolumes := cmd.Flags().Changed("volumes")
-			if err := openevec.PodPurge(volumesToPurge, appName, explicitVolumes); err != nil {
+			if err := openEVEC.PodPurge(volumesToPurge, appName, explicitVolumes); err != nil {
 				log.Fatalf("EVE pod purge failed: %s", err)
 			}
 		},
@@ -189,7 +189,7 @@ func newPodRestartCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			appName := args[0]
-			if err := openevec.PodRestart(appName); err != nil {
+			if err := openEVEC.PodRestart(appName); err != nil {
 				log.Fatalf("EVE pod restart failed: %s", err)
 			}
 		},
@@ -205,7 +205,7 @@ func newPodStartCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			appName := args[0]
-			if err := openevec.PodStart(appName); err != nil {
+			if err := openEVEC.PodStart(appName); err != nil {
 				log.Fatalf("EVE pod start failed: %s", err)
 			}
 		},
@@ -223,7 +223,7 @@ func newPodDeleteCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			appName := args[0]
-			if _, err := openevec.PodDelete(appName, deleteVolumes); err != nil {
+			if _, err := openEVEC.PodDelete(appName, deleteVolumes); err != nil {
 				log.Fatalf("EVE pod start failed: %s", err)
 			}
 		},
@@ -247,7 +247,7 @@ func newPodLogsCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			appName := args[0]
-			if err := openevec.PodLogs(appName, outputTail, outputFields, outputFormat); err != nil {
+			if err := openEVEC.PodLogs(appName, outputTail, outputFields, outputFormat); err != nil {
 				log.Fatalf("EVE pod start failed: %s", err)
 			}
 		},
@@ -273,7 +273,7 @@ func newPodModifyCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			appName := args[0]
-			if err := openevec.PodModify(appName, podNetworks, portPublish, acl, vlans, startDelay, cfg); err != nil {
+			if err := openEVEC.PodModify(appName, podNetworks, portPublish, acl, vlans, startDelay); err != nil {
 				log.Fatalf("EVE pod start failed: %s", err)
 			}
 		},

--- a/cmd/edenRol.go
+++ b/cmd/edenRol.go
@@ -58,7 +58,7 @@ func newGetRentConsoleOutputCmd(rolProjectID *string) *cobra.Command {
 		Short: "Get device console output",
 		Long:  `Get device console output from uart`,
 		Run: func(cmd *cobra.Command, args []string) {
-			output, err := openevec.GetRentConsoleOutput(*rolProjectID, rolRentID)
+			output, err := openEVEC.GetRentConsoleOutput(*rolProjectID, rolRentID)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -81,7 +81,7 @@ func newCreateRentCmd(rolProjectID *string, cfg *openevec.EdenSetupArgs) *cobra.
 		Long:  `Create a new device rent`,
 
 		Run: func(cmd *cobra.Command, args []string) {
-			err := openevec.CreateRent(*rolProjectID, rolRentName, rolModel, rolManufacturer, rolIPXEUrl, cfg)
+			err := openEVEC.CreateRent(*rolProjectID, rolRentName, rolModel, rolManufacturer, rolIPXEUrl)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -107,7 +107,7 @@ func newGetRentCmd(rolProjectID *string) *cobra.Command {
 		Short: "Get the device rent",
 		Long:  `Get the device rent`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.GetRent(*rolProjectID, rolRentID); err != nil {
+			if err := openEVEC.GetRent(*rolProjectID, rolRentID); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -127,7 +127,7 @@ func newCloseRentCmd(rolProjectID *string) *cobra.Command {
 		Short: "Close the device rent",
 		Long:  `Close the device rent`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.CloseRent(*rolProjectID, rolRentID); err != nil {
+			if err := openEVEC.CloseRent(*rolProjectID, rolRentID); err != nil {
 				log.Fatal(err)
 			}
 		},

--- a/cmd/edenSetup.go
+++ b/cmd/edenSetup.go
@@ -23,8 +23,7 @@ func newSetupCmd(configName, verbosity *string) *cobra.Command {
 		Long:              `Setup harness.`,
 		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.SetupEden(*configName, configDir, softSerial,
-				zedControlURL, ipxeOverride, grubOptions, netboot, installer, *cfg); err != nil {
+			if err := openEVEC.SetupEden(*configName, configDir, softSerial, zedControlURL, ipxeOverride, grubOptions, netboot, installer); err != nil {
 
 				log.Fatalf("Setup eden failed: %s", err)
 			}

--- a/cmd/edenStart.go
+++ b/cmd/edenStart.go
@@ -21,7 +21,7 @@ func newStartCmd(configName, verbosity *string) *cobra.Command {
 		Long:              `Start harness.`,
 		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.StartEden(cfg, vmName, zedControlURL, tapInterface); err != nil {
+			if err := openEVEC.StartEden(vmName, zedControlURL, tapInterface); err != nil {
 				log.Fatalf("Start eden failed: %s", err)
 			}
 		},

--- a/cmd/edenStatus.go
+++ b/cmd/edenStatus.go
@@ -21,7 +21,7 @@ func newStatusCmd(configName, verbosity *string) *cobra.Command {
 		Long:              `Status of harness.`,
 		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.Status(cfg, vmName, allConfigs); err != nil {
+			if err := openEVEC.Status(vmName, allConfigs); err != nil {
 				log.Fatal(err)
 			}
 		},

--- a/cmd/edenUtils.go
+++ b/cmd/edenUtils.go
@@ -54,7 +54,7 @@ func newSdInfoEveCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			devicePath := args[0]
-			if err := openevec.SDInfoEve(devicePath, syslogOutput, eveReleaseOutput); err != nil {
+			if err := openEVEC.SDInfoEve(devicePath, syslogOutput, eveReleaseOutput); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -92,7 +92,7 @@ func newUploadGitCmd() *cobra.Command {
 				directoryToSaveOnGit = args[3]
 			}
 
-			if err := openevec.UploadGit(absPath, args[1], args[2], directoryToSaveOnGit); err != nil {
+			if err := openEVEC.UploadGit(absPath, args[1], args[2], directoryToSaveOnGit); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -200,7 +200,7 @@ func newExportCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			tarFile := args[0]
-			if err := openevec.EdenExport(tarFile, cfg); err != nil {
+			if err := openEVEC.EdenExport(tarFile); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -220,7 +220,7 @@ func newImportCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			tarFile := args[0]
-			if err := openevec.EdenImport(tarFile, rewriteRoot, cfg); err != nil {
+			if err := openEVEC.EdenImport(tarFile, rewriteRoot); err != nil {
 				log.Fatal(err)
 			}
 		},

--- a/cmd/edenVolume.go
+++ b/cmd/edenVolume.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/dustin/go-humanize"
 	"github.com/lf-edge/eden/pkg/controller/types"
-	"github.com/lf-edge/eden/pkg/openevec"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/thediveo/enumflag"
@@ -39,7 +38,7 @@ func newVolumeLsCmd() *cobra.Command {
 		Use:   "ls",
 		Short: "List volumes",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.VolumeLs(outputFormat); err != nil {
+			if err := openEVEC.VolumeLs(outputFormat); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -62,7 +61,7 @@ func newVolumeCreateCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			appLink := args[0]
-			err := openevec.VolumeCreate(appLink, registry, diskSize, volumeName,
+			err := openEVEC.VolumeCreate(appLink, registry, diskSize, volumeName,
 				volumeType, datastoreOverride, sftpLoad, directLoad)
 			if err != nil {
 				log.Fatal(err)
@@ -89,7 +88,7 @@ func newVolumeDeleteCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			volumeName := args[0]
-			if err := openevec.VolumeDelete(volumeName); err != nil {
+			if err := openEVEC.VolumeDelete(volumeName); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -106,7 +105,7 @@ func newVolumeDetachCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			volumeName := args[0]
-			if err := openevec.VolumeDetach(volumeName); err != nil {
+			if err := openEVEC.VolumeDetach(volumeName); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -129,7 +128,7 @@ func newVolumeAttachCmd() *cobra.Command {
 				mountPoint = args[2]
 			}
 
-			if err := openevec.VolumeAttach(appName, volumeName, mountPoint); err != nil {
+			if err := openEVEC.VolumeAttach(appName, volumeName, mountPoint); err != nil {
 				log.Fatal(err)
 			}
 		},

--- a/cmd/eve.go
+++ b/cmd/eve.go
@@ -60,7 +60,7 @@ func newStartEveCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Short: "start eve",
 		Long:  `Start eve.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.StartEve(vmName, tapInterface, cfg); err != nil {
+			if err := openEVEC.StartEve(vmName, tapInterface); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -99,7 +99,7 @@ func newStopEveCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Short: "stop eve",
 		Long:  `Stop eve.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.StopEve(vmName, cfg); err != nil {
+			if err := openEVEC.StopEve(vmName); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -122,7 +122,7 @@ func newVersionEveCmd() *cobra.Command {
 		Short: "version of eve",
 		Long:  `Version of eve.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.VersionEve(); err != nil {
+			if err := openEVEC.VersionEve(); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -139,7 +139,7 @@ func newStatusEveCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Short: "status of eve",
 		Long:  `Status of eve.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.StatusEve(vmName, cfg); err != nil {
+			if err := openEVEC.StatusEve(vmName); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -162,7 +162,7 @@ func newIpEveCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Short: "ip of eve",
 		Long:  `Get IP of eve.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(openevec.GetEveIP("eth0", cfg))
+			fmt.Println(openEVEC.GetEveIP("eth0"))
 		},
 	}
 
@@ -177,7 +177,7 @@ func newConsoleEveCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Short: "telnet into eve",
 		Long:  `Telnet into eve.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.ConsoleEve(host, cfg); err != nil {
+			if err := openEVEC.ConsoleEve(host); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -199,7 +199,7 @@ func newSshEveCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 			if len(args) > 0 {
 				commandToRun = strings.Join(args, " ")
 			}
-			if err := openevec.SSHEve(commandToRun, cfg); err != nil {
+			if err := openEVEC.SSHEve(commandToRun); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -221,7 +221,7 @@ func newOnboardEveCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Short: "OnBoard EVE in Adam",
 		Long:  `Adding an EVE onboarding certificate to Adam and waiting for EVE to register.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.OnboardEve(cfg.Eve.CertsUUID); err != nil {
+			if err := openEVEC.OnboardEve(cfg.Eve.CertsUUID); err != nil {
 				log.Fatalf("Eve onboard failed: %s", err)
 			}
 		},
@@ -235,7 +235,7 @@ func newResetEveCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Use:   "reset",
 		Short: "Reset EVE to initial config",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.ResetEve(cfg.Eve.CertsUUID); err != nil {
+			if err := openEVEC.ResetEve(); err != nil {
 				log.Fatalf("EVE reset failed: %s", err)
 			}
 		},
@@ -251,7 +251,7 @@ func newEpochEveCmd() *cobra.Command {
 		Use:   "epoch",
 		Short: "Set new epoch of EVE",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.NewEpochEve(eveConfigFromFile); err != nil {
+			if err := openEVEC.NewEpochEve(eveConfigFromFile); err != nil {
 				log.Fatalf("EVE new epoch failed: %s", err)
 			}
 		},
@@ -274,7 +274,7 @@ func newLinkEveCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 			if len(args) > 0 {
 				command = args[0]
 			}
-			if err := openevec.NewLinkEve(command, eveInterfaceName, vmName, cfg); err != nil {
+			if err := openEVEC.NewLinkEve(command, eveInterfaceName, vmName); err != nil {
 				log.Fatalf("EVE new link failed: %s", err)
 			}
 		},

--- a/cmd/flowlog.go
+++ b/cmd/flowlog.go
@@ -22,7 +22,7 @@ func newNetStatCmd(configName, verbosity *string) *cobra.Command {
 (TCP and UDP flows with IP addresses, port numbers, counters, whether dropped or accepted)`,
 		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.EdenNetStat(cfg, outputFormat, follow, logTail, printFields, args); err != nil {
+			if err := openEVEC.EdenNetStat(outputFormat, follow, logTail, printFields, args); err != nil {
 				log.Fatalf("Setup eden failed: %s", err)
 			}
 		},

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"github.com/lf-edge/eden/pkg/controller/types"
-	"github.com/lf-edge/eden/pkg/openevec"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/thediveo/enumflag"
@@ -19,7 +18,7 @@ func newInfoCmd() *cobra.Command {
 		Short: "Get information reports from a running EVE device",
 		Long:  ` Scans the ADAM Info for correspondence with regular expressions requests to json fields.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.EdenInfo(outputFormat, infoTail, follow, printFields, args); err != nil {
+			if err := openEVEC.EdenInfo(outputFormat, infoTail, follow, printFields, args); err != nil {
 				log.Fatal("Eden info failed ", err)
 			}
 		},

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"github.com/lf-edge/eden/pkg/controller/types"
-	"github.com/lf-edge/eden/pkg/openevec"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/thediveo/enumflag"
@@ -24,7 +23,7 @@ func newLogCmd() *cobra.Command {
 		Short: "Get logs from a running EVE device",
 		Long:  ` Scans the ADAM logs for correspondence with regular expressions requests to json fields.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.EdenLog(outputFormat, follow, logTail, printFields, args); err != nil {
+			if err := openEVEC.EdenLog(outputFormat, follow, logTail, printFields, args); err != nil {
 				log.Fatalf("Log eden failed: %s", err)
 			}
 		},

--- a/cmd/metric.go
+++ b/cmd/metric.go
@@ -22,7 +22,7 @@ func newMetricCmd(configName, verbosity *string) *cobra.Command {
 Scans the ADAM metrics for correspondence with regular expressions requests to json fields.`,
 		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.EdenMetric(cfg, outputFormat, follow, metricTail, printFields, args); err != nil {
+			if err := openEVEC.EdenMetric(outputFormat, follow, metricTail, printFields, args); err != nil {
 				log.Fatalf("Metric eden failed: %s", err)
 			}
 		},

--- a/cmd/ociimage.go
+++ b/cmd/ociimage.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"github.com/lf-edge/eden/pkg/defaults"
-	"github.com/lf-edge/eden/pkg/openevec"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -20,7 +19,7 @@ func newOciImageCmd() *cobra.Command {
 		Short: "do oci image manipulations",
 		Long:  `Do oci image manipulations.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.OciImage(fileToSave, image, registry, isLocal); err != nil {
+			if err := openEVEC.OciImage(fileToSave, image, registry, isLocal); err != nil {
 				log.Fatal(err)
 			}
 		},

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -40,7 +40,7 @@ func newStartRegistryCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Short: "start registry",
 		Long:  `Start OCI/docker registry.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.RegistryStart(&cfg.Registry); err != nil {
+			if err := openEVEC.RegistryStart(); err != nil {
 				log.Fatalf("Registry start failed %s", err)
 			}
 		},
@@ -98,7 +98,7 @@ func newLoadRegistryCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Args: cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			ref := args[0]
-			if err := openevec.RegistryLoad(ref, &cfg.Registry); err != nil {
+			if err := openEVEC.RegistryLoad(ref); err != nil {
 				log.Fatalf("Load registry failed %s", err)
 			}
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,14 +12,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var openEVEC *openevec.OpenEVEC
+
 func NewEdenCommand() *cobra.Command {
 	var configName, verbosity string
+	cfg := &openevec.EdenSetupArgs{}
 
 	rootCmd := &cobra.Command{
-		Use: "eden",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return openevec.SetUpLogs(verbosity)
-		},
+		Use:               "eden",
+		PersistentPreRunE: preRunViperLoadFunction(cfg, &configName, &verbosity),
 	}
 
 	groups := CommandGroups{
@@ -76,6 +77,7 @@ func preRunViperLoadFunction(cfg *openevec.EdenSetupArgs, configName, verbosity 
 		}
 		openevec.Merge(reflect.ValueOf(viperCfg).Elem(), reflect.ValueOf(*cfg), cmd.Flags())
 		*cfg = *viperCfg
+		openEVEC = openevec.CreateOpenEVEC(cfg)
 		return nil
 	}
 }

--- a/cmd/sdn.go
+++ b/cmd/sdn.go
@@ -71,7 +71,7 @@ func newSdnModelGetCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Use:   "get",
 		Short: "Get currently applied network model (in JSON)",
 		Run: func(cmd *cobra.Command, args []string) {
-			model, err := openevec.SdnNetModelGet(cfg)
+			model, err := openEVEC.SdnNetModelGet()
 			if err != nil {
 				log.Fatal(err)
 			} else {
@@ -93,7 +93,7 @@ Use string \"default\" instead of a file path to apply the default network model
 		Args: cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			ref := args[0]
-			if err := openevec.SdnNetModelApply(ref, cfg); err != nil {
+			if err := openEVEC.SdnNetModelApply(ref); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -113,7 +113,7 @@ To generate graph image, run: eden sdn net-config-graph | dot -Tsvg > output.svg
 This requires to have Graphviz installed.
 Alternatively, visualize using the online tool: https://dreampuf.github.io/GraphvizOnline/`,
 		Run: func(cmd *cobra.Command, args []string) {
-			graph, err := openevec.SdnNetConfigGraph(cfg)
+			graph, err := openEVEC.SdnNetConfigGraph()
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -129,7 +129,8 @@ func newSdnStatusCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Use:   "status",
 		Short: "Get status of the running Eden-SDN",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.SdnStatus(cfg); err != nil {
+			if err := openEVEC.
+				SdnStatus(); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -146,7 +147,7 @@ func newSdnSshCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Use:   "ssh",
 		Short: "SSH into the running Eden-SDN VM",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.SdnSsh(cfg); err != nil {
+			if err := openEVEC.SdnSsh(); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -162,7 +163,7 @@ func newSdnLogsCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Use:   "logs",
 		Short: "Get all logs from running Eden-SDN VM",
 		Run: func(cmd *cobra.Command, args []string) {
-			if logs, err := openevec.SdnLogs(cfg); err != nil {
+			if logs, err := openEVEC.SdnLogs(); err != nil {
 				log.Fatal(err)
 			} else {
 				fmt.Println(logs)
@@ -180,7 +181,7 @@ func newSdnMgmtIPCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 		Use:   "mgmt-ip",
 		Short: "Get IP address assigned to Eden-SDN VM for management",
 		Run: func(cmd *cobra.Command, args []string) {
-			if mgmtIp, err := openevec.SdnMgmtIp(cfg); err != nil {
+			if mgmtIp, err := openEVEC.SdnMgmtIp(); err != nil {
 				log.Fatal(err)
 			} else {
 				fmt.Println(mgmtIp)
@@ -229,7 +230,7 @@ the EVE's port forwarding capability.`,
 			command := args[1]
 			args = args[2:]
 
-			if err := openevec.SdnEpExec(epName, command, args, cfg); err != nil {
+			if err := openEVEC.SdnEpExec(epName, command, args); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -273,7 +274,7 @@ This is currently limited to TCP port forwarding (i.e. not working with UDP)!`,
 			command := args[2]
 			args = args[3:]
 
-			err = openevec.SdnForwardCmd(sdnFwdFromEp, eveIfName, targetPort, command, cfg, args...)
+			err = openEVEC.SdnForwardCmd(sdnFwdFromEp, eveIfName, targetPort, command, args...)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/controller/adam/httpclient.go
+++ b/pkg/controller/adam/httpclient.go
@@ -50,12 +50,12 @@ func (adam *Ctx) deleteObj(path string) (err error) {
 	client := adam.getHTTPClient()
 	req, err := http.NewRequest("DELETE", u, nil)
 	if err != nil {
-		log.Fatalf("unable to create new http request: %v", err)
+		return fmt.Errorf("unable to create new http request: %v", err)
 	}
 
 	response, err := utils.RepeatableAttempt(client, req)
 	if err != nil {
-		log.Fatalf("unable to send request: %v", err)
+		return fmt.Errorf("unable to send request: %v", err)
 	}
 	if response.StatusCode != http.StatusOK {
 		return fmt.Errorf("status code: %d", response.StatusCode)

--- a/pkg/eden/eden.go
+++ b/pkg/eden/eden.go
@@ -783,11 +783,11 @@ func CleanContext(eveDist, certsDist, imagesDist, evePID, eveUUID, sdnPID, vmNam
 		}
 		log.Debugf("Deleting devUUID %s", devUUID)
 		if err := ctrl.DeviceRemove(devUUID); err != nil {
-			return fmt.Errorf("CleanContext: %s", err)
+			log.Errorf("CleanContext: %s", err)
 		}
 		log.Debugf("Deleting onboardUUID %s", eveUUID)
 		if err := ctrl.OnboardRemove(eveUUID); err != nil {
-			return fmt.Errorf("CleanContext: %s", err)
+			log.Errorf("CleanContext: %s", err)
 		}
 		localViper := viper.New()
 		localViper.SetConfigFile(eveStatusFile)

--- a/pkg/openevec/adam.go
+++ b/pkg/openevec/adam.go
@@ -8,7 +8,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func AdamStart(cfg *EdenSetupArgs) error {
+func (openEVEC *OpenEVEC) AdamStart() error {
+	cfg := openEVEC.cfg
 	command, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("cannot obtain executable path: %w", err)

--- a/pkg/openevec/controller.go
+++ b/pkg/openevec/controller.go
@@ -1,0 +1,11 @@
+package openevec
+
+// OpenEVEC base type for all actions
+type OpenEVEC struct {
+	cfg *EdenSetupArgs
+}
+
+// CreateOpenEVEC returns OpenEVEC instance
+func CreateOpenEVEC(cfg *EdenSetupArgs) *OpenEVEC {
+	return &OpenEVEC{cfg: cfg}
+}

--- a/pkg/openevec/disks.go
+++ b/pkg/openevec/disks.go
@@ -27,21 +27,21 @@ var LayoutTypeIds = map[device.DisksLayoutType][]string{
 	device.DisksLayoutTypeRaid10:      {"raid10"},
 }
 
-func GetDisksLayout() (device.DisksLayout, error) {
+func (openEVEC *OpenEVEC) GetDisksLayout() (device.DisksLayout, error) {
 	changer := &adamChanger{}
-	_, dev, err := changer.getControllerAndDev()
+	_, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return device.DisksLayout{}, fmt.Errorf("getControllerAndDev error: %w", err)
+		return device.DisksLayout{}, fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	layout := dev.GetDiskLayout()
 	return *layout, nil
 }
 
-func SetDiskLayout(dc *DisksConfig) error {
+func (openEVEC *OpenEVEC) SetDiskLayout(dc *DisksConfig) error {
 	changer := &adamChanger{}
-	ctrl, dev, err := changer.getControllerAndDev()
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return fmt.Errorf("getControllerAndDev error: %w", err)
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	layout := dev.GetDiskLayout()
 	if layout == nil {

--- a/pkg/openevec/edenNetwork.go
+++ b/pkg/openevec/edenNetwork.go
@@ -12,11 +12,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func NetworkLs(outputFormat types.OutputFormat) error {
+func (openEVEC *OpenEVEC) NetworkLs(outputFormat types.OutputFormat) error {
 	changer := &adamChanger{}
-	ctrl, dev, err := changer.getControllerAndDev()
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return fmt.Errorf("getControllerAndDev: %w", err)
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	state := eve.Init(ctrl, dev)
 	if err := ctrl.InfoLastCallback(dev.GetID(), nil, state.InfoCallback()); err != nil {
@@ -31,11 +31,11 @@ func NetworkLs(outputFormat types.OutputFormat) error {
 	return nil
 }
 
-func NetworkDelete(niName string) error {
+func (openEVEC *OpenEVEC) NetworkDelete(niName string) error {
 	changer := &adamChanger{}
-	ctrl, dev, err := changer.getControllerAndDev()
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return fmt.Errorf("getControllerAndDev: %w", err)
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	for id, el := range dev.GetNetworkInstances() {
 		ni, err := ctrl.GetNetworkInstanceConfig(el)
@@ -57,11 +57,11 @@ func NetworkDelete(niName string) error {
 	return nil
 }
 
-func NetworkNetstat(niName string, outputFormat types.OutputFormat, outputTail uint) error {
+func (openEVEC *OpenEVEC) NetworkNetstat(niName string, outputFormat types.OutputFormat, outputTail uint) error {
 	changer := &adamChanger{}
-	ctrl, dev, err := changer.getControllerAndDev()
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return fmt.Errorf("getControllerAndDev: %w", err)
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	for _, el := range dev.GetNetworkInstances() {
 		ni, err := ctrl.GetNetworkInstanceConfig(el)
@@ -93,7 +93,7 @@ func NetworkNetstat(niName string, outputFormat types.OutputFormat, outputTail u
 	return nil
 }
 
-func NetworkCreate(subnet, networkType, networkName, uplinkAdapter string, staticDNSEntries []string) error {
+func (openEVEC *OpenEVEC) NetworkCreate(subnet, networkType, networkName, uplinkAdapter string, staticDNSEntries []string) error {
 	if networkType != "local" && networkType != "switch" {
 		return fmt.Errorf("network type %s not supported now", networkType)
 	}
@@ -101,9 +101,9 @@ func NetworkCreate(subnet, networkType, networkName, uplinkAdapter string, stati
 		return fmt.Errorf("you must define subnet as first arg for local network")
 	}
 	changer := &adamChanger{}
-	ctrl, dev, err := changer.getControllerAndDev()
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return fmt.Errorf("getControllerAndDev: %w", err)
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	var opts []expect.ExpectationOption
 	opts = append(opts, expect.AddNetInstanceAndPortPublish(subnet, networkType, networkName, nil, uplinkAdapter))

--- a/pkg/openevec/edenPacket.go
+++ b/pkg/openevec/edenPacket.go
@@ -9,7 +9,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func PacketRun(packetKey, packetProjectName, packetVMName, packetZone, packetMachineType, packetIPXEUrl string, cfg *EdenSetupArgs) error {
+func (openEVEC *OpenEVEC) PacketRun(packetKey, packetProjectName, packetVMName, packetZone, packetMachineType, packetIPXEUrl string) error {
+	cfg := openEVEC.cfg
 	if packetIPXEUrl == "" {
 		configPrefix := cfg.ConfigName
 		if cfg.ConfigName == defaults.DefaultContext {
@@ -29,7 +30,7 @@ func PacketRun(packetKey, packetProjectName, packetVMName, packetZone, packetMac
 	return nil
 }
 
-func PacketDelete(packetKey, packetProjectName, packetVMName string) error {
+func (openEVEC *OpenEVEC) PacketDelete(packetKey, packetProjectName, packetVMName string) error {
 	packetClient, err := packet.NewPacketClient(packetKey, packetProjectName)
 	if err != nil {
 		return fmt.Errorf("unable to connect to create packet client: %w", err)
@@ -40,7 +41,7 @@ func PacketDelete(packetKey, packetProjectName, packetVMName string) error {
 	return nil
 }
 
-func PacketGetIP(packetKey, packetProjectName, packetVMName string) error {
+func (openEVEC *OpenEVEC) PacketGetIP(packetKey, packetProjectName, packetVMName string) error {
 	packetClient, err := packet.NewPacketClient(packetKey, packetProjectName)
 	if err != nil {
 		return fmt.Errorf("unable to connect to create packet client: %w", err)

--- a/pkg/openevec/edenRol.go
+++ b/pkg/openevec/edenRol.go
@@ -10,7 +10,8 @@ import (
 	"github.com/lf-edge/eden/pkg/defaults"
 )
 
-func CreateRent(rolProjectID, rolRentName, rolModel, rolManufacturer, rolIPXEUrl string, cfg *EdenSetupArgs) error {
+func (openEVEC *OpenEVEC) CreateRent(rolProjectID, rolRentName, rolModel, rolManufacturer, rolIPXEUrl string) error {
+	cfg := openEVEC.cfg
 	client, err := rolgo.NewClient()
 	if err != nil {
 		return err
@@ -34,7 +35,7 @@ func CreateRent(rolProjectID, rolRentName, rolModel, rolManufacturer, rolIPXEUrl
 	return nil
 }
 
-func GetRent(rolProjectID, rolRentID string) error {
+func (openEVEC *OpenEVEC) GetRent(rolProjectID, rolRentID string) error {
 	client, err := rolgo.NewClient()
 	if err != nil {
 		return err
@@ -51,7 +52,7 @@ func GetRent(rolProjectID, rolRentID string) error {
 	return nil
 }
 
-func CloseRent(rolProjectID, rolRentID string) error {
+func (openEVEC *OpenEVEC) CloseRent(rolProjectID, rolRentID string) error {
 	client, err := rolgo.NewClient()
 	if err != nil {
 		return err
@@ -63,7 +64,7 @@ func CloseRent(rolProjectID, rolRentID string) error {
 	return nil
 }
 
-func GetRentConsoleOutput(rolProjectID, rolRentID string) (string, error) {
+func (openEVEC *OpenEVEC) GetRentConsoleOutput(rolProjectID, rolRentID string) (string, error) {
 	client, err := rolgo.NewClient()
 	if err != nil {
 		return "", err

--- a/pkg/openevec/edenVolume.go
+++ b/pkg/openevec/edenVolume.go
@@ -17,11 +17,11 @@ import (
 	"github.com/spf13/viper"
 )
 
-func VolumeLs(outputFormat types.OutputFormat) error {
+func (openEVEC *OpenEVEC) VolumeLs(outputFormat types.OutputFormat) error {
 	changer := &adamChanger{}
-	ctrl, dev, err := changer.getControllerAndDev()
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return fmt.Errorf("getControllerAndDev: %w", err)
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	state := eve.Init(ctrl, dev)
 	if err := ctrl.MetricLastCallback(dev.GetID(), nil, state.MetricCallback()); err != nil {
@@ -36,11 +36,11 @@ func VolumeLs(outputFormat types.OutputFormat) error {
 	return nil
 }
 
-func VolumeCreate(appLink, registry, diskSize, volumeName, volumeType, datastoreOverride string, sftpLoad, directLoad bool) error {
+func (openEVEC *OpenEVEC) VolumeCreate(appLink, registry, diskSize, volumeName, volumeType, datastoreOverride string, sftpLoad, directLoad bool) error {
 	changer := &adamChanger{}
-	ctrl, dev, err := changer.getControllerAndDev()
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return fmt.Errorf("getControllerAndDev: %w", err)
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	var opts []expect.ExpectationOption
 	diskSizeParsed, err := humanize.ParseBytes(diskSize)
@@ -98,11 +98,11 @@ func VolumeCreate(appLink, registry, diskSize, volumeName, volumeType, datastore
 	return nil
 }
 
-func VolumeDelete(volumeName string) error {
+func (openEVEC *OpenEVEC) VolumeDelete(volumeName string) error {
 	changer := &adamChanger{}
-	ctrl, dev, err := changer.getControllerAndDev()
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return fmt.Errorf("getControllerAndDev: %w", err)
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	for id, el := range dev.GetVolumes() {
 		volume, err := ctrl.GetVolume(el)
@@ -124,11 +124,11 @@ func VolumeDelete(volumeName string) error {
 	return nil
 }
 
-func VolumeDetach(volumeName string) error {
+func (openEVEC *OpenEVEC) VolumeDetach(volumeName string) error {
 	changer := &adamChanger{}
-	ctrl, dev, err := changer.getControllerAndDev()
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return fmt.Errorf("getControllerAndDev: %w", err)
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	for _, el := range dev.GetVolumes() {
 		volume, err := ctrl.GetVolume(el)
@@ -167,11 +167,11 @@ func VolumeDetach(volumeName string) error {
 	return nil
 }
 
-func VolumeAttach(appName, volumeName, mountPoint string) error {
+func (openEVEC *OpenEVEC) VolumeAttach(appName, volumeName, mountPoint string) error {
 	changer := &adamChanger{}
-	ctrl, dev, err := changer.getControllerAndDev()
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return fmt.Errorf("getControllerAndDev: %w", err)
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	for _, el := range dev.GetVolumes() {
 		volume, err := ctrl.GetVolume(el)

--- a/pkg/openevec/gcp.go
+++ b/pkg/openevec/gcp.go
@@ -6,7 +6,7 @@ import (
 	"github.com/lf-edge/eden/pkg/linuxkit"
 )
 
-func GcpImageDelete(gcpKey, gcpProjectName, gcpImageName, gcpBucketName string) error {
+func (openEVEC *OpenEVEC) GcpImageDelete(gcpKey, gcpProjectName, gcpImageName, gcpBucketName string) error {
 	gcpClient, err := linuxkit.NewGCPClient(gcpKey, gcpProjectName)
 	if err != nil {
 		return fmt.Errorf("unable to connect to GCP: %w", err)
@@ -22,7 +22,7 @@ func GcpImageDelete(gcpKey, gcpProjectName, gcpImageName, gcpBucketName string) 
 	return nil
 }
 
-func GcpImageUpload(gcpKey, gcpProjectName, gcpImageName, gcpBucketName, eveImageFile string, gcpvTPM bool) error {
+func (openEVEC *OpenEVEC) GcpImageUpload(gcpKey, gcpProjectName, gcpImageName, gcpBucketName, eveImageFile string, gcpvTPM bool) error {
 	gcpClient, err := linuxkit.NewGCPClient(gcpKey, gcpProjectName)
 	if err != nil {
 		return fmt.Errorf("unable to connect to GCP: %w", err)
@@ -39,7 +39,7 @@ func GcpImageUpload(gcpKey, gcpProjectName, gcpImageName, gcpBucketName, eveImag
 	return nil
 }
 
-func GcpRun(gcpKey, gcpProjectName, gcpImageName, gcpVMName, gcpZone, gcpMachineType string, gcpvTPM bool, eveDisks, eveImageSizeMB int) error {
+func (openEVEC *OpenEVEC) GcpRun(gcpKey, gcpProjectName, gcpImageName, gcpVMName, gcpZone, gcpMachineType string, gcpvTPM bool, eveDisks, eveImageSizeMB int) error {
 	gcpClient, err := linuxkit.NewGCPClient(gcpKey, gcpProjectName)
 	if err != nil {
 		return fmt.Errorf("unable to connect to GCP: %w", err)
@@ -55,7 +55,7 @@ func GcpRun(gcpKey, gcpProjectName, gcpImageName, gcpVMName, gcpZone, gcpMachine
 	return nil
 }
 
-func GcpDelete(gcpKey, gcpProjectName, gcpVMName, gcpZone string) error {
+func (openEVEC *OpenEVEC) GcpDelete(gcpKey, gcpProjectName, gcpVMName, gcpZone string) error {
 	gcpClient, err := linuxkit.NewGCPClient(gcpKey, gcpProjectName)
 	if err != nil {
 		return fmt.Errorf("unable to connect to GCP: %w", err)

--- a/pkg/openevec/onboard.go
+++ b/pkg/openevec/onboard.go
@@ -9,7 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func OnboardEve(eveUUID string) error {
+func (openEVEC *OpenEVEC) OnboardEve(eveUUID string) error {
 
 	edenDir, err := utils.DefaultEdenDir()
 	if err != nil {
@@ -23,7 +23,11 @@ func OnboardEve(eveUUID string) error {
 	if err != nil {
 		return fmt.Errorf("error fetching controller %w", err)
 	}
-	vars := ctrl.GetVars()
+	vars, err := InitVarsFromConfig(openEVEC.cfg)
+	if err != nil {
+		return fmt.Errorf("InitVarsFromConfig error: %w", err)
+	}
+	ctrl.SetVars(vars)
 	dev, err := ctrl.GetDeviceCurrent()
 	if err != nil || dev == nil {
 		// create new one if not exists

--- a/pkg/openevec/pod.go
+++ b/pkg/openevec/pod.go
@@ -66,11 +66,11 @@ func processVLANs(vlans []string) (map[string]int, error) {
 	return m, nil
 }
 
-func PodDeploy(appLink string, pc PodConfig, cfg *EdenSetupArgs) error {
+func (openEVEC *OpenEVEC) PodDeploy(appLink string, pc PodConfig, cfg *EdenSetupArgs) error {
 	changer := &adamChanger{}
-	ctrl, dev, err := changer.getControllerAndDev()
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return fmt.Errorf("getControllerAndDev: %w", err)
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	var opts []expect.ExpectationOption
 	opts = append(opts, expect.WithMetadata(pc.Metadata))
@@ -149,11 +149,11 @@ func PodDeploy(appLink string, pc PodConfig, cfg *EdenSetupArgs) error {
 	return nil
 }
 
-func PodPs(_ *EdenSetupArgs, outputFormat types.OutputFormat) error {
+func (openEVEC *OpenEVEC) PodPs(outputFormat types.OutputFormat) error {
 	changer := &adamChanger{}
-	ctrl, dev, err := changer.getControllerAndDev()
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return fmt.Errorf("getControllerAndDev: %w", err)
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	state := eve.Init(ctrl, dev)
 	if err := ctrl.InfoLastCallback(dev.GetID(), nil, state.InfoCallback()); err != nil {
@@ -168,11 +168,11 @@ func PodPs(_ *EdenSetupArgs, outputFormat types.OutputFormat) error {
 	return nil
 }
 
-func PodStop(appName string) error {
+func (openEVEC *OpenEVEC) PodStop(appName string) error {
 	changer := &adamChanger{}
-	ctrl, dev, err := changer.getControllerAndDev()
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return fmt.Errorf("getControllerAndDev: %w", err)
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	for _, el := range dev.GetApplicationInstances() {
 		app, err := ctrl.GetApplicationInstanceConfig(el)
@@ -192,11 +192,11 @@ func PodStop(appName string) error {
 	return nil
 }
 
-func PodPurge(volumesToPurge []string, appName string, explicitVolumes bool) error {
+func (openEVEC *OpenEVEC) PodPurge(volumesToPurge []string, appName string, explicitVolumes bool) error {
 	changer := &adamChanger{}
-	ctrl, dev, err := changer.getControllerAndDev()
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return fmt.Errorf("getControllerAndDev: %w", err)
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	for _, el := range dev.GetApplicationInstances() {
 		app, err := ctrl.GetApplicationInstanceConfig(el)
@@ -252,11 +252,11 @@ func PodPurge(volumesToPurge []string, appName string, explicitVolumes bool) err
 	return nil
 }
 
-func PodRestart(appName string) error {
+func (openEVEC *OpenEVEC) PodRestart(appName string) error {
 	changer := &adamChanger{}
-	ctrl, dev, err := changer.getControllerAndDev()
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return fmt.Errorf("getControllerAndDev: %w", err)
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	for _, el := range dev.GetApplicationInstances() {
 		app, err := ctrl.GetApplicationInstanceConfig(el)
@@ -279,11 +279,11 @@ func PodRestart(appName string) error {
 	return nil
 }
 
-func PodStart(appName string) error {
+func (openEVEC *OpenEVEC) PodStart(appName string) error {
 	changer := &adamChanger{}
-	ctrl, dev, err := changer.getControllerAndDev()
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return fmt.Errorf("getControllerAndDev: %w", err)
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	for _, el := range dev.GetApplicationInstances() {
 		app, err := ctrl.GetApplicationInstanceConfig(el)
@@ -303,11 +303,11 @@ func PodStart(appName string) error {
 	return nil
 }
 
-func PodDelete(appName string, deleteVolumes bool) (bool, error) {
+func (openEVEC *OpenEVEC) PodDelete(appName string, deleteVolumes bool) (bool, error) {
 	changer := &adamChanger{}
-	ctrl, dev, err := changer.getControllerAndDev()
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return false, fmt.Errorf("getControllerAndDev: %w", err)
+		return false, fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	for id, el := range dev.GetApplicationInstances() {
 		app, err := ctrl.GetApplicationInstanceConfig(el)
@@ -346,11 +346,11 @@ func PodDelete(appName string, deleteVolumes bool) (bool, error) {
 	return false, nil
 }
 
-func PodLogs(appName string, outputTail uint, outputFields []string, outputFormat types.OutputFormat) error {
+func (openEVEC *OpenEVEC) PodLogs(appName string, outputTail uint, outputFields []string, outputFormat types.OutputFormat) error {
 	changer := &adamChanger{}
-	ctrl, dev, err := changer.getControllerAndDev()
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return fmt.Errorf("getControllerAndDev: %w", err)
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	for _, el := range dev.GetApplicationInstances() {
 		app, err := ctrl.GetApplicationInstanceConfig(el)
@@ -467,11 +467,11 @@ func PodLogs(appName string, outputTail uint, outputFields []string, outputForma
 	return nil
 }
 
-func PodModify(appName string, podNetworks, portPublish, acl, vlans []string, startDelay uint32, cfg *EdenSetupArgs) error {
+func (openEVEC *OpenEVEC) PodModify(appName string, podNetworks, portPublish, acl, vlans []string, startDelay uint32) error {
 	changer := &adamChanger{}
-	ctrl, dev, err := changer.getControllerAndDev()
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
-		return fmt.Errorf("getControllerAndDev: %w", err)
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
 	}
 	for _, appID := range dev.GetApplicationInstances() {
 		app, err := ctrl.GetApplicationInstanceConfig(appID)
@@ -597,7 +597,7 @@ func diskToStruct(path string) (*edgeRegistry.Disk, error) {
 	}, nil
 }
 
-func PodPublish(appName, kernelFile, initrdFile, rootFile, formatStr, arch string, local bool, disks []string, cfg *EdenSetupArgs) error {
+func (openEVEC *OpenEVEC) PodPublish(appName, kernelFile, initrdFile, rootFile, formatStr, arch string, local bool, disks []string) error {
 	var (
 		rootDisk     *edgeRegistry.Disk
 		kernelSource *edgeRegistry.FileSource
@@ -605,6 +605,7 @@ func PodPublish(appName, kernelFile, initrdFile, rootFile, formatStr, arch strin
 		remoteTarget resolver.ResolverCloser
 		err          error
 	)
+	cfg := openEVEC.cfg
 	ctx := context.TODO()
 	if local {
 		_, remoteTarget, err = utils.NewRegistryHTTP(ctx)

--- a/pkg/openevec/registry.go
+++ b/pkg/openevec/registry.go
@@ -9,7 +9,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func RegistryStart(cfg *RegistryConfig) error {
+func (openEVEC *OpenEVEC) RegistryStart() error {
+	cfg := openEVEC.cfg.Registry
 	command, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("cannot obtain executable path: %w", err)
@@ -22,7 +23,8 @@ func RegistryStart(cfg *RegistryConfig) error {
 	return nil
 }
 
-func RegistryLoad(ref string, cfg *RegistryConfig) error {
+func (openEVEC *OpenEVEC) RegistryLoad(ref string) error {
+	cfg := openEVEC.cfg.Registry
 	registry := fmt.Sprintf("%s:%d", cfg.IP, cfg.Port)
 	hash, err := utils.LoadRegistry(ref, registry)
 	if err != nil {

--- a/pkg/openevec/start.go
+++ b/pkg/openevec/start.go
@@ -9,7 +9,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-func StartAdam(cfg EdenSetupArgs) error {
+func (openEVEC *OpenEVEC) StartAdam() error {
+	cfg := openEVEC.cfg
 	command, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("startAdam: cannot obtain executable path: %w", err)
@@ -36,7 +37,7 @@ func stopAdam(_ string) error {
 	return nil
 }
 
-func GetAdamStatus() (string, error) {
+func (openEVEC *OpenEVEC) GetAdamStatus() (string, error) {
 	statusAdam, err := eden.StatusAdam()
 	if err != nil {
 		return "", fmt.Errorf("cannot obtain status of adam: %w", err)
@@ -45,7 +46,8 @@ func GetAdamStatus() (string, error) {
 	}
 }
 
-func StartRedis(cfg EdenSetupArgs) error {
+func (openEVEC *OpenEVEC) StartRedis() error {
+	cfg := openEVEC.cfg
 	if err := eden.StartRedis(cfg.Redis.Port, cfg.Adam.Redis.Dist, cfg.Redis.Force, cfg.Redis.Tag); err != nil {
 		return fmt.Errorf("cannot start redis: %w", err)
 	}
@@ -53,7 +55,8 @@ func StartRedis(cfg EdenSetupArgs) error {
 	return nil
 }
 
-func StartRegistry(cfg EdenSetupArgs) error {
+func (openEVEC *OpenEVEC) StartRegistry() error {
+	cfg := openEVEC.cfg
 	if err := eden.StartRegistry(cfg.Registry.Port, cfg.Registry.Tag, cfg.Registry.Dist); err != nil {
 		return fmt.Errorf("cannot start registry: %w", err)
 	}
@@ -61,7 +64,8 @@ func StartRegistry(cfg EdenSetupArgs) error {
 	return nil
 }
 
-func StartEServer(cfg EdenSetupArgs) error {
+func (openEVEC *OpenEVEC) StartEServer() error {
+	cfg := openEVEC.cfg
 	if err := eden.StartEServer(cfg.Eden.EServer.Port, cfg.Eden.Images.EServerImageDist, cfg.Eden.EServer.Force, cfg.Eden.EServer.Tag); err != nil {
 		return fmt.Errorf("cannot start eserver: %w", err)
 	}
@@ -69,25 +73,25 @@ func StartEServer(cfg EdenSetupArgs) error {
 	return nil
 }
 
-func StartEden(cfg *EdenSetupArgs, vmName, zedControlURL, tapInterface string) error {
-
+func (openEVEC *OpenEVEC) StartEden(vmName, zedControlURL, tapInterface string) error {
+	cfg := openEVEC.cfg
 	// Note that custom installer only works with zedcloud controller.
 	useZedcloud := cfg.Eve.CustomInstaller.Path != "" || zedControlURL != ""
 
 	if !useZedcloud {
-		if err := StartRedis(*cfg); err != nil {
+		if err := openEVEC.StartRedis(); err != nil {
 			return fmt.Errorf("cannot start redis %w", err)
 		}
 
-		if err := StartAdam(*cfg); err != nil {
+		if err := openEVEC.StartAdam(); err != nil {
 			return fmt.Errorf("cannot start adam %w", err)
 		}
 
-		if err := StartRegistry(*cfg); err != nil {
+		if err := openEVEC.StartRegistry(); err != nil {
 			return fmt.Errorf("cannot start registry %w", err)
 		}
 
-		if err := StartEServer(*cfg); err != nil {
+		if err := openEVEC.StartEServer(); err != nil {
 			return fmt.Errorf("cannot start adam %w", err)
 		}
 	}
@@ -96,7 +100,7 @@ func StartEden(cfg *EdenSetupArgs, vmName, zedControlURL, tapInterface string) e
 		return nil
 	}
 
-	if err := StartEve(vmName, tapInterface, cfg); err != nil {
+	if err := openEVEC.StartEve(vmName, tapInterface); err != nil {
 		return fmt.Errorf("cannot start eve %w", err)
 	}
 	log.Infof("EVE is starting")

--- a/pkg/openevec/test.go
+++ b/pkg/openevec/test.go
@@ -44,7 +44,7 @@ func InitVarsFromConfig(cfg *EdenSetupArgs) (*utils.ConfigVars, error) {
 	cv.AdamIP = cfg.Adam.CertsIP
 	cv.AdamPort = strconv.Itoa(cfg.Adam.Port)
 	cv.AdamDomain = cfg.Adam.CertsDomain
-	cv.AdamDir = cfg.Adam.Dist
+	cv.AdamDir = utils.ResolveAbsPath(cfg.Adam.Dist)
 	cv.AdamCA = caCertPath
 	cv.AdamRedisURLEden = cfg.Adam.Redis.RemoteURL
 	cv.AdamRemote = cfg.Adam.Remote.Enabled
@@ -53,17 +53,17 @@ func InitVarsFromConfig(cfg *EdenSetupArgs) (*utils.ConfigVars, error) {
 	cv.AdamCachingPrefix = cfg.Adam.Caching.Prefix
 	cv.AdamCachingRedis = cfg.Adam.Caching.Redis
 
-	cv.SSHKey = cfg.Eden.SSHKey
+	cv.SSHKey = utils.ResolveAbsPath(cfg.Eden.SSHKey)
 	cv.EdenBinDir = cfg.Eden.BinDir
 	cv.EdenProg = cfg.Eden.EdenBin
 	cv.TestProg = cfg.Eden.TestBin
 	cv.TestScenario = cfg.Eden.TestScenario
-	cv.EServerImageDist = cfg.Eden.Images.EServerImageDist
+	cv.EServerImageDist = utils.ResolveAbsPath(cfg.Eden.Images.EServerImageDist)
 	cv.EServerPort = strconv.Itoa(cfg.Eden.EServer.Port)
 	cv.EServerIP = cfg.Eden.EServer.IP
 
-	cv.EveCert = cfg.Eve.Cert
-	cv.EveDeviceCert = cfg.Eve.DeviceCert
+	cv.EveCert = utils.ResolveAbsPath(cfg.Eve.Cert)
+	cv.EveDeviceCert = utils.ResolveAbsPath(cfg.Eve.DeviceCert)
 	cv.EveSerial = cfg.Eve.Serial
 	cv.EveDist = cfg.Eve.Dist
 	cv.EveQemuConfig = cfg.Eve.QemuFileToSave

--- a/pkg/openevec/utils.go
+++ b/pkg/openevec/utils.go
@@ -25,7 +25,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func DownloadEve(cfg *EdenSetupArgs) error {
+func (openEVEC *OpenEVEC) DownloadEve() error {
+	cfg := openEVEC.cfg
 	model, err := models.GetDevModelByName(cfg.Eve.DevModel)
 	if err != nil {
 		return fmt.Errorf("GetDevModelByName: %w", err)
@@ -51,7 +52,7 @@ func DownloadEve(cfg *EdenSetupArgs) error {
 	return nil
 }
 
-func OciImage(fileToSave, image, registry string, isLocal bool) error {
+func (openEVEC *OpenEVEC) OciImage(fileToSave, image, registry string, isLocal bool) error {
 	var imageManifest []byte
 	var err error
 	ref, err := name.ParseReference(image)
@@ -202,7 +203,7 @@ func DockerHashFromManifest(imageManifest []byte) (string, error) {
 	return layers[len(layers)-1].Digest.Hex, nil
 }
 
-func SDInfoEve(devicePath, syslogOutput, eveReleaseOutput string) error {
+func (openEVEC *OpenEVEC) SDInfoEve(devicePath, syslogOutput, eveReleaseOutput string) error {
 	eveInfo, err := eden.GetInfoFromSDCard(devicePath)
 	if err != nil {
 		log.Info("Check is EVE on SD and your access to read SD")
@@ -227,7 +228,7 @@ func SDInfoEve(devicePath, syslogOutput, eveReleaseOutput string) error {
 	return nil
 }
 
-func UploadGit(absPath, object, branch, directoryToSave string) error {
+func (openEVEC *OpenEVEC) UploadGit(absPath, object, branch, directoryToSave string) error {
 	commandToRun := fmt.Sprintf("-i /in/%s -o %s -b %s -d %s git",
 		filepath.Base(absPath), object, branch, directoryToSave)
 	image := fmt.Sprintf("%s:%s", defaults.DefaultProcContainerRef, defaults.DefaultProcTag)


### PR DESCRIPTION
To use the same semantic in openevec we should use the same base type.
Also we use novel changers to load config directly to be able to load config directly from openevec.