### PR TITLE
GitHub Actions: Make Smoke job not fail fast

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
   smoke:
     continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         file_system: ['ext4', 'zfs']
         tpm: [true, false]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
           file_system: ${{ matrix.file_system }}
           tpm_enabled: ${{ matrix.tpm }}
           suite: "smoke.tests.txt"
-          eve_image:  ${{ inputs.eve_image }}
+          eve_image: ${{ inputs.eve_image }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
 
   networking:
@@ -71,7 +71,7 @@ jobs:
           file_system: "ext4"
           tpm_enabled: true
           suite: "networking.tests.txt"
-          eve_image:   ${{ inputs.eve_image }}
+          eve_image: ${{ inputs.eve_image }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
 
   storage:
@@ -157,4 +157,3 @@ jobs:
           suite: "user-apps.tests.txt"
           eve_image: ${{ inputs.eve_image }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
-


### PR DESCRIPTION
So that you can see which smoke tests on which architectures passed