### PR TITLE
appended the run attempt no. to prevent overwriting logs

### DIFF
--- a/.github/actions/run-eden-test/action.yml
+++ b/.github/actions/run-eden-test/action.yml
@@ -62,7 +62,7 @@ runs:
       if: always()
       uses: ./eden/.github/actions/publish-logs
       with:
-        report_name: eden-report-${{ inputs.suite }}-tpm-${{ inputs.tpm_enabled }}-${{ inputs.file_system }}
+        report_name: eden-report-${{ inputs.suite }}-tpm-${{ inputs.tpm_enabled }}-${{ inputs.file_system }}-${{ github.run_attempt }}
     - name: Clean up after test
       if: always()
       run: |


### PR DESCRIPTION
Appended the `${{ github.run_attempt }}` to prevent overwriting logs for the collect logs job.
