### PR TITLE
Change default remote loglevel

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -119,8 +119,8 @@ const (
 	DefaultRequestsRedisPrefix   = "REQUESTS_EVE_"
 	DefaultFlowLogRedisPrefix    = "FLOW_MESSAGE_EVE_"
 
-	DefaultEveLogLevel  = "info"    //min level of logs saved in files on EVE device
-	DefaultAdamLogLevel = "warning" //min level of logs sent from EVE to Adam
+	DefaultEveLogLevel  = "info" // min level of logs saved in files on EVE device
+	DefaultAdamLogLevel = "info" // min level of logs sent from EVE to Adam
 
 	DefaultQemuAccelDarwin      = "-machine q35,accel=hvf -cpu kvm64,kvmclock=off "
 	DefaultQemuAccelDarwinArm64 = "-machine virt,accel=hvf,usb=off,dump-guest-core=off -cpu host "

--- a/tests/lim/testdata/log_test.txt
+++ b/tests/lim/testdata/log_test.txt
@@ -1,7 +1,19 @@
 {{$test1 := "test eden.lim.test -test.v -timewait 10m -test.run TestLog"}}
 
+# save the current config before changing it
+eden -t 1m controller edge-node get-config --file /tmp/full-config.json
+
+# set the remote log level to info, because the expected message is logged with info level
+eden -t 1m controller edge-node update --config agent.debug.debug.loglevel=info
+eden -t 1m controller edge-node update --config agent.debug.debug.remote.loglevel=info
+# wait for the config changes to apply
+exec sleep 15
+
 # ssh into EVE to force log creation
 exec -t 5m bash ssh.sh &
+
+# restore the original config
+eden -t 1m controller edge-node set-config --file /tmp/full-config.json
 
 # Trying to find messages about ssh in log
 {{$test1}} -out content 'content:.*Disconnected.*'


### PR DESCRIPTION
This PR is preparing Eden tests to work with the re-enabled remote log level config parameter that's coming in https://github.com/lf-edge/eve/pull/4413.