### PR TITLE
GitHub Actions: Bump reusable actions to be compatible with node16

### DIFF
--- a/.github/workflows/eden_setup.yml
+++ b/.github/workflows/eden_setup.yml
@@ -18,9 +18,9 @@ jobs:
       - name: get eden
         uses: actions/checkout@v4.1.1
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: setup go
         uses: actions/setup-go@v3
         with:
@@ -42,9 +42,9 @@ jobs:
       - name: get eden
         uses: actions/checkout@v4.1.1
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: setup go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,9 +26,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Login to DockerHUB
         id: login
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: setup
         run: |
           sudo apt update
@@ -36,7 +36,7 @@ jobs:
         run: echo "TAG=$(echo "$REF" | sed -e 's#^.*/##')" >> "$GITHUB_ENV"
       - name: Create a GitHub release
         id: create-release
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |
@@ -72,11 +72,10 @@ jobs:
           tar -zcvf eden.${{ matrix.os }}.${{ matrix.arch }}.tar.gz -C ./ ./eden ./README.md dist docs tests
       - name: Upload Release Asset
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           upload_url: ${{ steps.create-release.outputs.result }}
-          asset_path: ./eden.${{ matrix.os }}.${{ matrix.arch }}.tar.gz
-          asset_name: eden.${{ matrix.os }}.${{ matrix.arch }}.tar.gz
-          asset_content_type: application/gzip
+          files: ./eden.${{ matrix.os }}.${{ matrix.arch }}.tar.gz


### PR DESCRIPTION
Following actions were using node12 which is deprecated and they were forced to use node16. Also upload-release-asset was deprecated so this patch switches to maintained action listed in official repository