### PR TITLE
Increase default VirtMemory

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -93,7 +93,7 @@ const (
 	DefaultIsLocal               = false
 	DefaultEVEHV                 = "kvm"
 	DefaultCpus                  = 4
-	DefaultMemory                = 4096
+	DefaultMemory                = 8192
 	DefaultEVESerial             = "31415926"
 	NetDHCPID                    = "6822e35f-c1b8-43ca-b344-0bbc0ece8cf1"
 	NetDHCPID2                   = "6822e35f-c1b8-43ca-b344-0bbc0ece8cf2"


### PR DESCRIPTION
We saw failures in tests, due to insufficient memory, This should solve #951

Increasing in defaults makes more sense rather than in GitHub actions, so that error won't happen locally

cc: @giggsoff @eriknordmark 