### PR TITLE
qemu: replace serial console port

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -42,7 +42,7 @@ const (
 	DefaultIP                   = "192.168.0.1"
 	DefaultEVEIP                = "192.168.1.2"
 	DefaultEserverPort          = 8888
-	DefaultTelnetPort           = 7777
+	DefaultTelnetPort           = 17777
 	DefaultQemuMonitorPort      = 7788
 	DefaultQemuNetdevSocketPort = 7790
 	DefaultSSHPort              = 2222

--- a/shell-scripts/collect-info-console.sh
+++ b/shell-scripts/collect-info-console.sh
@@ -18,7 +18,7 @@ for i in $(seq 3); do
   {
     echo "eve verbose off"; echo "eve enter debug"; sleep 3;
     echo "which collect-info.sh"; sleep 3
-  } | telnet localhost 7777 | tee telnet.stdout
+  } | telnet 127.1 17777 | tee telnet.stdout
   grep -q "/usr/bin/collect-info.sh" telnet.stdout && break
   sleep 60
 done
@@ -27,7 +27,7 @@ for i in $(seq 3); do
   {
     echo "rm -f /persist/eve-info*"; echo "/usr/bin/collect-info.sh";
     sleep $((WAIT_TIME+60*(i-1)))
-  } | telnet localhost 7777 | tee telnet.stdout
+  } | telnet 127.1 17777 | tee telnet.stdout
   TGZNAME="$(sed -n "s/EVE info is collected '\(.*\)'/\1/p" telnet.stdout)"
   [ -n "${TGZNAME}" ] && break
 done
@@ -44,7 +44,7 @@ for i in $(seq 3); do
     # This is fairly quick even on Github runners - around 10 seconds, but depends
     # on the tarball size.
     sleep $((20+60*(i-1)))
-  } | telnet localhost 7777 | sed -n "s/>>>\(.*\)<<</\1/p" | base64 -id > "${OUTPUT}"
+  } | telnet 127.1 17777 | sed -n "s/>>>\(.*\)<<</\1/p" | base64 -id > "${OUTPUT}"
   [ -s "${OUTPUT}" ] && break
   echo "Failed to receive eve-info tarball, retrying..."
 done


### PR DESCRIPTION
7777 is used by gh action runner on IPv6

zededa@eve-runner:~/actions-runner$ sudo netstat -ltnp Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
tcp        0      0 127.0.0.54:53           0.0.0.0:*               LISTEN      1165/systemd-resolv
tcp        0      0 127.0.0.53:53           0.0.0.0:*               LISTEN      1165/systemd-resolv
tcp6       0      0 ::1:7777                :::*                    LISTEN      14603/node
tcp6       0      0 :::22                   :::*
LISTEN      1/init

also some implementations of telnet try IPv6 first if the host has both addresses assigned