### PR TITLE
[WIP]: Fix arguments for Edge Application

### DIFF
--- a/tests/network/testdata/switch_net_vlans.txt
+++ b/tests/network/testdata/switch_net_vlans.txt
@@ -48,14 +48,14 @@ stdout '10.2.100.1  netmask 255.255.255.0'
 stdout '10.2.200.1  netmask 255.255.255.0'
 
 # Deploy app1 and connect it to VLAN 100
-eden pod deploy -n app1 --memory=448MB --networks=nat --networks=switch -p 8028:80 --vlan=switch:100 --metadata='url={{$test_data}}' {{$image}}
+eden pod deploy -n app1 --memory=448MB --networks=nat --networks=switch -p 8028:80 --vlan=switch:100 --metadata='url=\"{{$test_data}}\"' {{$image}}
 test eden.app.test -test.v -timewait 10m RUNNING app1
 exec -t 5m bash wait_and_get_ip.sh app1 8028
 grep 'app1_ip=10.2.100.\d+' .env
 source .env
 
 # Deploy app2 and connect it to VLAN 100
-eden pod deploy -n app2 --memory=448MB --networks=nat --networks=switch -p 8029:80 --vlan=switch:100 --metadata="url=http://${app1_ip}/user-data.html" {{$image}}
+eden pod deploy -n app2 --memory=448MB --networks=nat --networks=switch -p 8029:80 --vlan=switch:100 --metadata="url=\"http://${app1_ip}/user-data.html\"" {{$image}}
 test eden.app.test -test.v -timewait 10m RUNNING app2
 exec -t 5m bash wait_and_get_ip.sh app2 8029
 grep 'app2_ip=10.2.100.\d+' .env
@@ -69,7 +69,7 @@ eden pod delete app2
 test eden.app.test -test.v -timewait 10m - app2
 
 # Deploy app3 and connect it to VLAN 200
-eden pod deploy -n app3 --memory=448MB --networks=nat --networks=switch -p 8030:80 --vlan=switch:200 --metadata="url=http://${app1_ip}/user-data.html" {{$image}}
+eden pod deploy -n app3 --memory=448MB --networks=nat --networks=switch -p 8030:80 --vlan=switch:200 --metadata="url=\"http://${app1_ip}/user-data.html\"" {{$image}}
 test eden.app.test -test.v -timewait 10m RUNNING app3
 exec -t 5m bash wait_and_get_ip.sh app3 8030
 grep 'app3_ip=10.2.200.\d+' .env
@@ -83,7 +83,7 @@ eden pod delete app3
 test eden.app.test -test.v -timewait 10m - app3
 
 # Deploy app4 outside of VLANs
-eden pod deploy -n app4 --memory=448MB --networks=nat --networks=switch -p 8031:80 --metadata="url=http://${app1_ip}/user-data.html" {{$image}}
+eden pod deploy -n app4 --memory=448MB --networks=nat --networks=switch -p 8031:80 --metadata="url=\"http://${app1_ip}/user-data.html\"" {{$image}}
 test eden.app.test -test.v -timewait 10m RUNNING app4
 exec -t 5m bash wait_and_get_ip.sh app4 8031
 grep 'app4_ip=10.2.0.\d+' .env


### PR DESCRIPTION
**[WORK IN PROGRESS, please don't merge]**

EVE changed a bit the way of parsing custom configuration options for Edge Applications in order to avoid break containers due to variables that were doubled quoted. For instance:

myvar = "value"

Was breaking containers because it was interpreted like this:

myvar = ""value""

Now EVE trims spaces and double quotes from the value before write the declaration in environment file.

This commit fixes some declarations in swtich_net_vlans.txt that were leading to variables defined like this (also breaking containers):

"myvar = "value"