### PR TITLE
Switch to new workflows

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -34,7 +34,7 @@ runs:
     - name: Install Packages
       run: |
         sudo add-apt-repository ppa:stefanberger/swtpm-jammy
-        sudo apt install -y qemu-utils qemu-system-x86 jq swtpm
+        sudo apt install -y qemu-utils qemu-system-x86 jq swtpm util-linux
       shell: bash
     - name: Build tests
       run: |
@@ -44,7 +44,11 @@ runs:
     - name: Configure
       run: |
         ./eden config add default
-        ./eden config set default --key=eve.accel --value=false
+        if lscpu | grep -oEq "vmx|svm"; then
+          ./eden config set default --key=eve.accel --value=true
+        else
+          ./eden config set default --key=eve.accel --value=false
+        fi
         ./eden config set default --key=eve.tpm --value=${{ inputs.tpm_enabled }}
         ./eden config set default --key=eve.cpu --value=2
       shell: bash

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -50,13 +50,17 @@ runs:
       shell: bash
       working-directory: "./eden"
     - name: Setup eve version
-      if: ${{ inputs.eve_image != '' }} and contains(${{ inputs.eve_image }}, ":" )
       run: |
         image=${{ inputs.eve_image }}
-        eve_pr_registry=$(echo "$image" |  cut -d ':' -f 1)
-        eve_pr=$(echo "$image" |  cut -d ':' -f 2 | cut -d "-" -f1)
-        ./eden config set default --key=eve.registry --value="$eve_pr_registry"
-        ./eden config set default --key=eve.tag --value="$eve_pr"
+        if [[ -n "$image" && "$image" == *:* ]]; then
+          echo "Setting up eve image ${image}"
+          eve_pr_registry=$(echo "$image" |  cut -d ':' -f 1)
+          eve_pr=$(echo "$image" |  cut -d ':' -f 2 | cut -d "-" -f1)
+          ./eden config set default --key=eve.registry --value="$eve_pr_registry"
+          ./eden config set default --key=eve.tag --value="$eve_pr"
+        else
+          echo "Skipping setting up eve image ${image}"
+        fi
       shell: bash
       working-directory: "./eden"
     - name: Setup ext4

--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -1,105 +1,19 @@
 ---
 name: Eden
-on:  # yamllint disable-line rule:truthy
+on: # yamllint disable-line rule:truthy
   pull_request:
     branches: [master]
+    paths-ignore:
+      - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  integration:
-    name: Integration test (tpm=${{ matrix.tpm }};${{ matrix.fs }})
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        tpm: ["true", "false"]
-        fs: ["zfs", "ext4"]
-    steps:
-      - name: get eden
-        uses: actions/checkout@v3
-      - name: setup go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.18'
-      - name: Check
-        run: |
-          for addr in $(ip addr list|sed -En -e 's/.*inet ([0-9.]+).*/\1/p')
-          do
-              if echo "$addr" | grep -q -E "10.11.(12|13).[0-9]+"; then
-                echo "$addr overlaps with test"; exit 1
-              fi
-          done
-          sudo df -h
-          sudo swapoff -a
-          sudo free
-      - name: setup
-        run: |
-          sudo add-apt-repository ppa:stefanberger/swtpm-jammy
-          sudo apt install -y qemu-utils qemu-system-x86 jq swtpm
-      - name: build eden
-        run: |
-          make build-tests
-      - name: configure
-        run: |
-          ./eden config add default
-          ./eden config set default --key=eve.accel --value=false
-          ./eden config set default --key=eve.tpm --value=${{ matrix.tpm }}
-          ./eden config set default --key=eve.cpu --value=2
-      - name: setup-ext4
-        if: matrix.fs == 'ext4'
-        run: ./eden setup -v debug
-      - name: setup-zfs
-        if: matrix.fs == 'zfs'
-        run: |
-          ./eden config set default --key=eve.disks --value=4
-          ./eden config set default --key=eve.disk --value=4096
-          ./eden setup -v debug --grub-options='set_global dom0_extra_args "$dom0_extra_args eve_install_zfs_with_raid_level "'
-      - name: clean-docker
-        run: docker system prune -f -a
-      - name: run
-        run: EDEN_TEST_STOP=n ./eden test ./tests/workflow -v debug
-      - name: Collect info
-        if: ${{ failure() }}
-        uses: ./.github/actions/collect-info
-        with:
-          working-directory: ${{ github.workspace }}
-      - name: Collect logs
-        if: ${{ always() }}
-        run: |
-          ./eden log --format json > trace.log || echo "no log"
-          ./eden info --format json > info.log || echo "no info"
-          ./eden metric --format json > metric.log || echo "no metric"
-          ./eden netstat --format json > netstat.log || echo "no netstat"
-          cp dist/default-eve.log console.log || echo "no device log"
-          docker logs eden_adam > adam.log 2>&1 || echo "no adam log"
-      - name: Log counting
-        if: ${{ always() }}
-        run: |
-          echo "::group::Total errors"
-          echo "$(jq '.severity' trace.log|grep err|wc -l)"
-          echo "::endgroup::"
-          echo "::group::Errors by source"
-          echo "errors by source: $(jq -s 'map(select(.severity|contains("err")))|group_by(.source)|map({"source": .[0].source, "total":length})|sort_by(.total)|reverse[]' trace.log)"
-          echo "::endgroup::"
-          echo "::group::Error log content duplicates"
-          echo "$(jq -s 'map(select(.severity | contains("err")))|group_by(.content)|map(select(length>1))' trace.log)"
-          echo "::endgroup::"
-          echo "::group::Error log function filename duplicates"
-          echo "$(jq -s 'map(select(.severity | contains("err")))|group_by(.filename)|map(select(length>10))|map({"source": .[0].source, "filename": .[0].filename, "function": .[0].function, "content": [.[].content], "total":length})|sort_by(.total)| reverse[]' trace.log)"
-          echo "::endgroup::"
-          echo "::group::Segfaults"
-          echo "$(jq -s 'map(select(.content | contains("segfault at")))' trace.log)"|tee segfaults.log
-          [ "$(jq length segfaults.log)" -gt 0 ] && echo "::warning::segfaults found, you can see them in Log counting->Segfaults section"
-          echo "::endgroup::"
-      - name: Store raw test results
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: eden-report-tpm-${{ matrix.tpm }}-${{ matrix.fs }}
-          path: |
-              ${{ github.workspace }}/eve-info.tar.gz
-              ${{ github.workspace }}/trace.log
-              ${{ github.workspace }}/info.log
-              ${{ github.workspace }}/metric.log
-              ${{ github.workspace }}/netstat.log
-              ${{ github.workspace }}/console.log
-              ${{ github.workspace }}/adam.log
+  run_tests:
+    name: Execute Eden test workflow
+    uses: ./.github/workflows/test.yml
+    with:
+      eve_image: "lfedge/eve:10.11.0"
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,18 +6,26 @@ on:
     inputs:
       eve_image:
         type: string
-      runner:
-        type: string
-        default: buildjet-4vcpu-ubuntu-2204
   workflow_call:
     inputs:
       eve_image:
         type: string
-      runner:
-        type: string
-        default: buildjet-4vcpu-ubuntu-2204
 
 jobs:
+  determine-runner:
+    name: Determine best available runner
+    runs-on: ubuntu-latest
+    outputs:
+      runner: ${{ steps.fork-check.outputs.runner }}
+    steps:
+      - id: fork-check
+        run: |
+          if [[ "${{ github.event.repository.full_name}}" == "lf-edge/eve" ]] || [[ "${{ github.event.repository.full_name}}" == "lf-edge/eden" ]]; then
+            echo "runner=buildjet-4vcpu-ubuntu-2204" >> "$GITHUB_OUTPUT"
+          else
+            echo "runner=ubuntu-22.04" >> "$GITHUB_OUTPUT"
+          fi
+
   smoke:
     continue-on-error: true
     strategy:
@@ -25,7 +33,8 @@ jobs:
         file_system: ['ext4', 'zfs']
         tpm: [true, false]
     name: Smoke tests
-    runs-on: ${{ inputs.runner }}
+    needs: determine-runner
+    runs-on: ${{ needs.determine-runner.outputs.runner }}
     steps:
       - name: Get code
         uses: actions/checkout@v3.5.3
@@ -42,8 +51,8 @@ jobs:
 
   networking:
     name: Networking test suite
-    needs: smoke
-    runs-on: ${{ inputs.runner }}
+    needs: [smoke, determine-runner]
+    runs-on: ${{ needs.determine-runner.outputs.runner }}
     steps:
       - name: Get code
         uses: actions/checkout@v3.5.3
@@ -64,8 +73,8 @@ jobs:
       matrix:
         file_system: ['ext4', 'zfs']
     name: Storage test suite
-    needs: smoke
-    runs-on: ${{ inputs.runner }}
+    needs: [smoke, determine-runner]
+    runs-on: ${{ needs.determine-runner.outputs.runner }}
     steps:
       - name: Get code
         uses: actions/checkout@v3.5.3
@@ -82,8 +91,8 @@ jobs:
 
   lpc-loc:
     name: LPC LOC test suite
-    needs: smoke
-    runs-on: ${{ inputs.runner }}
+    needs: [smoke, determine-runner]
+    runs-on: ${{ needs.determine-runner.outputs.runner }}
     steps:
       - name: Get code
         uses: actions/checkout@v3.5.3
@@ -104,8 +113,8 @@ jobs:
       matrix:
         file_system: ['ext4', 'zfs']
     name: EVE upgrade test suite
-    needs: smoke
-    runs-on: ${{ inputs.runner }}
+    needs: [smoke, determine-runner]
+    runs-on: ${{ needs.determine-runner.outputs.runner }}
     steps:
       - name: Get code
         uses: actions/checkout@v3.5.3
@@ -122,8 +131,8 @@ jobs:
 
   user-apps:
     name: User apps test suite
-    needs: smoke
-    runs-on: ${{ inputs.runner }}
+    needs: [smoke, determine-runner]
+    runs-on: ${{ needs.determine-runner.outputs.runner }}
     steps:
       - name: Get code
         uses: actions/checkout@v3.5.3

--- a/tests/vnc/testdata/vnc_test.txt
+++ b/tests/vnc/testdata/vnc_test.txt
@@ -1,3 +1,7 @@
+exec -t 2m bash check_vm_support.sh
+source .env
+[!env:with_hw_virt] skip 'Missing HW-assisted virtualization capability'
+
 {{$test_opts := "-test.v -name vnc-app"}}
 
 # Starting of reboot detector with a 1 reboot limit
@@ -18,6 +22,23 @@ stdout '--- PASS: TestAppLogs'
 #TestVNCVMDelete initiates deleting of app and checks if app deleted from EVE
 test eden.vnc.test {{$test_opts}} -timewait 10m -test.run TestVNCVMDelete
 stdout '--- PASS: TestVNCVMDelete'
+
+-- check_vm_support.sh --
+#!/bin/sh
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+:>.env
+while true;
+do
+    virt=$($EDEN info --out InfoContent.dinfo.Capabilities.HWAssistedVirtualization | tail -n 1)
+    if [ -z "$virt" ]; then
+        sleep 3
+        continue
+    fi
+    [ "$virt" == "true" ] && echo "with_hw_virt=true" >>.env
+    break
+done
 
 # Test's config. file
 -- eden-config.yml --


### PR DESCRIPTION
Following work done to split eden test workflows in https://github.com/lf-edge/eden/issues/863 and integration
of this workflows in EVE repository, this commit switches to use new
workflows in eden itself

Also, new workflows are running on Buildjet runners, however, they
are not available in personal forks and it is useful to run test.yml
in fork, that is why this commit introduces determine-runner job,
which checks if we are in fork and changes runner to ubuntu-2204 which
is available everywhere