### PR TITLE
Removing Viper bindings from openEVEC: template parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/mcuadros/go-lookup v0.0.0-20200831155250-80f87a4fa5ee
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
 	github.com/nerd2/gexto v0.0.0-20190529073929-39468ec063f6
+	github.com/onsi/gomega v1.19.0
 	github.com/packethost/packngo v0.25.0
 	github.com/rogpeppe/go-internal v1.6.2
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b

--- a/go.sum
+++ b/go.sum
@@ -1018,6 +1018,7 @@ github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1ls
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
+github.com/onsi/ginkgo/v2 v2.1.3 h1:e/3Cwtogj0HA+25nMP1jCMDIf8RtRYbGwGGuBIFztkc=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -1029,6 +1030,7 @@ github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDs
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
+github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=

--- a/pkg/openevec/eden.go
+++ b/pkg/openevec/eden.go
@@ -35,22 +35,6 @@ import (
 	"golang.org/x/term"
 )
 
-func generateScripts(in string, out string, configFile string) error {
-	tmpl, err := os.ReadFile(in)
-	if err != nil {
-		return err
-	}
-	script, err := utils.RenderTemplate(configFile, string(tmpl))
-	if err != nil {
-		return err
-	}
-	err = os.WriteFile(out, []byte(script), 0644)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 func (openEVEC *OpenEVEC) SetupEden(configName, configDir, softSerial, zedControlURL, ipxeOverride string, grubOptions []string, netboot, installer bool) error {
 
 	cfg := *openEVEC.cfg

--- a/pkg/openevec/eden_test.go
+++ b/pkg/openevec/eden_test.go
@@ -1,0 +1,46 @@
+package openevec_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/lf-edge/eden/pkg/openevec"
+	. "github.com/onsi/gomega"
+)
+
+func TestParseTemplateFile(t *testing.T) {
+	t.Parallel()
+
+	g := NewGomegaWithT(t)
+
+	var buf bytes.Buffer
+
+	f, err := os.CreateTemp("", "template.*.tmpl")
+	if err != nil {
+		t.Errorf("CreateTemp failed %v", err)
+		return
+	}
+	defer f.Close()
+
+	const tmpl = "{{.Eden.Root}} {{.Eden.BinDir}}"
+	_, err = f.Write([]byte(tmpl))
+	g.Expect(err).To(BeNil())
+
+	const rootVal = "rv"
+	const binDirVal = "bdv"
+	cfg := openevec.EdenSetupArgs{
+		Eden: openevec.EdenConfig{
+			Root:   rootVal,
+			BinDir: binDirVal,
+		},
+	}
+
+	if err = openevec.ParseTemplateFile(f.Name(), cfg, &buf); err != nil {
+		t.Errorf("parseTemplateFile failed: %v", err)
+		return
+	}
+
+	g.Expect(buf.String()).To(BeEquivalentTo(fmt.Sprintf("%s %s", rootVal, binDirVal)))
+}

--- a/shell-scripts/activate.csh.tmpl
+++ b/shell-scripts/activate.csh.tmpl
@@ -14,10 +14,10 @@ alias eden-config 'eden config delete \!:1; eden_config default'
 # Unset irrelevant variables.
 eden_deactivate nondestructive
 
-setenv EDEN_HOME "{{EdenConfig "eden.root"}}"
+setenv EDEN_HOME "{{.Eden.Root}}"
 
 set _OLD_EDEN_PATH="$PATH:q"
-setenv PATH "$EDEN_HOME/{{EdenConfig "eden.bin-dist"}}:$PATH:q"
+setenv PATH "{{.Eden.BinDir}}:$PATH:q"
 
 if ( $?EDEN_DISABLE_PROMPT ) then
     if ( $EDEN_DISABLE_PROMPT == "" ) then

--- a/shell-scripts/activate.sh.tmpl
+++ b/shell-scripts/activate.sh.tmpl
@@ -75,8 +75,8 @@ eden-config () {
 # unset irrelevant variables
 eden_deactivate nondestructive
 
-EDEN_HOME={{EdenConfig "eden.root"}}
-EDEN_BIN="$EDEN_HOME/{{EdenConfig "eden.bin-dist"}}"
+EDEN_HOME={{.Eden.Root}}
+EDEN_BIN={{.Eden.BinDir}}
 export EDEN_HOME
 
 _OLD_EDEN_PATH="$PATH"


### PR DESCRIPTION
This small PR is part of bigger agenda of removing viper bindings from openEVEC package. This bindings restrict us from using eden as library, since it assumes that there should be a configuration file for eve (and we want configuration file to be just a structure passed to openevec) 