### PR TITLE
eden/qemu: start QMP logger to log QEMU events

### DIFF
--- a/.github/actions/publish-logs/action.yml
+++ b/.github/actions/publish-logs/action.yml
@@ -17,6 +17,7 @@ runs:
         ./eden metric --format json > metric.log || echo "no metric"
         ./eden netstat --format json > netstat.log || echo "no netstat"
         cp dist/default-eve.log console.log || echo "no device log"
+        cp dist/qmp.log qmp.log || echo "no qmp log"
         docker logs eden_adam > adam.log 2>&1 || echo "no adam log"
       shell: bash
       working-directory: "./eden"
@@ -53,4 +54,5 @@ runs:
             ${{ github.workspace }}/eden/metric.log
             ${{ github.workspace }}/eden/netstat.log
             ${{ github.workspace }}/eden/console.log
+            ${{ github.workspace }}/eden/qmp.log
             ${{ github.workspace }}/eden/adam.log

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -40,7 +40,7 @@ runs:
     - name: Install Packages
       run: |
         sudo add-apt-repository ppa:stefanberger/swtpm-jammy
-        sudo apt install -y qemu-utils qemu-system-x86 jq swtpm util-linux
+        sudo apt install -y qemu-utils qemu-system-x86 jq swtpm util-linux socat
       shell: bash
     - name: Build tests
       run: |


### PR DESCRIPTION
Nice to have QMP events from QEMU, probably can help to debug sudden reboots/reset issues.

This commit uses simple shell "echo | socat" cmd for reading qemu qmp events. Probably makes sense to rewrite on native go.

QEMU creates a socket file and uses is as server socket. socat attaches to it, sends handshake message and redirects output (qmp events) to the `qmp.log` file. if socket file was not created within 5 seconds, the `startQMPLogger()` complains, but this error is not considered as fatal and eden continues.