### PR TITLE
Add upload certificate command to adam

### DIFF
--- a/cmd/adam.go
+++ b/cmd/adam.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eden/pkg/eden"
@@ -24,6 +25,7 @@ func newAdamCmd(configName, verbosity *string) *cobra.Command {
 				newStartAdamCmd(cfg),
 				newStopAdamCmd(),
 				newStatusAdamCmd(),
+				newChangeCertCmd(),
 			},
 		},
 	}
@@ -90,4 +92,28 @@ func newStatusAdamCmd() *cobra.Command {
 	}
 
 	return statusAdamCmd
+}
+
+func newChangeCertCmd() *cobra.Command {
+	var certFile string
+
+	var changeCertCmd = &cobra.Command{
+		Use:   "change-signing-cert",
+		Short: "change signing certificate for adam",
+		Long:  `Set Adam's signing certificate from a file.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			certData, err := os.ReadFile(certFile)
+			if err != nil {
+				log.Fatalf("Failed to read certificate file: %s", err)
+			}
+
+			if err := openEVEC.ChangeSigningCert(certData); err != nil {
+				log.Fatalf("Failed to upload certificate to adam: %s", err)
+			}
+		},
+	}
+
+	changeCertCmd.Flags().StringVarP(&certFile, "cert-file", "", "", "path to the signing certificate file")
+
+	return changeCertCmd
 }

--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eden/pkg/eden"
 	"github.com/lf-edge/eden/pkg/openevec"
+	"github.com/lf-edge/eden/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -44,6 +45,32 @@ func newCertsCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 	certsCmd.Flags().StringVar(&cfg.Eve.Ssid, "ssid", "", "SSID for wifi")
 	certsCmd.Flags().StringVar(&cfg.Eve.Password, "password", "", "password for wifi")
 	certsCmd.Flags().StringArrayVar(&grubOptions, "grub-options", []string{}, "append lines to grub options")
+
+	return certsCmd
+}
+
+func newGenSigningCertCmd() *cobra.Command {
+	var certPath string
+
+	var certsCmd = &cobra.Command{
+		Use:   "gen-signing-cert",
+		Short: "generate new signing certificate for controller",
+		Long:  `Generate a new signing certificate for the controller using the same signing key`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := utils.GenServerCertFromPrevCertAndKey(certPath); err != nil {
+				log.Errorf("cannot generate signing cert: %s", err)
+			} else {
+				log.Info("GenServerCertEllipticFromPrevCertAndKey done")
+			}
+		},
+	}
+
+	edenHome, err := utils.DefaultEdenDir()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	certsCmd.Flags().StringVarP(&certPath, "out", "o", filepath.Join(edenHome, defaults.DefaultCertsDist, "signing-new.pem"), "certificate output path")
 
 	return certsCmd
 }

--- a/cmd/edenUtils.go
+++ b/cmd/edenUtils.go
@@ -30,6 +30,7 @@ func newUtilsCmd(configName, verbosity *string) *cobra.Command {
 				newDownloaderCmd(cfg),
 				newOciImageCmd(),
 				newCertsCmd(cfg),
+				newGenSigningCertCmd(),
 				newGcpCmd(cfg),
 				newSdInfoEveCmd(),
 				newDebugCmd(cfg),

--- a/pkg/controller/application.go
+++ b/pkg/controller/application.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+
 	"github.com/lf-edge/eden/pkg/utils"
 	"github.com/lf-edge/eve-api/go/config"
 )
@@ -15,7 +16,7 @@ func (cloud *CloudCtx) getApplicationInstanceInd(id string) (applicationInstance
 	return -1, fmt.Errorf("not found applicationInstance with ID: %s", id)
 }
 
-//GetApplicationInstanceConfig return AppInstanceConfig config from cloud by ID
+// GetApplicationInstanceConfig return AppInstanceConfig config from cloud by ID
 func (cloud *CloudCtx) GetApplicationInstanceConfig(id string) (applicationInstanceConfig *config.AppInstanceConfig, err error) {
 	applicationInstanceConfigInd, err := cloud.getApplicationInstanceInd(id)
 	if err != nil {
@@ -24,13 +25,13 @@ func (cloud *CloudCtx) GetApplicationInstanceConfig(id string) (applicationInsta
 	return cloud.applicationInstances[applicationInstanceConfigInd], nil
 }
 
-//AddApplicationInstanceConfig add AppInstanceConfig config to cloud
+// AddApplicationInstanceConfig add AppInstanceConfig config to cloud
 func (cloud *CloudCtx) AddApplicationInstanceConfig(applicationInstanceConfig *config.AppInstanceConfig) error {
 	cloud.applicationInstances = append(cloud.applicationInstances, applicationInstanceConfig)
 	return nil
 }
 
-//RemoveApplicationInstanceConfig remove AppInstanceConfig config to cloud
+// RemoveApplicationInstanceConfig remove AppInstanceConfig config to cloud
 func (cloud *CloudCtx) RemoveApplicationInstanceConfig(id string) error {
 	applicationInstanceConfigInd, err := cloud.getApplicationInstanceInd(id)
 	if err != nil {
@@ -40,7 +41,7 @@ func (cloud *CloudCtx) RemoveApplicationInstanceConfig(id string) error {
 	return nil
 }
 
-//ListApplicationInstanceConfig return ApplicationInstance configs from cloud
+// ListApplicationInstanceConfig return ApplicationInstance configs from cloud
 func (cloud *CloudCtx) ListApplicationInstanceConfig() []*config.AppInstanceConfig {
 	return cloud.applicationInstances
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -15,9 +15,10 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-//Controller is an interface of controller
+// Controller is an interface of controller
 type Controller interface {
-	CertsGet(devUUID uuid.UUID) (out string, err error)
+	GetECDHCert(devUUID uuid.UUID) ([]byte, error)
+	SigningCertGet() (signCert []byte, err error)
 	ConfigGet(devUUID uuid.UUID) (out string, err error)
 	ConfigSet(devUUID uuid.UUID, devConfig []byte) (err error)
 	LogAppsChecker(devUUID uuid.UUID, appUUID uuid.UUID, q map[string]string, handler eapps.HandlerFunc, mode eapps.LogCheckerMode, timeout time.Duration) (err error)

--- a/pkg/controller/functions.go
+++ b/pkg/controller/functions.go
@@ -165,8 +165,8 @@ func (cloud *CloudCtx) OnBoardDev(node *device.Ctx) error {
 				if err = cloud.ConfigSync(node); err != nil {
 					log.Fatal(err)
 				}
-				//wait for certs
-				if _, err = cloud.CertsGet(node.GetID()); err != nil {
+				// wait for certs
+				if _, err = cloud.GetECDHCert(node.GetID()); err != nil {
 					log.Fatal(err)
 				}
 			}

--- a/pkg/openevec/adam.go
+++ b/pkg/openevec/adam.go
@@ -3,11 +3,17 @@ package openevec
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
+	"github.com/lf-edge/eden/pkg/controller"
+	"github.com/lf-edge/eden/pkg/defaults"
+	"github.com/lf-edge/eden/pkg/device"
 	"github.com/lf-edge/eden/pkg/eden"
+	"github.com/lf-edge/eden/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
 
+// AdamStart starts the OpenEVEC controller.
 func (openEVEC *OpenEVEC) AdamStart() error {
 	cfg := openEVEC.cfg
 	command, err := os.Executable()
@@ -23,5 +29,120 @@ func (openEVEC *OpenEVEC) AdamStart() error {
 	} else {
 		log.Infof("Adam is running and accessible on port %d", cfg.Adam.Port)
 	}
+	return nil
+}
+
+// ChangeSigningCert uploads the provided signing certificate to the OpenEVEC controller.
+func (openEVEC *OpenEVEC) ChangeSigningCert(newSignCert []byte) error {
+	changer := &adamChanger{}
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
+	if err != nil {
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
+	}
+
+	// we need to re-encrypt existing configs with the new certificate because EVE has support only for one server signing certificate
+	err = reencryptConfigs(ctrl, dev, newSignCert)
+	if err != nil {
+		return fmt.Errorf("failed to reencrypt existing configs: %w", err)
+	}
+
+	if err = changer.setControllerAndDev(ctrl, dev); err != nil {
+		return fmt.Errorf("setControllerAndDev: %w", err)
+	}
+
+	edenHome, err := utils.DefaultEdenDir()
+	if err != nil {
+		return err
+	}
+	globalCertsDir := filepath.Join(edenHome, defaults.DefaultCertsDist)
+	signingCertPath := filepath.Join(globalCertsDir, "signing.pem")
+
+	if err = os.WriteFile(signingCertPath, newSignCert, 0644); err != nil {
+		return fmt.Errorf("cannot write signing cert to %s: %w", signingCertPath, err)
+	}
+
+	log.Infof("Signing cert changed successfully")
+	return nil
+}
+
+func reencryptConfigs(ctrl controller.Cloud, dev *device.Ctx, newSignCert []byte) error {
+	// get device certificate from the controller
+	devCert, err := ctrl.GetECDHCert(dev.GetID())
+	if err != nil {
+		return fmt.Errorf("cannot get device certificate from cloud: %w", err)
+	}
+
+	// get signing certificate from the controller
+	oldSignCert, err := ctrl.SigningCertGet()
+	if err != nil {
+		log.Error("cannot get cloud's signing certificate. will use plaintext")
+		return nil
+	}
+
+	edenHome, err := utils.DefaultEdenDir()
+	if err != nil {
+		return fmt.Errorf("DefaultEdenDir: %w", err)
+	}
+	keyPath := filepath.Join(edenHome, defaults.DefaultCertsDist, "signing-key.pem")
+	ctrlPrivKey, err := os.ReadFile(keyPath)
+	if err != nil {
+		return fmt.Errorf("cannot read %s: %w", keyPath, err)
+	}
+
+	oldCryptoConfig, err := utils.GetCommonCryptoConfig(devCert, oldSignCert, ctrlPrivKey)
+	if err != nil {
+		return fmt.Errorf("GetCommonCryptoConfig: %w", err)
+	}
+
+	newCryptoConfig, err := utils.GetCommonCryptoConfig(devCert, newSignCert, ctrlPrivKey)
+	if err != nil {
+		return fmt.Errorf("GetCommonCryptoConfig: %w", err)
+	}
+
+	cipherCtx, err := utils.CreateCipherCtx(newCryptoConfig)
+	if err != nil {
+		return fmt.Errorf("CreateCipherCtx: %w", err)
+	}
+	// add cipher context to device or return a matching existing one
+	cipherCtx = utils.AddCipherCtxToDev(dev, cipherCtx)
+
+	// re-encrypt all app configs with the new signing certificate
+	appConfigs := ctrl.ListApplicationInstanceConfig()
+	for _, config := range appConfigs {
+		if err = utils.ReencryptConfigData(config, oldCryptoConfig, newCryptoConfig, cipherCtx); err != nil {
+			return fmt.Errorf("reencryptConfigData: %w", err)
+		}
+	}
+
+	// re-encrypt all datastore configs with the new signing certificate
+	dsConfigs := ctrl.ListDataStore()
+	for _, config := range dsConfigs {
+		if err = utils.ReencryptConfigData(config, oldCryptoConfig, newCryptoConfig, cipherCtx); err != nil {
+			return fmt.Errorf("reencryptConfigData: %w", err)
+		}
+	}
+
+	// re-encrypt all wireless configs with the new signing certificate
+	for _, networkConfigID := range dev.GetNetworks() {
+		networkConfig, err := ctrl.GetNetworkConfig(networkConfigID)
+		if err != nil {
+			return fmt.Errorf("GetNetworkConfig: %w", err)
+		}
+		if networkConfig != nil && networkConfig.Wireless != nil {
+			for _, config := range networkConfig.Wireless.CellularCfg {
+				for _, ap := range config.AccessPoints {
+					if err = utils.ReencryptConfigData(ap, oldCryptoConfig, newCryptoConfig, cipherCtx); err != nil {
+						return fmt.Errorf("reencryptConfigData: %w", err)
+					}
+				}
+			}
+			for _, config := range networkConfig.Wireless.WifiCfg {
+				if err = utils.ReencryptConfigData(config, oldCryptoConfig, newCryptoConfig, cipherCtx); err != nil {
+					return fmt.Errorf("reencryptConfigData: %w", err)
+				}
+			}
+		}
+	}
+
 	return nil
 }

--- a/pkg/utils/cipher.go
+++ b/pkg/utils/cipher.go
@@ -34,7 +34,7 @@ func createCipherBlock(plainText []byte, cipherCtxID string, cmnCryptoCfg *Commo
 	cipherBlock.ClearTextSha256 = shaOfPlainTextSecret[:]
 	cipherBlock.InitialValue = iv
 
-	//encrypt paintext secret using symmetric key and initial value.
+	// encrypt paintext secret using symmetric key and initial value.
 	cipherText, ecErr := aesEncrypt(iv, cmnCryptoCfg.SymmetricKey, plainText)
 	if ecErr != nil {
 		return nil, ecErr
@@ -55,12 +55,87 @@ func CryptoConfigWrapper(encBlock *evecommon.EncryptionBlock, cmnCryptoCfg *Comm
 
 	mEncBlock, mErr := proto.Marshal(encBlock)
 	if mErr != nil {
-		return nil, fmt.Errorf("error marshalling user data: %v", mErr)
+		return nil, fmt.Errorf("error marshalling user data: %w", mErr)
 	}
-	//Fill CipherBlock.
+	// Fill CipherBlock.
 	cipherBlock, cbErr := createCipherBlock(mEncBlock, cipherCtx.ContextId, cmnCryptoCfg, iv[:16])
 	if cbErr != nil {
-		return nil, fmt.Errorf("error creating cipher block: %v", cbErr)
+		return nil, fmt.Errorf("error creating cipher block: %w", cbErr)
 	}
 	return cipherBlock, nil
+}
+
+// internal decryption method
+func aesDecrypt(iv, symmetricKey, ciphertext []byte) ([]byte, error) {
+	plaintext := make([]byte, len(ciphertext))
+	aesBlockDecrypter, err := aes.NewCipher(symmetricKey)
+	if err != nil {
+		return nil, err
+	}
+	aesDecrypter := cipher.NewCFBDecrypter(aesBlockDecrypter, iv)
+	aesDecrypter.XORKeyStream(plaintext, ciphertext)
+	return plaintext, nil
+}
+
+// reverse the process of creating a cipher block
+func decryptCipherBlock(cipherBlock *evecommon.CipherBlock, cmnCryptoCfg *CommonCryptoConfig) ([]byte, error) {
+	if cipherBlock == nil {
+		return nil, fmt.Errorf("nil cipher block in decrypt cipher block method")
+	}
+
+	// decrypt ciphertext using symmetric key and initial value
+	decryptedText, decErr := aesDecrypt(cipherBlock.InitialValue, cmnCryptoCfg.SymmetricKey, cipherBlock.CipherData)
+	if decErr != nil {
+		return nil, decErr
+	}
+
+	// verify sha256 checksum of decrypted text
+	shaOfDecryptedText := sha256.Sum256(decryptedText)
+	if !CompareSlices(shaOfDecryptedText[:], cipherBlock.ClearTextSha256) {
+		return nil, fmt.Errorf("decrypted text does not match original sha256 checksum")
+	}
+
+	return decryptedText, nil
+}
+
+// CryptoConfigUnwrapper reverses the process of CryptoConfigWrapper
+func CryptoConfigUnwrapper(cipherBlock *evecommon.CipherBlock, cmnCryptoCfg *CommonCryptoConfig) (*evecommon.EncryptionBlock, error) {
+	decryptedBytes, err := decryptCipherBlock(cipherBlock, cmnCryptoCfg)
+	if err != nil {
+		return nil, fmt.Errorf("error decrypting cipher block: %w", err)
+	}
+
+	var encBlock evecommon.EncryptionBlock
+	if err := proto.Unmarshal(decryptedBytes, &encBlock); err != nil {
+		return nil, fmt.Errorf("error unmarshalling decrypted bytes: %w", err)
+	}
+
+	return &encBlock, nil
+}
+
+// CipherDataHolder is an interface for objects that have CipherData field.
+type CipherDataHolder interface {
+	GetCipherData() *evecommon.CipherBlock
+}
+
+// ReencryptConfigData re-encrypts config data with new crypto config.
+func ReencryptConfigData(holder CipherDataHolder, oldCryptoConfig, newCryptoConfig *CommonCryptoConfig, cipherCtx *evecommon.CipherContext) error {
+	if cipherData := holder.GetCipherData(); cipherData != nil {
+		encBlock, err := CryptoConfigUnwrapper(cipherData, oldCryptoConfig)
+		if err != nil {
+			return fmt.Errorf("CryptoConfigUnwrapper error: %w", err)
+		}
+
+		newCipherData, err := CryptoConfigWrapper(encBlock, newCryptoConfig, cipherCtx)
+		if err != nil {
+			return fmt.Errorf("CryptoConfigWrapper error: %w", err)
+		}
+
+		// copy each field separately to avoid copying the lock in MessageState
+		cipherData.CipherContextId = newCipherData.CipherContextId
+		cipherData.InitialValue = newCipherData.InitialValue
+		cipherData.CipherData = newCipherData.CipherData
+		cipherData.ClearTextSha256 = newCipherData.ClearTextSha256
+	}
+	return nil
 }

--- a/pkg/utils/slices.go
+++ b/pkg/utils/slices.go
@@ -3,8 +3,8 @@ package utils
 import "reflect"
 
 // DelEleInSlice delete an element from slice by index
-//  - arr: the reference of slice
-//  - index: the index of element will be deleted
+//   - arr: the reference of slice
+//   - index: the index of element will be deleted
 func DelEleInSlice(arr interface{}, index int) {
 	vField := reflect.ValueOf(arr)
 	value := vField.Elem()
@@ -15,8 +15,8 @@ func DelEleInSlice(arr interface{}, index int) {
 }
 
 // DelEleInSliceByFunction delete an element from slice by function
-//  - arr: the reference of slice
-//  - f: delete if it returns true on element of slice
+//   - arr: the reference of slice
+//   - f: delete if it returns true on element of slice
 func DelEleInSliceByFunction(arr interface{}, f func(interface{}) bool) {
 	vField := reflect.ValueOf(arr)
 	value := vField.Elem()
@@ -40,4 +40,20 @@ func FindEleInSlice(slice []string, val string) (int, bool) {
 		}
 	}
 	return -1, false
+}
+
+// CompareSlices compares two slices of comparable types. It returns true if
+// they are equal and false otherwise.
+func CompareSlices[T comparable](lhs, rhs []T) bool {
+	if len(lhs) != len(rhs) {
+		return false
+	}
+
+	for i := range lhs {
+		if lhs[i] != rhs[i] {
+			return false
+		}
+	}
+
+	return true
 }

--- a/tests/eclient/testdata/ctrl_cert_change.txt
+++ b/tests/eclient/testdata/ctrl_cert_change.txt
@@ -1,0 +1,77 @@
+# Test of controller certificate change
+# This test validates the re-encryption of an application's user data
+# following a change in the controller's certificate, accompanied by an edge node reboot.
+# The test involves deploying three applications to make sure the config is (re)applied to all of them.
+
+{{$port := "2223"}}
+
+{{$userdata := "variable=value"}}
+{{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:chmod] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
+
+eden network create 10.11.12.0/24 -n n1
+eden pod deploy -n eclient1 --memory=512MB --networks=n1 {{template "eclient_image"}} -p {{$port}}:22 --metadata={{$userdata}}
+
+test eden.app.test -test.v -timewait 20m RUNNING eclient1
+
+# generate new controller certificate
+eden utils gen-signing-cert -o /tmp/signing-new.pem
+
+# upload new certificate to controller, resign old config and reapply it
+eden adam change-signing-cert --cert-file /tmp/signing-new.pem
+
+# wait for changes to be applied
+test eden.lim.test -test.v -timewait 15m -test.run TestLog -out content 'content:Rebuilding.intended.global.config,.reasons:.reconnecting.app'
+
+eden pod deploy -n eclient2 --memory=512MB --networks=n1 {{template "eclient_image"}} --metadata={{$userdata}}
+
+test eden.app.test -test.v -timewait 20m RUNNING eclient2
+
+# check EVE got the new signing certificate
+exec -t 2m bash check_sign_cert.sh
+
+# send reboot command and wait in background
+test eden.reboot.test -test.v -timewait=20m -reboot=1 -count=1 &
+
+# wait for RUNNING state after reboot
+test eden.app.test -test.v -timewait 20m -check-new RUNNING eclient1
+test eden.app.test -test.v -timewait 20m -check-new RUNNING eclient2
+
+eden pod deploy -n eclient3 --memory=512MB --networks=n1 {{template "eclient_image"}} --metadata={{$userdata}}
+
+# check all apps are RUNNING
+
+test eden.app.test -test.v -timewait 20m RUNNING eclient1
+test eden.app.test -test.v -timewait 20m RUNNING eclient2
+test eden.app.test -test.v -timewait 20m RUNNING eclient3
+
+# cleanup
+eden pod delete eclient1
+eden pod delete eclient2
+eden pod delete eclient3
+eden network delete n1
+
+test eden.app.test -test.v -timewait 10m - eclient1
+test eden.app.test -test.v -timewait 10m - eclient2
+test eden.app.test -test.v -timewait 10m - eclient3
+test eden.network.test -test.v -timewait 10m - n1
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- check_sign_cert.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+$EDEN eve ssh cat /persist/certs/server-signing-cert.pem > /tmp/server-signing-cert.pem
+diff -Z /tmp/signing-new.pem /tmp/server-signing-cert.pem

--- a/tests/workflow/smoke.tests.txt
+++ b/tests/workflow/smoke.tests.txt
@@ -1,5 +1,5 @@
 # Number of tests
-{{$tests := 22}}
+{{$tests := 23}}
 # EDEN_TEST_SETUP env. var. -- "y"(default) performs the EDEN setup steps
 {{$setup := "y"}}
 {{$setup_env := EdenGetEnv "EDEN_TEST_SETUP"}}
@@ -70,12 +70,14 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/metad
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/userdata
 /bin/echo Eden app log test (19/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/app_logs
+/bin/echo Eden change controller certificate test (20/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/ctrl_cert_change
 
-/bin/echo Eden Shutdown test (20/{{$tests}})
+/bin/echo Eden Shutdown test (21/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/shutdown_test
 
-/bin/echo EVE reset (21/{{$tests}})
+/bin/echo EVE reset (22/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_reset
 
-/bin/echo EVE security tests (22/{{$tests}})
+/bin/echo EVE security tests (23/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/sec_eden


### PR DESCRIPTION
A new CLI option is added: on eden adam upload-cert the provided certificate is uploaded to <adam-ip>/admin/certs via an HTTP POST

NOTE: the new EDEN test needs to be run with an EVE version that includes [this fix](https://github.com/lf-edge/eve/pull/3675) and with the Adam version that includes [this](https://github.com/lf-edge/adam/pull/120) change.

Closes #896 