### PR TITLE
Remove viper config serialization

### DIFF
--- a/cmd/edenConfig.go
+++ b/cmd/edenConfig.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eden/pkg/openevec"
@@ -10,7 +11,12 @@ import (
 )
 
 func newConfigCmd(configName, verbosity *string) *cobra.Command {
-	cfg := &openevec.EdenSetupArgs{}
+	currentPath, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cfg := openevec.GetDefaultConfig(currentPath)
 	var configCmd = &cobra.Command{
 		Use:               "config",
 		Short:             "work with config",
@@ -71,15 +77,15 @@ func newConfigAddCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 	configAddCmd.Flags().StringVar(&contextFile, "file", "", "file with config to add")
 	//not used in function
 	configAddCmd.Flags().StringVarP(&cfg.Eve.QemuFileToSave, "qemu-config", "", defaults.DefaultQemuFileToSave, "file to save config")
-	configAddCmd.Flags().IntVarP(&cfg.Eve.QemuCpus, "cpus", "", defaults.DefaultCpus, "cpus")
-	configAddCmd.Flags().IntVarP(&cfg.Eve.QemuMemory, "memory", "", defaults.DefaultMemory, "memory (MB)")
-	configAddCmd.Flags().StringSliceVarP(&cfg.Eve.QemuFirmware, "eve-firmware", "", nil, "firmware path")
-	configAddCmd.Flags().StringVarP(&cfg.Eve.QemuConfigPath, "config-part", "", "", "path for config drive")
-	configAddCmd.Flags().StringVarP(&cfg.Eve.QemuDTBPath, "dtb-part", "", "", "path for device tree drive (for arm)")
-	configAddCmd.Flags().StringToStringVarP(&cfg.Eve.HostFwd, "eve-hostfwd", "", defaults.DefaultQemuHostFwd, "port forward map")
-	configAddCmd.Flags().StringVar(&cfg.Eve.Ssid, "ssid", "", "set ssid of wifi for rpi")
-	configAddCmd.Flags().StringVar(&cfg.Eve.Arch, "arch", "", "arch of EVE (amd64 or arm64)")
-	configAddCmd.Flags().StringVar(&cfg.Eve.ModelFile, "devmodel-file", "", "File to use for overwrite of model defaults")
+	configAddCmd.Flags().IntVarP(&cfg.Eve.QemuCpus, "cpus", "", cfg.Eve.QemuCpus, "cpus")
+	configAddCmd.Flags().IntVarP(&cfg.Eve.QemuMemory, "memory", "", cfg.Eve.QemuMemory, "memory (MB)")
+	configAddCmd.Flags().StringSliceVarP(&cfg.Eve.QemuFirmware, "eve-firmware", "", cfg.Eve.QemuFirmware, "firmware path")
+	configAddCmd.Flags().StringVarP(&cfg.Eve.QemuConfigPath, "config-part", "", cfg.Eve.QemuConfigPath, "path for config drive")
+	configAddCmd.Flags().StringVarP(&cfg.Eve.QemuDTBPath, "dtb-part", "", cfg.Eve.QemuDTBPath, "path for device tree drive (for arm)")
+	configAddCmd.Flags().StringToStringVarP(&cfg.Eve.HostFwd, "eve-hostfwd", "", cfg.Eve.HostFwd, "port forward map")
+	configAddCmd.Flags().StringVar(&cfg.Eve.Ssid, "ssid", cfg.Eve.Ssid, "set ssid of wifi for rpi")
+	configAddCmd.Flags().StringVar(&cfg.Eve.Arch, "arch", cfg.Eve.Arch, "arch of EVE (amd64 or arm64)")
+	configAddCmd.Flags().StringVar(&cfg.Eve.ModelFile, "devmodel-file", cfg.Eve.ModelFile, "File to use for overwrite of model defaults")
 	configAddCmd.Flags().BoolVarP(&force, "force", "", false, "force overwrite config file")
 
 	return configAddCmd

--- a/cmd/edenTest.go
+++ b/cmd/edenTest.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eden/pkg/openevec"
-	"github.com/lf-edge/eden/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -42,7 +41,7 @@ test <test_dir> -r <regexp> [-t <timewait>] [-v <level>]
 				}
 			}
 
-			vars, err := utils.InitVars()
+			vars, err := openevec.InitVarsFromConfig(cfg)
 
 			if err != nil {
 				return fmt.Errorf("error reading config: %s\n", err)

--- a/pkg/controller/functions.go
+++ b/pkg/controller/functions.go
@@ -23,11 +23,7 @@ import (
 )
 
 // CloudPrepare is for init controller connection and obtain device list
-func CloudPrepare() (Cloud, error) {
-	vars, err := utils.InitVars()
-	if err != nil {
-		return nil, fmt.Errorf("utils.InitVars: %s", err)
-	}
+func CloudPrepare(vars *utils.ConfigVars) (Cloud, error) {
 	ctx := &CloudCtx{vars: vars, Controller: &adam.Ctx{}}
 	if err := ctx.InitWithVars(vars); err != nil {
 		return nil, fmt.Errorf("cloud.InitWithVars: %s", err)

--- a/pkg/openevec/changers.go
+++ b/pkg/openevec/changers.go
@@ -72,16 +72,13 @@ func (ctx *fileChanger) getControllerAndDevFromConfig(cfg *EdenSetupArgs) (contr
 	if _, err := os.Lstat(ctx.fileConfig); os.IsNotExist(err) {
 		return nil, nil, err
 	}
-	ctrl, err := controller.CloudPrepare()
+	vars, err := InitVarsFromConfig(cfg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("InitVarsFromConfig error: %w", err)
+	}
+	ctrl, err := controller.CloudPrepare(vars)
 	if err != nil {
 		return nil, nil, err
-	}
-	if cfg != nil {
-		vars, err := InitVarsFromConfig(cfg)
-		if err != nil {
-			return nil, nil, fmt.Errorf("InitVarsFromConfig error: %w", err)
-		}
-		ctrl.SetVars(vars)
 	}
 	data, err := os.ReadFile(ctx.fileConfig)
 	if err != nil {
@@ -108,8 +105,12 @@ type adamChanger struct {
 	adamURL string
 }
 
-func (ctx *adamChanger) getController() (controller.Cloud, error) {
-	ctrl, err := controller.CloudPrepare()
+func (ctx *adamChanger) getController(cfg *EdenSetupArgs) (controller.Cloud, error) {
+	vars, err := InitVarsFromConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("InitVarsFromConfig error: %w", err)
+	}
+	ctrl, err := controller.CloudPrepare(vars)
 	if err != nil {
 		return nil, fmt.Errorf("CloudPrepare error: %w", err)
 	}
@@ -117,7 +118,7 @@ func (ctx *adamChanger) getController() (controller.Cloud, error) {
 }
 
 func (ctx *adamChanger) getControllerAndDevFromConfig(cfg *EdenSetupArgs) (controller.Cloud, *device.Ctx, error) {
-	ctrl, err := ctx.getController()
+	ctrl, err := ctx.getController(cfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("getController error: %w", err)
 	}

--- a/pkg/openevec/changers.go
+++ b/pkg/openevec/changers.go
@@ -14,7 +14,6 @@ import (
 )
 
 type configChanger interface {
-	getControllerAndDev() (controller.Cloud, *device.Ctx, error)
 	getControllerAndDevFromConfig(cfg *EdenSetupArgs) (controller.Cloud, *device.Ctx, error)
 	setControllerAndDev(controller.Cloud, *device.Ctx) error
 }
@@ -45,10 +44,6 @@ func changerByControllerMode(controllerMode string) (configChanger, error) {
 		return nil, fmt.Errorf("not implemented type: %s", modeType)
 	}
 	return changer, nil
-}
-
-func (ctx *fileChanger) getControllerAndDev() (controller.Cloud, *device.Ctx, error) {
-	return ctx.getControllerAndDevFromConfig(nil)
 }
 
 func (ctx *fileChanger) setControllerAndDev(ctrl controller.Cloud, dev *device.Ctx) error {
@@ -119,18 +114,6 @@ func (ctx *adamChanger) getController() (controller.Cloud, error) {
 		return nil, fmt.Errorf("CloudPrepare error: %w", err)
 	}
 	return ctrl, nil
-}
-
-func (ctx *adamChanger) getControllerAndDev() (controller.Cloud, *device.Ctx, error) {
-	ctrl, err := ctx.getController()
-	if err != nil {
-		return nil, nil, fmt.Errorf("getController error: %w", err)
-	}
-	devFirst, err := ctrl.GetDeviceCurrent()
-	if err != nil {
-		return nil, nil, fmt.Errorf("GetDeviceCurrent error: %w", err)
-	}
-	return ctrl, devFirst, nil
 }
 
 func (ctx *adamChanger) getControllerAndDevFromConfig(cfg *EdenSetupArgs) (controller.Cloud, *device.Ctx, error) {

--- a/pkg/openevec/config.go
+++ b/pkg/openevec/config.go
@@ -22,6 +22,12 @@ type EServerConfig struct {
 	Tag    string       `mapstructure:"tag" cobraflag:"eserver-tag"`
 	IP     string       `mapstructure:"ip"`
 	Images ImagesConfig `mapstructure:"images"`
+	EVEIP  string       `mapstructure:"eve-ip"`
+}
+
+type EClientConfig struct {
+	Tag   string `mapstructure:"tag"`
+	Image string `mapstructure:"image"`
 }
 
 type ImagesConfig struct {
@@ -34,14 +40,16 @@ type EdenConfig struct {
 	CertsDir     string `mapstructure:"certs-dist" cobraflag:"certs-dist" resolvepath:""`
 	Dist         string `mapstructure:"dist"`
 	Root         string `mapstructure:"root"`
-	SSHKey       string `mapstructure:"ssh-key" cobraflag:"ssh-key" resolvepath:""`
+	SSHKey       string `mapstructure:"ssh-key" cobraflag:"ssh-key"`
 	EdenBin      string `mapstructure:"eden-bin"`
 	TestBin      string `mapstructure:"test-bin"`
 	TestScenario string `mapstructure:"test-scenario"`
+	Tests        string `mapstructure:"tests" resolvepath:""`
 
 	EServer EServerConfig `mapstructure:"eserver"`
 
-	Images ImagesConfig `mapstructure:"images"`
+	EClient EClientConfig `mapstructure:"eclient"`
+	Images  ImagesConfig  `mapstructure:"images"`
 }
 
 type RedisConfig struct {
@@ -74,6 +82,7 @@ type AdamConfig struct {
 	CertsEVEIP  string `mapstructure:"eve-ip" cobraflag:"eve-ip"`
 	APIv1       bool   `mapstructure:"v1" cobrafalg:"force"`
 	Force       bool   `mapstructure:"force" cobraflag:"force"`
+	CA          string `mapstructure:"ca"`
 
 	Redis   RedisConfig   `mapstructure:"redis"`
 	Remote  RemoteConfig  `mapstructure:"remote"`
@@ -95,7 +104,7 @@ type EveConfig struct {
 	QemuConfig      QemuConfig            `mapstructure:"qemu"`
 
 	QemuFirmware   []string          `mapstructure:"firmware" cobraflag:"eve-firmware"`
-	QemuConfigPath string            `mapstructure:"config-part" cobraflag:"config-path" resolvepath:""`
+	QemuConfigPath string            `mapstructure:"config-part" cobraflag:"config-path"`
 	QemuDTBPath    string            `mapstructure:"dtb-part" cobraflag:"dtb-part" resolvepath:""`
 	QemuOS         string            `mapstructure:"os" cobraflag:"eve-os"`
 	ImageFile      string            `mapstructure:"image-file" cobraflag:"image-file" resolvepath:""`
@@ -114,7 +123,6 @@ type EveConfig struct {
 	QemuMemory     int               `mapstructure:"ram" cobraflag:"memory"`
 	ImageSizeMB    int               `mapstructure:"disk" cobraflag:"image-size"`
 	DevModel       string            `mapstructure:"devmodel" cobraflag:"devmodel"`
-	DevModelFile   string            `mapstructure:"devmodelfile"`
 	Ssid           string            `mapstructure:"ssid" cobraflag:"ssid"`
 	Password       string            `mapstructure:"password" cobraflag:"password"`
 	Serial         string            `mapstructure:"serial" cobraflag:"eve-serial"`
@@ -153,7 +161,7 @@ type GcpConfig struct {
 }
 
 type SdnConfig struct {
-	ImageFile      string `mapstructure:"image-file" cobraflag:"sdn-image-file" resolvepath:""`
+	ImageFile      string `mapstructure:"image-file" cobraflag:"sdn-image-file"`
 	SourceDir      string `mapstructure:"source-dir" cobraflag:"sdn-source-dir" resolvepath:""`
 	RAM            int    `mapstructure:"ram" cobraflag:"sdn-ram"`
 	CPU            int    `mapstructure:"cpu" cobraflag:"sdn-cpu"`
@@ -180,6 +188,7 @@ type EdenSetupArgs struct {
 
 	ConfigFile string
 	ConfigName string
+	EdenDir    string
 }
 
 // PodConfig store configuration for Pod deployment

--- a/pkg/openevec/config_test.go
+++ b/pkg/openevec/config_test.go
@@ -1,0 +1,97 @@
+package openevec_test
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/lf-edge/eden/pkg/openevec"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/viper"
+)
+
+type NestedConfig struct {
+	NumField int `mapstructure:"numfield"`
+}
+
+type ServerConfig struct {
+	Field   string            `mapstructure:"field"`
+	Access  int               `mapstructure:"access"`
+	HostFwd map[string]string `mapstructure:"hostfwd"`
+
+	NestedField NestedConfig `mapstructure:"nested"`
+}
+
+type Config struct {
+	Names     []string `mapstructure:"names"`
+	IsSpecial bool     `mapstructure:"special"`
+
+	Server ServerConfig `mapstructure:"server"`
+}
+
+func TestViperSerializeFromWriteConfig(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	cfg := Config{
+		Names:     []string{"test1", "test2"},
+		IsSpecial: false,
+
+		Server: ServerConfig{
+			Field:  "ServerField",
+			Access: 42,
+
+			HostFwd: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+
+			NestedField: NestedConfig{
+				NumField: 21,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	openevec.WriteConfig(reflect.ValueOf(cfg), &buf, 0)
+
+	v := viper.New()
+	v.SetConfigType("yaml")
+	err := v.ReadConfig(&buf)
+	if err != nil {
+		t.Errorf("error reading config: %v", err)
+		return
+	}
+
+	// Unmarshal the configuration into the Config struct.
+	gotCfg := &Config{}
+	err = v.Unmarshal(&gotCfg)
+
+	g.Expect(*gotCfg).To(BeEquivalentTo(cfg))
+}
+
+func TestConfigSliceType(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	cfg := Config{
+		Names: []string{"test1", "test2"},
+	}
+
+	var buf bytes.Buffer
+	openevec.WriteConfig(reflect.ValueOf(cfg), &buf, 0)
+
+	v := viper.New()
+	v.SetConfigType("yaml")
+	err := v.ReadConfig(&buf)
+	if err != nil {
+		fmt.Println("error reading config:", err)
+		return
+	}
+
+	gotCfg := &Config{}
+	err = v.Unmarshal(&gotCfg)
+
+	g.Expect(reflect.TypeOf(cfg.Names[0]).Kind()).To(BeEquivalentTo(reflect.String))
+}

--- a/pkg/openevec/controller.go
+++ b/pkg/openevec/controller.go
@@ -1,5 +1,7 @@
 package openevec
 
+import "reflect"
+
 // OpenEVEC base type for all actions
 type OpenEVEC struct {
 	cfg *EdenSetupArgs
@@ -7,5 +9,6 @@ type OpenEVEC struct {
 
 // CreateOpenEVEC returns OpenEVEC instance
 func CreateOpenEVEC(cfg *EdenSetupArgs) *OpenEVEC {
+	resolvePath(cfg.Eden.Root, reflect.ValueOf(cfg).Elem())
 	return &OpenEVEC{cfg: cfg}
 }

--- a/pkg/openevec/defaults.go
+++ b/pkg/openevec/defaults.go
@@ -1,97 +1,222 @@
 package openevec
 
 import (
-	"log"
-	"os"
+	"fmt"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 
+	"github.com/dustin/go-humanize"
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eden/pkg/utils"
+	uuid "github.com/satori/go.uuid"
 )
 
-func GetDefaultConfig() *EdenSetupArgs {
+func GetDefaultConfig(currentPath string) *EdenSetupArgs {
 
-	currentPath, err := os.Getwd()
+	ip, err := utils.GetIPForDockerAccess()
 	if err != nil {
-		log.Fatal(err)
+		return nil
+	}
+
+	edenDir, err := utils.DefaultEdenDir()
+	if err != nil {
+		return nil
+	}
+
+	id, err := uuid.NewV4()
+	if err != nil {
+		return nil
+	}
+
+	imageDist := fmt.Sprintf("%s-%s", defaults.DefaultContext, defaults.DefaultImageDist)
+	certsDist := fmt.Sprintf("%s-%s", defaults.DefaultContext, defaults.DefaultCertsDist)
+
+	firmware := []string{filepath.Join(imageDist, "eve", "OVMF.fd")}
+	if runtime.GOARCH == "amd64" {
+		firmware = []string{
+			filepath.Join(imageDist, "eve", "OVMF_CODE.fd"),
+			filepath.Join(imageDist, "eve", "OVMF_VARS.fd")}
 	}
 
 	defaultEdenConfig := &EdenSetupArgs{
 		Eden: EdenConfig{
-			Download: true,
-			BinDir:   filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultBinDist),
-			SSHKey:   filepath.Join(currentPath, defaults.DefaultCertsDist, "id_rsa"),
+			Root:         filepath.Join(currentPath, defaults.DefaultDist),
+			Tests:        filepath.Join(currentPath, defaults.DefaultDist, "tests"),
+			Download:     true,
+			BinDir:       defaults.DefaultBinDist,
+			SSHKey:       fmt.Sprintf("%s-%s", defaults.DefaultContext, defaults.DefaultSSHKey),
+			CertsDir:     certsDist,
+			TestBin:      defaults.DefaultTestProg,
+			EdenBin:      "eden",
+			TestScenario: defaults.DefaultTestScenario,
+
+			Images: ImagesConfig{
+				EServerImageDist: defaults.DefaultEserverDist,
+			},
 
 			EServer: EServerConfig{
+				IP:    ip,
+				EVEIP: defaults.DefaultDomain,
+
 				Port:  defaults.DefaultEserverPort,
-				Force: false,
+				Force: true,
 				Tag:   defaults.DefaultEServerTag,
+			},
+
+			EClient: EClientConfig{
+				Tag:   defaults.DefaultEClientTag,
+				Image: defaults.DefaultEClientContainerRef,
 			},
 		},
 
 		Adam: AdamConfig{
-			Tag:        defaults.DefaultAdamTag,
-			Port:       defaults.DefaultAdamPort,
-			CertsIP:    defaults.DefaultIP,
-			CertsEVEIP: defaults.DefaultEVEIP,
+			Tag:         defaults.DefaultAdamTag,
+			Port:        defaults.DefaultAdamPort,
+			Dist:        defaults.DefaultAdamDist,
+			CertsDomain: defaults.DefaultDomain,
+			CertsIP:     ip,
+			CertsEVEIP:  ip,
+			Force:       true,
+			CA:          filepath.Join(certsDist, "root-certificate.pem"),
+			APIv1:       false,
 
 			Redis: RedisConfig{
-				Tag:  defaults.DefaultRedisTag,
-				Port: defaults.DefaultRedisPort,
+				RemoteURL: fmt.Sprintf("%s:%d", defaults.DefaultRedisContainerName, defaults.DefaultRedisPort),
+				Tag:       defaults.DefaultRedisTag,
+				Port:      defaults.DefaultRedisPort,
+				Eden:      fmt.Sprintf("%s:%d", ip, defaults.DefaultRedisPort),
+			},
+
+			Remote: RemoteConfig{
+				Enabled: true,
+				Redis:   true,
+			},
+
+			Caching: CachingConfig{
+				Enabled: false,
+				Redis:   false,
+				Prefix:  "cache",
 			},
 		},
 
 		Eve: EveConfig{
-			QemuConfig: QemuConfig{
-				MonitorPort:      defaults.DefaultQemuMonitorPort,
-				NetDevSocketPort: defaults.DefaultQemuNetdevSocketPort,
-			},
-			CertsUUID:      defaults.DefaultUUID,
-			Dist:           filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultEVEDist),
-			Repo:           defaults.DefaultEveRepo,
-			Registry:       defaults.DefaultEveRegistry,
-			Tag:            defaults.DefaultEVETag,
-			UefiTag:        defaults.DefaultEVETag,
-			HV:             defaults.DefaultEVEHV,
-			Arch:           runtime.GOARCH,
-			HostFwd:        defaults.DefaultQemuHostFwd,
+			Name:         strings.ToLower(defaults.DefaultContext),
+			DevModel:     defaults.DefaultQemuModel,
+			ModelFile:    "",
+			Arch:         runtime.GOARCH,
+			QemuOS:       runtime.GOOS,
+			Accel:        true,
+			HV:           defaults.DefaultEVEHV,
+			CertsUUID:    id.String(),
+			Cert:         filepath.Join(certsDist, "onboard.cert.pem"),
+			DeviceCert:   filepath.Join(certsDist, "device.cert.pem"),
+			QemuFirmware: firmware,
+			Dist:         fmt.Sprintf("%s-%s", defaults.DefaultContext, defaults.DefaultEVEDist),
+			Repo:         defaults.DefaultEveRepo,
+			Registry:     defaults.DefaultEveRegistry,
+			Tag:          defaults.DefaultEVETag,
+			UefiTag:      defaults.DefaultEVETag,
+			HostFwd: map[string]string{
+				strconv.Itoa(defaults.DefaultSSHPort): "22",
+				"5911":                                "5901",
+				"5912":                                "5902",
+				"8027":                                "8027",
+				"8028":                                "8028"},
 			QemuFileToSave: defaults.DefaultQemuFileToSave,
 			QemuCpus:       defaults.DefaultCpus,
 			QemuMemory:     defaults.DefaultMemory,
 			ImageSizeMB:    defaults.DefaultEVEImageSize,
-			DevModel:       defaults.DefaultQemuModel,
 			Serial:         defaults.DefaultEVESerial,
-			Pid:            filepath.Join(currentPath, defaults.DefaultDist),
-			Log:            filepath.Join(currentPath, defaults.DefaultDist),
+			Pid:            fmt.Sprintf("%s-eve.pid", strings.ToLower(defaults.DefaultContext)),
+			Log:            fmt.Sprintf("%s-eve.log", strings.ToLower(defaults.DefaultContext)),
 			TelnetPort:     defaults.DefaultTelnetPort,
 			TPM:            defaults.DefaultTPMEnabled,
+			ImageFile:      filepath.Join(imageDist, "eve", "live.img"),
+			QemuDTBPath:    "",
+			QemuConfigPath: certsDist,
+			Remote:         defaults.DefaultEVERemote,
+			RemoteAddr:     defaults.DefaultEVEHost,
+			LogLevel:       defaults.DefaultEveLogLevel,
+			AdamLogLevel:   defaults.DefaultAdamLogLevel,
+			Ssid:           "",
+			Disks:          defaults.DefaultAdditionalDisks,
+			BootstrapFile:  "",
+			UsbNetConfFile: "",
+			Platform:       "none",
+
+			CustomInstaller: CustomInstallerConfig{
+				Path:   "",
+				Format: "",
+			},
+
+			QemuConfig: QemuConfig{
+				MonitorPort:      defaults.DefaultQemuMonitorPort,
+				NetDevSocketPort: defaults.DefaultQemuNetdevSocketPort,
+			},
 		},
 
 		Redis: RedisConfig{
 			Tag:  defaults.DefaultRedisTag,
 			Port: defaults.DefaultRedisPort,
+			Dist: defaults.DefaultRedisDist,
 		},
 
 		Registry: RegistryConfig{
 			Tag:  defaults.DefaultRegistryTag,
 			Port: defaults.DefaultRegistryPort,
+			IP:   ip,
+			Dist: defaults.DefaultRegistryDist,
 		},
 
 		Sdn: SdnConfig{
 			RAM:            defaults.DefaultSdnMemory,
 			CPU:            defaults.DefaultSdnCpus,
 			ConsoleLogFile: filepath.Join(currentPath, defaults.DefaultDist, "sdn-console.log"),
-			Disable:        false,
+			Disable:        true,
 			TelnetPort:     defaults.DefaultSdnTelnetPort,
 			MgmtPort:       defaults.DefaultSdnMgmtPort,
 			PidFile:        filepath.Join(currentPath, defaults.DefaultDist, "sdn.pid"),
 			SSHPort:        defaults.DefaultSdnSSHPort,
+			SourceDir:      filepath.Join(currentPath, "sdn"),
+			ConfigDir:      filepath.Join(edenDir, fmt.Sprintf("%s-sdn", "default")),
+			ImageFile:      filepath.Join(imageDist, "eden", "sdn-efi.qcow2"),
+			LinuxkitBin:    filepath.Join(currentPath, defaults.DefaultBuildtoolsDir, "linuxkit"),
+			NetModelFile:   "",
+		},
+
+		Gcp: GcpConfig{
+			Key: "",
+		},
+
+		Packet: PacketConfig{
+			Key: "",
 		},
 
 		ConfigName: defaults.DefaultContext,
 		ConfigFile: utils.GetConfig(defaults.DefaultContext),
+		EdenDir:    edenDir,
 	}
 
 	return defaultEdenConfig
+}
+
+func GetDefaultPodConfig() *PodConfig {
+	dpc := &PodConfig{
+		AppMemory:         humanize.Bytes(defaults.DefaultAppMem * 1024),
+		DiskSize:          humanize.Bytes(0),
+		VolumeType:        "qcow2",
+		AppCpus:           defaults.DefaultAppCPU,
+		ACLOnlyHost:       false,
+		NoHyper:           false,
+		Registry:          "remote",
+		DirectLoad:        true,
+		SftpLoad:          false,
+		VolumeSize:        humanize.IBytes(defaults.DefaultVolumeSize),
+		OpenStackMetadata: false,
+		PinCpus:           false,
+	}
+
+	return dpc
 }

--- a/pkg/openevec/eden.go
+++ b/pkg/openevec/eden.go
@@ -535,10 +535,14 @@ func (openEVEC *OpenEVEC) cleanContext(vmName string, configSaved string) (err e
 	if err != nil {
 		return fmt.Errorf("CleanContext: %s", err)
 	}
+	vars, err := InitVarsFromConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("InitVarsFromConfig error: %w", err)
+	}
 
 	eveStatusFile := filepath.Join(edenDir, fmt.Sprintf("state-%s.yml", cfg.Eve.CertsUUID))
 	if _, err = os.Stat(eveStatusFile); !os.IsNotExist(err) {
-		ctrl, err := controller.CloudPrepare()
+		ctrl, err := controller.CloudPrepare(vars)
 		if err != nil {
 			return fmt.Errorf("CleanContext: error in CloudPrepare: %s", err)
 		}

--- a/pkg/openevec/eden.go
+++ b/pkg/openevec/eden.go
@@ -337,7 +337,7 @@ func setupEdenScripts(cfg EdenSetupArgs) error {
 		fmt.Printf("Directory %s access error: %s\n",
 			cfgDir, err)
 	} else {
-		shPath := viper.GetString("eden.root") + "/scripts/shell/"
+		shPath := cfg.Eden.Root + "/scripts/shell/"
 
 		activateShFile, err := os.Create(cfgDir + "activate.sh")
 		defer activateShFile.Close()

--- a/pkg/openevec/edenConfig.go
+++ b/pkg/openevec/edenConfig.go
@@ -26,34 +26,6 @@ func isEncodingNeeded(contextKeySet string) bool {
 	return false
 }
 
-func ReloadConfigDetails(cfg *EdenSetupArgs) error {
-	viperLoaded, err := utils.LoadConfigFile(cfg.ConfigFile)
-	if err != nil {
-		return fmt.Errorf("error reading config: %w", err)
-	}
-	if viperLoaded {
-		cfg.Eve.QemuFirmware = viper.GetStringSlice("eve.firmware")
-		cfg.Eve.QemuConfigPath = utils.ResolveAbsPath(viper.GetString("eve.config-part"))
-		cfg.Eve.QemuDTBPath = utils.ResolveAbsPath(viper.GetString("eve.dtb-part"))
-		cfg.Eve.ImageFile = utils.ResolveAbsPath(viper.GetString("eve.image-file"))
-		cfg.Eve.HostFwd = viper.GetStringMapString("eve.hostfwd")
-		cfg.Eve.QemuFileToSave = utils.ResolveAbsPath(viper.GetString("eve.qemu-config"))
-		cfg.Eve.DevModel = viper.GetString("eve.devmodel")
-		cfg.Eve.Remote = viper.GetBool("eve.remote")
-		cfg.Eve.ModelFile = viper.GetString("eve.devmodelfile")
-		if cfg.Eve.ModelFile != "" {
-			filePath, err := filepath.Abs(cfg.Eve.ModelFile)
-			if err != nil {
-				return fmt.Errorf("cannot get absolute path for devmodelfile (%s): %w", cfg.Eve.ModelFile, err)
-			}
-			if _, err := os.Stat(filePath); err != nil {
-				return fmt.Errorf("cannot parse devmodelfile (%s): %w", cfg.Eve.ModelFile, err)
-			}
-		}
-	}
-	return nil
-}
-
 func saveConfig(cfg *EdenSetupArgs) error {
 	if err := os.MkdirAll(filepath.Dir(cfg.ConfigFile), 0755); err != nil {
 		return fmt.Errorf("Error creating folders: %v", err)

--- a/pkg/openevec/edenConfig.go
+++ b/pkg/openevec/edenConfig.go
@@ -81,9 +81,6 @@ func ConfigAdd(cfg *EdenSetupArgs, currentContext, contextFile string, force boo
 		}
 		log.Infof("Config file generated: %s", cfg.ConfigFile)
 	}
-	if err := ReloadConfigDetails(cfg); err != nil {
-		return err
-	}
 
 	context, err := utils.ContextLoad()
 	if err != nil {

--- a/pkg/openevec/edgeNode.go
+++ b/pkg/openevec/edgeNode.go
@@ -273,15 +273,14 @@ func (openEVEC *OpenEVEC) EdgeNodeGetConfig(controllerMode, fileWithConfig strin
 }
 
 func (openEVEC *OpenEVEC) EdgeNodeSetConfig(fileWithConfig string) error {
-	ctrl, err := controller.CloudPrepare()
-	if err != nil {
-		return fmt.Errorf("CloudPrepare: %w", err)
-	}
 	vars, err := InitVarsFromConfig(openEVEC.cfg)
 	if err != nil {
 		return fmt.Errorf("InitVarsFromConfig error: %w", err)
 	}
-	ctrl.SetVars(vars)
+	ctrl, err := controller.CloudPrepare(vars)
+	if err != nil {
+		return fmt.Errorf("CloudPrepare: %w", err)
+	}
 	devFirst, err := ctrl.GetDeviceCurrent()
 	if err != nil {
 		return fmt.Errorf("GetDeviceCurrent error: %w", err)
@@ -382,15 +381,14 @@ func (openEVEC *OpenEVEC) EdgeNodeSetOptions(controllerMode, fileWithConfig stri
 }
 
 func (openEVEC *OpenEVEC) ControllerGetOptions(fileWithConfig string) error {
-	ctrl, err := controller.CloudPrepare()
-	if err != nil {
-		return fmt.Errorf("CloudPrepare error: %w", err)
-	}
 	vars, err := InitVarsFromConfig(openEVEC.cfg)
 	if err != nil {
 		return fmt.Errorf("InitVarsFromConfig error: %w", err)
 	}
-	ctrl.SetVars(vars)
+	ctrl, err := controller.CloudPrepare(vars)
+	if err != nil {
+		return fmt.Errorf("CloudPrepare error: %w", err)
+	}
 	res, err := ctrl.GetGlobalOptions()
 	if err != nil {
 		return fmt.Errorf("GetGlobalOptions error: %w", err)
@@ -410,15 +408,14 @@ func (openEVEC *OpenEVEC) ControllerGetOptions(fileWithConfig string) error {
 }
 
 func (openEVEC *OpenEVEC) ControllerSetOptions(fileWithConfig string) error {
-	ctrl, err := controller.CloudPrepare()
-	if err != nil {
-		return fmt.Errorf("CloudPrepare error: %w", err)
-	}
 	vars, err := InitVarsFromConfig(openEVEC.cfg)
 	if err != nil {
 		return fmt.Errorf("InitVarsFromConfig error: %w", err)
 	}
-	ctrl.SetVars(vars)
+	ctrl, err := controller.CloudPrepare(vars)
+	if err != nil {
+		return fmt.Errorf("CloudPrepare error: %w", err)
+	}
 	var newOptionsBytes []byte
 	if fileWithConfig != "" {
 		newOptionsBytes, err = os.ReadFile(fileWithConfig)

--- a/pkg/openevec/onboard.go
+++ b/pkg/openevec/onboard.go
@@ -10,7 +10,6 @@ import (
 )
 
 func (openEVEC *OpenEVEC) OnboardEve(eveUUID string) error {
-
 	edenDir, err := utils.DefaultEdenDir()
 	if err != nil {
 		return fmt.Errorf("error getting default eden dir %w", err)
@@ -19,7 +18,7 @@ func (openEVEC *OpenEVEC) OnboardEve(eveUUID string) error {
 		return fmt.Errorf("error getting file %w", err)
 	}
 	changer := &adamChanger{}
-	ctrl, err := changer.getController()
+	ctrl, err := changer.getController(openEVEC.cfg)
 	if err != nil {
 		return fmt.Errorf("error fetching controller %w", err)
 	}
@@ -27,7 +26,6 @@ func (openEVEC *OpenEVEC) OnboardEve(eveUUID string) error {
 	if err != nil {
 		return fmt.Errorf("InitVarsFromConfig error: %w", err)
 	}
-	ctrl.SetVars(vars)
 	dev, err := ctrl.GetDeviceCurrent()
 	if err != nil || dev == nil {
 		// create new one if not exists

--- a/pkg/openevec/start.go
+++ b/pkg/openevec/start.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/lf-edge/eden/pkg/eden"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 func (openEVEC *OpenEVEC) StartAdam() error {
@@ -25,15 +24,6 @@ func (openEVEC *OpenEVEC) StartAdam() error {
 		return fmt.Errorf("cannot start adam: %w", err)
 	}
 	log.Infof("Adam is runnig and accessible on port %d", cfg.Adam.Port)
-	return nil
-}
-
-func stopAdam(_ string) error {
-	adamRm := viper.GetBool("adam-rm")
-
-	if err := eden.StopAdam(adamRm); err != nil {
-		return fmt.Errorf("cannot stop adam: %w", err)
-	}
 	return nil
 }
 

--- a/pkg/openevec/test.go
+++ b/pkg/openevec/test.go
@@ -44,7 +44,7 @@ func InitVarsFromConfig(cfg *EdenSetupArgs) (*utils.ConfigVars, error) {
 	cv.AdamIP = cfg.Adam.CertsIP
 	cv.AdamPort = strconv.Itoa(cfg.Adam.Port)
 	cv.AdamDomain = cfg.Adam.CertsDomain
-	cv.AdamDir = utils.ResolveAbsPath(cfg.Adam.Dist)
+	cv.AdamDir = utils.ResolveAbsPathWithRoot(cfg.Eden.Root, cfg.Adam.Dist)
 	cv.AdamCA = caCertPath
 	cv.AdamRedisURLEden = cfg.Adam.Redis.RemoteURL
 	cv.AdamRemote = cfg.Adam.Remote.Enabled
@@ -53,17 +53,17 @@ func InitVarsFromConfig(cfg *EdenSetupArgs) (*utils.ConfigVars, error) {
 	cv.AdamCachingPrefix = cfg.Adam.Caching.Prefix
 	cv.AdamCachingRedis = cfg.Adam.Caching.Redis
 
-	cv.SSHKey = utils.ResolveAbsPath(cfg.Eden.SSHKey)
+	cv.SSHKey = utils.ResolveAbsPathWithRoot(cfg.Eden.Root, cfg.Eden.SSHKey)
 	cv.EdenBinDir = cfg.Eden.BinDir
 	cv.EdenProg = cfg.Eden.EdenBin
 	cv.TestProg = cfg.Eden.TestBin
 	cv.TestScenario = cfg.Eden.TestScenario
-	cv.EServerImageDist = utils.ResolveAbsPath(cfg.Eden.Images.EServerImageDist)
+	cv.EServerImageDist = utils.ResolveAbsPathWithRoot(cfg.Eden.Root, cfg.Eden.Images.EServerImageDist)
 	cv.EServerPort = strconv.Itoa(cfg.Eden.EServer.Port)
 	cv.EServerIP = cfg.Eden.EServer.IP
 
-	cv.EveCert = utils.ResolveAbsPath(cfg.Eve.Cert)
-	cv.EveDeviceCert = utils.ResolveAbsPath(cfg.Eve.DeviceCert)
+	cv.EveCert = utils.ResolveAbsPathWithRoot(cfg.Eden.Root, cfg.Eve.Cert)
+	cv.EveDeviceCert = utils.ResolveAbsPathWithRoot(cfg.Eden.Root, cfg.Eve.DeviceCert)
 	cv.EveSerial = cfg.Eve.Serial
 	cv.EveDist = cfg.Eve.Dist
 	cv.EveQemuConfig = cfg.Eve.QemuFileToSave
@@ -71,7 +71,6 @@ func InitVarsFromConfig(cfg *EdenSetupArgs) (*utils.ConfigVars, error) {
 	cv.EveSSID = cfg.Eve.Ssid
 	cv.EveHV = cfg.Eve.HV
 	cv.DevModel = cfg.Eve.DevModel
-	cv.DevModelFIle = cfg.Eve.DevModelFile
 	cv.EveName = cfg.Eve.Name
 	cv.EveUUID = cfg.Eve.CertsUUID
 	cv.AdamLogLevel = cfg.Eve.AdamLogLevel

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-//SHA256SUM calculates sha256 of file
+// SHA256SUM calculates sha256 of file
 func SHA256SUM(filePath string) string {
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -30,7 +30,7 @@ func SHA256SUM(filePath string) string {
 	return hex.EncodeToString(hash.Sum(nil))
 }
 
-//CopyFileNotExists copy file from src to dst with same permission if not exists
+// CopyFileNotExists copy file from src to dst with same permission if not exists
 func CopyFileNotExists(src string, dst string) (err error) {
 	if _, err = os.Lstat(dst); os.IsNotExist(err) {
 		if err = CopyFile(src, dst); err != nil {
@@ -40,7 +40,7 @@ func CopyFileNotExists(src string, dst string) (err error) {
 	return nil
 }
 
-//CopyFile copy file from src to dst with same permission
+// CopyFile copy file from src to dst with same permission
 func CopyFile(src string, dst string) (err error) {
 	info, err := os.Lstat(src)
 	if err != nil {
@@ -81,7 +81,7 @@ func CopyFile(src string, dst string) (err error) {
 	return
 }
 
-//TouchFile create empty file
+// TouchFile create empty file
 func TouchFile(src string) (err error) {
 	if _, err := os.Stat(src); os.IsNotExist(err) {
 		file, err := os.Create(src)
@@ -99,23 +99,28 @@ func TouchFile(src string) (err error) {
 	return nil
 }
 
-//FileNameWithoutExtension trim file extension and path
+// FileNameWithoutExtension trim file extension and path
 func FileNameWithoutExtension(fileName string) string {
 	return filepath.Base(strings.TrimSuffix(fileName, filepath.Ext(fileName)))
 }
 
-//ResolveAbsPath use eden.root parameter to resolve path
+// ResolveAbsPath use eden.root parameter to resolve path
 func ResolveAbsPath(curPath string) string {
+	return ResolveAbsPathWithRoot(viper.GetString("eden.root"), curPath)
+}
+
+// ResolveAbsPathWithRoot use rootPath parameter to resolve path
+func ResolveAbsPathWithRoot(rootPath, curPath string) string {
 	if strings.TrimSpace(curPath) == "" {
 		return ""
 	}
 	if !filepath.IsAbs(curPath) {
-		return filepath.Join(viper.GetString("eden.root"), strings.TrimSpace(curPath))
+		return filepath.Join(rootPath, strings.TrimSpace(curPath))
 	}
 	return curPath
 }
 
-//GetFileFollowLinks resolve file by walking through symlinks
+// GetFileFollowLinks resolve file by walking through symlinks
 func GetFileFollowLinks(filePath string) (string, error) {
 	log.Debugf("GetFileFollowLinks %s", filePath)
 	filePath = ResolveHomeDir(filePath)
@@ -137,7 +142,7 @@ func GetFileFollowLinks(filePath string) (string, error) {
 	return filepath.Join(filepath.Dir(filePath), fileInfo.Name()), nil
 }
 
-//GetFileSize returns file size
+// GetFileSize returns file size
 func GetFileSize(filePath string) int64 {
 	fi, err := os.Stat(filePath)
 	if err != nil {
@@ -146,7 +151,7 @@ func GetFileSize(filePath string) int64 {
 	return fi.Size()
 }
 
-//ResolveHomeDir resolve ~ in path
+// ResolveHomeDir resolve ~ in path
 func ResolveHomeDir(filePath string) string {
 	usr, err := user.Current()
 	if err != nil {
@@ -161,7 +166,7 @@ func ResolveHomeDir(filePath string) string {
 	return filePath
 }
 
-//CopyFolder from source to destination
+// CopyFolder from source to destination
 func CopyFolder(source, destination string) error {
 	var err = filepath.Walk(source, func(path string, info os.FileInfo, err error) error {
 		var relPath = strings.Replace(path, source, "", 1)
@@ -182,7 +187,7 @@ func IsInputFromPipe() bool {
 	return fileInfo.Mode()&os.ModeCharDevice == 0
 }
 
-//SHA256SUMAll calculates sha256 of directory
+// SHA256SUMAll calculates sha256 of directory
 func SHA256SUMAll(dir string) (string, error) {
 	hash := sha256.New()
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
@@ -207,7 +212,7 @@ func SHA256SUMAll(dir string) (string, error) {
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
-//CreateDisk creates empty disk with defined format on diskFile with size bytes capacity
+// CreateDisk creates empty disk with defined format on diskFile with size bytes capacity
 func CreateDisk(diskFile, format string, size uint64) error {
 	if err := os.MkdirAll(filepath.Dir(diskFile), 0755); err != nil {
 		return err


### PR DESCRIPTION
This  continues work on removing viper from openevec package so that we can create default configuration structure and use it to call openevec functions in golang. 

In this PR use EdenSetupArgs default generated config in config add function. That means that we remove configuration generated from templates (so there are no comments or spacing in file, just pure yml, we can, of course add template comments to struct fields in go file)
Also we force cloudPrepare() function to use EdenSetupArgs, because before it fetched variables from viper, which creates unnecessary coupling and forces us to create file and use viper in openevec. 

So far I played with default parameters, will try to change configurations. 