### PR TITLE
Read Docker credantials as plain user and password for basic authentication

### DIFF
--- a/pkg/expect/docker.go
+++ b/pkg/expect/docker.go
@@ -72,12 +72,17 @@ func (exp *AppExpectation) checkDataStoreDocker(ds *config.DatastoreConfig) bool
 
 // createDataStoreDocker creates DatastoreConfig for docker.io with provided id
 func (exp *AppExpectation) createDataStoreDocker(id uuid.UUID) *config.DatastoreConfig {
+	fqdn := exp.getDataStoreFQDN(true)
+	user, password, err := utils.GetDockerAuthPlain(fqdn)
+	if err != nil {
+		log.Errorf("cannot get docker plain auth for %s: %v", fqdn, err)
+	}
 	return &config.DatastoreConfig{
 		Id:         id.String(),
 		DType:      config.DsType_DsContainerRegistry,
-		Fqdn:       exp.getDataStoreFQDN(true),
-		ApiKey:     "",
-		Password:   "",
+		Fqdn:       fqdn,
+		ApiKey:     user,
+		Password:   password,
 		Dpath:      "",
 		Region:     "",
 		CipherData: nil,

--- a/pkg/utils/container.go
+++ b/pkg/utils/container.go
@@ -178,7 +178,7 @@ func CreateAndRunContainer(containerName string, imageName string, portMap map[s
 		return fmt.Errorf("ContainerCreate: %w", err)
 	}
 
-	if err := cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
+	if err := cli.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
 		return fmt.Errorf("ContainerStart: %w", err)
 	}
 
@@ -482,7 +482,7 @@ func ExtractFromImage(imageName, localPath, containerPath string) error {
 	}
 	containerID := resp.ID
 	defer func() {
-		if err := cli.ContainerRemove(ctx, containerID, types.ContainerRemoveOptions{Force: true}); err != nil {
+		if err := cli.ContainerRemove(ctx, containerID, container.RemoveOptions{Force: true}); err != nil {
 			log.Errorf("ContainerRemove error: %s", err)
 		}
 	}()
@@ -522,7 +522,7 @@ func StopContainer(containerName string, remove bool) error {
 		return err
 	}
 
-	containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{All: true})
+	containers, err := cli.ContainerList(context.Background(), container.ListOptions{All: true})
 	if err != nil {
 		return err
 	}
@@ -537,14 +537,14 @@ func StopContainer(containerName string, remove bool) error {
 		if isFound {
 			if cont.State != "running" {
 				if remove {
-					if err = cli.ContainerRemove(ctx, cont.ID, types.ContainerRemoveOptions{}); err != nil {
+					if err = cli.ContainerRemove(ctx, cont.ID, container.RemoveOptions{}); err != nil {
 						return err
 					}
 				}
 				return nil
 			}
 			if remove {
-				if err = cli.ContainerRemove(ctx, cont.ID, types.ContainerRemoveOptions{Force: true}); err != nil {
+				if err = cli.ContainerRemove(ctx, cont.ID, container.RemoveOptions{Force: true}); err != nil {
 					return err
 				}
 			} else {
@@ -569,7 +569,7 @@ func StateContainer(containerName string) (state string, err error) {
 		return "", err
 	}
 
-	containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{All: true})
+	containers, err := cli.ContainerList(context.Background(), container.ListOptions{All: true})
 	if err != nil {
 		return "", err
 	}
@@ -596,7 +596,7 @@ func StartContainer(containerName string) error {
 		return err
 	}
 
-	containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{All: true})
+	containers, err := cli.ContainerList(context.Background(), container.ListOptions{All: true})
 	if err != nil {
 		return err
 	}
@@ -609,7 +609,7 @@ func StartContainer(containerName string) error {
 			}
 		}
 		if isFound {
-			if err = cli.ContainerStart(ctx, cont.ID, types.ContainerStartOptions{}); err != nil {
+			if err = cli.ContainerStart(ctx, cont.ID, container.StartOptions{}); err != nil {
 				return err
 			}
 			break
@@ -666,7 +666,7 @@ func RunDockerCommand(image string, command string, volumeMap map[string]string)
 	if err != nil {
 		return "", err
 	}
-	if err := cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
+	if err := cli.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
 		return "", err
 	}
 	statusCh, errCh := cli.ContainerWait(ctx, resp.ID, container.WaitConditionNotRunning)
@@ -679,14 +679,14 @@ func RunDockerCommand(image string, command string, volumeMap map[string]string)
 
 	}
 
-	out, err := cli.ContainerLogs(ctx, resp.ID, types.ContainerLogsOptions{ShowStdout: true, ShowStderr: true})
+	out, err := cli.ContainerLogs(ctx, resp.ID, container.LogsOptions{ShowStdout: true, ShowStderr: true})
 	if err != nil {
 		return "", err
 	}
 	defer out.Close()
 	b, err := io.ReadAll(out)
 
-	if err := cli.ContainerRemove(ctx, resp.ID, types.ContainerRemoveOptions{RemoveVolumes: true}); err != nil {
+	if err := cli.ContainerRemove(ctx, resp.ID, container.RemoveOptions{RemoveVolumes: true}); err != nil {
 		log.Errorf("ContainerRemove error: %s", err)
 	}
 

--- a/tests/escript/go-internal/testscript/testscript.go
+++ b/tests/escript/go-internal/testscript/testscript.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/cli/cli/config"
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eden/tests/escript/go-internal/imports"
 	"github.com/lf-edge/eden/tests/escript/go-internal/internal/os/execpath"
@@ -311,6 +312,7 @@ func (ts *TestScript) setup() string {
 			"WORK=" + ts.workdir, // must be first for ts.abbrev
 			"PATH=" + os.Getenv("PATH"),
 			"DOCKER_HOST=" + os.Getenv("DOCKER_HOST"),
+			config.EnvOverrideConfigDir + "=" + config.Dir(),
 			tempEnvName() + "=" + filepath.Join(ts.workdir, "tmp"),
 			"devnull=" + os.DevNull,
 			"/=" + string(os.PathSeparator),


### PR DESCRIPTION
This PR improves Docker Hub authentication in EDEN and its tests to avoid running into unauthenticated pull limits ("429 - unauthenticated limit reached" errors) during test runs.

EDEN tests create Docker datastores and reference test application images to be installed on EVE. Previously, the username and password for Docker Hub were not set in these datastores, resulting in unauthenticated pulls and frequent rate limiting.

To fix this, credentials are now read from the host’s ~/.docker/config.json and patched into the datastore definitions dynamically. This avoids the need to hardcode secrets into the test suite.

Since EDEN overrides the HOME environment variable during tests (which interferes with the docker library’s default config discovery), the code now respects the DOCKER_CONFIG environment variable, which explicitly points to the credentials directory, following Docker client conventions.

Also includes a minor update to deprecated types in the codebase.

These changes should reduce spurious test failures due to Docker Hub rate limits and align our credential handling with best practices.