### PR TITLE
Update Dockerhub token

### DIFF
--- a/.github/workflows/eden_setup.yml
+++ b/.github/workflows/eden_setup.yml
@@ -1,7 +1,7 @@
 ---
 name: Eden_setup
 on:  # yamllint disable-line rule:truthy
-  pull_request:
+  pull_request_target:
     branches: [master]
 
 jobs:
@@ -25,6 +25,12 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: '1.22'
+      - name: Login to DockerHub (Pull)
+        if: ${{ github.event.repository.full_name }} == 'lf-edge/eden'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_PULL_USER }}
+          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
       - name: build docker images
         run: |
           make LINUXKIT_TARGET=build DOCKER_PLATFORM=linux/arm64 build-docker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,11 @@ jobs:
             })).data
 
             return release.upload_url
+      - name: Login to DockerHub (Pull)
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_PULL_USER }}
+          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
       - name: Build project
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,8 +80,8 @@ jobs:
           eve_log_level: ${{ inputs.eve_log_level }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
-          docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
-          docker_token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
+          docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
           aziot_id_scope: ${{ secrets.AZIOT_ID_SCOPE }}
           aziot_connection_string: ${{ secrets.AZIOT_CONNECTION_STRING }}
 
@@ -107,8 +107,8 @@ jobs:
           eve_log_level: ${{ inputs.eve_log_level }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
-          docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
-          docker_token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
+          docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
   storage:
     continue-on-error: true
@@ -135,8 +135,8 @@ jobs:
           eve_log_level: ${{ inputs.eve_log_level }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
-          docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
-          docker_token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
+          docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
   lps-loc:
     name: LPS LOC test suite
@@ -159,8 +159,8 @@ jobs:
           eve_log_level: ${{ inputs.eve_log_level }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
-          docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
-          docker_token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
+          docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
   eve-upgrade:
     continue-on-error: true
@@ -187,8 +187,8 @@ jobs:
           eve_log_level: ${{ inputs.eve_log_level }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
-          docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
-          docker_token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
+          docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
   user-apps:
     name: User apps test suite
@@ -211,8 +211,8 @@ jobs:
           eve_log_level: ${{ inputs.eve_log_level }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
-          docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
-          docker_token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
+          docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
   virtualization:
     name: Virtualization test suite
@@ -236,5 +236,5 @@ jobs:
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
           require_virtualization: true
-          docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
-          docker_token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
+          docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}


### PR DESCRIPTION
- We need to use a pro version of dockerhub token to avoid "429 Too Many Requests" error
- Also we need to login to dockerhub before building or we can reach "unauthenticated limit reached" error