### PR TITLE
Run acl test twice - with and without flow logging 

### DIFF
--- a/cmd/edenNetwork.go
+++ b/cmd/edenNetwork.go
@@ -93,6 +93,7 @@ func newNetworkNetstatCmd() *cobra.Command {
 func newNetworkCreateCmd() *cobra.Command {
 	var networkType, networkName, uplinkAdapter string
 	var staticDNSEntries []string
+	var enableFlowlog bool
 
 	//networkCreateCmd is command for create network instance in EVE
 	var networkCreateCmd = &cobra.Command{
@@ -104,7 +105,8 @@ func newNetworkCreateCmd() *cobra.Command {
 			if len(args) == 1 {
 				subnet = args[0]
 			}
-			if err := openEVEC.NetworkCreate(subnet, networkType, networkName, uplinkAdapter, staticDNSEntries); err != nil {
+			if err := openEVEC.NetworkCreate(subnet, networkType, networkName, uplinkAdapter,
+				staticDNSEntries, enableFlowlog); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -114,6 +116,7 @@ func newNetworkCreateCmd() *cobra.Command {
 	networkCreateCmd.Flags().StringVarP(&networkName, "name", "n", "", "Name of network (empty for auto generation)")
 	networkCreateCmd.Flags().StringVarP(&uplinkAdapter, "uplink", "u", "eth0", "Name of uplink adapter, set to 'none' to not use uplink")
 	networkCreateCmd.Flags().StringArrayVarP(&staticDNSEntries, "static-dns-entries", "s", []string{}, "List of static DNS entries in format HOSTNAME:IP_ADDR,IP_ADDR,...")
+	networkCreateCmd.Flags().BoolVar(&enableFlowlog, "enable-flowlog", false, "enable flow logging (EVE collecting and publishing records of application network flows)")
 
 	return networkCreateCmd
 }

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/lf-edge/eden/eserver v0.0.0-20220711180217-6e2bfa9c3f67
 	github.com/lf-edge/eden/sdn/vm v0.0.0-00010101000000-000000000000
 	github.com/lf-edge/edge-containers v0.0.0-20240207093504-5dfda0619b80
-	github.com/lf-edge/eve-api/go v0.0.0-20231214160111-99ce4e43be4b
+	github.com/lf-edge/eve-api/go v0.0.0-20240723213520-106b1d6b72e6
 	github.com/mcuadros/go-lookup v0.0.0-20200831155250-80f87a4fa5ee
 	github.com/moby/term v0.0.0-20221205130635-1aeaba878587
 	github.com/nerd2/gexto v0.0.0-20190529073929-39468ec063f6

--- a/go.sum
+++ b/go.sum
@@ -1340,8 +1340,8 @@ github.com/lf-edge/eden/eserver v0.0.0-20220711180217-6e2bfa9c3f67 h1:lUJ/IASqGL
 github.com/lf-edge/eden/eserver v0.0.0-20220711180217-6e2bfa9c3f67/go.mod h1:D8XwIk3t45EzFr7Yxf4EE3G9H+4H2nEkvte/2ItzkNk=
 github.com/lf-edge/edge-containers v0.0.0-20240207093504-5dfda0619b80 h1:kiqB1Rk8fmWci0idN68azRDJfPxCivD3zNDddWZocFw=
 github.com/lf-edge/edge-containers v0.0.0-20240207093504-5dfda0619b80/go.mod h1:4yXdumKdTzF0URMtxOl8Xnzdxnoy1QR+2dzfOr4CIZY=
-github.com/lf-edge/eve-api/go v0.0.0-20231214160111-99ce4e43be4b h1:uxB8HRp0NgOf8tb9nSoVEcMOo8TQ8YdohfSX+q91vnI=
-github.com/lf-edge/eve-api/go v0.0.0-20231214160111-99ce4e43be4b/go.mod h1:6XqpOM8p1HsluNIGw2ihYPYsaAisQ5CuJpbIKHXQo5w=
+github.com/lf-edge/eve-api/go v0.0.0-20240723213520-106b1d6b72e6 h1:5teGmUuRb6ch8C/Mu7pM1H4U+DqbkXc1dU6ygmYaYeA=
+github.com/lf-edge/eve-api/go v0.0.0-20240723213520-106b1d6b72e6/go.mod h1:ot6MhAhBXapUDl/hXklaX4kY88T3uC4PTg0D2wD8DzA=
 github.com/lf-edge/eve/libs/depgraph v0.0.0-20220711144346-0659e3b03496 h1:txHCOKhVsKIZKvKWzyIMe3J+ATKk61o4bADhsdLk42Y=
 github.com/lf-edge/eve/libs/depgraph v0.0.0-20220711144346-0659e3b03496/go.mod h1:8gtCaEwMJftnaP8PjjgRStLhOoHquzzlmYzj441QwpU=
 github.com/lf-edge/eve/libs/reconciler v0.0.0-20220711144346-0659e3b03496/go.mod h1:BWuSpe83TvdUmwqhSPa8/gGfapb91OkJ1jNHEnSypr4=

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -54,7 +54,7 @@ const (
 
 	//tags, versions, repos
 	DefaultEVETag               = "12.4.0" // DefaultEVETag tag for EVE image
-	DefaultAdamTag              = "0.0.43"
+	DefaultAdamTag              = "0.0.56"
 	DefaultRedisTag             = "7"
 	DefaultRegistryTag          = "2.7"
 	DefaultProcTag              = "83cfe07"

--- a/pkg/expect/networkInstance.go
+++ b/pkg/expect/networkInstance.go
@@ -25,6 +25,7 @@ type NetInstanceExpectation struct {
 	netInstType      string
 	uplinkAdapter    string
 	staticDNSEntries map[string][]string
+	enableFlowlog    bool
 }
 
 // checkNetworkInstance checks if provided netInst match expectation
@@ -60,12 +61,13 @@ func (exp *AppExpectation) createNetworkInstance(instanceExpect *NetInstanceExpe
 			Uuid:    id.String(),
 			Version: "1",
 		},
-		InstType: config.ZNetworkInstType_ZnetInstLocal, //we use local networks for now
-		Activate: true,
-		Port:     adapter,
-		Cfg:      &config.NetworkInstanceOpaqueConfig{},
-		IpType:   config.AddressType_IPV4,
-		Ip:       &config.Ipspec{},
+		InstType:       config.ZNetworkInstType_ZnetInstLocal, //we use local networks for now
+		Activate:       true,
+		Port:           adapter,
+		Cfg:            &config.NetworkInstanceOpaqueConfig{},
+		IpType:         config.AddressType_IPV4,
+		Ip:             &config.Ipspec{},
+		DisableFlowlog: !instanceExpect.enableFlowlog,
 	}
 	if instanceExpect.netInstType == "switch" {
 		netInst.InstType = config.ZNetworkInstType_ZnetInstSwitch

--- a/pkg/expect/options.go
+++ b/pkg/expect/options.go
@@ -163,6 +163,18 @@ func WithStaticDNSEntries(networkName string, dnsEntries []string) ExpectationOp
 	}
 }
 
+// WithFlowlog enables flow logging for the given network instance.
+func WithFlowlog(networkName string) ExpectationOption {
+	return func(expectation *AppExpectation) {
+		for _, netInstance := range expectation.netInstances {
+			if netInstance.name != networkName {
+				continue
+			}
+			netInstance.enableFlowlog = true
+		}
+	}
+}
+
 // WithDiskSize set disk size for created app (equals with image size if not defined)
 func WithDiskSize(diskSizeBytes int64) ExpectationOption {
 	return func(expectation *AppExpectation) {

--- a/pkg/openevec/edenNetwork.go
+++ b/pkg/openevec/edenNetwork.go
@@ -93,7 +93,8 @@ func (openEVEC *OpenEVEC) NetworkNetstat(niName string, outputFormat types.Outpu
 	return nil
 }
 
-func (openEVEC *OpenEVEC) NetworkCreate(subnet, networkType, networkName, uplinkAdapter string, staticDNSEntries []string) error {
+func (openEVEC *OpenEVEC) NetworkCreate(subnet, networkType, networkName, uplinkAdapter string,
+	staticDNSEntries []string, enableFlowlog bool) error {
 	if networkType != "local" && networkType != "switch" {
 		return fmt.Errorf("network type %s not supported now", networkType)
 	}
@@ -108,6 +109,9 @@ func (openEVEC *OpenEVEC) NetworkCreate(subnet, networkType, networkName, uplink
 	var opts []expect.ExpectationOption
 	opts = append(opts, expect.AddNetInstanceAndPortPublish(subnet, networkType, networkName, nil, uplinkAdapter))
 	opts = append(opts, expect.WithStaticDNSEntries(networkName, staticDNSEntries))
+	if enableFlowlog {
+		opts = append(opts, expect.WithFlowlog(networkName))
+	}
 	expectation := expect.AppExpectationFromURL(ctrl, dev, defaults.DefaultDummyExpect, "", opts...)
 	netInstancesConfigs := expectation.NetworkInstances()
 mainloop:

--- a/tests/eclient/testdata/acl.txt
+++ b/tests/eclient/testdata/acl.txt
@@ -1,4 +1,4 @@
-# Test particular host access
+# Test application ACLs
 
 {{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 
@@ -11,6 +11,13 @@
 {{$network_name := "n1"}}
 
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+
+{{$flowlog := EdenGetEnv "EDEN_FLOWLOG"}}
+{{$flowlog_opt := ""}}
+{{if (eq $flowlog "y")}}
+{{$flowlog_opt = "--enable-flowlog"}}
+{{end}}
+
 
 [!exec:bash] stop
 [!exec:sleep] stop
@@ -32,7 +39,7 @@ exec -t 10m bash dns_lookup.sh zededa.com
 source .env
 
 # Create network for which ACLs will be defined.
-eden network create 10.11.12.0/24 -n {{$network_name}} -s {{$fake_domain}}:$host_ip
+eden network create 10.11.12.0/24 -n {{$network_name}} {{$flowlog_opt}} -s {{$fake_domain}}:$host_ip
 test eden.network.test -test.v -timewait 10m ACTIVATED {{$network_name}}
 
 # First app is only allowed to access github.com and $long_domain.
@@ -75,6 +82,7 @@ stderr 'Connected to {{$long_domain}}'
 ! exec -t 1m bash curl.sh 2224 google.com
 ! stderr 'Connected'
 
+{{if (eq $flowlog "y")}}
 # Wait for network packets information
 exec -t 10m bash wait_netstat.sh curl-acl1 google.com github.com {{$long_domain}} {{$fake_domain}}
 stdout 'google.com'
@@ -88,6 +96,7 @@ stdout 'github.com'
 stdout '{{$long_domain}}'
 ! stdout '{{$fake_domain}}'
 stdout 'ieee.org'
+{{end}}
 
 # Cleanup - undeploy applications
 eden pod delete curl-acl1

--- a/tests/escript/escript_test.go
+++ b/tests/escript/escript_test.go
@@ -31,6 +31,9 @@ func TestEdenScripts(t *testing.T) {
 		split := strings.SplitN(fl, "=", 2)
 		if len(split) == 2 {
 			flagsParsed[strings.TrimSpace(split[0])] = strings.TrimSpace(split[1])
+			// Also store the key=value argument into the environment variables so that
+			// it can be used with EdenGetEnv inside Go templates.
+			os.Setenv(split[0], split[1])
 		}
 	}
 

--- a/tests/workflow/networking.tests.txt
+++ b/tests/workflow/networking.tests.txt
@@ -1,5 +1,5 @@
 # Number of tests
-{{$tests := 13}}
+{{$tests := 14}}
 # EDEN_TEST_SETUP env. var. -- "y"(default) performs the EDEN setup steps
 {{$setup := "y"}}
 {{$setup_env := EdenGetEnv "EDEN_TEST_SETUP"}}
@@ -35,22 +35,25 @@ eden.escript.test -test.run TestEdenScripts/template_check
 /bin/echo Eden basic network test (5/{{$tests}})
 eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/network_test
 
-/bin/echo Eden ACL to particular host (6/{{$tests}})
-eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/acl
-/bin/echo Eden Network light (7/{{$tests}})
+/bin/echo Eden ACLs without flow logging (6/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/acl --args="EDEN_FLOWLOG=n"
+/bin/echo Eden ACLs with flow logging (7/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/acl --args="EDEN_FLOWLOG=y"
+
+/bin/echo Eden Network light (8/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/networking_light
 
-/bin/echo Eden Networks switch (8/{{$tests}})
+/bin/echo Eden Networks switch (9/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/nw_switch
-/bin/echo Eden Network Ports switch (9/{{$tests}})
+/bin/echo Eden Network Ports switch (10/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_switch
-/bin/echo Eden Network portmap test (10/{{$tests}})
+/bin/echo Eden Network portmap test (11/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/port_forward
-/bin/echo Eden Test DNS service provided to applications (11/{{$tests}})
+/bin/echo Eden Test DNS service provided to applications (12/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/app_dns
 
-/bin/echo Eden Nginx (12/{{$tests}})
+/bin/echo Eden Nginx (13/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/nginx
 
-/bin/echo Testing quick replace of network instances (13/{{$tests}})
+/bin/echo Testing quick replace of network instances (14/{{$tests}})
 eden.escript.test -testdata ../network/testdata/ -test.run TestEdenScripts/network_replace_test


### PR DESCRIPTION
Soon EVE will allow to disable flow logging (and it will become the default behavior),
which reduces the amount of data published to the controller and simplifies iptables
rules installed by EVE.
See: https://github.com/lf-edge/eve-api/pull/62

However, the ACL implementation is quite different between enabled and
disabled flow logging. Therefore, it makes sense to run the ACL test twice
to test both cases.