### PR TITLE
GitHub actions: restore and load images if specified for test

### DIFF
--- a/.github/actions/run-eden-test/action.yml
+++ b/.github/actions/run-eden-test/action.yml
@@ -13,6 +13,8 @@ inputs:
     type: string
   eve_image:
     type: string
+  eve_artifact_name:
+    type: string
 
 runs:
   using: 'composite'
@@ -23,6 +25,7 @@ runs:
         file_system: ${{ inputs.file_system }}
         tpm_enabled: ${{ inputs.tpm_enabled }}
         eve_image: ${{ inputs.eve_image }}
+        eve_artifact_name: ${{ inputs.eve_artifact_name }}
     - name: Run tests
       run: EDEN_TEST_STOP=n ./eden test ./tests/workflow -s ${{ inputs.suite }} -v debug
       shell: bash

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -10,6 +10,8 @@ inputs:
     type: bool
   eve_image:
     type: string
+  eve_artifact_name:
+    type: string
 
 runs:
   using: 'composite'
@@ -53,6 +55,16 @@ runs:
         ./eden config set default --key=eve.cpu --value=2
       shell: bash
       working-directory: "./eden"
+    - name: Download artifact if specified
+      if: github.event.inputs.eve_artifact_name != ''
+      uses: actions/download-artifact@v3
+      with:
+        name: inputs.eve_artifact_name
+    - name: Load containers to docker if specified
+      if: github.event.inputs.eve_artifact_name != ''
+      run: |
+        docker load -q -i ${{ inputs.eve_artifact_name }}.tar
+      shell: bash
     - name: Setup eve version
       run: |
         image=${{ inputs.eve_image }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,13 @@ on:
     inputs:
       eve_image:
         type: string
+      eve_artifact_name:
+        type: string
   workflow_call:
     inputs:
       eve_image:
+        type: string
+      eve_artifact_name:
         type: string
 
 jobs:
@@ -48,6 +52,7 @@ jobs:
           tpm_enabled: ${{ matrix.tpm }}
           suite: "smoke.tests.txt"
           eve_image:  ${{ inputs.eve_image }}
+          eve_artifact_name: ${{ inputs.eve_artifact_name }}
 
   networking:
     name: Networking test suite
@@ -66,6 +71,7 @@ jobs:
           tpm_enabled: true
           suite: "networking.tests.txt"
           eve_image:   ${{ inputs.eve_image }}
+          eve_artifact_name: ${{ inputs.eve_artifact_name }}
 
   storage:
     continue-on-error: true
@@ -88,6 +94,7 @@ jobs:
           tpm_enabled: true
           suite: "storage.tests.txt"
           eve_image: ${{ inputs.eve_image }}
+          eve_artifact_name: ${{ inputs.eve_artifact_name }}
 
   lpc-loc:
     name: LPC LOC test suite
@@ -106,6 +113,7 @@ jobs:
           tpm_enabled: true
           suite: "lpc-loc.tests.txt"
           eve_image: ${{ inputs.eve_image }}
+          eve_artifact_name: ${{ inputs.eve_artifact_name }}
 
   eve-upgrade:
     continue-on-error: true
@@ -128,6 +136,7 @@ jobs:
           tpm_enabled: true
           suite: "eve-upgrade.tests.txt"
           eve_image: ${{ inputs.eve_image }}
+          eve_artifact_name: ${{ inputs.eve_artifact_name }}
 
   user-apps:
     name: User apps test suite
@@ -146,4 +155,5 @@ jobs:
           tpm_enabled: true
           suite: "user-apps.tests.txt"
           eve_image: ${{ inputs.eve_image }}
+          eve_artifact_name: ${{ inputs.eve_artifact_name }}
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,7 +1,22 @@
 # Github Actions
 
 Eden is a part of testing infrastructure of EVE and it's integrated in EVE CI/CD pipelines. EVE uses [test.yml](https://github.com/lf-edge/eden/blob/master/.github/workflows/test.yml) reusable workflow to run eden tests against specific EVE version in PR.
-Eden reusable workflows are running using [BuildJet](https://buildjet.com/for-github-actions) runners provided by LF-EDGE. They provide both Arm and x86_64 architectures.
+
+## About runners
+
+Eden reusable workflow (`test.yml`) is running using [BuildJet](https://buildjet.com/for-github-actions) runners provided by LF-EDGE. They provide both Arm and x86_64 architectures.
 Currently we are provided with 4vCPU/16GBs of RAM and 8vCPU/32GBs of RAM runners. Maximum CPUs running in parallel is 64 for x86_64, that means with 4vCPUs we can have 16 jobs running in parallel.
 In case one wants to run eden workflows locally in their own fork, `runner` and `repo` input variables for reusable workflow should be specified.
 
+## Using GitHub Cache to run `test.yml` with custom EVE build
+
+Sometimes you want to run tests in your CI/CD with EVE version, which is not published on Dockerhub,
+for instance, when you have pull request to master. Eden [will](https://github.com/lf-edge/eden/blob/ed507793968a2005212d589d6c3d88824783a9a7/pkg/utils/container.go#L175-L178) prefer local image over pulling from Dockerhub. That means if you load image before running tests it will work with local image. For workflow `test.yml` you can use `eve_image_cache_key` parameter
+
+### Why GitHub Artifacts and `eve_artifact_name` parameter?
+
+In order to pass objects between jobs you need to either use cache or artifacts. Artifacts are published and stored for 90 days, cache is not published and GitHub deletes previous entries if total amount of cache is more than 10GBs. Artifacts also rebuild each time.
+
+Unfortunately, you can't add additional steps before invoking reusable workflow, otherwise we could have just do `docker load` before invoking tests workflow.
+
+**Important note:** Archive you store in GitHub Artifacts should be `eve_artifact_name`.tar


### PR DESCRIPTION
In case when we want to run test suite against newly build EVE from PR we don't want to store it dockerhub, because it just takes up the space and bandwitdth of dockerhub.
This patch introduces option to cache docker images and load them for testing