### PR TITLE
Use latest EVE LTS version for testing upgrades

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -53,7 +53,7 @@ const (
 	DefaultRegistryPort         = 5050
 
 	//tags, versions, repos
-	DefaultEVETag               = "11.7.0" // DefaultEVETag tag for EVE image
+	DefaultEVETag               = "12.1.0" // DefaultEVETag tag for EVE image
 	DefaultAdamTag              = "0.0.43"
 	DefaultRedisTag             = "7"
 	DefaultRegistryTag          = "2.7"

--- a/tests/update_eve_image/testdata/update_eve_image_http.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_http.txt
@@ -1,5 +1,5 @@
 # Default EVE version to update
-{{$eve_ver := "9.7.0"}}
+{{$eve_ver := "12.0.1"}}
 
 # Default EVE registry to update
 {{$eve_registry := "lfedge/eve"}}

--- a/tests/update_eve_image/testdata/update_eve_image_oci.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_oci.txt
@@ -1,5 +1,5 @@
 # Default EVE version to update
-{{$eve_ver := "9.6.0"}}
+{{$eve_ver := "12.0.1"}}
 
 # Default EVE registry to update
 {{$eve_registry := "lfedge/eve"}}


### PR DESCRIPTION
If EVE 12.X is installed, downgrade to 11.X (or older) version is going to fail. This is because the `policy_version` of fscrypt was bumped from 1 to 2 and this change is not backward compatible. See:

https://github.com/lf-edge/eve/commit/8b8424668cc76098f3326c790333502ff5fc51a3