### PR TITLE
[EVE-11.0-stable] Revert "userdata: add tests for write_files in containers"

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -53,7 +53,7 @@ const (
 	DefaultRegistryPort         = 5050
 
 	//tags, versions, repos
-	DefaultEVETag               = "12.4.0" // DefaultEVETag tag for EVE image
+	DefaultEVETag               = "11.0.7-lts" // DefaultEVETag tag for EVE image
 	DefaultAdamTag              = "0.0.56"
 	DefaultRedisTag             = "7"
 	DefaultRegistryTag          = "2.7"

--- a/tests/eclient/testdata/userdata.txt
+++ b/tests/eclient/testdata/userdata.txt
@@ -3,13 +3,11 @@
 {{$port := "2223"}}
 
 {{$userdata_file := "/tmp/userdata_file_eden_test"}}
-{{define "ssh"}}ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
 {{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
 
 [!exec:bash] stop
 [!exec:sleep] stop
 [!exec:chmod] stop
-[!exec:ssh] stop
 
 exec -t 10s bash generate_file.sh
 
@@ -19,9 +17,6 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 ! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
 
 eden network create 10.11.12.0/24 -n n1
-
-# test basic functionality
-
 eden pod deploy -n eclient --memory=512MB --networks=n1 {{template "eclient_image"}} -p {{$port}}:22 --metadata={{$userdata_file}}
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient
@@ -29,30 +24,9 @@ test eden.app.test -test.v -timewait 20m RUNNING eclient
 exec sleep 10
 
 eden pod delete eclient
-
-test eden.app.test -test.v -timewait 10m - eclient
-
-# test functionality to write files
-
-exec -t 10s bash generate_userdata.sh
-eden pod deploy -n eclient --memory=512MB --networks=n1 {{template "eclient_image"}} -p {{$port}}:22 --metadata={{$userdata_file}}
-test eden.app.test -test.v -timewait 20m RUNNING eclient
-
-exec -t 40s bash test_injected_file.sh "before_restart"
-
-exec -t 40s bash change_injected_file.sh "after_restart"
-
-eden pod restart eclient
-test eden.app.test -test.v -timewait 20m -check-new RUNNING eclient
-
-exec -t 40s bash test_injected_file.sh "after_restart"
-
-eden pod delete eclient
-
-test eden.app.test -test.v -timewait 10m - eclient
-
 eden network delete n1
 
+test eden.app.test -test.v -timewait 10m - eclient
 test eden.network.test -test.v -timewait 10m - n1
 
 -- eden-config.yml --
@@ -69,35 +43,3 @@ test:
 # allocate about 90014 of raw data
 printf 'variable=value\n%.0s' {1..6000} >{{$userdata_file}}
 printf 'variable=value' >>{{$userdata_file}}
-
--- generate_userdata.sh --
-cat > {{$userdata_file}} <<EOF
-#cloud-config
-write_files:
- - path: /etc/injected_file.txt
-   owner: root:root
-   permissions: '0644'
-   encoding:
-   content: before_restart
-EOF
-
--- test_injected_file.sh --
-EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-TEXT=$1
-
-echo $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep -q $TEXT /etc/injected_file.txt
-
-# Retry in case there are connectivity issues
-for i in `seq 30`
-do
-  echo Try $i
-  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep -q $TEXT /etc/injected_file.txt && echo "Success" && break
-  sleep 2
-done
-
--- change_injected_file.sh --
-EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-TEXT=$1
-
-echo $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} "echo $TEXT > /etc/injected_file.txt"
-$EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} "echo $TEXT > /etc/injected_file.txt"


### PR DESCRIPTION
This reverts commit 843d3709a7ed57847b4bef567fe8623dee541907 because using `write_files` in the cloud-init configuration for containers is not yet supported in EVE 11.0

In a separate commit I also changed the default EVE version for this branch to 11.0.7-lts