### PR TITLE
Allow to configure MTU for Eden-SDN networks

### DIFF
--- a/pkg/edensdn/qemu.go
+++ b/pkg/edensdn/qemu.go
@@ -30,6 +30,12 @@ func (vm *SdnVMQemuRunner) Start() error {
 	qemuOptions += fmt.Sprintf("-serial chardev:char0 -chardev socket,id=char0,port=%d,"+
 		"host=localhost,server,nodelay,nowait,telnet,logfile=%s ",
 		vm.TelnetPort, vm.ConsoleLogFile)
+	// Please note that the SDN agent uses maxMTU=16110, which is the limit imposed
+	// by the e1000 device. Should a different network device be used, do not forget
+	// to update maxMTU value accordingly.
+	// Virtio driver used for arm64 architecture does not impose any MTU limit,
+	// meaning that MTU can be up to the theoretical limit of 65535 bytes
+	// (but we still use 16110 as maxMTU even for arm64).
 	netDev := "e1000"
 	hostOS := strings.ToLower(vm.HostOS)
 	if hostOS == "" {

--- a/sdn/vm/api/endpoints.go
+++ b/sdn/vm/api/endpoints.go
@@ -70,6 +70,8 @@ type Endpoint struct {
 	// IP should be inside of the Subnet.
 	IP string `json:"ip"`
 	// MTU of the endpoint's interface.
+	// If not defined (zero value), the default MTU for Ethernet, which is 1500 bytes,
+	// will be set.
 	MTU uint16 `json:"mtu"`
 }
 

--- a/sdn/vm/api/netModel.go
+++ b/sdn/vm/api/netModel.go
@@ -89,8 +89,6 @@ type Port struct {
 	// MAC address assigned to the interface on the SDN side.
 	// If not specified by the user, Eden will generate a random MAC address.
 	MAC string `json:"mac"`
-	// MTU : Maximum transmission unit (for the SDN side).
-	MTU uint16 `json:"mtu"`
 	// AdminUP : whether the interface should be UP on the SDN side.
 	// Put down to test link-down scenarios on EVE.
 	AdminUP bool `json:"adminUP"`
@@ -217,6 +215,10 @@ type Network struct {
 	Subnet string `json:"subnet"`
 	// GwIP should be inside the Subnet.
 	GwIP string `json:"gwIP"`
+	// MTU : Maximum transmission unit size set for this network.
+	// If not defined (zero value), the default MTU for Ethernet, which is 1500 bytes,
+	// will be set.
+	MTU uint16 `json:"mtu"`
 	// DHCP configuration.
 	DHCP DHCP `json:"dhcp"`
 	// TransparentProxy : Logical label of a TransparentProxy endpoint, performing

--- a/sdn/vm/cmd/sdnagent/config.go
+++ b/sdn/vm/cmd/sdnagent/config.go
@@ -157,6 +157,7 @@ func (a *agent) getIntendedHostConnectivity() dg.Graph {
 		},
 		Usage:   configitems.IfUsageL3,
 		AdminUP: true,
+		MTU:     maxMTU,
 	}, nil)
 	intendedCfg.PutItem(configitems.Sysctl{
 		EnableIPv4Forwarding:  true,
@@ -232,7 +233,7 @@ func (a *agent) getIntendedBridges() dg.Graph {
 			ParentLL: masterID.logicalLabel,
 			Usage:    usage,
 			AdminUP:  port.AdminUP,
-			MTU:      port.MTU,
+			MTU:      maxMTU,
 		}, nil)
 	}
 	for _, bond := range a.netModel.Bonds {
@@ -252,6 +253,7 @@ func (a *agent) getIntendedBridges() dg.Graph {
 			Bond:              bond,
 			IfName:            a.bondIfName(bond.LogicalLabel),
 			AggregatedPhysIfs: aggrPhysIfs,
+			MTU:               maxMTU,
 		}, nil)
 	}
 	for _, bridge := range a.netModel.Bridges {
@@ -289,6 +291,7 @@ func (a *agent) getIntendedBridges() dg.Graph {
 			PhysIfs:      physIfs,
 			BondIfs:      bonds,
 			VLANs:        vlans,
+			MTU:          maxMTU,
 		}, nil)
 	}
 	return intendedCfg
@@ -317,6 +320,7 @@ func (a *agent) getIntendedNetwork(network api.Network) dg.Graph {
 			IfName:       brInIfName,
 			NetNamespace: nsName,
 			IPAddresses:  []*net.IPNet{gwIP},
+			MTU:          network.MTU,
 		},
 		Peer2: configitems.VethPeer{
 			IfName:       brOutIfName,
@@ -325,6 +329,7 @@ func (a *agent) getIntendedNetwork(network api.Network) dg.Graph {
 				IfName: a.bridgeIfName(network.Bridge),
 				VLAN:   network.VlanID,
 			},
+			MTU: network.MTU,
 		},
 	}, nil)
 
@@ -338,13 +343,13 @@ func (a *agent) getIntendedNetwork(network api.Network) dg.Graph {
 			IfName:       rtInIfName,
 			NetNamespace: nsName,
 			IPAddresses:  []*net.IPNet{inIP},
-			MTU:          maxMTU, // do not limit MTU on this link
+			MTU:          network.MTU,
 		},
 		Peer2: configitems.VethPeer{
 			IfName:       rtOutIfName,
 			NetNamespace: configitems.MainNsName,
 			IPAddresses:  []*net.IPNet{outIP},
-			MTU:          maxMTU, // do not limit MTU on this link
+			MTU:          network.MTU,
 		},
 	}, nil)
 

--- a/tests/eclient/image/Dockerfile
+++ b/tests/eclient/image/Dockerfile
@@ -26,7 +26,8 @@ RUN apk add --no-cache lshw \
     setserial \
     avahi \
     lsblk \
-    tcpdump && \
+    tcpdump \
+    iputils && \
     apk --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/edge/community add -U --upgrade dhcping sysbench
 
 COPY --from=build /out /


### PR DESCRIPTION
Soon EVE will allow to configure MTU for network adapters and network
instances (to support jumbo frames for application traffic).
For testing purposes, it is therefore desirable to allow changing
network MTU size also on the Eden-SDN side.