### PR TITLE
Fix firmware path for Eden-SDN and define DeviceName

### DIFF
--- a/pkg/controller/device.go
+++ b/pkg/controller/device.go
@@ -638,6 +638,7 @@ volumeLoop:
 			Uuid:    dev.GetID().String(),
 			Version: strconv.Itoa(dev.GetConfigVersion()),
 		},
+		DeviceName:         dev.GetID().String(),
 		Volumes:            volumes,
 		ContentInfo:        contentTrees,
 		Apps:               applicationInstances,

--- a/pkg/openevec/eve.go
+++ b/pkg/openevec/eve.go
@@ -82,7 +82,8 @@ func (openEVEC *OpenEVEC) StartEveQemu(tapInterface string) error {
 		imageDir := filepath.Dir(cfg.Sdn.ImageFile)
 		firmware := []string{"OVMF_CODE.fd", "OVMF_VARS.fd"}
 		for i := range firmware {
-			firmware[i] = utils.ResolveAbsPath(filepath.Join(imageDir, firmware[i]))
+			firmware[i] = utils.ResolveAbsPath(
+				filepath.Join(imageDir, "firmware", firmware[i]))
 		}
 		sdnConfig := edensdn.SdnVMConfig{
 			Architecture: cfg.Eve.Arch,


### PR DESCRIPTION
[Recent changes](https://github.com/lf-edge/eden/pull/946) broke building of the Eden-SDN VM by moving the firmware files one directory deeper in the dist dir layout.

Another change in this commit is to set `DeviceName` inside the `EdgeDevConfig`. [The Kubevirt-variant of EVE will depend on this](https://github.com/naiming-zededa/eve/blob/poc-dec3/pkg/kube/cluster-init.sh#L114-L136) being set in the received config. However, it does not matter what the value is as long as it is not empty. In Eden will therefore simply use the device UUID as the device name.