### PR TITLE
Make eden compatible with EVE 12.0 LTS

### DIFF
--- a/.github/actions/run-eden-test/action.yml
+++ b/.github/actions/run-eden-test/action.yml
@@ -67,7 +67,7 @@ runs:
       if: always()
       run: |
         ./eden stop
-        make clean
-        docker system prune -f -a
+        make clean >/dev/null
+        docker system prune -f -a >/dev/null
       shell: bash
       working-directory: "./eden"

--- a/pkg/openevec/pod.go
+++ b/pkg/openevec/pod.go
@@ -559,8 +559,9 @@ func (openEVEC *OpenEVEC) PodModify(appName string, podNetworks, portPublish, ac
 			if needPurge {
 				processingFunction := func(im *info.ZInfoMsg) bool {
 					if im.Ztype == info.ZInfoTypes_ZiApp {
-						// waiting for halting state
-						if im.GetAinfo().State == info.ZSwState_HALTING {
+						// waiting for purging or halting state
+						if im.GetAinfo().State == info.ZSwState_PURGING ||
+							im.GetAinfo().State == info.ZSwState_HALTING {
 							return true
 						}
 					}

--- a/sdn/vm/scripts/get-eve-ip.sh
+++ b/sdn/vm/scripts/get-eve-ip.sh
@@ -8,7 +8,7 @@ find_ip() {
   if [ -n "$NETNS" ]; then
     PREFIX="ip netns exec $NETNS "
   fi
-  $PREFIX arp -a | while read ARP_ENTRY; do
+  $PREFIX arp -an | while read ARP_ENTRY; do
       local ENTRY_IP="$(echo "$ARP_ENTRY" | cut -d ' ' -f 2 | tr -d '()')"
       local ENTRY_MAC="$(echo "$ARP_ENTRY" | cut -d ' ' -f 4)"
       if [ "$MAC" = "$ENTRY_MAC" ]; then

--- a/tests/app/app_test.go
+++ b/tests/app/app_test.go
@@ -62,6 +62,13 @@ func checkNewLastState(appName, state string) bool {
 	appStates, ok := states[appName]
 	if ok {
 		lastState := appStates[len(appStates)-1]
+		// PURGING and RESTARTING are not published by EVE since 12.3
+		if state == "PURGING" || state == "RESTARTING" {
+			if lastState.state == "HALTING" {
+				// The expected state was reached.
+				return false
+			}
+		}
 		if lastState.state != state {
 			return true
 		}

--- a/tests/eclient/testdata/app_dns.txt
+++ b/tests/eclient/testdata/app_dns.txt
@@ -61,7 +61,7 @@ stdout 'Address:\s*172.26.11.1'
 # Repeat DNS resolution tests after purging (we had bugs affecting this scenario).
 message 'Purging app1'
 eden pod purge app1
-test eden.app.test -test.v -timewait 5m HALTING app1
+test eden.app.test -test.v -timewait 5m PURGING app1
 test eden.app.test -test.v -timewait 5m RUNNING app1
 
 message 'Re-checking accessibility after purge of app1'

--- a/tests/eclient/testdata/app_local_info.txt
+++ b/tests/eclient/testdata/app_local_info.txt
@@ -73,7 +73,7 @@ exec -t 1m bash get-appinfo-status.sh app1
 ! stdout 'lastCmdTimestamp'
 ! stderr .
 exec -t 1m bash put-appinfo-cmd.sh app1 123 COMMAND_PURGE &
-exec -t 5m bash wait-for-app-state.sh app1 HALTING
+exec -t 5m bash wait-for-app-state.sh app1 "PURGING|HALTING"
 exec -t 5m bash wait-for-app-state.sh app1 RUNNING
 exec -t 5m bash wait-for-volume.sh app1
 stdout DELIVERED
@@ -92,7 +92,7 @@ exec -t 5m bash wait-ssh.sh {{template "app_port"}}
 # Note that eve sums local and remote purge counters.
 exec -t 1m bash create-file-in-app1.sh /root/purge_test
 eden pod purge app1
-exec -t 5m bash wait-for-app-state.sh app1 HALTING
+exec -t 5m bash wait-for-app-state.sh app1 "PURGING|HALTING"
 exec -t 5m bash wait-for-app-state.sh app1 RUNNING
 exec -t 5m bash wait-for-volume.sh app1
 stdout DELIVERED
@@ -109,7 +109,7 @@ exec -t 5m bash wait-ssh.sh {{template "app_port"}}
 exec -t 1m bash create-file-in-app1.sh /run/restart_test
 exec -t 1m bash create-file-in-app1.sh /root/purge_test
 exec -t 1m bash put-appinfo-cmd.sh app1 456 COMMAND_RESTART &
-exec -t 5m bash wait-for-app-state.sh app1 HALTING
+exec -t 5m bash wait-for-app-state.sh app1 "RESTARTING|HALTING"
 exec -t 5m bash wait-for-app-state.sh app1 RUNNING
 exec -t 1m bash get-appinfo-status.sh app1
 stdout '"lastCmdTimestamp": "456"'
@@ -123,7 +123,7 @@ exec -t 1m bash file-exists-in-app1.sh /root/purge_test
 exec -t 1m bash create-file-in-app1.sh /run/restart_test
 exec -t 1m bash create-file-in-app1.sh /root/purge_test
 eden pod restart app1
-exec -t 5m bash wait-for-app-state.sh app1 HALTING
+exec -t 5m bash wait-for-app-state.sh app1 "RESTARTING|HALTING"
 exec -t 5m bash wait-for-app-state.sh app1 RUNNING
 exec -t 1m bash get-appinfo-status.sh app1
 stdout '"lastCmdTimestamp": "456"'
@@ -212,7 +212,7 @@ EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "ede
 while true; do
     APPINFO="$($EDEN sdn fwd eth0 {{template "mngr_port"}} -- {{template "ssh"}} "cat {{template "app_info_status_file"}}")"
     APPINFO="$(echo "$APPINFO" | jq --arg APP "$APP" '.appsInfo[] | select(.name==$APP)')"
-    echo "$APPINFO" | grep "$EXPSTATE" && break
+    echo "$APPINFO" | grep -E "$EXPSTATE" && break
     sleep 1
 done
 

--- a/tests/volume/testdata/volumes_test.txt
+++ b/tests/volume/testdata/volumes_test.txt
@@ -63,7 +63,7 @@ exec sleep 10
 
 # check purging of app with large volume
 eden pod purge eclient-mount
-test eden.app.test -test.v -timewait 2m HALTING eclient-mount
+test eden.app.test -test.v -timewait 2m PURGING eclient-mount
 test eden.app.test -test.v -timewait 10m RUNNING eclient-mount
 
 exec sleep 10


### PR DESCRIPTION
Few changes (and some minor improvements) to make eden tests pass on both the latest EVE master as well as on the 12.0-stable branch.