### PR TITLE
Add disable logs option for pod configuration

### DIFF
--- a/cmd/edenPod.go
+++ b/cmd/edenPod.go
@@ -123,6 +123,7 @@ You can set access VLAN ID (VID) for a particular network in the format '<networ
 	podDeployCmd.Flags().StringVar(&pc.DatastoreOverride, "datastoreOverride", "", "Override datastore path for disks (when we use different URL for Eden and EVE or for local datastore)")
 	podDeployCmd.Flags().Uint32Var(&pc.StartDelay, "start-delay", 0, "The amount of time (in seconds) that EVE waits (after boot finish) before starting application")
 	podDeployCmd.Flags().BoolVar(&pc.PinCpus, "pin-cpus", false, "Pin the CPUs used by the pod")
+	podDeployCmd.Flags().BoolVar(&pc.DisableLogs, "disable-logs", false, "Disable logs for pod")
 
 	return podDeployCmd
 }

--- a/pkg/expect/application.go
+++ b/pkg/expect/application.go
@@ -48,6 +48,7 @@ func (exp *AppExpectation) createAppInstanceConfig(img *config.Image, netInstanc
 		return nil, fmt.Errorf("not supported appType")
 	}
 	bundle.appInstanceConfig.Fixedresources.PinCpu = exp.pinCpus
+	bundle.appInstanceConfig.Fixedresources.DisableLogs = exp.disableLogs
 	bundle.appInstanceConfig.StartDelayInSeconds = exp.startDelay
 	for _, d := range exp.disks {
 		mountPoint := ""

--- a/pkg/expect/expectation.go
+++ b/pkg/expect/expectation.go
@@ -54,8 +54,8 @@ type AppExpectation struct {
 
 	baseOSVersion string
 
-	vncDisplay  int
-	vncPassword string
+	vncDisplay   int
+	vncPassword  string
 	vncForShimVM bool
 
 	netInstances []*NetInstanceExpectation
@@ -87,6 +87,7 @@ type AppExpectation struct {
 	datastoreOverride string
 	startDelay        uint32
 	pinCpus           bool
+	disableLogs       bool // disable logs for pod
 }
 
 // use provided appLink to try predict format of volume

--- a/pkg/expect/options.go
+++ b/pkg/expect/options.go
@@ -309,3 +309,10 @@ func WithPinCpus(pinCpus bool) ExpectationOption {
 
 	}
 }
+
+// WithDisableLogs sets disable-logs option
+func WithDisableLogs(disableLogs bool) ExpectationOption {
+	return func(expectation *AppExpectation) {
+		expectation.disableLogs = disableLogs
+	}
+}

--- a/pkg/openevec/config.go
+++ b/pkg/openevec/config.go
@@ -231,6 +231,7 @@ type PodConfig struct {
 	OpenStackMetadata bool
 	DatastoreOverride string
 	ACLOnlyHost       bool
+	DisableLogs       bool
 }
 
 func Merge(dst, src reflect.Value, flags *pflag.FlagSet) {

--- a/pkg/openevec/pod.go
+++ b/pkg/openevec/pod.go
@@ -140,6 +140,7 @@ func (openEVEC *OpenEVEC) PodDeploy(appLink string, pc PodConfig, cfg *EdenSetup
 	opts = append(opts, expect.WithDatastoreOverride(pc.DatastoreOverride))
 	opts = append(opts, expect.WithStartDelay(pc.StartDelay))
 	opts = append(opts, expect.WithPinCpus(pc.PinCpus))
+	opts = append(opts, expect.WithDisableLogs(pc.DisableLogs))
 	expectation := expect.AppExpectationFromURL(ctrl, dev, appLink, pc.Name, opts...)
 	appInstanceConfig := expectation.Application()
 	dev.SetApplicationInstanceConfig(append(dev.GetApplicationInstances(), appInstanceConfig.Uuidandversion.Uuid))


### PR DESCRIPTION
This commit introduces a new option to disable upload of logs from pods to Adam.