### PR TITLE
GitHub Actions: use GitHub Artifact as EVE image if specified

### DIFF
--- a/.github/actions/run-eden-test/action.yml
+++ b/.github/actions/run-eden-test/action.yml
@@ -15,6 +15,8 @@ inputs:
     type: string
   eve_artifact_name:
     type: string
+  artifact_run_id:
+    type: string
 
 runs:
   using: 'composite'
@@ -26,6 +28,7 @@ runs:
         tpm_enabled: ${{ inputs.tpm_enabled }}
         eve_image: ${{ inputs.eve_image }}
         eve_artifact_name: ${{ inputs.eve_artifact_name }}
+        artifact_run_id: ${{ inputs.artifact_run_id }}
     - name: Run tests
       run: EDEN_TEST_STOP=n ./eden test ./tests/workflow -s ${{ inputs.suite }} -v debug
       shell: bash

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -12,6 +12,8 @@ inputs:
     type: string
   eve_artifact_name:
     type: string
+  artifact_run_id:
+    type: string
 
 runs:
   using: 'composite'
@@ -56,14 +58,18 @@ runs:
       shell: bash
       working-directory: "./eden"
     - name: Download artifact if specified
-      if: github.event.inputs.eve_artifact_name != ''
-      uses: actions/download-artifact@v3
+      if: inputs.eve_artifact_name != ''
+      uses: actions/download-artifact@v4
       with:
-        name: inputs.eve_artifact_name
+        github-token: ${{ github.token }}
+        name: ${{ inputs.eve_artifact_name }}
+        path: artifacts  # this is the directory where it will put the artifact, not its name
+        run-id: ${{ inputs.artifact_run_id }}
     - name: Load containers to docker if specified
-      if: github.event.inputs.eve_artifact_name != ''
+      if: inputs.eve_artifact_name != ''
       run: |
-        docker load -q -i ${{ inputs.eve_artifact_name }}.tar
+        docker load -q -i artifacts/${{ inputs.eve_artifact_name }}.tar
+        docker image ls
       shell: bash
     - name: Setup eve version
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,15 @@ on:
         type: string
       eve_artifact_name:
         type: string
+      artifact_run_id:
+        type: string
   workflow_call:
     inputs:
       eve_image:
         type: string
       eve_artifact_name:
+        type: string
+      artifact_run_id:
         type: string
 
 jobs:
@@ -54,6 +58,7 @@ jobs:
           suite: "smoke.tests.txt"
           eve_image: ${{ inputs.eve_image }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
+          artifact_run_id: ${{ inputs.artifact_run_id }}
 
   networking:
     name: Networking test suite
@@ -73,6 +78,7 @@ jobs:
           suite: "networking.tests.txt"
           eve_image: ${{ inputs.eve_image }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
+          artifact_run_id: ${{ inputs.artifact_run_id }}
 
   storage:
     continue-on-error: true
@@ -96,6 +102,7 @@ jobs:
           suite: "storage.tests.txt"
           eve_image: ${{ inputs.eve_image }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
+          artifact_run_id: ${{ inputs.artifact_run_id }}
 
   lpc-loc:
     name: LPC LOC test suite
@@ -115,6 +122,7 @@ jobs:
           suite: "lpc-loc.tests.txt"
           eve_image: ${{ inputs.eve_image }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
+          artifact_run_id: ${{ inputs.artifact_run_id }}
 
   eve-upgrade:
     continue-on-error: true
@@ -138,6 +146,7 @@ jobs:
           suite: "eve-upgrade.tests.txt"
           eve_image: ${{ inputs.eve_image }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
+          artifact_run_id: ${{ inputs.artifact_run_id }}
 
   user-apps:
     name: User apps test suite
@@ -157,3 +166,4 @@ jobs:
           suite: "user-apps.tests.txt"
           eve_image: ${{ inputs.eve_image }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
+          artifact_run_id: ${{ inputs.artifact_run_id }}


### PR DESCRIPTION
Previously, EVE images used for tests in PR were pushed to dockerhub. This comes with several disadvantages, amongst them is dockerhub rate limit and intermediate images published. Now we use GitHub artifacts instead. That still gives you flexibility of downloading specific EVE images to test locally, but removes dockerhub rate limit

Now action user can specify run id and artifact name which contains EVE image, which could be pulled and used to run tests