### PR TITLE
Update DefaultEVETag to version 12.7.0

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -53,7 +53,7 @@ const (
 	DefaultRegistryPort         = 5050
 
 	//tags, versions, repos
-	DefaultEVETag               = "12.4.0" // DefaultEVETag tag for EVE image
+	DefaultEVETag               = "12.7.0" // DefaultEVETag tag for EVE image
 	DefaultAdamTag              = "0.0.56"
 	DefaultRedisTag             = "7"
 	DefaultRegistryTag          = "2.7"


### PR DESCRIPTION
Some changes have been made in https://github.com/lf-edge/eve/pull/4088 that help track the sporadic bug that occurs in the Eden metadata test. Those changes are included in EVE 12.7.0, that's why the version bump.