### PR TITLE
marshal logs and metrics with json for print

### DIFF
--- a/pkg/controller/eapps/eappslog.go
+++ b/pkg/controller/eapps/eappslog.go
@@ -3,6 +3,7 @@
 package eapps
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -83,7 +84,7 @@ func HandleFactory(format types.OutputFormat, once bool) HandlerFunc {
 func LogPrn(le *logs.LogEntry, format types.OutputFormat) {
 	switch format {
 	case types.OutputFormatJSON:
-		b, err := protojson.Marshal(le)
+		b, err := json.Marshal(le)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/controller/einfo/einfo.go
+++ b/pkg/controller/einfo/einfo.go
@@ -3,6 +3,7 @@
 package einfo
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -17,7 +18,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -40,7 +40,7 @@ func ParseZInfoMsg(data []byte) (ZInfoMsg *info.ZInfoMsg, err error) {
 func ZInfoPrn(im *info.ZInfoMsg, format types.OutputFormat) {
 	switch format {
 	case types.OutputFormatJSON:
-		b, err := protojson.Marshal(im)
+		b, err := json.Marshal(im)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/controller/elog/elog.go
+++ b/pkg/controller/elog/elog.go
@@ -3,6 +3,7 @@
 package elog
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -109,7 +110,7 @@ func HandleFactory(format types.OutputFormat, once bool) HandlerFunc {
 func LogPrn(le *FullLogEntry, format types.OutputFormat) {
 	switch format {
 	case types.OutputFormatJSON:
-		b, err := protojson.Marshal(le)
+		b, err := json.Marshal(le)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/controller/emetric/emetric.go
+++ b/pkg/controller/emetric/emetric.go
@@ -3,6 +3,7 @@
 package emetric
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -17,7 +18,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -104,7 +104,7 @@ func MetricItemFind(mm *metrics.ZMetricMsg, query map[string]string) bool {
 func MetricPrn(le *metrics.ZMetricMsg, format types.OutputFormat) {
 	switch format {
 	case types.OutputFormatJSON:
-		b, err := protojson.Marshal(le)
+		b, err := json.Marshal(le)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
I was wondering for a long time why msgid is marshalled as a string, while it's defined as int64. Turns out that protojson.Marshal converts all int64 to string according to the protobuf spec.

I find this peculiar, so I decided to use json.Marshal instead. We'll only use this for printing, to avoid compatibility issues.

As can be seen [here](https://github.com/golang/protobuf/issues/1414) it's a known issue and is by design.