### PR TITLE
docker.go: Fetch and setup registry credentials

### DIFF
--- a/pkg/expect/docker.go
+++ b/pkg/expect/docker.go
@@ -90,6 +90,15 @@ func (exp *AppExpectation) createDataStoreDocker(id uuid.UUID) *config.Datastore
 		}
 	}
 
+	fmt.Println("DEBUG: fqdn:", fqdn)
+	fmt.Println("DEBUG: fqdn-true:", exp.getDataStoreFQDN(true))
+	fmt.Println("DEBUG: docker credentials:", username)
+	if (password != "") {
+		fmt.Println("DEBUG: password is NOT NULL! :)")
+	} else {
+		fmt.Println("DEBUG: password is NULL! :(")
+	}
+
 	// Return the new datastore
 	return &config.DatastoreConfig{
 		Id:         id.String(),


### PR DESCRIPTION
## Description
Fetch and setup registry datastore local credentials (when available), so pull operations can be performed authenticated.

## Notes
I've tested it only locally and it works, credentials from ~/.docker/config.json are retrieved correctly.