### PR TITLE
bump up go version to 1.22 in setup-environment action

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.20'
+        go-version: '1.22'
     - name: Check
       run: |
         for addr in $(ip addr list|sed -En -e 's/.*inet ([0-9.]+).*/\1/p')


### PR DESCRIPTION
missed this one in https://github.com/lf-edge/eden/pull/1012 .