### PR TITLE
pass azure IOT secrets to composite actions via the inputs

### DIFF
--- a/.github/actions/run-eden-test/action.yml
+++ b/.github/actions/run-eden-test/action.yml
@@ -27,6 +27,13 @@ inputs:
     type: string
     required: false
     default: ''
+  aziot_id_scope:
+    description: 'Azure IoT ID scope'
+    required: false
+  aziot_connection_string:
+    description: 'Azure IoT connection string'
+    required: false
+
 
 runs:
   using: 'composite'
@@ -55,6 +62,9 @@ runs:
       run: EDEN_TEST_STOP=n ./eden test ./tests/workflow -s ${{ inputs.suite }} -v debug
       shell: bash
       working-directory: "./eden"
+      env:
+        AZIOT_ID_SCOPE: ${{ inputs.aziot_id_scope }}
+        AZIOT_CONNECTION_STRING: ${{ inputs.aziot_connection_string }}
     - name: Collect info
       if: failure()
       uses: ./eden/.github/actions/collect-info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,9 @@ jobs:
           artifact_run_id: ${{ inputs.artifact_run_id }}
           docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
           docker_token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          aziot_id_scope: ${{ secrets.AZIOT_ID_SCOPE }}
+          aziot_connection_string: ${{ secrets.AZIOT_CONNECTION_STRING }}
+
 
   networking:
     name: Networking test suite


### PR DESCRIPTION
With reference to the [PR-1018](https://github.com/lf-edge/eden/pull/1018).

Secrets defined in the `env` section of a GitHub Actions workflow cannot be accessed directly within composite actions. Instead, you need to pass the secrets as inputs to the composite action and then map them as environment variables within the action.