### PR TITLE
eclient image improvements

### DIFF
--- a/tests/eclient/image/Dockerfile
+++ b/tests/eclient/image/Dockerfile
@@ -25,7 +25,8 @@ RUN apk add --no-cache lshw \
     jq \
     setserial \
     avahi \
-    lsblk && \
+    lsblk \
+    tcpdump && \
     apk --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/edge/community add -U --upgrade dhcping sysbench
 
 COPY --from=build /out /

--- a/tests/eclient/image/files/entrypoint.sh
+++ b/tests/eclient/image/files/entrypoint.sh
@@ -19,8 +19,26 @@ rm -rf /run/*
 mkdir -p /run/sshd
 mkdir -p /run/nginx
 
+# eclient can be also used as a router app
+IP_FORWARDING="$(sysctl -n net.ipv4.ip_forward)"
+if [ "$IP_FORWARDING" -eq 1 ]; then
+    # With bare containers (eve.accel=false), IP forwarding is always enabled.
+    echo "IP forwarding is already enabled"
+else
+    echo "Enabling IP forwarding..."
+    sysctl -w net.ipv4.ip_forward=1 && echo "IP forwarding is now enabled"
+fi
+
 nginx
 
 /usr/sbin/sshd -h /root/.ssh/id_rsa
 
-avahi-daemon
+avahi-daemon -D
+
+# For app_logs test.
+echo "Started eclient"
+
+# Running shell as the entrypoint allows to enter the container using
+# `eve attach-app-console <console-id>/cons` and have interactive session.
+# This is useful when a deployed container cannot be accessed via ssh over the network.
+while true; do /bin/sh; done

--- a/tests/eclient/image/pkg/go.sum
+++ b/tests/eclient/image/pkg/go.sum
@@ -6,5 +6,6 @@ github.com/lf-edge/eve-api/go v0.0.0-20231214160111-99ce4e43be4b/go.mod h1:6XqpO
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
+google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=


### PR DESCRIPTION
3 small improvements:
- enable IP forwarding so that eclient can be used in tests to simulate router application
- run shell as the final foreground process. This enables to attach to the container using `eve attach-app-console` and enjoy interactive session
- add tcpdump - it can be useful when debugging connectivity issues that prevent installing it in runtime