### PR TITLE
Remove Viper from openEVEC EdenVolume

### DIFF
--- a/cmd/edenVolume.go
+++ b/cmd/edenVolume.go
@@ -3,14 +3,17 @@ package cmd
 import (
 	"github.com/dustin/go-humanize"
 	"github.com/lf-edge/eden/pkg/controller/types"
+	"github.com/lf-edge/eden/pkg/openevec"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/thediveo/enumflag"
 )
 
-func newVolumeCmd() *cobra.Command {
+func newVolumeCmd(configName, verbosity *string) *cobra.Command {
+	cfg := &openevec.EdenSetupArgs{}
 	var volumeCmd = &cobra.Command{
-		Use: "volume",
+		Use:               "volume",
+		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
 	}
 
 	groups := CommandGroups{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,7 +53,7 @@ func NewEdenCommand() *cobra.Command {
 				newUtilsCmd(&configName, &verbosity),
 				newControllerCmd(&configName, &verbosity),
 				newNetworkCmd(),
-				newVolumeCmd(),
+				newVolumeCmd(&configName, &verbosity),
 				newDisksCmd(),
 				newPacketCmd(&configName, &verbosity),
 				newRolCmd(&configName, &verbosity),

--- a/pkg/openevec/edenVolume.go
+++ b/pkg/openevec/edenVolume.go
@@ -14,7 +14,6 @@ import (
 	"github.com/lf-edge/eve/api/go/config"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 func (openEVEC *OpenEVEC) VolumeLs(outputFormat types.OutputFormat) error {
@@ -83,7 +82,7 @@ func (openEVEC *OpenEVEC) VolumeCreate(appLink, registry, diskSize, volumeName, 
 		registryToUse := registry
 		switch registry {
 		case "local":
-			registryToUse = fmt.Sprintf("%s:%d", viper.GetString("registry.ip"), viper.GetInt("registry.port"))
+			registryToUse = fmt.Sprintf("%s:%d", openEVEC.cfg.Registry.IP, openEVEC.cfg.Registry.Port)
 		case "remote":
 			registryToUse = ""
 		}


### PR DESCRIPTION
This is another PR to cleanup Viper usage in openevec package 