### PR TITLE
GH Action  artifacts v3-> v4

### DIFF
--- a/.github/actions/publish-logs/action.yml
+++ b/.github/actions/publish-logs/action.yml
@@ -44,7 +44,7 @@ runs:
       working-directory: "./eden"
     - name: Store raw test results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.report_name }}
         path: |

--- a/.github/workflows/eden_emh_arm.yml
+++ b/.github/workflows/eden_emh_arm.yml
@@ -109,7 +109,7 @@ jobs:
           PACKET_TOKEN: ${{ secrets.PACKET_TOKEN }}
       - name: Store raw test results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: eden-packet${{ matrix.conf_eden_server }}---eve-packet${{ matrix.conf_eve_server }}-${{ matrix.hv }}
           path: |

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -163,7 +163,7 @@ jobs:
           echo "::endgroup::"
       - name: Store raw test results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: eden-report-${{ matrix.hv }}-${{ matrix.fs }}
           path: |

--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Store Yetus artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'yetus-scan'
           path: ${{ github.workspace }}/out


### PR DESCRIPTION
This pull request updates the GitHub Actions configuration to use the latest version of the `upload-artifact` action. 

Context: 
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/