### PR TITLE
add eve_log_level parameter to GH test workflow

### DIFF
--- a/.github/actions/run-eden-test/action.yml
+++ b/.github/actions/run-eden-test/action.yml
@@ -13,6 +13,10 @@ inputs:
     type: string
   eve_image:
     type: string
+  eve_log_level:
+    type: string
+    required: false
+    default: 'info'
   eve_artifact_name:
     type: string
   artifact_run_id:
@@ -55,6 +59,7 @@ runs:
         file_system: ${{ inputs.file_system }}
         tpm_enabled: ${{ inputs.tpm_enabled }}
         eve_image: ${{ inputs.eve_image }}
+        eve_log_level: ${{ inputs.eve_log_level }}
         eve_artifact_name: ${{ inputs.eve_artifact_name }}
         artifact_run_id: ${{ inputs.artifact_run_id }}
         require_virtualization: ${{ inputs.require_virtualization }}

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -10,6 +10,10 @@ inputs:
     type: bool
   eve_image:
     type: string
+  eve_log_level:
+    type: string
+    required: false
+    default: 'info'
   eve_artifact_name:
     type: string
   artifact_run_id:
@@ -90,6 +94,10 @@ runs:
         else
           echo "Skipping setting up eve image ${image}"
         fi
+      shell: bash
+      working-directory: "./eden"
+    - name: Set eve log level
+      run: ./eden config set default --key=eve.log-level --value=${{ inputs.eve_log_level }}
       shell: bash
       working-directory: "./eden"
     - name: Setup ext4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ on:  # yamllint disable-line rule:truthy
       eve_log_level:
         type: string
         required: false
-        default: 'info'
+        default: 'debug'
       eve_artifact_name:
         type: string
       artifact_run_id:
@@ -29,7 +29,7 @@ on:  # yamllint disable-line rule:truthy
       eve_log_level:
         type: string
         required: false
-        default: 'info'
+        default: 'debug'
       eve_artifact_name:
         type: string
       artifact_run_id:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ on:  # yamllint disable-line rule:truthy
         default: ''  # if not provided: When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, uses the default branch.
       eve_image:
         type: string
+      eve_log_level:
+        type: string
+        required: false
+        default: 'info'
       eve_artifact_name:
         type: string
       artifact_run_id:
@@ -22,6 +26,10 @@ on:  # yamllint disable-line rule:truthy
         default: ''  # if not provided: When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, uses the default branch.
       eve_image:
         type: string
+      eve_log_level:
+        type: string
+        required: false
+        default: 'info'
       eve_artifact_name:
         type: string
       artifact_run_id:
@@ -69,6 +77,7 @@ jobs:
           tpm_enabled: ${{ matrix.tpm }}
           suite: "smoke.tests.txt"
           eve_image: ${{ inputs.eve_image }}
+          eve_log_level: ${{ inputs.eve_log_level }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
           docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
@@ -95,6 +104,7 @@ jobs:
           tpm_enabled: true
           suite: "networking.tests.txt"
           eve_image: ${{ inputs.eve_image }}
+          eve_log_level: ${{ inputs.eve_log_level }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
           docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
@@ -122,6 +132,7 @@ jobs:
           tpm_enabled: true
           suite: "storage.tests.txt"
           eve_image: ${{ inputs.eve_image }}
+          eve_log_level: ${{ inputs.eve_log_level }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
           docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
@@ -145,6 +156,7 @@ jobs:
           tpm_enabled: true
           suite: "lps-loc.tests.txt"
           eve_image: ${{ inputs.eve_image }}
+          eve_log_level: ${{ inputs.eve_log_level }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
           docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
@@ -172,6 +184,7 @@ jobs:
           tpm_enabled: true
           suite: "eve-upgrade.tests.txt"
           eve_image: ${{ inputs.eve_image }}
+          eve_log_level: ${{ inputs.eve_log_level }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
           docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
@@ -195,6 +208,7 @@ jobs:
           tpm_enabled: true
           suite: "user-apps.tests.txt"
           eve_image: ${{ inputs.eve_image }}
+          eve_log_level: ${{ inputs.eve_log_level }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
           docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
@@ -218,6 +232,7 @@ jobs:
           tpm_enabled: true
           suite: "virtualization.tests.txt"
           eve_image: ${{ inputs.eve_image }}
+          eve_log_level: ${{ inputs.eve_log_level }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
           require_virtualization: true


### PR DESCRIPTION
It would be useful to be able to set the log level for EVE when running tests, as e.g. "debug" log level would provide more information for debugging failed tests.

It would be good to include this change in the next release of Eden, so that it can be used workflows started from EVE repository.