### PR TITLE
add secrets for aziot test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,9 @@ jobs:
           path: "./eden"
       - name: Run Smoke tests
         uses: ./eden/.github/actions/run-eden-test
+        env:
+          AZIOT_ID_SCOPE: ${{ secrets.AZIOT_ID_SCOPE }}
+          AZIOT_CONNECTION_STRING: ${{ secrets.AZIOT_CONNECTION_STRING }}
         with:
           file_system: ${{ matrix.file_system }}
           tpm_enabled: ${{ matrix.tpm }}


### PR DESCRIPTION
Aure-Iot-Edge test need access to some secrets to onboard a device into the Azure portal before testing, secrets are already added to the repository but #1011  fails to access them, according to Github documentation "_GitHub Actions can only read a secret if you explicitly include the secret in a workflow._"

Hope the syntax is correct.