### PR TITLE
bug : getAppConfig should return node.apps pointer

### DIFF
--- a/pkg/evetestkit/utils.go
+++ b/pkg/evetestkit/utils.go
@@ -94,9 +94,9 @@ func createEveNode(node *device.Ctx, tc *projects.TestContext) (*EveNode, error)
 }
 
 func (node *EveNode) getAppConfig(appName string) *appInstanceConfig {
-	for _, app := range node.apps {
-		if app.name == appName {
-			return &app
+	for i := range node.apps {
+		if node.apps[i].name == appName {
+			return &node.apps[i]
 		}
 	}
 	return nil


### PR DESCRIPTION
getAppConfig should return node.apps pointer instead of a pointer to local variable app which is a copy.