### PR TITLE
Increase memory available for EVE-OS in EdenGCP tests

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -175,7 +175,7 @@ const (
 	DefaultGcpBucketName   = "eve-live"
 	DefaultGcpProjectName  = "lf-edge-eve"
 	DefaultGcpZone         = "us-west1-a"
-	DefaultGcpMachineType  = "n1-highcpu-4"
+	DefaultGcpMachineType  = "n1-standard-2" // 2 vCPU 7.5 GB RAM
 	DefaultGcpRulePriority = 10
 
 	//defaults for packet


### PR DESCRIPTION
We have DefaultMemory [increased](https://github.com/lf-edge/eden/pull/963) up to 8GB but did not change GcpMachineType accordingly. Let's use less vCPUs (2 instead of 4, we do not have stress tests for now) and increase RAM (7.5GB instead of 3 .75GB) to fit tests and do not increase costs.
Hope it will solve the problem with [no remaining memory in test](https://github.com/lf-edge/eden/actions/runs/9487971898/job/26145793146#step:17:2024).