### PR TITLE
gha: add neoeden job to test.yml workflow

### DIFF
--- a/.github/actions/run-neoeden-test/action.yml
+++ b/.github/actions/run-neoeden-test/action.yml
@@ -28,6 +28,8 @@ inputs:
     type: string
     required: false
     default: ''
+  test_suite:
+    type: string
   aziot_id_scope:
     description: 'Azure IoT ID scope'
     required: false
@@ -60,14 +62,10 @@ runs:
         eve_artifact_name: ${{ inputs.eve_artifact_name }}
         artifact_run_id: ${{ inputs.artifact_run_id }}
         require_virtualization: ${{ inputs.require_virtualization }}
-    - name: Run kubevirt tests
-      run: go test
+    - name: Run neoeden test suite
+      run: go test -timeout 30m
       shell: bash
-      working-directory: "./eden/tests/kubevirt"
-    - name: Run security tests
-      run: go test
-      shell: bash
-      working-directory: "./eden/tests/sec"
+      working-directory: ${{ inputs.test_suite }}
       env:
         AZIOT_ID_SCOPE: ${{ inputs.aziot_id_scope }}
         AZIOT_CONNECTION_STRING: ${{ inputs.aziot_connection_string }}
@@ -87,4 +85,3 @@ runs:
         docker system prune -f -a >/dev/null
       shell: bash
       working-directory: "./eden"
-

--- a/.github/actions/run-neoeden-test/action.yml
+++ b/.github/actions/run-neoeden-test/action.yml
@@ -1,0 +1,90 @@
+name: 'Run Neo-Eden test workflow'
+description: 'Setup Eden, run go test and publish logs'
+
+inputs:
+  file_system:
+    required: true
+    type: string
+  tpm_enabled:
+    required: true
+    type: bool
+  eve_image:
+    type: string
+  eve_log_level:
+    type: string
+    required: false
+    default: 'info'
+  eve_artifact_name:
+    type: string
+  artifact_run_id:
+    type: string
+  require_virtualization:
+    type: bool
+  docker_account:  # if not provided: use anonymous docker user
+    type: string
+    required: false
+    default: ''
+  docker_token:
+    type: string
+    required: false
+    default: ''
+  aziot_id_scope:
+    description: 'Azure IoT ID scope'
+    required: false
+  aziot_connection_string:
+    description: 'Azure IoT connection string'
+    required: false
+
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Collect Workflow Telemetry
+      uses: catchpoint/workflow-telemetry-action@v2
+      with:
+        proc_trace_sys_enable: true
+        comment_on_pr: false
+    - name: Login to Docker Hub
+      if: inputs.docker_account != ''
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.docker_account }}
+        password: ${{ inputs.docker_token }}
+    - name: Setup Environment
+      uses: ./eden/.github/actions/setup-environment
+      with:
+        file_system: ${{ inputs.file_system }}
+        tpm_enabled: ${{ inputs.tpm_enabled }}
+        eve_image: ${{ inputs.eve_image }}
+        eve_log_level: ${{ inputs.eve_log_level }}
+        eve_artifact_name: ${{ inputs.eve_artifact_name }}
+        artifact_run_id: ${{ inputs.artifact_run_id }}
+        require_virtualization: ${{ inputs.require_virtualization }}
+    - name: Run kubevirt tests
+      run: go test
+      shell: bash
+      working-directory: "./eden/tests/kubevirt"
+    - name: Run security tests
+      run: go test
+      shell: bash
+      working-directory: "./eden/tests/sec"
+      env:
+        AZIOT_ID_SCOPE: ${{ inputs.aziot_id_scope }}
+        AZIOT_CONNECTION_STRING: ${{ inputs.aziot_connection_string }}
+    - name: Collect info
+      if: failure()
+      uses: ./eden/.github/actions/collect-info
+    - name: Collect logs
+      if: always()
+      uses: ./eden/.github/actions/publish-logs
+      with:
+        report_name: eden-report-${{ inputs.suite }}-tpm-${{ inputs.tpm_enabled }}-${{ inputs.file_system }}
+    - name: Clean up after test
+      if: always()
+      run: |
+        ./eden stop
+        make clean >/dev/null
+        docker system prune -f -a >/dev/null
+      shell: bash
+      working-directory: "./eden"
+

--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -20,5 +20,6 @@ jobs:
     uses: ./.github/workflows/test.yml
     with:
       eve_image: "lfedge/eve:15.8.0"
+      eve_kubevirt_image: "lfedge/eve:0.0.0-master-75241279-kubevirt-amd64"
       eden_version: ${{ github.event.pull_request.head.sha }}
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -500,5 +500,43 @@ jobs:
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
           require_virtualization: true
-          docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
-          docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+          docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+          docker_token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+
+
+  neoeden:
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        file_system: ['ext4', 'zfs']
+        tpm: [true, false]
+    name: Neoeden (golang only) tests
+    needs: [determine-runner]
+    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
+    steps:
+      - name: Dockerhub Login
+        if: ${{ github.event.repository.full_name }} == 'lf-edge/eve'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_PULL_USER }}
+          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+      - name: Get code
+        uses: actions/checkout@v4.1.1
+        with:
+          repository: "lf-edge/eden"
+          ref: ${{ inputs.eden_version }}
+          path: "./eden"
+      - name: Run Neoeden tests
+        uses: ./eden/.github/actions/run-neoeden-test
+        with:
+          file_system: ${{ matrix.file_system }}
+          tpm_enabled: ${{ matrix.tpm }}
+          eve_image: ${{ inputs.eve_image }}
+          eve_log_level: ${{ inputs.eve_log_level }}
+          eve_artifact_name: ${{ inputs.eve_artifact_name }}
+          artifact_run_id: ${{ inputs.artifact_run_id }}
+          docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+          docker_token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          aziot_id_scope: ${{ secrets.AZIOT_ID_SCOPE }}
+          aziot_connection_string: ${{ secrets.AZIOT_CONNECTION_STRING }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,15 @@ on:  # yamllint disable-line rule:truthy
         default: ''  # if not provided: When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, uses the default branch.
       eve_image:
         type: string
+      eve_kubevirt_image:
+        type: string
       eve_log_level:
         type: string
         required: false
         default: 'debug'
       eve_artifact_name:
+        type: string
+      eve_kubevirt_artifact_name:
         type: string
       artifact_run_id:
         type: string
@@ -26,11 +30,15 @@ on:  # yamllint disable-line rule:truthy
         default: ''  # if not provided: When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, uses the default branch.
       eve_image:
         type: string
+      eve_kubevirt_image:
+        type: string
       eve_log_level:
         type: string
         required: false
         default: 'debug'
       eve_artifact_name:
+        type: string
+      eve_kubevirt_artifact_name:
         type: string
       artifact_run_id:
         type: string
@@ -504,14 +512,14 @@ jobs:
           docker_token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
 
 
-  neoeden:
+  neoeden-sec:
     continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
         file_system: ['ext4', 'zfs']
         tpm: [true, false]
-    name: Neoeden (golang only) tests
+    name: Neoeden security tests
     needs: [determine-runner]
     runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
     steps:
@@ -553,11 +561,58 @@ jobs:
       - name: Run Neoeden tests
         uses: ./eden/.github/actions/run-neoeden-test
         with:
+          test_suite: "./eden/tests/sec"
           file_system: ${{ matrix.file_system }}
           tpm_enabled: ${{ matrix.tpm }}
           eve_image: ${{ inputs.eve_image }}
           eve_log_level: ${{ inputs.eve_log_level }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
+          artifact_run_id: ${{ inputs.artifact_run_id }}
+          docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+          docker_token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          aziot_id_scope: ${{ secrets.AZIOT_ID_SCOPE }}
+          aziot_connection_string: ${{ secrets.AZIOT_CONNECTION_STRING }}
+
+  neoeden-kubevirt:
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        file_system: ['ext4', 'zfs']
+        tpm: [true, false]
+    name: Neoeden kubevirt tests
+    needs: [determine-runner]
+    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
+    steps:
+      - name: Check for DockerHub credentials
+        id: check-dockerhub-creds
+        run: |
+          if [ -n "${{ secrets.DOCKERHUB_PULL_USER }}" ] && [ -n "${{ secrets.DOCKERHUB_PULL_TOKEN }}" ]; then
+            echo "creds_exist=true" >> $GITHUB_OUTPUT
+          else
+            echo "creds_exist=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Login to DockerHub
+        if: steps.check-dockerhub-creds.outputs.creds_exist == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_PULL_USER }}
+          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+      - name: Get code
+        uses: actions/checkout@v4.1.1
+        with:
+          repository: "lf-edge/eden"
+          ref: ${{ inputs.eden_version }}
+          path: "./eden"
+      - name: Run Neoeden tests
+        uses: ./eden/.github/actions/run-neoeden-test
+        with:
+          test_suite: "./eden/tests/kubevirt"
+          file_system: ${{ matrix.file_system }}
+          tpm_enabled: ${{ matrix.tpm }}
+          eve_image: ${{ inputs.eve_kubevirt_image }}
+          eve_log_level: ${{ inputs.eve_log_level }}
+          eve_artifact_name: ${{ inputs.eve_kubevirt_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
           docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
           docker_token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -515,8 +515,31 @@ jobs:
     needs: [determine-runner]
     runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
     steps:
+      - name: Check job status from previous attempt
+        id: prev_attempt
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          FULL_JOB_NAME: ${{ env.JOB_NAME }}
+        run: |
+            PREV_ATTEMPT=$((${{ github.run_attempt }} - 1 ))
+            # For the first attempt, we don't need to check the previous attempt, just set conclusion to 'skipped'
+            if [ "$PREV_ATTEMPT" -le 0 ]; then
+                echo "conclusion=skipped" >> "$GITHUB_OUTPUT"
+                exit 0
+            fi
+            prev_conclusion=$(
+                gh api \
+                -X GET \
+                repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${PREV_ATTEMPT}/jobs \
+                -q ".jobs[] | select(.name | contains(\"${{ env.FULL_JOB_NAME }}\")) | .conclusion"
+            )
+            if [ -z "$prev_conclusion" ]; then
+                echo "Could not find matching job in attempt ${PREV_ATTEMPT}" >&2
+                exit 1
+            fi
+            echo "conclusion=$prev_conclusion" >> "$GITHUB_OUTPUT"
       - name: Dockerhub Login
-        if: ${{ github.event.repository.full_name }} == 'lf-edge/eve'
+        if: ${{ github.event.repository.full_name == 'lf-edge/eve' && steps.prev_attempt.outputs.conclusion != 'success' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_PULL_USER }}


### PR DESCRIPTION
Instead of adding additional workflow to eden, we run neoeden alongside with older version intent is that end user (EVE CI/CD pipeline) will not require any changes, it will still call test.yml there will be an additional test suite. End goal is to gradually move all the test suites to golang-based tests, so at some point smoke tests will be running in neoeden, or networking tests, etc. etc.