### PR TITLE
Support for go 1 23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 # Test binary, built with `go test -c`
 *.test
 
+# make build-tests artifacts
+tests/**/eden.*.test*
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/tests/escript/go-internal/testscript/testing_1.23.go
+++ b/tests/escript/go-internal/testscript/testing_1.23.go
@@ -1,5 +1,5 @@
-//go:build go1.18 && !go1.23
-// +build go1.18,!go1.23
+//go:build go1.23
+// +build go1.23
 
 package testscript
 
@@ -45,6 +45,10 @@ func (d nopTestDeps) ResetCoverage() {
 }
 
 func (d nopTestDeps) SnapshotCoverage() {
+	return
+}
+
+func (d nopTestDeps) InitRuntimeCoverage() (mode string, tearDown func(coverprofile string, gocoverdir string) (string, error), snapcov func() float64) {
 	return
 }
 


### PR DESCRIPTION
Keeping up with the good tradition to use go's internal APIs and update the dependencies by hand :smile: 

Doesn't really need to be merged until we move to go 1.23 in go.mod, but can be useful for people using 1.23 locally.