### PR TITLE
Remove Viper from EdgeNode

### DIFF
--- a/cmd/edenController.go
+++ b/cmd/edenController.go
@@ -29,8 +29,8 @@ func newControllerCmd(configName, verbosity *string) *cobra.Command {
 			Commands: []*cobra.Command{
 				newEdgeNodeReboot(controllerMode),
 				newEdgeNodeShutdown(controllerMode),
-				newEdgeNodeEVEImageUpdate(controllerMode, cfg),
-				newEdgeNodeEVEImageRemove(controllerMode, cfg),
+				newEdgeNodeEVEImageUpdate(controllerMode),
+				newEdgeNodeEVEImageRemove(controllerMode),
 				newEdgeNodeEVEImageUpdateRetry(controllerMode),
 				newEdgeNodeUpdate(controllerMode),
 				newEdgeNodeGetConfig(controllerMode),
@@ -96,7 +96,7 @@ func newEdgeNodeShutdown(controllerMode string) *cobra.Command {
 	return edgeNodeShutdown
 }
 
-func newEdgeNodeEVEImageUpdate(controllerMode string, cfg *openevec.EdenSetupArgs) *cobra.Command {
+func newEdgeNodeEVEImageUpdate(controllerMode string) *cobra.Command {
 	var baseOSVersion, registry string
 	var baseOSImageActivate, baseOSVDrive bool
 
@@ -121,7 +121,7 @@ func newEdgeNodeEVEImageUpdate(controllerMode string, cfg *openevec.EdenSetupArg
 	return edgeNodeEVEImageUpdate
 }
 
-func newEdgeNodeEVEImageRemove(controllerMode string, cfg *openevec.EdenSetupArgs) *cobra.Command {
+func newEdgeNodeEVEImageRemove(controllerMode string) *cobra.Command {
 	var baseOSVersion string
 
 	var edgeNodeEVEImageRemove = &cobra.Command{
@@ -131,7 +131,7 @@ func newEdgeNodeEVEImageRemove(controllerMode string, cfg *openevec.EdenSetupArg
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			baseOSImage := args[0]
-			if err := openEVEC.EdgeNodeEVEImageRemove(controllerMode, baseOSVersion, baseOSImage, cfg.Eden.Dist); err != nil {
+			if err := openEVEC.EdgeNodeEVEImageRemove(controllerMode, baseOSVersion, baseOSImage); err != nil {
 				log.Fatal(err)
 			}
 		},

--- a/pkg/openevec/edgeNode.go
+++ b/pkg/openevec/edgeNode.go
@@ -18,7 +18,6 @@ import (
 	"github.com/lf-edge/eden/pkg/utils"
 	"github.com/lf-edge/eve/api/go/config"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -74,7 +73,7 @@ func (openEVEC *OpenEVEC) EdgeNodeEVEImageUpdate(baseOSImage, baseOSVersion, reg
 	registryToUse := registry
 	switch registry {
 	case "local":
-		registryToUse = fmt.Sprintf("%s:%d", viper.GetString("registry.ip"), viper.GetInt("registry.port"))
+		registryToUse = fmt.Sprintf("%s:%d", openEVEC.cfg.Registry.IP, openEVEC.cfg.Registry.Port)
 	case "remote":
 		registryToUse = ""
 	}
@@ -138,7 +137,8 @@ func checkIsFileOrURL(pathToCheck string) (isFile bool, pathToRet string, err er
 	}
 }
 
-func (openEVEC *OpenEVEC) EdgeNodeEVEImageRemove(controllerMode, baseOSVersion, baseOSImage, edenDist string) error {
+func (openEVEC *OpenEVEC) EdgeNodeEVEImageRemove(controllerMode, baseOSVersion, baseOSImage string) error {
+	cfg := *openEVEC.cfg
 	isFile, baseOSImage, err := checkIsFileOrURL(baseOSImage)
 	if err != nil {
 		return fmt.Errorf("checkIsFileOrURL: %w", err)
@@ -153,10 +153,10 @@ func (openEVEC *OpenEVEC) EdgeNodeEVEImageRemove(controllerMode, baseOSVersion, 
 		r, _ := url.Parse(baseOSImage)
 		switch r.Scheme {
 		case "http", "https":
-			if err = os.MkdirAll(filepath.Join(edenDist, "tmp"), 0755); err != nil {
+			if err = os.MkdirAll(filepath.Join(cfg.Eden.Dist, "tmp"), 0755); err != nil {
 				return fmt.Errorf("cannot create dir for download image %w", err)
 			}
-			rootFsPath = filepath.Join(edenDist, "tmp", path.Base(r.Path))
+			rootFsPath = filepath.Join(cfg.Eden.Dist, "tmp", path.Base(r.Path))
 			defer os.Remove(rootFsPath)
 			if err := utils.DownloadFile(rootFsPath, baseOSImage); err != nil {
 				return fmt.Errorf("DownloadFile error: %w", err)


### PR DESCRIPTION
Another PR to remove Viper dependencies from openevec. This time edgeNode file 