### PR TITLE
Add virtualization workflow with no TPM

### DIFF
--- a/.github/actions/run-eden-test/action.yml
+++ b/.github/actions/run-eden-test/action.yml
@@ -5,9 +5,9 @@ inputs:
   file_system:
     required: true
     type: string
-  tpm_enabled:
+  crypto_module:
     required: true
-    type: bool
+    type: string
   suite:
     required: true
     type: string
@@ -53,7 +53,7 @@ runs:
       uses: ./eden/.github/actions/setup-environment
       with:
         file_system: ${{ inputs.file_system }}
-        tpm_enabled: ${{ inputs.tpm_enabled }}
+        crypto_module: ${{ inputs.crypto_module }}
         eve_image: ${{ inputs.eve_image }}
         eve_artifact_name: ${{ inputs.eve_artifact_name }}
         artifact_run_id: ${{ inputs.artifact_run_id }}

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -5,9 +5,9 @@ inputs:
   file_system:
     required: true
     type: string
-  tpm_enabled:
+  crypto_module:
     required: true
-    type: bool
+    type: string
   eve_image:
     type: string
   eve_artifact_name:
@@ -60,7 +60,10 @@ runs:
         else
           ./eden config set default --key=eve.accel --value=false
         fi
-        ./eden config set default --key=eve.tpm --value=${{ inputs.tpm_enabled }}
+        crypto_module="${{ inputs.crypto_module }}"
+        if [[ "$crypto_module" == "tpm" ]]; then
+          ./eden config set default --key=eve.tpm --value=true
+        fi
         ./eden config set default --key=eve.cpu --value=2
       shell: bash
       working-directory: "./eden"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        file_system: ['ext4', 'zfs']
-        tpm: [true, false]
+        file_system: ["ext4", "zfs"]
+        crypto_module: ["tpm", "no-tpm"]
     name: Smoke tests
     needs: determine-runner
     runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
@@ -66,7 +66,7 @@ jobs:
         uses: ./eden/.github/actions/run-eden-test
         with:
           file_system: ${{ matrix.file_system }}
-          tpm_enabled: ${{ matrix.tpm }}
+          crypto_module: ${{ matrix.crypto_module }}
           suite: "smoke.tests.txt"
           eve_image: ${{ inputs.eve_image }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
@@ -92,7 +92,7 @@ jobs:
         uses: ./eden/.github/actions/run-eden-test
         with:
           file_system: "ext4"
-          tpm_enabled: true
+          crypto_module: "tpm"
           suite: "networking.tests.txt"
           eve_image: ${{ inputs.eve_image }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
@@ -104,7 +104,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        file_system: ['ext4', 'zfs']
+        file_system: ["ext4", "zfs"]
     name: Storage test suite
     needs: [determine-runner]
     runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
@@ -119,7 +119,7 @@ jobs:
         uses: ./eden/.github/actions/run-eden-test
         with:
           file_system: ${{ matrix.file_system }}
-          tpm_enabled: true
+          crypto_module: "tpm"
           suite: "storage.tests.txt"
           eve_image: ${{ inputs.eve_image }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
@@ -142,7 +142,7 @@ jobs:
         uses: ./eden/.github/actions/run-eden-test
         with:
           file_system: "ext4"
-          tpm_enabled: true
+          crypto_module: "tpm"
           suite: "lps-loc.tests.txt"
           eve_image: ${{ inputs.eve_image }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
@@ -169,7 +169,7 @@ jobs:
         uses: ./eden/.github/actions/run-eden-test
         with:
           file_system: ${{ matrix.file_system }}
-          tpm_enabled: true
+          crypto_module: "tpm"
           suite: "eve-upgrade.tests.txt"
           eve_image: ${{ inputs.eve_image }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
@@ -192,7 +192,7 @@ jobs:
         uses: ./eden/.github/actions/run-eden-test
         with:
           file_system: "ext4"
-          tpm_enabled: true
+          crypto_module: "tpm"
           suite: "user-apps.tests.txt"
           eve_image: ${{ inputs.eve_image }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
@@ -201,6 +201,10 @@ jobs:
           docker_token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
 
   virtualization:
+    continue-on-error: true
+    strategy:
+      matrix:
+        crypto_module: ["tmp", "no-tpm"]
     name: Virtualization test suite
     needs: [determine-runner]
     runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner_virt) }}
@@ -215,7 +219,7 @@ jobs:
         uses: ./eden/.github/actions/run-eden-test
         with:
           file_system: "ext4"
-          tpm_enabled: true
+          crypto_module: ${{ matrix.crypto_module }}
           suite: "virtualization.tests.txt"
           eve_image: ${{ inputs.eve_image }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}


### PR DESCRIPTION
We want to test deploying container-in-VM to a device without TPM. In the past we had some bug merged because this was not tested. Also, it is better to use string attributes for workflow matrix, even for the boolean tpm option.

Then instead of workflow names:
```
eden-report-smoke.tests.txt-tpm-true-ext4
eden-report-smoke.tests.txt-tpm-false-zfs
```
We get somewhat more readable:
```
eden-report-smoke.tests.txt-tpm-ext4
eden-report-smoke.tests.txt-no-tpm-zfs
```
I'm open for one-word suggestions to replace "no-tpm". What EVE uses when TPM is not available? Golang crypto library? Should we call it "gocrypto"? I don't know.