### PR TITLE
Print public IP for buildjet runners

### DIFF
--- a/.github/actions/run-eden-test/action.yml
+++ b/.github/actions/run-eden-test/action.yml
@@ -42,6 +42,12 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Print Public IP Address
+      run: |
+        echo "Public IP Address of the runner:"
+        curl -s https://api.ipify.org
+      shell: bash
+        
     - name: Collect Workflow Telemetry
       uses: catchpoint/workflow-telemetry-action@v2
       with:

--- a/.github/actions/run-neoeden-test/action.yml
+++ b/.github/actions/run-neoeden-test/action.yml
@@ -1,0 +1,86 @@
+name: 'Run Neo-Eden test workflow'
+description: 'Setup Eden, run go test and publish logs'
+
+inputs:
+  file_system:
+    required: true
+    type: string
+  tpm_enabled:
+    required: true
+    type: bool
+  eve_image:
+    type: string
+  eve_log_level:
+    type: string
+    required: false
+    default: 'info'
+  eve_artifact_name:
+    type: string
+  artifact_run_id:
+    type: string
+  require_virtualization:
+    type: bool
+  docker_account:  # if not provided: use anonymous docker user
+    type: string
+    required: false
+    default: ''
+  docker_token:
+    type: string
+    required: false
+    default: ''
+  aziot_id_scope:
+    description: 'Azure IoT ID scope'
+    required: false
+  aziot_connection_string:
+    description: 'Azure IoT connection string'
+    required: false
+
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Collect Workflow Telemetry
+      uses: catchpoint/workflow-telemetry-action@v2
+      with:
+        proc_trace_sys_enable: true
+        comment_on_pr: false
+    - name: Login to Docker Hub
+      if: inputs.docker_account != ''
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.docker_account }}
+        password: ${{ inputs.docker_token }}
+    - name: Setup Environment
+      uses: ./eden/.github/actions/setup-environment
+      with:
+        file_system: ${{ inputs.file_system }}
+        tpm_enabled: ${{ inputs.tpm_enabled }}
+        eve_image: ${{ inputs.eve_image }}
+        eve_log_level: ${{ inputs.eve_log_level }}
+        eve_artifact_name: ${{ inputs.eve_artifact_name }}
+        artifact_run_id: ${{ inputs.artifact_run_id }}
+        require_virtualization: ${{ inputs.require_virtualization }}
+    - name: Run security tests
+      run: cd tests/sec && go test
+      shell: bash
+      working-directory: "./eden"
+      env:
+        AZIOT_ID_SCOPE: ${{ inputs.aziot_id_scope }}
+        AZIOT_CONNECTION_STRING: ${{ inputs.aziot_connection_string }}
+    - name: Collect info
+      if: failure()
+      uses: ./eden/.github/actions/collect-info
+    - name: Collect logs
+      if: always()
+      uses: ./eden/.github/actions/publish-logs
+      with:
+        report_name: eden-report-${{ inputs.suite }}-tpm-${{ inputs.tpm_enabled }}-${{ inputs.file_system }}
+    - name: Clean up after test
+      if: always()
+      run: |
+        ./eden stop
+        make clean >/dev/null
+        docker system prune -f -a >/dev/null
+      shell: bash
+      working-directory: "./eden"
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,15 +53,244 @@ jobs:
             echo "runner_virt=['ubuntu-22.04']" >> "$GITHUB_OUTPUT"
           fi
 
-  smoke:
+  # smoke:
+  #   continue-on-error: true
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       file_system: ['ext4', 'zfs']
+  #       tpm: [true, false]
+  #   name: Smoke tests
+  #   needs: determine-runner
+  #   runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
+  #   steps:
+  #     - name: Dockerhub Login
+  #       if: ${{ github.event.repository.full_name }} == 'lf-edge/eve'
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_PULL_USER }}
+  #         password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+  #     - name: Get code
+  #       uses: actions/checkout@v4.1.1
+  #       with:
+  #         repository: "lf-edge/eden"
+  #         ref: ${{ inputs.eden_version }}
+  #         path: "./eden"
+  #     - name: Run Smoke tests
+  #       uses: ./eden/.github/actions/run-eden-test
+  #       with:
+  #         file_system: ${{ matrix.file_system }}
+  #         tpm_enabled: ${{ matrix.tpm }}
+  #         suite: "smoke.tests.txt"
+  #         eve_image: ${{ inputs.eve_image }}
+  #         eve_log_level: ${{ inputs.eve_log_level }}
+  #         eve_artifact_name: ${{ inputs.eve_artifact_name }}
+  #         artifact_run_id: ${{ inputs.artifact_run_id }}
+  #         docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
+  #         docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+  #         aziot_id_scope: ${{ secrets.AZIOT_ID_SCOPE }}
+  #         aziot_connection_string: ${{ secrets.AZIOT_CONNECTION_STRING }}
+
+
+  # networking:
+  #   name: Networking test suite
+  #   needs: [determine-runner]
+  #   runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
+  #   steps:
+  #     - name: Dockerhub Login
+  #       if: ${{ github.event.repository.full_name }} == 'lf-edge/eve'
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_PULL_USER }}
+  #         password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+  #     - name: Get code
+  #       uses: actions/checkout@v4.1.1
+  #       with:
+  #         repository: "lf-edge/eden"
+  #         ref: ${{ inputs.eden_version }}
+  #         path: "./eden"
+  #     - name: Run Networking tests
+  #       uses: ./eden/.github/actions/run-eden-test
+  #       with:
+  #         file_system: "ext4"
+  #         tpm_enabled: true
+  #         suite: "networking.tests.txt"
+  #         eve_image: ${{ inputs.eve_image }}
+  #         eve_log_level: ${{ inputs.eve_log_level }}
+  #         eve_artifact_name: ${{ inputs.eve_artifact_name }}
+  #         artifact_run_id: ${{ inputs.artifact_run_id }}
+  #         docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
+  #         docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+
+  # storage:
+  #   continue-on-error: true
+  #   strategy:
+  #     matrix:
+  #       file_system: ['ext4', 'zfs']
+  #   name: Storage test suite
+  #   needs: [determine-runner]
+  #   runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
+  #   steps:
+  #     - name: Dockerhub Login
+  #       if: ${{ github.event.repository.full_name }} == 'lf-edge/eve'
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_PULL_USER }}
+  #         password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+  #     - name: Get code
+  #       uses: actions/checkout@v4.1.1
+  #       with:
+  #         repository: "lf-edge/eden"
+  #         ref: ${{ inputs.eden_version }}
+  #         path: "./eden"
+  #     - name: Run Storage tests
+  #       uses: ./eden/.github/actions/run-eden-test
+  #       with:
+  #         file_system: ${{ matrix.file_system }}
+  #         tpm_enabled: true
+  #         suite: "storage.tests.txt"
+  #         eve_image: ${{ inputs.eve_image }}
+  #         eve_log_level: ${{ inputs.eve_log_level }}
+  #         eve_artifact_name: ${{ inputs.eve_artifact_name }}
+  #         artifact_run_id: ${{ inputs.artifact_run_id }}
+  #         docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
+  #         docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+
+  # lps-loc:
+  #   name: LPS LOC test suite
+  #   needs: [determine-runner]
+  #   runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
+  #   steps:
+  #     - name: Dockerhub Login
+  #       if: ${{ github.event.repository.full_name }} == 'lf-edge/eve'
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_PULL_USER }}
+  #         password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+  #     - name: Get code
+  #       uses: actions/checkout@v4.1.1
+  #       with:
+  #         repository: "lf-edge/eden"
+  #         ref: ${{ inputs.eden_version }}
+  #         path: "./eden"
+  #     - name: Run LPS and LOC tests
+  #       uses: ./eden/.github/actions/run-eden-test
+  #       with:
+  #         file_system: "ext4"
+  #         tpm_enabled: true
+  #         suite: "lps-loc.tests.txt"
+  #         eve_image: ${{ inputs.eve_image }}
+  #         eve_log_level: ${{ inputs.eve_log_level }}
+  #         eve_artifact_name: ${{ inputs.eve_artifact_name }}
+  #         artifact_run_id: ${{ inputs.artifact_run_id }}
+  #         docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
+  #         docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+
+  # eve-upgrade:
+  #   continue-on-error: true
+  #   strategy:
+  #     matrix:
+  #       file_system: ['ext4', 'zfs']
+  #   name: EVE upgrade test suite
+  #   needs: [determine-runner]
+  #   runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
+  #   steps:
+  #     - name: Dockerhub Login
+  #       if: ${{ github.event.repository.full_name }} == 'lf-edge/eve'
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_PULL_USER }}
+  #         password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+  #     - name: Get code
+  #       uses: actions/checkout@v4.1.1
+  #       with:
+  #         repository: "lf-edge/eden"
+  #         ref: ${{ inputs.eden_version }}
+  #         path: "./eden"
+  #     - name: Run EVE upgrade tests
+  #       uses: ./eden/.github/actions/run-eden-test
+  #       with:
+  #         file_system: ${{ matrix.file_system }}
+  #         tpm_enabled: true
+  #         suite: "eve-upgrade.tests.txt"
+  #         eve_image: ${{ inputs.eve_image }}
+  #         eve_log_level: ${{ inputs.eve_log_level }}
+  #         eve_artifact_name: ${{ inputs.eve_artifact_name }}
+  #         artifact_run_id: ${{ inputs.artifact_run_id }}
+  #         docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
+  #         docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+
+  # user-apps:
+  #   name: User apps test suite
+  #   needs: [determine-runner]
+  #   runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
+  #   steps:
+  #     - name: Dockerhub Login
+  #       if: ${{ github.event.repository.full_name }} == 'lf-edge/eve'
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_PULL_USER }}
+  #         password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+  #     - name: Get code
+  #       uses: actions/checkout@v4.1.1
+  #       with:
+  #         repository: "lf-edge/eden"
+  #         ref: ${{ inputs.eden_version }}
+  #         path: "./eden"
+  #     - name: Run User apps tests
+  #       uses: ./eden/.github/actions/run-eden-test
+  #       with:
+  #         file_system: "ext4"
+  #         tpm_enabled: true
+  #         suite: "user-apps.tests.txt"
+  #         eve_image: ${{ inputs.eve_image }}
+  #         eve_log_level: ${{ inputs.eve_log_level }}
+  #         eve_artifact_name: ${{ inputs.eve_artifact_name }}
+  #         artifact_run_id: ${{ inputs.artifact_run_id }}
+  #         docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
+  #         docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+
+  # virtualization:
+  #   name: Virtualization test suite
+  #   needs: [determine-runner]
+  #   runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner_virt) }}
+  #   steps:
+  #     - name: Dockerhub Login
+  #       if: ${{ github.event.repository.full_name }} == 'lf-edge/eve'
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_PULL_USER }}
+  #         password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+  #     - name: Get code
+  #       uses: actions/checkout@v4.1.1
+  #       with:
+  #         repository: "lf-edge/eden"
+  #         ref: ${{ inputs.eden_version }}
+  #         path: "./eden"
+  #     - name: Run Virtualization tests
+  #       uses: ./eden/.github/actions/run-eden-test
+  #       with:
+  #         file_system: "ext4"
+  #         tpm_enabled: true
+  #         suite: "virtualization.tests.txt"
+  #         eve_image: ${{ inputs.eve_image }}
+  #         eve_log_level: ${{ inputs.eve_log_level }}
+  #         eve_artifact_name: ${{ inputs.eve_artifact_name }}
+  #         artifact_run_id: ${{ inputs.artifact_run_id }}
+  #         require_virtualization: true
+  #         docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+  #         docker_token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+
+
+  neoeden:
     continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
         file_system: ['ext4', 'zfs']
         tpm: [true, false]
-    name: Smoke tests
-    needs: determine-runner
+    name: Neoeden (golang only) tests
+    needs: [determine-runner]
     runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
     steps:
       - name: Dockerhub Login
@@ -76,207 +305,16 @@ jobs:
           repository: "lf-edge/eden"
           ref: ${{ inputs.eden_version }}
           path: "./eden"
-      - name: Run Smoke tests
-        uses: ./eden/.github/actions/run-eden-test
+      - name: Run Neoeden tests
+        uses: ./eden/.github/actions/run-neoeden-test
         with:
           file_system: ${{ matrix.file_system }}
           tpm_enabled: ${{ matrix.tpm }}
-          suite: "smoke.tests.txt"
           eve_image: ${{ inputs.eve_image }}
           eve_log_level: ${{ inputs.eve_log_level }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
-          docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
-          docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+          docker_account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+          docker_token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
           aziot_id_scope: ${{ secrets.AZIOT_ID_SCOPE }}
           aziot_connection_string: ${{ secrets.AZIOT_CONNECTION_STRING }}
-
-
-  networking:
-    name: Networking test suite
-    needs: [determine-runner]
-    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
-    steps:
-      - name: Dockerhub Login
-        if: ${{ github.event.repository.full_name }} == 'lf-edge/eve'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_PULL_USER }}
-          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
-      - name: Get code
-        uses: actions/checkout@v4.1.1
-        with:
-          repository: "lf-edge/eden"
-          ref: ${{ inputs.eden_version }}
-          path: "./eden"
-      - name: Run Networking tests
-        uses: ./eden/.github/actions/run-eden-test
-        with:
-          file_system: "ext4"
-          tpm_enabled: true
-          suite: "networking.tests.txt"
-          eve_image: ${{ inputs.eve_image }}
-          eve_log_level: ${{ inputs.eve_log_level }}
-          eve_artifact_name: ${{ inputs.eve_artifact_name }}
-          artifact_run_id: ${{ inputs.artifact_run_id }}
-          docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
-          docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
-
-  storage:
-    continue-on-error: true
-    strategy:
-      matrix:
-        file_system: ['ext4', 'zfs']
-    name: Storage test suite
-    needs: [determine-runner]
-    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
-    steps:
-      - name: Dockerhub Login
-        if: ${{ github.event.repository.full_name }} == 'lf-edge/eve'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_PULL_USER }}
-          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
-      - name: Get code
-        uses: actions/checkout@v4.1.1
-        with:
-          repository: "lf-edge/eden"
-          ref: ${{ inputs.eden_version }}
-          path: "./eden"
-      - name: Run Storage tests
-        uses: ./eden/.github/actions/run-eden-test
-        with:
-          file_system: ${{ matrix.file_system }}
-          tpm_enabled: true
-          suite: "storage.tests.txt"
-          eve_image: ${{ inputs.eve_image }}
-          eve_log_level: ${{ inputs.eve_log_level }}
-          eve_artifact_name: ${{ inputs.eve_artifact_name }}
-          artifact_run_id: ${{ inputs.artifact_run_id }}
-          docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
-          docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
-
-  lps-loc:
-    name: LPS LOC test suite
-    needs: [determine-runner]
-    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
-    steps:
-      - name: Dockerhub Login
-        if: ${{ github.event.repository.full_name }} == 'lf-edge/eve'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_PULL_USER }}
-          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
-      - name: Get code
-        uses: actions/checkout@v4.1.1
-        with:
-          repository: "lf-edge/eden"
-          ref: ${{ inputs.eden_version }}
-          path: "./eden"
-      - name: Run LPS and LOC tests
-        uses: ./eden/.github/actions/run-eden-test
-        with:
-          file_system: "ext4"
-          tpm_enabled: true
-          suite: "lps-loc.tests.txt"
-          eve_image: ${{ inputs.eve_image }}
-          eve_log_level: ${{ inputs.eve_log_level }}
-          eve_artifact_name: ${{ inputs.eve_artifact_name }}
-          artifact_run_id: ${{ inputs.artifact_run_id }}
-          docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
-          docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
-
-  eve-upgrade:
-    continue-on-error: true
-    strategy:
-      matrix:
-        file_system: ['ext4', 'zfs']
-    name: EVE upgrade test suite
-    needs: [determine-runner]
-    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
-    steps:
-      - name: Dockerhub Login
-        if: ${{ github.event.repository.full_name }} == 'lf-edge/eve'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_PULL_USER }}
-          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
-      - name: Get code
-        uses: actions/checkout@v4.1.1
-        with:
-          repository: "lf-edge/eden"
-          ref: ${{ inputs.eden_version }}
-          path: "./eden"
-      - name: Run EVE upgrade tests
-        uses: ./eden/.github/actions/run-eden-test
-        with:
-          file_system: ${{ matrix.file_system }}
-          tpm_enabled: true
-          suite: "eve-upgrade.tests.txt"
-          eve_image: ${{ inputs.eve_image }}
-          eve_log_level: ${{ inputs.eve_log_level }}
-          eve_artifact_name: ${{ inputs.eve_artifact_name }}
-          artifact_run_id: ${{ inputs.artifact_run_id }}
-          docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
-          docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
-
-  user-apps:
-    name: User apps test suite
-    needs: [determine-runner]
-    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
-    steps:
-      - name: Dockerhub Login
-        if: ${{ github.event.repository.full_name }} == 'lf-edge/eve'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_PULL_USER }}
-          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
-      - name: Get code
-        uses: actions/checkout@v4.1.1
-        with:
-          repository: "lf-edge/eden"
-          ref: ${{ inputs.eden_version }}
-          path: "./eden"
-      - name: Run User apps tests
-        uses: ./eden/.github/actions/run-eden-test
-        with:
-          file_system: "ext4"
-          tpm_enabled: true
-          suite: "user-apps.tests.txt"
-          eve_image: ${{ inputs.eve_image }}
-          eve_log_level: ${{ inputs.eve_log_level }}
-          eve_artifact_name: ${{ inputs.eve_artifact_name }}
-          artifact_run_id: ${{ inputs.artifact_run_id }}
-          docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
-          docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
-
-  virtualization:
-    name: Virtualization test suite
-    needs: [determine-runner]
-    runs-on: ${{ fromJSON(needs.determine-runner.outputs.runner_virt) }}
-    steps:
-      - name: Dockerhub Login
-        if: ${{ github.event.repository.full_name }} == 'lf-edge/eve'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_PULL_USER }}
-          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
-      - name: Get code
-        uses: actions/checkout@v4.1.1
-        with:
-          repository: "lf-edge/eden"
-          ref: ${{ inputs.eden_version }}
-          path: "./eden"
-      - name: Run Virtualization tests
-        uses: ./eden/.github/actions/run-eden-test
-        with:
-          file_system: "ext4"
-          tpm_enabled: true
-          suite: "virtualization.tests.txt"
-          eve_image: ${{ inputs.eve_image }}
-          eve_log_level: ${{ inputs.eve_log_level }}
-          eve_artifact_name: ${{ inputs.eve_artifact_name }}
-          artifact_run_id: ${{ inputs.artifact_run_id }}
-          require_virtualization: true
-          docker_account: ${{ secrets.DOCKERHUB_PULL_USER }}
-          docker_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}


### PR DESCRIPTION
Apparently, DockerHub blacklisted some of IPs, we need to tell them explicitly which ones, so we print them during workflow