### PR TITLE
Increase timeout for deployment of two nginx apps

### DIFF
--- a/tests/app/testdata/2dockers_test.txt
+++ b/tests/app/testdata/2dockers_test.txt
@@ -17,7 +17,7 @@ eden -t 1m pod deploy -p 8028:80 docker://nginx -n t2 --memory 512MB
 stdout 'deploy pod t2 with docker://nginx request sent'
 
 # Wait for run
-test eden.app.test -test.v -timewait 10m RUNNING t1 t2
+test eden.app.test -test.v -timewait 15m RUNNING t1 t2
 
 # Dockers detecting
 eden -t 1m pod ps

--- a/tests/registry/testdata/registry_test.txt
+++ b/tests/registry/testdata/registry_test.txt
@@ -21,7 +21,7 @@ eden -t 1m pod deploy -p 8028:80 --registry=local docker://nginx -n t2
 stdout 'deploy pod t2 with docker://nginx request sent'
 
 # Wait for run
-test eden.app.test -test.v -timewait 10m RUNNING t1 t2
+test eden.app.test -test.v -timewait 15m RUNNING t1 t2
 
 # Dockers detecting
 eden -t 1m pod ps


### PR DESCRIPTION
10 minutes is sometimes not enough with ZFS and slower runner.