### PR TITLE
Get eden home path from environment variable

### DIFF
--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -150,6 +150,10 @@ func DefaultEdenDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	edenHome := strings.TrimSpace(os.Getenv("EDEN_HOME"))
+	if edenHome != "" {
+		return edenHome, nil
+	}
 	return filepath.Join(usr.HomeDir, defaults.DefaultEdenHomeDir), nil
 }
 


### PR DESCRIPTION
Read from the environment variable EDEN_HOME. If the environment variable is not set, then use the default path.