### PR TITLE
Eden-SDN: add examples for application IP routing configurations

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -53,7 +53,7 @@ const (
 	DefaultRegistryPort         = 5050
 
 	//tags, versions, repos
-	DefaultEVETag               = "10.11.0" // DefaultEVETag tag for EVE image
+	DefaultEVETag               = "11.7.0" // DefaultEVETag tag for EVE image
 	DefaultAdamTag              = "0.0.43"
 	DefaultRedisTag             = "7"
 	DefaultRegistryTag          = "2.7"

--- a/sdn/examples/app-routing/README.md
+++ b/sdn/examples/app-routing/README.md
@@ -1,0 +1,377 @@
+# SDN Examples with application IP routing configurations
+
+Most of the edge deployments will deploy applications (VMs or containers) that will have
+connectivity to both WAN (Internet) and LAN (shop floor, machine floor).
+There may be a single WAN interface and multiple LAN interfaces. With the IP route
+configurability of Network instances provided by EVE, we can automatically (zero-touch)
+provision routing for applications that have access to both the Internet and one or more LANs.
+This is possible because EVE allows to:
+
+- use DHCP to propagate the connected routes to applications (routes for external networks
+  that uplink ports are connected to)
+- configure a set of static IP routes for a network instance and have them propagated
+  to applications
+
+Another common case is using one application as a network gateway for other applications
+running on the same device. The gateway application may provide some network function(s),
+such as firewall, IDS, network monitoring, etc. Such application will connect on one side with
+the external network(s) using directly attached network adapter(s) or via switch network
+instance(s), and the other side will make use of an air-gap local network instance to connect
+with other applications running on the device. Propagated static IP routes are necessary
+to make the application traffic flow through the gateway app. In theory, multiple network
+functions can be chained together in this way using several air-gap network instances
+with static IP routes.
+
+## Example 1: Application with multiple uplink ports
+
+[In this example](./multiple-uplinks), we connect a single application into 3 local network
+instances, each with a different uplink port. Network instance `ni-eth0` is connected
+to the management port `eth0`, `ni-eth1` uses app-shared uplink `eth1` with static IP
+configuration and default route disabled by setting `0.0.0.0` as the gateway IP in the network
+config, and finally `ni-eth2` with app-shared `eth2` running DHCP client but not getting
+the Router option (code: 3) from the DHCP server (i.e. not installing default route).
+
+Within the Eden-SDN environment, a dedicated HTTP "hello-world" server is deployed for each
+of these uplink ports, accessible exclusively through its assigned port. Note that these
+HTTP servers run in dedicated networks and not in the subnets of uplinks.
+
+Here is a diagram depicting the network topology:
+
+```text
+          +---------+    +-------------+     +-------------+
+   ------>| ni-eth0 |----| eth0 (mgmt) | ... | httpserver0 |
+   |      +---------+    +-------------+     +-------------+
+   |
++-----+   +---------+    +-------------------------+     +-------------+
+| app |-->| ni-eth1 |----|    eth1 (app-shared)    | ... | httpserver1 |
++-----+   +---------+    | (static, no def. route) |     +-------------+
+   |                     +-------------------------+
+   |
+   |      +---------+    +-------------------------+     +-------------+
+   ------>| ni-eth2 |----|    eth2 (app-shared)    | ... | httpserver2 |
+          +---------+    |  (DHCP, no def. route)  |     +-------------+
+                         +-------------------------+
+```
+
+Under typical circumstances, when network instances are configured with default IP routing
+settings, application would receive routes exclusively for the internal subnets of these
+local network instances. Consequently, the application would lack information about
+the specific interface to utilize when reaching endpoints within a particular uplink subnet
+or beyond.
+
+In order for the application to be able to access endpoints inside subnets of individual
+uplinks, we *enable propagation of connected routes* for `ni-eth0` and `ni-eth1` (excluding
+`ni-eth2` just to show that eth2 subnet will not be routed):
+
+```text
+  "networkInstances": [
+    {
+      "displayname": "ni-eth0",
+      ...
+      "propagateConnectedRoutes": true
+    },
+    {
+      "displayname": "ni-eth1",
+      ...
+      "propagateConnectedRoutes": true
+    },
+    ...
+  ]
+```
+
+This will result in the following routes added into the routing table of the application:
+
+```text
+172.22.12.0/24 via 10.50.0.1 dev eth0
+192.168.55.0/24 via 10.50.1.1 dev eth1
+```
+
+However, HTTP servers are not inside these networks but further in the routing path.
+Therefore, we have to add static routes targeting networks where servers are deployed:
+
+```text
+  "networkInstances": [
+    {
+      "displayname": "ni-eth0",
+      ...
+      "staticRoutes": [
+        {
+          "destinationNetwork": "10.20.20.0/24",
+          "gateway": "10.50.0.1"
+        }
+      ]
+    },
+    {
+      "displayname": "ni-eth1",
+      ...
+      "staticRoutes": [
+        {
+          "destinationNetwork": "10.21.21.0/24",
+          "gateway": "192.168.55.1"
+        }
+      ]
+    },
+    {
+      "displayname": "ni-eth2",
+      ...
+      "staticRoutes": [
+        {
+          "destinationNetwork": "10.22.22.0/24",
+          "gateway": "10.140.2.1"
+        }
+      ]
+    },
+    ...
+  ]
+```
+
+Note that gateway can be either from the uplink subnet (e.g. gateway of eth1 is `192.168.55.1`),
+or the NI bridge IP itself (`10.50.0.1` for ni-eth0). The latter is used when uplink
+IP addressing is not known ahead or can change in run-time. In such case it is better
+to first route the selected traffic towards the NI bridge and then let the NI default
+route received from uplink to route it further.
+
+Please refer to the [network model](multiple-uplinks/network-model.json) to find out the IP
+addressing used for uplinks and HTTP servers in this example.
+
+Run the example with:
+
+```shell
+make clean && make build-tests
+./eden config add default
+./eden config set default --key sdn.disable --value false
+./eden setup
+./eden start --sdn-network-model $(pwd)/sdn/examples/app-routing/multiple-uplinks/network-model.json
+./eden eve onboard
+./eden controller edge-node set-config --file $(pwd)/sdn/examples/app-routing/multiple-uplinks/device-config.json
+```
+
+Once deployed, login to the application:
+
+```shell
+./eden eve ssh
+CONSOLE="$(eve list-app-consoles | grep cee082fd-3a43-4599-bbd3-8216ffa8652d | grep CONTAINER | awk '{print $4}')"
+eve attach-app-console "$CONSOLE"
+```
+
+Inside the app, check IP routing table:
+
+```shell
+app$ ip route
+default via 10.50.0.1 dev eth0
+10.20.20.0/24 via 10.50.0.1 dev eth0
+10.21.21.0/24 via 10.50.1.1 dev eth1
+10.22.22.0/24 via 10.50.2.1 dev eth2
+10.50.0.0/24 via 10.50.0.1 dev eth0
+10.50.0.1 dev eth0 scope link src 10.50.0.2
+10.50.1.0/24 via 10.50.1.1 dev eth1
+10.50.1.1 dev eth1 scope link src 10.50.1.2
+10.50.2.0/24 via 10.50.2.1 dev eth2
+10.50.2.1 dev eth2 scope link src 10.50.2.2
+172.22.12.0/24 via 10.50.0.1 dev eth0
+192.168.55.0/24 via 10.50.1.1 dev eth1
+```
+
+Try to ping uplink gateways to test the propagation of connected routes. Note that `ni-eth2`
+does not have connected routes propagated:
+
+```shell
+app$ ping -c 3 172.22.12.1
+PING 172.22.12.1 (172.22.12.1): 56 data bytes
+64 bytes from 172.22.12.1: seq=0 ttl=63 time=1.446 ms
+64 bytes from 172.22.12.1: seq=1 ttl=63 time=2.574 ms
+64 bytes from 172.22.12.1: seq=2 ttl=63 time=4.058 ms
+
+--- 172.22.12.1 ping statistics ---
+3 packets transmitted, 3 packets received, 0% packet loss
+round-trip min/avg/max = 1.446/2.692/4.058 ms
+
+app$ ping -c 3 192.168.55.1
+PING 192.168.55.1 (192.168.55.1): 56 data bytes
+64 bytes from 192.168.55.1: seq=0 ttl=63 time=2.691 ms
+64 bytes from 192.168.55.1: seq=1 ttl=63 time=2.555 ms
+64 bytes from 192.168.55.1: seq=2 ttl=63 time=3.555 ms
+
+--- 192.168.55.1 ping statistics ---
+3 packets transmitted, 3 packets received, 0% packet loss
+round-trip min/avg/max = 2.555/2.933/3.555 ms
+
+app$ ping -c 3 10.140.2.1
+PING 10.140.2.1 (10.140.2.1): 56 data bytes
+
+--- 10.140.2.1 ping statistics ---
+3 packets transmitted, 0 packets received, 100% packet loss
+```
+
+Next, try to access HTTP servers to exercise static routes. Each will be routed through
+a different app interface (`httpserver1` and `httpserver2` would not be accessible if
+default route was taken):
+
+```shell
+app$ curl 10.20.20.70/helloworld
+Hello world from HTTP server no. 0
+app$ curl 10.21.21.70/helloworld
+Hello world from HTTP server no. 1
+app$ curl 10.22.22.70/helloworld
+Hello world from HTTP server no. 2
+```
+
+Finally, in terms of the default route, only the DHCP server of `ni-eth0` will advertise it
+(with NI bridge IP as the gateway). This is because both `eth1` and `eth2` are app-shared
+(not for management traffic) and have no default route of their own. EVE policy is defined
+to not propagate default route in such case. In this example, this leads to (typically desired)
+state of the application having only one default route.
+
+## Example 2: Application used as network gateway
+
+[In this example](./app-gateway), we deploy 3 applications, where one of them will act as
+an IP routing gateway for the other two. This simulates a scenario where "gateway" application
+is used to provide some network function, such as firewall. However, in this case the app merely
+routes traffic between the other two "client" applications and external endpoints. Air-gap network
+instances are used to interconnect client apps with the gateway app. One of the client apps
+directs a subset of its traffic through the gateway app, while the other designates
+it as the default gateway for all traffic.
+Inside Eden-SDN, we deploy an HTTP "hello-world" server to emulate an external endpoint.
+
+Here is a diagram depicting the network topology:
+
+```text
+                  +---------+    +-------------+     +-------------+
+       ---------->| ni-eth0 |----| eth0 (mgmt) | ... | httpserver0 |
+       |          +---------+    +-------------+     +-------------+
+       |
++-------------+   +---------+
+| app-client1 |-->| airgap1 |
++-------------+   +---------+
+                       |
+                       v
+                  +--------+    +------------------+    +-------------------+     +-------------+
+                  | app-gw |--->| ni-eth1 (switch) |----| eth1 (app-shared) | ... | httpserver1 |
+                  +--------+    +------------------+    +-------------------+     +-------------+
+                       ^
+                       |
++-------------+   +---------+
+| app-client2 |-->| airgap2 |
++-------------+   +---------+
+```
+
+To make this possible, `airgap1` is configured with static IP route that sends traffic destined
+to the network with `httpserver1` via `app-gw` IP. `app-client1` will receive default route
+for `ni-eth0` and this static IP route for `airgap1`.
+For `airgap2` we add static IP route sending all traffic via `app-gw`, i.e. `app-client2`
+will receive it as the default route.
+
+```text
+  "networkInstances": [
+    {
+      "displayname": "airgap1",
+      ...
+      "staticRoutes": [
+        {
+          "destinationNetwork": "10.21.21.0/24",
+          "gateway": "172.28.1.2"
+        }
+      ]
+    },
+    {
+      "displayname": "airgap2",
+      ...
+      "staticRoutes": [
+        {
+          "destinationNetwork": "0.0.0.0/0",
+          "gateway": "172.28.2.2"
+        }
+      ]
+    },
+    ...
+  ]
+```
+
+Note that `172.28.1.2` and `172.28.2.2` are IP addresses of `app-gw` inside the respective
+air-gap network instances (statically assigned).
+
+Run the example with:
+
+```shell
+make clean && make build-tests
+./eden config add default
+./eden config set default --key sdn.disable --value false
+./eden setup
+./eden start --sdn-network-model $(pwd)/sdn/examples/app-routing/app-gateway/network-model.json
+./eden eve onboard
+./eden controller edge-node set-config --file $(pwd)/sdn/examples/app-routing/app-gateway/device-config.json
+```
+
+Once deployed, login to `app-client1`:
+
+```shell
+./eden eve ssh
+CONSOLE="$(eve list-app-consoles | grep cee082fd-3a43-4599-bbd3-8216ffa8652d | grep CONTAINER | awk '{print $4}')"
+eve attach-app-console "$CONSOLE"
+```
+
+Inside the application, check IP routing table:
+
+```shell
+app-client1$ ip route
+default via 10.50.0.1 dev eth0
+10.50.0.0/24 via 10.50.0.1 dev eth0
+10.50.0.1 dev eth0 scope link src 10.50.0.2
+10.21.21.0/24 via 172.28.1.1 dev eth1
+172.28.1.0/24 via 172.28.1.1 dev eth1
+172.28.1.1 dev eth1 scope link src 172.28.1.3
+```
+
+Try to access `httpserver0`, this should not be routed via `app-gw`:
+
+```shell
+app-client1$ curl 10.20.20.70/helloworld
+Hello world from HTTP server no. 0
+```
+
+Then try to access `httpserver1`, this will be routed via `app-gw`:
+
+```shell
+app-client1$ curl 10.21.21.70/helloworld
+Hello world from HTTP server no. 1
+```
+
+Next, login to `app-client2`:
+
+```shell
+./eden eve ssh
+CONSOLE="$(eve list-app-consoles | grep 5341bfb9-c828-4f98-807e-e9763d4dc316 | grep CONTAINER | awk '{print $4}')"
+eve attach-app-console "$CONSOLE"
+```
+
+Check IP routing table:
+
+```shell
+app-client2$ ip route
+default via 172.28.2.1 dev eth0
+172.28.2.0/24 via 172.28.2.1 dev eth0
+172.28.2.1 dev eth0 scope link src 172.28.2.3
+```
+
+Try to access `httpserver1`. This, just like any request from `app-client2`, will be routed
+via `app-gw`:
+
+```shell
+app-client2$ curl 10.21.21.70/helloworld
+Hello world from HTTP server no. 1
+```
+
+At the same time, you can login to `app-gw` and observe traffic that passes through while
+making requests from client apps:
+
+```shell
+./eden eve ssh
+CONSOLE="$(eve list-app-consoles | grep 4d88a7c5-64fc-43ee-a58a-f5944bc7872c | grep CONTAINER | awk '{print $4}')"
+eve attach-app-console "$CONSOLE"
+tcpdump -i any -n
+```
+
+Please be aware that in both examples, you have the opportunity to experiment with
+the `debug.disable.dhcp.all-ones.netmask` config property. Initially, you can try the default
+value of `false`, then switch to `true`, and observe how the IP routing tables of applications
+differ while the behavior from the application's perspective remains consistent.

--- a/sdn/examples/app-routing/app-gateway/device-config.json
+++ b/sdn/examples/app-routing/app-gateway/device-config.json
@@ -1,0 +1,423 @@
+{
+  "deviceIoList": [
+    {
+      "ptype": 1,
+      "phylabel": "eth0",
+      "phyaddrs": {
+        "Ifname": "eth0"
+      },
+      "logicallabel": "eth0",
+      "assigngrp": "eth0",
+      "usage": 1,
+      "usagePolicy": {
+        "freeUplink": true
+      }
+    },
+    {
+      "ptype": 1,
+      "phylabel": "eth1",
+      "phyaddrs": {
+        "Ifname": "eth1"
+      },
+      "logicallabel": "eth1",
+      "assigngrp": "eth1",
+      "usage": 2,
+      "usagePolicy": {
+        "freeUplink": false
+      }
+    }
+  ],
+  "networks": [
+    {
+      "id": "6605d17b-3273-4108-8e6e-4965441ebe01",
+      "type": 4,
+      "ip": {
+        "dhcp": 4
+      }
+    },
+    {
+      "id": "9d003e2a-d8c4-4b44-a983-98aff1f957ec",
+      "type": 4,
+      "ip": {
+        "dhcp": 2
+      }
+    }
+  ],
+  "systemAdapterList": [
+    {
+      "name": "eth0",
+      "uplink": true,
+      "networkUUID": "6605d17b-3273-4108-8e6e-4965441ebe01"
+    },
+    {
+      "name": "eth1",
+      "networkUUID": "9d003e2a-d8c4-4b44-a983-98aff1f957ec"
+    }
+  ],
+  "networkInstances": [
+    {
+      "uuidandversion": {
+        "uuid": "3bc88a2c-3253-40ac-bb49-6a18d476eaf4",
+        "version": "1"
+      },
+      "displayname": "airgap1",
+      "instType": 2,
+      "activate": true,
+      "cfg": {},
+      "ipType": 1,
+      "ip": {
+        "subnet": "172.28.1.0/24",
+        "gateway": "172.28.1.1",
+        "dns": [
+          "172.28.1.1"
+        ],
+        "dhcpRange": {
+          "start": "172.28.1.100",
+          "end": "172.28.1.200"
+        }
+      },
+      "staticRoutes": [
+        {
+          "destinationNetwork": "10.21.21.0/24",
+          "gateway": "172.28.1.2"
+        }
+      ]
+    },
+    {
+      "uuidandversion": {
+        "uuid": "93d3ced2-e63a-4349-b031-9662ac970329",
+        "version": "1"
+      },
+      "displayname": "airgap2",
+      "instType": 2,
+      "activate": true,
+      "cfg": {},
+      "ipType": 1,
+      "ip": {
+        "subnet": "172.28.2.0/24",
+        "gateway": "172.28.2.1",
+        "dns": [
+          "172.28.2.1"
+        ],
+        "dhcpRange": {
+          "start": "172.28.2.100",
+          "end": "172.28.2.200"
+        }
+      },
+      "staticRoutes": [
+        {
+          "destinationNetwork": "0.0.0.0/0",
+          "gateway": "172.28.2.2"
+        }
+      ]
+    },
+    {
+      "uuidandversion": {
+        "uuid": "9ca83da9-94e8-48b4-9ae8-3f188c5c694a",
+        "version": "1"
+      },
+      "displayname": "ni-eth0",
+      "instType": 2,
+      "activate": true,
+      "port": {
+        "type": 1,
+        "name": "eth0"
+      },
+      "cfg": {},
+      "ipType": 1,
+      "ip": {
+        "subnet": "10.50.0.0/24",
+        "gateway": "10.50.0.1",
+        "dns": [
+          "10.50.0.1"
+        ],
+        "dhcpRange": {
+          "start": "10.50.0.2",
+          "end": "10.50.0.254"
+        }
+      }
+    },
+    {
+      "uuidandversion": {
+        "uuid": "207239ec-2d71-4f40-a698-c21c6422fe3d",
+        "version": "1"
+      },
+      "displayname": "ni-eth1",
+      "instType": 1,
+      "activate": true,
+      "port": {
+        "type": 1,
+        "name": "eth1"
+      },
+      "cfg": {},
+      "ipType": 1,
+      "ip": {}
+    }
+  ],
+  "apps": [
+    {
+      "uuidandversion": {
+        "uuid": "cee082fd-3a43-4599-bbd3-8216ffa8652d",
+        "version": "1"
+      },
+      "displayname": "app-client1",
+      "fixedresources": {
+        "memory": 512000,
+        "maxmem": 512000,
+        "vcpus": 1,
+        "virtualizationMode": 1
+      },
+      "drives": [
+        {
+          "image": {
+            "uuidandversion": {
+              "uuid": "398710ca-bf4f-46b0-b012-0d4e32214ba4",
+              "version": "1"
+            },
+            "name": "lfedge/eden-eclient:8a279cd",
+            "iformat": 8,
+            "dsId": "f204830d-cce1-4316-aa5e-3e8567cd09a9"
+          }
+        }
+      ],
+      "activate": true,
+      "interfaces": [
+        {
+          "name": "ni-eth0",
+          "networkId": "9ca83da9-94e8-48b4-9ae8-3f188c5c694a",
+          "acls": [
+            {
+              "matches": [
+                {
+                  "type": "ip",
+                  "value": "0.0.0.0/0"
+                }
+              ],
+              "id": 1
+            }
+          ]
+        },
+        {
+          "name": "airgap1",
+          "networkId": "3bc88a2c-3253-40ac-bb49-6a18d476eaf4",
+          "addr": "172.28.1.3",
+          "acls": [
+            {
+              "matches": [
+                {
+                  "type": "ip",
+                  "value": "0.0.0.0/0"
+                }
+              ],
+              "id": 1
+            }
+          ]
+        }
+      ],
+      "volumeRefList": [
+        {
+          "uuid": "d8fe3e53-cc6c-4cee-8562-b406a1a8ada7",
+          "mount_dir": "/"
+        }
+      ]
+    },
+    {
+      "uuidandversion": {
+        "uuid": "5341bfb9-c828-4f98-807e-e9763d4dc316",
+        "version": "1"
+      },
+      "displayname": "app-client2",
+      "fixedresources": {
+        "memory": 512000,
+        "maxmem": 512000,
+        "vcpus": 1,
+        "virtualizationMode": 1
+      },
+      "drives": [
+        {
+          "image": {
+            "uuidandversion": {
+              "uuid": "398710ca-bf4f-46b0-b012-0d4e32214ba4",
+              "version": "1"
+            },
+            "name": "lfedge/eden-eclient:8a279cd",
+            "iformat": 8,
+            "dsId": "f204830d-cce1-4316-aa5e-3e8567cd09a9"
+          }
+        }
+      ],
+      "activate": true,
+      "interfaces": [
+        {
+          "name": "airgap2",
+          "networkId": "93d3ced2-e63a-4349-b031-9662ac970329",
+          "addr": "172.28.2.3",
+          "acls": [
+            {
+              "matches": [
+                {
+                  "type": "ip",
+                  "value": "0.0.0.0/0"
+                }
+              ],
+              "id": 1
+            }
+          ]
+        }
+      ],
+      "volumeRefList": [
+        {
+          "uuid": "cee944a3-ae6f-4887-9d8d-adcc0ed02370",
+          "mount_dir": "/"
+        }
+      ]
+    },
+    {
+      "uuidandversion": {
+        "uuid": "4d88a7c5-64fc-43ee-a58a-f5944bc7872c",
+        "version": "1"
+      },
+      "displayname": "app-gw",
+      "fixedresources": {
+        "memory": 512000,
+        "maxmem": 512000,
+        "vcpus": 1,
+        "virtualizationMode": 1
+      },
+      "drives": [
+        {
+          "image": {
+            "uuidandversion": {
+              "uuid": "398710ca-bf4f-46b0-b012-0d4e32214ba4",
+              "version": "1"
+            },
+            "name": "lfedge/eden-eclient:8a279cd",
+            "iformat": 8,
+            "dsId": "f204830d-cce1-4316-aa5e-3e8567cd09a9"
+          }
+        }
+      ],
+      "activate": true,
+      "interfaces": [
+        {
+          "name": "ni-eth1",
+          "networkId": "207239ec-2d71-4f40-a698-c21c6422fe3d",
+          "macAddress": "02:01:02:03:04:05",
+          "acls": [
+            {
+              "matches": [
+                {
+                  "type": "ip",
+                  "value": "0.0.0.0/0"
+                }
+              ],
+              "id": 1
+            }
+          ]
+        },
+        {
+          "name": "airgap1",
+          "networkId": "3bc88a2c-3253-40ac-bb49-6a18d476eaf4",
+          "addr": "172.28.1.2",
+          "acls": [
+            {
+              "matches": [
+                {
+                  "type": "ip",
+                  "value": "0.0.0.0/0"
+                }
+              ],
+              "id": 1
+            }
+          ]
+        },
+        {
+          "name": "airgap2",
+          "networkId": "93d3ced2-e63a-4349-b031-9662ac970329",
+          "addr": "172.28.2.2",
+          "acls": [
+            {
+              "matches": [
+                {
+                  "type": "ip",
+                  "value": "0.0.0.0/0"
+                }
+              ],
+              "id": 1
+            }
+          ]
+        }
+      ],
+      "volumeRefList": [
+        {
+          "uuid": "5605093b-c7cf-4beb-bb6b-14d86d39c42b",
+          "mount_dir": "/"
+        }
+      ]
+    }
+  ],
+  "volumes": [
+    {
+      "uuid": "d8fe3e53-cc6c-4cee-8562-b406a1a8ada7",
+      "origin": {
+        "type": 2,
+        "downloadContentTreeID": "63d3b01f-f44f-4007-ba33-6e720bd52992"
+      },
+      "displayName": "app-client1-volume"
+    },
+    {
+      "uuid": "cee944a3-ae6f-4887-9d8d-adcc0ed02370",
+      "origin": {
+        "type": 2,
+        "downloadContentTreeID": "63d3b01f-f44f-4007-ba33-6e720bd52992"
+      },
+      "displayName": "app-client2-volume"
+    },
+    {
+      "uuid": "5605093b-c7cf-4beb-bb6b-14d86d39c42b",
+      "origin": {
+        "type": 2,
+        "downloadContentTreeID": "63d3b01f-f44f-4007-ba33-6e720bd52992"
+      },
+      "displayName": "app-gw-volume"
+    }
+  ],
+  "contentInfo": [
+    {
+      "uuid": "63d3b01f-f44f-4007-ba33-6e720bd52992",
+      "dsId": "f204830d-cce1-4316-aa5e-3e8567cd09a9",
+      "URL": "lfedge/eden-eclient:8a279cd",
+      "iformat": 8,
+      "displayName": "eden-eclient"
+    }
+  ],
+  "datastores": [
+    {
+      "id": "f204830d-cce1-4316-aa5e-3e8567cd09a9",
+      "dType": 5,
+      "fqdn": "docker://index.docker.io"
+    }
+  ],
+  "configItems": [
+    {
+      "key": "newlog.allow.fastupload",
+      "value": "true"
+    },
+    {
+      "key": "timer.config.interval",
+      "value": "10"
+    },
+    {
+      "key": "timer.download.retry",
+      "value": "60"
+    },
+    {
+      "key": "debug.default.loglevel",
+      "value": "debug"
+    },
+    {
+      "key": "debug.disable.dhcp.all-ones.netmask",
+      "value": "false"
+    }
+  ]
+}

--- a/sdn/examples/app-routing/app-gateway/network-model.json
+++ b/sdn/examples/app-routing/app-gateway/network-model.json
@@ -1,0 +1,126 @@
+{
+  "ports": [
+    {
+      "logicalLabel": "eveport0",
+      "adminUP": true
+    },
+    {
+      "logicalLabel": "eveport1",
+      "adminUP": true
+    }
+  ],
+  "bridges": [
+    {
+      "logicalLabel": "bridge0",
+      "ports": ["eveport0"]
+    },
+    {
+      "logicalLabel": "bridge1",
+      "ports": ["eveport1"]
+    }
+  ],
+  "networks": [
+    {
+      "logicalLabel": "network0",
+      "bridge": "bridge0",
+      "subnet": "172.22.12.0/24",
+      "gwIP": "172.22.12.1",
+      "dhcp": {
+        "enable": true,
+        "ipRange": {
+          "fromIP": "172.22.12.10",
+          "toIP": "172.22.12.20"
+        },
+        "domainName": "sdn",
+        "privateDNS": ["dns-server"]
+      },
+      "router": {
+        "outsideReachability": true,
+        "reachableEndpoints": ["dns-server", "httpserver0"]
+      }
+    },
+    {
+      "logicalLabel": "network1",
+      "bridge": "bridge1",
+      "subnet": "10.203.10.0/24",
+      "gwIP": "10.203.10.1",
+      "dhcp": {
+        "enable": true,
+        "ipRange": {
+          "fromIP": "10.203.10.100",
+          "toIP": "10.203.10.200"
+        },
+        "staticEntries": [
+          {
+            "mac": "02:01:02:03:04:05",
+            "ip": "10.203.10.150"
+          }
+        ],
+        "domainName": "sdn",
+        "privateDNS": ["dns-server"]
+      },
+      "router": {
+        "outsideReachability": false,
+        "reachableEndpoints": ["dns-server", "httpserver1"],
+        "routesTowardsEVE": [
+          {
+            "dstNetwork": "172.28.1.0/24",
+            "gateway": "10.203.10.150"
+          },
+          {
+            "dstNetwork": "172.28.2.0/24",
+            "gateway": "10.203.10.150"
+          }
+        ]
+      }
+    }
+  ],
+  "endpoints": {
+    "dnsServers": [
+      {
+        "logicalLabel": "dns-server",
+        "fqdn": "mdns-server.sdn",
+        "subnet": "10.16.16.0/24",
+        "ip": "10.16.16.25",
+        "staticEntries": [
+          {
+            "fqdn": "mydomain.adam",
+            "ip": "adam-ip"
+          }
+        ],
+        "upstreamServers": [
+          "1.1.1.1",
+          "8.8.8.8"
+        ]
+      }
+    ],
+    "httpServers": [
+      {
+        "logicalLabel": "httpserver0",
+        "fqdn": "httpserver0.sdn",
+        "subnet": "10.20.20.0/24",
+        "ip": "10.20.20.70",
+        "httpPort": 80,
+        "paths": {
+          "/helloworld": {
+            "contentType": "text/plain",
+            "content": "Hello world from HTTP server no. 0\n"
+          }
+        }
+      },
+      {
+        "logicalLabel": "httpserver1",
+        "fqdn": "httpserver1.sdn",
+        "subnet": "10.21.21.0/24",
+        "ip": "10.21.21.70",
+        "httpPort": 80,
+        "paths": {
+          "/helloworld": {
+            "contentType": "text/plain",
+            "content": "Hello world from HTTP server no. 1\n"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/sdn/examples/app-routing/multiple-uplinks/device-config.json
+++ b/sdn/examples/app-routing/multiple-uplinks/device-config.json
@@ -1,0 +1,316 @@
+{
+  "deviceIoList": [
+    {
+      "ptype": 1,
+      "phylabel": "eth0",
+      "phyaddrs": {
+        "Ifname": "eth0"
+      },
+      "logicallabel": "eth0",
+      "assigngrp": "eth0",
+      "usage": 1,
+      "usagePolicy": {
+        "freeUplink": true
+      }
+    },
+    {
+      "ptype": 1,
+      "phylabel": "eth1",
+      "phyaddrs": {
+        "Ifname": "eth1"
+      },
+      "logicallabel": "eth1",
+      "assigngrp": "eth1",
+      "usage": 2,
+      "usagePolicy": {
+        "freeUplink": false
+      }
+    },
+    {
+      "ptype": 1,
+      "phylabel": "eth2",
+      "phyaddrs": {
+        "Ifname": "eth2"
+      },
+      "logicallabel": "eth2",
+      "assigngrp": "eth2",
+      "usage": 2,
+      "usagePolicy": {
+        "freeUplink": false
+      }
+    }
+  ],
+  "networks": [
+    {
+      "id": "6605d17b-3273-4108-8e6e-4965441ebe01",
+      "type": 4,
+      "ip": {
+        "dhcp": 4
+      }
+    },
+    {
+      "id": "86cddf1a-badd-41ba-993d-6381611a2112",
+      "type": 4,
+      "ip": {
+        "dhcp": 1,
+        "subnet": "192.168.55.0/24",
+        "gateway": "0.0.0.0",
+        "dns": ["10.16.16.25"]
+      }
+    },
+    {
+      "id": "b970ac70-2ef7-4c6b-8bb8-ff8626321313",
+      "type": 4,
+      "ip": {
+        "dhcp": 4
+      }
+    }
+  ],
+  "systemAdapterList": [
+    {
+      "name": "eth0",
+      "uplink": true,
+      "networkUUID": "6605d17b-3273-4108-8e6e-4965441ebe01"
+    },
+    {
+      "name": "eth1",
+      "networkUUID": "86cddf1a-badd-41ba-993d-6381611a2112",
+      "addr": "192.168.55.2"
+    },
+    {
+      "name": "eth2",
+      "networkUUID": "b970ac70-2ef7-4c6b-8bb8-ff8626321313"
+    }
+  ],
+  "networkInstances": [
+    {
+      "uuidandversion": {
+        "uuid": "9ca83da9-94e8-48b4-9ae8-3f188c5c694a",
+        "version": "1"
+      },
+      "displayname": "ni-eth0",
+      "instType": 2,
+      "activate": true,
+      "port": {
+        "type": 1,
+        "name": "eth0"
+      },
+      "cfg": {},
+      "ipType": 1,
+      "ip": {
+        "subnet": "10.50.0.0/24",
+        "gateway": "10.50.0.1",
+        "dns": [
+          "10.50.0.1"
+        ],
+        "dhcpRange": {
+          "start": "10.50.0.2",
+          "end": "10.50.0.254"
+        }
+      },
+      "propagateConnectedRoutes": true,
+      "staticRoutes": [
+        {
+          "destinationNetwork": "10.20.20.0/24",
+          "gateway": "10.50.0.1"
+        }
+      ]
+    },
+    {
+      "uuidandversion": {
+        "uuid": "dfb79e0e-ebaf-40e7-93a5-e1267a366416",
+        "version": "1"
+      },
+      "displayname": "ni-eth1",
+      "instType": 2,
+      "activate": true,
+      "port": {
+        "type": 1,
+        "name": "eth1"
+      },
+      "cfg": {},
+      "ipType": 1,
+      "ip": {
+        "subnet": "10.50.1.0/24",
+        "gateway": "10.50.1.1",
+        "dns": [
+          "10.50.1.1"
+        ],
+        "dhcpRange": {
+          "start": "10.50.1.2",
+          "end": "10.50.1.254"
+        }
+      },
+      "propagateConnectedRoutes": true,
+      "staticRoutes": [
+        {
+          "destinationNetwork": "10.21.21.0/24",
+          "gateway": "192.168.55.1"
+        }
+      ]
+    },
+    {
+      "uuidandversion": {
+        "uuid": "398cfcca-0773-48ea-a314-f004a75e00de",
+        "version": "1"
+      },
+      "displayname": "ni-eth2",
+      "instType": 2,
+      "activate": true,
+      "port": {
+        "type": 1,
+        "name": "eth2"
+      },
+      "cfg": {},
+      "ipType": 1,
+      "ip": {
+        "subnet": "10.50.2.0/24",
+        "gateway": "10.50.2.1",
+        "dns": [
+          "10.50.2.1"
+        ],
+        "dhcpRange": {
+          "start": "10.50.2.2",
+          "end": "10.50.2.254"
+        }
+      },
+      "propagateConnectedRoutes": false,
+      "staticRoutes": [
+        {
+          "destinationNetwork": "10.22.22.0/24",
+          "gateway": "10.140.2.1"
+        }
+      ]
+    }
+  ],
+  "apps": [
+    {
+      "uuidandversion": {
+        "uuid": "cee082fd-3a43-4599-bbd3-8216ffa8652d",
+        "version": "1"
+      },
+      "displayname": "app",
+      "fixedresources": {
+        "memory": 512000,
+        "maxmem": 512000,
+        "vcpus": 1,
+        "virtualizationMode": 1
+      },
+      "drives": [
+        {
+          "image": {
+            "uuidandversion": {
+              "uuid": "398710ca-bf4f-46b0-b012-0d4e32214ba4",
+              "version": "1"
+            },
+            "name": "lfedge/eden-eclient:8a279cd",
+            "iformat": 8,
+            "dsId": "f204830d-cce1-4316-aa5e-3e8567cd09a9"
+          }
+        }
+      ],
+      "activate": true,
+      "interfaces": [
+        {
+          "name": "ni-eth0",
+          "networkId": "9ca83da9-94e8-48b4-9ae8-3f188c5c694a",
+          "acls": [
+            {
+              "matches": [
+                {
+                  "type": "ip",
+                  "value": "0.0.0.0/0"
+                }
+              ],
+              "id": 1
+            }
+          ]
+        },
+        {
+          "name": "ni-eth1",
+          "networkId": "dfb79e0e-ebaf-40e7-93a5-e1267a366416",
+          "acls": [
+            {
+              "matches": [
+                {
+                  "type": "ip",
+                  "value": "0.0.0.0/0"
+                }
+              ],
+              "id": 1
+            }
+          ]
+        },
+        {
+          "name": "ni-eth2",
+          "networkId": "398cfcca-0773-48ea-a314-f004a75e00de",
+          "acls": [
+            {
+              "matches": [
+                {
+                  "type": "ip",
+                  "value": "0.0.0.0/0"
+                }
+              ],
+              "id": 1
+            }
+          ]
+        }
+      ],
+      "volumeRefList": [
+        {
+          "uuid": "d8fe3e53-cc6c-4cee-8562-b406a1a8ada7",
+          "mount_dir": "/"
+        }
+      ]
+    }
+  ],
+  "volumes": [
+    {
+      "uuid": "d8fe3e53-cc6c-4cee-8562-b406a1a8ada7",
+      "origin": {
+        "type": 2,
+        "downloadContentTreeID": "63d3b01f-f44f-4007-ba33-6e720bd52992"
+      },
+      "displayName": "app-volume"
+    }
+  ],
+  "contentInfo": [
+    {
+      "uuid": "63d3b01f-f44f-4007-ba33-6e720bd52992",
+      "dsId": "f204830d-cce1-4316-aa5e-3e8567cd09a9",
+      "URL": "lfedge/eden-eclient:8a279cd",
+      "iformat": 8,
+      "displayName": "eden-eclient"
+    }
+  ],
+  "datastores": [
+    {
+      "id": "f204830d-cce1-4316-aa5e-3e8567cd09a9",
+      "dType": 5,
+      "fqdn": "docker://index.docker.io"
+    }
+  ],
+  "configItems": [
+    {
+      "key": "newlog.allow.fastupload",
+      "value": "true"
+    },
+    {
+      "key": "timer.config.interval",
+      "value": "10"
+    },
+    {
+      "key": "timer.download.retry",
+      "value": "60"
+    },
+    {
+      "key": "debug.default.loglevel",
+      "value": "debug"
+    },
+    {
+      "key": "debug.disable.dhcp.all-ones.netmask",
+      "value": "false"
+    }
+  ]
+}

--- a/sdn/examples/app-routing/multiple-uplinks/network-model.json
+++ b/sdn/examples/app-routing/multiple-uplinks/network-model.json
@@ -1,0 +1,145 @@
+{
+  "ports": [
+    {
+      "logicalLabel": "eveport0",
+      "adminUP": true
+    },
+    {
+      "logicalLabel": "eveport1",
+      "adminUP": true
+    },
+    {
+      "logicalLabel": "eveport2",
+      "adminUP": true
+    }
+  ],
+  "bridges": [
+    {
+      "logicalLabel": "bridge0",
+      "ports": ["eveport0"]
+    },
+    {
+      "logicalLabel": "bridge1",
+      "ports": ["eveport1"]
+    },
+    {
+      "logicalLabel": "bridge2",
+      "ports": ["eveport2"]
+    }
+  ],
+  "networks": [
+    {
+      "logicalLabel": "network0",
+      "bridge": "bridge0",
+      "subnet": "172.22.12.0/24",
+      "gwIP": "172.22.12.1",
+      "dhcp": {
+        "enable": true,
+        "ipRange": {
+          "fromIP": "172.22.12.10",
+          "toIP": "172.22.12.20"
+        },
+        "domainName": "sdn",
+        "privateDNS": ["dns-server"]
+      },
+      "router": {
+        "outsideReachability": true,
+        "reachableEndpoints": ["dns-server", "httpserver0"]
+      }
+    },
+    {
+      "logicalLabel": "network1",
+      "bridge": "bridge1",
+      "subnet": "192.168.55.0/24",
+      "gwIP": "192.168.55.1",
+      "dhcp": {
+        "enable": false
+      },
+      "router": {
+        "outsideReachability": false,
+        "reachableEndpoints": ["dns-server", "httpserver1"]
+      }
+    },
+    {
+      "logicalLabel": "network2",
+      "bridge": "bridge2",
+      "subnet": "10.140.2.0/24",
+      "gwIP": "10.140.2.1",
+      "dhcp": {
+        "enable": true,
+        "ipRange": {
+          "fromIP": "10.140.2.10",
+          "toIP": "10.140.2.100"
+        },
+        "withoutDefaultRoute": true,
+        "domainName": "sdn",
+        "privateDNS": ["dns-server"]
+      },
+      "router": {
+        "outsideReachability": false,
+        "reachableEndpoints": ["dns-server", "httpserver2"]
+      }
+    }
+  ],
+  "endpoints": {
+    "dnsServers": [
+      {
+        "logicalLabel": "dns-server",
+        "fqdn": "mdns-server.sdn",
+        "subnet": "10.16.16.0/24",
+        "ip": "10.16.16.25",
+        "staticEntries": [
+          {
+            "fqdn": "mydomain.adam",
+            "ip": "adam-ip"
+          }
+        ],
+        "upstreamServers": [
+          "1.1.1.1",
+          "8.8.8.8"
+        ]
+      }
+    ],
+    "httpServers": [
+      {
+        "logicalLabel": "httpserver0",
+        "fqdn": "httpserver0.sdn",
+        "subnet": "10.20.20.0/24",
+        "ip": "10.20.20.70",
+        "httpPort": 80,
+        "paths": {
+          "/helloworld": {
+            "contentType": "text/plain",
+            "content": "Hello world from HTTP server no. 0\n"
+          }
+        }
+      },
+      {
+        "logicalLabel": "httpserver1",
+        "fqdn": "httpserver1.sdn",
+        "subnet": "10.21.21.0/24",
+        "ip": "10.21.21.70",
+        "httpPort": 80,
+        "paths": {
+          "/helloworld": {
+            "contentType": "text/plain",
+            "content": "Hello world from HTTP server no. 1\n"
+          }
+        }
+      },
+      {
+        "logicalLabel": "httpserver2",
+        "fqdn": "httpserver2.sdn",
+        "subnet": "10.22.22.0/24",
+        "ip": "10.22.22.70",
+        "httpPort": 80,
+        "paths": {
+          "/helloworld": {
+            "contentType": "text/plain",
+            "content": "Hello world from HTTP server no. 2\n"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/sdn/vm/api/netModel.go
+++ b/sdn/vm/api/netModel.go
@@ -383,6 +383,20 @@ type Router struct {
 	ReachableEndpoints []string `json:"reachableEndpoints"`
 	// ReachableNetworks : Logical labels of reachable networks.
 	ReachableNetworks []string `json:"reachableNetworks"`
+	// RoutesTowardsEVE : a set of routes for traffic going towards EVE.
+	// This is typically used if one of the apps running on EVE is used as a gateway
+	// for other apps. Static routes are then needed on the Eden-SDN side to route
+	// returning traffic back via that gw app.
+	RoutesTowardsEVE []IPRoute `json:"routesTowardsEVE"`
+}
+
+// IPRoute : a single IP route entry.
+type IPRoute struct {
+	// DstNetwork : destination network address in the CIDR format:
+	// <IP-address>/<prefix-length>
+	DstNetwork string `json:"dstNetwork"`
+	// Gateway IP address. It should be from within the EVE port network subnet.
+	Gateway string `json:"gateway"`
 }
 
 // Firewall : network firewall.

--- a/sdn/vm/api/netModel.go
+++ b/sdn/vm/api/netModel.go
@@ -332,6 +332,8 @@ type DHCP struct {
 	// IPRange : a range of IP addresses to allocate from.
 	// Not applicable for IPv6.
 	IPRange IPRange `json:"ipRange"`
+	// WithoutDefaultRoute : do not advertise default route to DHCP clients.
+	WithoutDefaultRoute bool `json:"withoutDefaultRoute"`
 	// DomainName : name of the domain assigned to the network.
 	// It is propagated to clients using the DHCP option 15 (24 in DHCPv6).
 	DomainName string `json:"domainName"`

--- a/sdn/vm/api/netModel.go
+++ b/sdn/vm/api/netModel.go
@@ -332,6 +332,8 @@ type DHCP struct {
 	// IPRange : a range of IP addresses to allocate from.
 	// Not applicable for IPv6.
 	IPRange IPRange `json:"ipRange"`
+	// StaticEntries : list of MAC->IP entries statically configured for the DHCP server.
+	StaticEntries []MACToIP `json:"staticEntries"`
 	// WithoutDefaultRoute : do not advertise default route to DHCP clients.
 	WithoutDefaultRoute bool `json:"withoutDefaultRoute"`
 	// DomainName : name of the domain assigned to the network.
@@ -360,6 +362,14 @@ type DHCP struct {
 	// Eden-SDN will announce either IP address or FQDN depending on whether any of the assigned
 	// private DNS servers is able to resolve the NetbootServer domain name.
 	NetbootServer string `json:"netbootServer"`
+}
+
+// MACToIP maps MAC address to IP address.
+type MACToIP struct {
+	// MAC address.
+	MAC string `json:"mac"`
+	// IP address.
+	IP string `json:"ip"`
 }
 
 // DNSClientConfig : DNS configuration for a client.

--- a/sdn/vm/cmd/sdnagent/config.go
+++ b/sdn/vm/cmd/sdnagent/config.go
@@ -369,6 +369,10 @@ func (a *agent) getIntendedNetwork(network api.Network) dg.Graph {
 			ep := a.getEndpoint(dnsServer)
 			dnsServers = append(dnsServers, net.ParseIP(ep.IP))
 		}
+		gatewayIP := gwIP.IP
+		if dhcp.WithoutDefaultRoute {
+			gatewayIP = nil
+		}
 		intendedCfg.PutItem(configitems.DhcpServer{
 			ServerName:     network.LogicalLabel,
 			NetNamespace:   nsName,
@@ -376,7 +380,7 @@ func (a *agent) getIntendedNetwork(network api.Network) dg.Graph {
 			VethPeerIfName: brInIfName,
 			Subnet:         subnet,
 			IPRange:        ipRange,
-			GatewayIP:      gwIP.IP,
+			GatewayIP:      gatewayIP,
 			DomainName:     dhcp.DomainName,
 			DNSServers:     dnsServers,
 			NTPServer:      ntpServer,

--- a/sdn/vm/cmd/sdnagent/config.go
+++ b/sdn/vm/cmd/sdnagent/config.go
@@ -373,6 +373,14 @@ func (a *agent) getIntendedNetwork(network api.Network) dg.Graph {
 		if dhcp.WithoutDefaultRoute {
 			gatewayIP = nil
 		}
+		var staticEntries []configitems.MACToIP
+		for _, entry := range dhcp.StaticEntries {
+			mac, _ := net.ParseMAC(entry.MAC)
+			staticEntries = append(staticEntries, configitems.MACToIP{
+				MAC: mac,
+				IP:  net.ParseIP(entry.IP),
+			})
+		}
 		intendedCfg.PutItem(configitems.DhcpServer{
 			ServerName:     network.LogicalLabel,
 			NetNamespace:   nsName,
@@ -380,6 +388,7 @@ func (a *agent) getIntendedNetwork(network api.Network) dg.Graph {
 			VethPeerIfName: brInIfName,
 			Subnet:         subnet,
 			IPRange:        ipRange,
+			StaticEntries:  staticEntries,
 			GatewayIP:      gatewayIP,
 			DomainName:     dhcp.DomainName,
 			DNSServers:     dnsServers,

--- a/sdn/vm/cmd/sdnagent/parse.go
+++ b/sdn/vm/cmd/sdnagent/parse.go
@@ -197,6 +197,18 @@ func (a *agent) validateNetworks(netModel *parsedNetModel) (err error) {
 				network.LogicalLabel)
 			return
 		}
+		for _, entry := range dhcp.StaticEntries {
+			if _, err = net.ParseMAC(entry.MAC); err != nil {
+				err = fmt.Errorf("network %s has static DHCP entry with invalid MAC (%s)",
+					network.LogicalLabel, entry.MAC)
+				return
+			}
+			if ip := net.ParseIP(entry.IP); ip == nil {
+				err = fmt.Errorf("network %s has static DHCP entry with invalid IP (%s)",
+					network.LogicalLabel, entry.IP)
+				return
+			}
+		}
 	}
 
 	// Do not mix VLAN and non-VLAN network with the same bridge

--- a/sdn/vm/pkg/configitems/dhcpSrv.go
+++ b/sdn/vm/pkg/configitems/dhcpSrv.go
@@ -204,11 +204,13 @@ func (c *DhcpServerConfigurator) createDnsmasqConfFile(server DhcpServer) error 
 		}
 	}
 	// Default gateway.
-	if len(server.GatewayIP) != 0 {
-		// IPv6 needs to be handled with radvd.
-		if !isIPv6 {
+	// Note that gateway for IPv6 needs to be handled with radvd.
+	if !isIPv6 {
+		if len(server.GatewayIP) != 0 {
 			gwIP := server.GatewayIP.String()
 			file.WriteString(fmt.Sprintf("dhcp-option=option:router,%s\n", gwIP))
+		} else {
+			file.WriteString("dhcp-option=option:router\n")
 		}
 	}
 	// DNS servers.


### PR DESCRIPTION
These examples cover propagation of IP routes from network instances to applications, implemented in EVE by this PR: https://github.com/lf-edge/eve/pull/3690
Eventually, I would like to prepare an eden test (in Go), but for now we will have at least examples that can be run manually and used to test EVE.