### PR TITLE
GitHub Actions: Integrate telemetry action

### DIFF
--- a/.github/actions/run-eden-test/action.yml
+++ b/.github/actions/run-eden-test/action.yml
@@ -21,6 +21,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Collect Workflow Telemetry
+      uses: catchpoint/workflow-telemetry-action@v2
+      with:
+        proc_trace_sys_enable: true
+        comment_on_pr: false
     - name: Setup Environment
       uses: ./eden/.github/actions/setup-environment
       with:


### PR DESCRIPTION
This action will gather statistics around eden test execution in GitHub Runners, helping us identify bottlenecks

CC: @milan-zededa 

Let's see what we have in Eden repo 