### PR TITLE
Revert "pkg: defaults: Workaround to fix QEMU's MSR errors"

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -123,7 +123,7 @@ const (
 	DefaultAdamLogLevel = "warning" //min level of logs sent from EVE to Adam
 
 	DefaultQemuAccelDarwin     = "-machine q35,accel=hvf -cpu kvm64,kvmclock=off "
-	DefaultQemuAccelLinuxAmd64 = "-machine q35,accel=kvm,dump-guest-core=off,kernel-irqchip=split -cpu host,-vmx-true-ctls,-vmx-secondary-ctls,invtsc=on,kvmclock=off -device intel-iommu,intremap=on,caching-mode=on,aw-bits=48 "
+	DefaultQemuAccelLinuxAmd64 = "-machine q35,accel=kvm,dump-guest-core=off,kernel-irqchip=split -cpu host,invtsc=on,kvmclock=off -device intel-iommu,intremap=on,caching-mode=on,aw-bits=48 "
 	DefaultQemuAmd64           = "-machine q35,smm=on --cpu SandyBridge "
 
 	DefaultQemuAccelArm64 = "-machine virt,accel=kvm,usb=off,dump-guest-core=off -cpu host "


### PR DESCRIPTION
This reverts commit 72eb8206f5987c544fec30d5dc33bb5df4076eb5.

It seems this workaround is no longer required on newer systems and it's causing a new error:

KVM: entry failed, hardware error 0x80000021

Removing the workaround solves this issue and it also works with kernel 5.10.186.