### PR TITLE
Switch to GitHub based runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,8 @@ jobs:
       - id: fork-check
         run: |
           if [[ "${{ github.event.repository.full_name}}" == "lf-edge/eve" ]] || [[ "${{ github.event.repository.full_name}}" == "lf-edge/eden" ]]; then
-            echo "runner=['buildjet-4vcpu-ubuntu-2204', 'buildjet-pinned-7950x']" >> "$GITHUB_OUTPUT"
-            echo "runner_virt=['buildjet-4vcpu-ubuntu-2204', 'buildjet-pinned-7950x']" >> "$GITHUB_OUTPUT"
+            echo "runner=['ubuntu-22.04']" >> "$GITHUB_OUTPUT"
+            echo "runner_virt=['ubuntu-22.04']" >> "$GITHUB_OUTPUT"
           else
             echo "runner=['ubuntu-22.04']" >> "$GITHUB_OUTPUT"
             echo "runner_virt=['ubuntu-22.04']" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This is a temprorary measurement as we are investigating alternatives to BuildJet. Runners from BuildJet do not pick up our workflows and that affects us. We haven't received response in 2 weeks now, so I want to find an alternative. In the meantime, to stop the bleeding I want to switch to GitHub-based runners, they're slower, since they do not provide hardware virtualisation, so we expect workflow to run 1.5 hr instead of 45 minutes.