### PR TITLE
Add support for eden_version input in test workflow

### DIFF
--- a/.github/workflows/eden_emh_arm.yml
+++ b/.github/workflows/eden_emh_arm.yml
@@ -21,7 +21,7 @@ jobs:
           sudo add-apt-repository ppa:longsleep/golang-backports
           sudo apt install -y golang jq expect
       - name: Get eden
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: Create ubuntu server on packet hosting
         id: ubuntu
         run: |

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -30,7 +30,7 @@ jobs:
         fs: ["zfs", "ext4"]
     steps:
       - name: get eden
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: setup go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/eden_setup.yml
+++ b/.github/workflows/eden_setup.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           ip a
       - name: get eden
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Set up QEMU
@@ -40,7 +40,7 @@ jobs:
         run: |
           ip a
       - name: get eden
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Set up QEMU
@@ -80,9 +80,9 @@ jobs:
           ./eden config add setup --devmodel general
           ./eden --config setup setup
           ./eden --config setup clean
-          ./eden config delete setup         
-          
-          # try download and build from repo 
+          ./eden config delete setup
+
+          # try download and build from repo
           ./eden config add setup
           # use stable tag as eve tag and branch may differ
           ./eden config set setup --key eve.tag --value="8.6.0"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
     if: needs.check-secrets.outputs.available == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Set up QEMU

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             arch: arm64
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Set up QEMU

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ needs.determine-runner.outputs.runner }}
     steps:
       - name: Get code
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.1.1
         with:
           repository: "lf-edge/eden"
           ref: ${{ inputs.eden_version }}
@@ -71,7 +71,7 @@ jobs:
     runs-on: ${{ needs.determine-runner.outputs.runner }}
     steps:
       - name: Get code
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.1.1
         with:
           repository: "lf-edge/eden"
           ref: ${{ inputs.eden_version }}
@@ -96,7 +96,7 @@ jobs:
     runs-on: ${{ needs.determine-runner.outputs.runner }}
     steps:
       - name: Get code
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.1.1
         with:
           repository: "lf-edge/eden"
           ref: ${{ inputs.eden_version }}
@@ -117,7 +117,7 @@ jobs:
     runs-on: ${{ needs.determine-runner.outputs.runner }}
     steps:
       - name: Get code
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.1.1
         with:
           repository: "lf-edge/eden"
           ref: ${{ inputs.eden_version }}
@@ -142,7 +142,7 @@ jobs:
     runs-on: ${{ needs.determine-runner.outputs.runner }}
     steps:
       - name: Get code
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.1.1
         with:
           repository: "lf-edge/eden"
           ref: ${{ inputs.eden_version }}
@@ -163,7 +163,7 @@ jobs:
     runs-on: ${{ needs.determine-runner.outputs.runner }}
     steps:
       - name: Get code
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.1.1
         with:
           repository: "lf-edge/eden"
           ref: ${{ inputs.eden_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,13 @@
 ---
 name: Test
 
-on:
+on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:
+      eden_version:
+        type: string
+        required: false
+        default: ''  # if not provided: When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, uses the default branch.
       eve_image:
         type: string
       eve_artifact_name:
@@ -49,6 +53,7 @@ jobs:
         uses: actions/checkout@v3.5.3
         with:
           repository: "lf-edge/eden"
+          ref: ${{ inputs.eden_version }}
           path: "./eden"
       - name: Run Smoke tests
         uses: ./eden/.github/actions/run-eden-test
@@ -69,6 +74,7 @@ jobs:
         uses: actions/checkout@v3.5.3
         with:
           repository: "lf-edge/eden"
+          ref: ${{ inputs.eden_version }}
           path: "./eden"
       - name: Run Networking tests
         uses: ./eden/.github/actions/run-eden-test
@@ -93,6 +99,7 @@ jobs:
         uses: actions/checkout@v3.5.3
         with:
           repository: "lf-edge/eden"
+          ref: ${{ inputs.eden_version }}
           path: "./eden"
       - name: Run Storage tests
         uses: ./eden/.github/actions/run-eden-test
@@ -113,6 +120,7 @@ jobs:
         uses: actions/checkout@v3.5.3
         with:
           repository: "lf-edge/eden"
+          ref: ${{ inputs.eden_version }}
           path: "./eden"
       - name: Run LPC LOC tests
         uses: ./eden/.github/actions/run-eden-test
@@ -137,6 +145,7 @@ jobs:
         uses: actions/checkout@v3.5.3
         with:
           repository: "lf-edge/eden"
+          ref: ${{ inputs.eden_version }}
           path: "./eden"
       - name: Run EVE upgrade tests
         uses: ./eden/.github/actions/run-eden-test
@@ -157,6 +166,7 @@ jobs:
         uses: actions/checkout@v3.5.3
         with:
           repository: "lf-edge/eden"
+          ref: ${{ inputs.eden_version }}
           path: "./eden"
       - name: Run User apps upgrade tests
         uses: ./eden/.github/actions/run-eden-test

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: get eden
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: setup go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           path: src
           fetch-depth: 0


### PR DESCRIPTION
When the workflow is triggered from the outside, action/checkout defaults to checking out the latest master which is not always desired. For better compatibility with older EVE release the user should be able to specify the version of eden to be used in the test workflow. If no version is specified, the workflow should resert to the default behavior.