### PR TITLE
Pull docker image only if latest flag is set

### DIFF
--- a/cmd/edenConfig.go
+++ b/cmd/edenConfig.go
@@ -80,6 +80,7 @@ func newConfigAddCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 	configAddCmd.Flags().StringVar(&cfg.Eve.Ssid, "ssid", "", "set ssid of wifi for rpi")
 	configAddCmd.Flags().StringVar(&cfg.Eve.Arch, "arch", "", "arch of EVE (amd64 or arm64)")
 	configAddCmd.Flags().StringVar(&cfg.Eve.ModelFile, "devmodel-file", "", "File to use for overwrite of model defaults")
+	configAddCmd.Flags().BoolVarP(&cfg.Eve.PullImage, "pull-image", "", true, "Download latest EVE")
 	configAddCmd.Flags().BoolVarP(&force, "force", "", false, "force overwrite config file")
 
 	return configAddCmd

--- a/cmd/edenSetup.go
+++ b/cmd/edenSetup.go
@@ -71,6 +71,7 @@ func newSetupCmd(configName, verbosity *string) *cobra.Command {
 	setupCmd.Flags().StringToStringVarP(&cfg.Eve.HostFwd, "eve-hostfwd", "", defaults.DefaultQemuHostFwd, "port forward map")
 	setupCmd.Flags().StringVarP(&cfg.Eve.QemuFileToSave, "qemu-config", "", cfg.Eve.QemuFileToSave, "file to save qemu config")
 	setupCmd.Flags().StringVarP(&cfg.Eve.HV, "eve-hv", "", defaults.DefaultEVEHV, "hv of rootfs to use")
+	setupCmd.Flags().BoolVarP(&cfg.Eve.PullImage, "pull-image", "", true, "Download latest EVE")
 
 	setupCmd.Flags().StringVarP(&cfg.Eden.Images.EServerImageDist, "image-dist", "", cfg.Eden.Images.EServerImageDist, "image dist for eserver")
 	setupCmd.Flags().StringVarP(&cfg.Eden.BinDir, "bin-dist", "", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultBinDist), "directory for binaries")

--- a/pkg/openevec/config.go
+++ b/pkg/openevec/config.go
@@ -118,6 +118,7 @@ type EveConfig struct {
 	Password       string            `mapstructure:"password" cobraflag:"password"`
 	Serial         string            `mapstructure:"serial" cobraflag:"eve-serial"`
 	Accel          bool              `mapstructure:"accel" cobraflag:"eve-accel"`
+	PullImage      bool              `mapstructure:"latest" cobraflag:"pull-image"`
 
 	Pid            string `mapstructure:"pid" cobraflag:"eve-pid" resolvepath:""`
 	Log            string `mapstructure:"log" cobraflag:"eve-log" resolvepath:""`

--- a/pkg/openevec/eden.go
+++ b/pkg/openevec/eden.go
@@ -147,6 +147,7 @@ func setupEve(netboot, installer bool, softSerial, ipxeOverride string, cfg Eden
 		Tag:         cfg.Eve.Tag,
 		Format:      imageFormat,
 		ImageSizeMB: cfg.Eve.ImageSizeMB,
+		Latest:      cfg.Eve.PullImage,
 	}
 	if cfg.Eve.CustomInstaller.Path != "" {
 		// With installer image already prepared, install only UEFI.

--- a/pkg/utils/downloaders.go
+++ b/pkg/utils/downloaders.go
@@ -25,6 +25,7 @@ type EVEDescription struct {
 	Tag         string
 	Format      string
 	ImageSizeMB int
+	PullImage   bool
 }
 
 // Image extracts image tag from EVEDescription
@@ -75,8 +76,10 @@ func DownloadUEFI(eve EVEDescription, outputDir string) (err error) {
 	if err != nil {
 		return err
 	}
-	if err := PullImage(image); err != nil {
-		return fmt.Errorf("ImagePull (%s): %s", image, err)
+	if eve.PullImage {
+		if err := PullImage(image); err != nil {
+			return fmt.Errorf("ImagePull (%s): %s", image, err)
+		}
 	}
 	if err := SaveImageAndExtract(image, outputDir, "/bits/firmware"); err != nil {
 		return fmt.Errorf("SaveImageAndExtract: %w", err)
@@ -90,9 +93,11 @@ func DownloadEveLive(eve EVEDescription, outputFile string) (err error) {
 	if err != nil {
 		return err
 	}
-	log.Debugf("Try ImagePull with (%s)", image)
-	if err := PullImage(image); err != nil {
-		return fmt.Errorf("ImagePull (%s): %s", image, err)
+	if eve.PullImage {
+		log.Debugf("Try ImagePull with (%s)", image)
+		if err := PullImage(image); err != nil {
+			return fmt.Errorf("ImagePull (%s): %s", image, err)
+		}
 	}
 	if eve.ConfigPath != "" {
 		if _, err := os.Stat(eve.ConfigPath); os.IsNotExist(err) {
@@ -281,9 +286,11 @@ func DownloadEveNetBoot(eve EVEDescription, outputDir string) (err error) {
 	if err != nil {
 		return err
 	}
-	log.Debugf("Try ImagePull with (%s)", image)
-	if err := PullImage(image); err != nil {
-		return fmt.Errorf("ImagePull (%s): %s", image, err)
+	if eve.PullImage {
+		log.Debugf("Try ImagePull with (%s)", image)
+		if err := PullImage(image); err != nil {
+			return fmt.Errorf("ImagePull (%s): %s", image, err)
+		}
 	}
 	if eve.ConfigPath != "" {
 		if _, err := os.Stat(eve.ConfigPath); os.IsNotExist(err) {


### PR DESCRIPTION
Context: we are making eve danger-less (removing danger.yml from CI/CD). For that we want to be able to do docker load of cached containers and don't do docker pull during eden setup . First can be done within GHA, for the second part this PR is created

This commit introduces EdenSetupArgs.Eve.Latest bool flag which is used to determine if we need to pull latest docker images.

This enables us to use docker load to get EVE image from cache