### PR TITLE
qemu,action.yml: introduce context for the QMP log and socket

### DIFF
--- a/.github/actions/publish-logs/action.yml
+++ b/.github/actions/publish-logs/action.yml
@@ -17,7 +17,7 @@ runs:
         ./eden metric --format json > metric.log || echo "no metric"
         ./eden netstat --format json > netstat.log || echo "no netstat"
         cp dist/default-eve.log console.log || echo "no device log"
-        cp dist/qmp.log qmp.log || echo "no qmp log"
+        cp dist/default-qmp.log qmp.log || echo "no qmp log"
         docker logs eden_adam > adam.log 2>&1 || echo "no adam log"
       shell: bash
       working-directory: "./eden"

--- a/pkg/eden/qemu.go
+++ b/pkg/eden/qemu.go
@@ -222,8 +222,16 @@ func StartEVEQemu(qemuARCH, qemuOS, eveImageFile, imageFormat string, isInstalle
 		qemuOptions += fmt.Sprintf("-readconfig %s ", qemuConfigFile)
 	}
 
-	qmpSockFile := filepath.Join(filepath.Dir(pidFile), "qmp.sock")
-	qmpLogFile := filepath.Join(filepath.Dir(pidFile), "qmp.log")
+	context, err := utils.ContextLoad()
+	if err != nil {
+		return fmt.Errorf("StartEVEQemu: load context error: %w", err)
+	}
+
+	qmpSockFile := fmt.Sprintf("%s-qmp.sock", strings.ToLower(context.Current))
+	qmpLogFile := fmt.Sprintf("%s-qmp.log", strings.ToLower(context.Current))
+
+	qmpSockFile = filepath.Join(filepath.Dir(pidFile), qmpSockFile)
+	qmpLogFile = filepath.Join(filepath.Dir(pidFile), qmpLogFile)
 
 	// QMP sock
 	qemuOptions += fmt.Sprintf("-qmp unix:%s,server,wait=off", qmpSockFile)


### PR DESCRIPTION
Two separate instances of eden may compete for same QMP files. Let's separate them with context names, so not just `qmp.log` but `default-qmp.log` instead.

CC: @giggsoff 