### PR TITLE
Set App virtualization mode via PodConfig

### DIFF
--- a/pkg/openevec/config.go
+++ b/pkg/openevec/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eden/pkg/utils"
+	"github.com/lf-edge/eve-api/go/config"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -210,6 +211,7 @@ type PodConfig struct {
 	OpenStackMetadata bool
 	DatastoreOverride string
 	ACLOnlyHost       bool
+	VirtMode          config.VmMode
 }
 
 func Merge(dst, src reflect.Value, flags *pflag.FlagSet) {

--- a/pkg/openevec/pod.go
+++ b/pkg/openevec/pod.go
@@ -77,6 +77,7 @@ func (openEVEC *OpenEVEC) PodDeploy(appLink string, pc PodConfig, cfg *EdenSetup
 	opts = append(opts, expect.WithVnc(pc.VncDisplay))
 	opts = append(opts, expect.WithVncPassword(pc.VncPassword))
 	opts = append(opts, expect.WithAppAdapters(pc.AppAdapters))
+	opts = append(opts, expect.WithVirtualizationMode(pc.VirtMode))
 	if len(pc.Networks) > 0 {
 		for i, el := range pc.Networks {
 			if i == 0 {


### PR DESCRIPTION
This is needed, for example for loading FML based windows VMs.