### PR TITLE
fix: create errors from non-constant strings

### DIFF
--- a/tests/app/app_test.go
+++ b/tests/app/app_test.go
@@ -1,6 +1,7 @@
 package lim
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -108,7 +109,7 @@ func checkState(eveState *eve.State, state string, appNames []string) error {
 				"no app with %s found\n",
 				appName))
 		}
-		return fmt.Errorf(out)
+		return errors.New(out)
 	}
 	for _, app := range eveState.Applications() {
 		if _, inSlice := utils.FindEleInSlice(appNames, app.Name); inSlice {
@@ -125,7 +126,7 @@ func checkState(eveState *eve.State, state string, appNames []string) error {
 				return nil
 			}
 		}
-		return fmt.Errorf(out)
+		return errors.New(out)
 	}
 	return nil
 }

--- a/tests/docker/docker_test.go
+++ b/tests/docker/docker_test.go
@@ -1,6 +1,7 @@
 package lim
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -118,7 +119,7 @@ func checkAppAccess(edgeNode *device.Ctx) testcontext.ProcTimerFunc {
 			if err != nil {
 				return nil
 			}
-			return fmt.Errorf(res)
+			return errors.New(res)
 		}
 		return tc.PortForwardCommand(func(fwdPort uint16) error {
 			res, err := utils.RequestHTTPWithTimeout(
@@ -126,7 +127,7 @@ func checkAppAccess(edgeNode *device.Ctx) testcontext.ProcTimerFunc {
 			if err != nil {
 				return nil
 			}
-			return fmt.Errorf(res)
+			return errors.New(res)
 		}, "eth0", uint16(*externalPort))
 	}
 }

--- a/tests/lim/lim_test.go
+++ b/tests/lim/lim_test.go
@@ -1,6 +1,7 @@
 package lim
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -183,7 +184,7 @@ func TestLog(t *testing.T) {
 
 			cnt := count("Received %d logs from %s", name.String())
 			if cnt != "" {
-				return fmt.Errorf(cnt)
+				return errors.New(cnt)
 			}
 			return nil
 		}(t, edgeNode, log)
@@ -253,7 +254,7 @@ func TestAppLog(t *testing.T) {
 
 			cnt := count("Received %d app logs from %s", name.String())
 			if cnt != "" {
-				return fmt.Errorf(cnt)
+				return errors.New(cnt)
 			}
 			return nil
 		}(t, edgeNode, log)
@@ -294,7 +295,7 @@ func TestInfo(t *testing.T) {
 			}
 			cnt := count("Received %d infos from %s", name.String())
 			if cnt != "" {
-				return fmt.Errorf(cnt)
+				return errors.New(cnt)
 			}
 			return nil
 		}(t, edgeNode, ei)
@@ -337,7 +338,7 @@ func TestMetrics(t *testing.T) {
 
 			cnt := count("Received %d metrics from %s", name.String())
 			if cnt != "" {
-				return fmt.Errorf(cnt)
+				return errors.New(cnt)
 			}
 			return nil
 		}(t, edgeNode, metric)
@@ -377,7 +378,7 @@ func TestFlowLog(t *testing.T) {
 
 			cnt := count("Received %d FlowLog from %s", name.String())
 			if cnt != "" {
-				return fmt.Errorf(cnt)
+				return errors.New(cnt)
 			}
 			return nil
 		}(t, edgeNode, log)

--- a/tests/network/nw_test.go
+++ b/tests/network/nw_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -88,7 +89,7 @@ func checkState(eveState *eve.State, state string, netNames []string) error {
 				"no network with %s found\n",
 				netName)
 		}
-		return fmt.Errorf(out)
+		return errors.New(out)
 	}
 	for _, net := range eveState.Networks() {
 		if _, inSlice := utils.FindEleInSlice(netNames, net.Name); inSlice {
@@ -105,7 +106,7 @@ func checkState(eveState *eve.State, state string, netNames []string) error {
 				return nil
 			}
 		}
-		return fmt.Errorf(out)
+		return errors.New(out)
 	}
 	return nil
 }

--- a/tests/vcom/vcom_test.go
+++ b/tests/vcom/vcom_test.go
@@ -38,7 +38,7 @@ func logFatalf(format string, args ...interface{}) {
 func logInfof(format string, args ...interface{}) {
 	out := utils.AddTimestampf(format+"\n", args...)
 	if logT != nil {
-		logT.Logf(out)
+		logT.Log(out)
 	} else {
 		fmt.Print(out)
 	}

--- a/tests/volume/vol_test.go
+++ b/tests/volume/vol_test.go
@@ -1,6 +1,7 @@
 package lim
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -92,7 +93,7 @@ func checkState(eveState *eve.State, state string, volNames []string) error {
 				"no volume with %s found\n",
 				volName)
 		}
-		return fmt.Errorf(out)
+		return errors.New(out)
 	}
 	for _, vol := range eveState.Volumes() {
 		if _, inSlice := utils.FindEleInSlice(volNames, vol.Name); inSlice {
@@ -109,7 +110,7 @@ func checkState(eveState *eve.State, state string, volNames []string) error {
 				return nil
 			}
 		}
-		return fmt.Errorf(out)
+		return errors.New(out)
 	}
 	return nil
 }


### PR DESCRIPTION
Since go 1.24 vet reports the usage of non-constant strings in Printf as errors (see https://tip.golang.org/doc/go1.24#vet). This change fixes the found occurrences in our tests.

Example:
```
./nw_test.go:91:21: non-constant format string in call to fmt.Errorf
```

This fix is mostly relevant for local builds as we are not yet using go 1.24 in the CI, but the nature of the issue itself is independent of the go version used.