### PR TITLE
Use checkout@3.5.3 version to pull correct code tag, not master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Get code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
         with:
           repository: "lf-edge/eden"
           path: "./eden"
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Get code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
         with:
           repository: "lf-edge/eden"
           path: "./eden"
@@ -68,7 +68,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Get code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
         with:
           repository: "lf-edge/eden"
           path: "./eden"
@@ -86,7 +86,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Get code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
         with:
           repository: "lf-edge/eden"
           path: "./eden"
@@ -108,7 +108,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Get code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
         with:
           repository: "lf-edge/eden"
           path: "./eden"
@@ -126,7 +126,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Get code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
         with:
           repository: "lf-edge/eden"
           path: "./eden"


### PR DESCRIPTION
Following on #910 we saw that EVE checks out Eden master code and not code from tag from yml file and if master fails tests are failing on EVE, which is undesirable

https://github.com/lf-edge/eve/actions/runs/6613253197/job/17960730583?pr=3516#step:2:474

Investigating it more turns out in version 3.5.3 of github checkout action behaviour is what we need. Check #909 for more info