### PR TITLE
Fix nginx test

### DIFF
--- a/docs/test-examples.md
+++ b/docs/test-examples.md
@@ -29,7 +29,7 @@ eden eve reset
 eden test tests/eclient -e port_switch -t 20m
 eden eve reset
 # Just a simple test of nginx image -- tested in port_switch test
-#eden test tests/eclient -e ngnix -t 20m
+#eden test tests/eclient -e nginx -t 20m
 eden test tests/eclient -e maridb -t 20m
 eden eve reset
 ## tests/escript
@@ -89,7 +89,7 @@ eden test tests/workflow -e host-only -a '-testdata ../eclient/testdata/'
 eden eve reset
 eden test tests/workflow -e networking_light -a '-testdata ../eclient/testdata/'
 eden eve reset
-eden test tests/workflow -e ngnix -a '-testdata ../eclient/testdata/'
+eden test tests/workflow -e nginx -a '-testdata ../eclient/testdata/'
 eden eve reset
 eden test tests/workflow -e maridb -a '-testdata ../eclient/testdata/'
 eden eve reset

--- a/tests/eclient/eden.eclient.tests.txt
+++ b/tests/eclient/eden.eclient.tests.txt
@@ -8,6 +8,6 @@ eden.escript.test -test.run TestEdenScripts/nw_switch -test.timeout 20m
 eden.escript.test -test.run TestEdenScripts/port_switch -test.timeout 20m
 eden.escript.test -test.run TestEdenScripts/port_forward -test.timeout 20m
 # Just a simple test of nginx image -- tested in port_switch test
-#eden.escript.test -test.run TestEdenScripts/ngnix -test.timeout 20m
+#eden.escript.test -test.run TestEdenScripts/nginx -test.timeout 20m
 eden.escript.test -test.run TestEdenScripts/maridb -test.timeout 20m
 eden-ports.sh 2223:2223 2224:2224

--- a/tests/eclient/testdata/nginx.txt
+++ b/tests/eclient/testdata/nginx.txt
@@ -10,6 +10,7 @@
 [!exec:sleep] stop
 [!exec:ssh] stop
 [!exec:chmod] stop
+[!exec:awk] stop
 
 exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
@@ -50,7 +51,7 @@ done
 
 -- server_ip.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-echo export ESERVER_IP=$(grep "^$1\s" pod_ps | cut -f 4) > env
+echo export ESERVER_IP=$(grep "^$1\s" pod_ps | awk '{print $4}') > env
 
 -- run_client.sh --
 . ./env

--- a/tests/workflow/eden.workflow.tests.txt
+++ b/tests/workflow/eden.workflow.tests.txt
@@ -165,7 +165,7 @@ eden.escript.test -testdata ../app/testdata/ -test.run TestEdenScripts/2dockers_
 /bin/echo Testing replacement of one application with another (27.2/{{$tests}})
 eden.escript.test -testdata ../app/testdata/ -test.run TestEdenScripts/app_replace_test
 /bin/echo Eden Nginx (28/{{$tests}})
-eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/ngnix
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/nginx
 
 /bin/echo Eden Mariadb (29.1/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/maridb

--- a/tests/workflow/networking.tests.txt
+++ b/tests/workflow/networking.tests.txt
@@ -62,7 +62,7 @@ eden.escript.test -testdata ../vnc/testdata/ -test.run TestEdenScripts/vnc_test
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/air-gapped-switch
 
 /bin/echo Eden Nginx (17/{{$tests}})
-eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/ngnix
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/nginx
 
 /bin/echo Verifying that we can use a switch network instance on a management port (18/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/app_nonat


### PR DESCRIPTION
Use `awk` instead of `cut` to make the test robust against any extra space that may occur in the output from `eden pod ps`.
Also fixed is the misspelling in the test file name.