### PR TITLE
Build multi-platform eden-sdn image

### DIFF
--- a/sdn/Makefile
+++ b/sdn/Makefile
@@ -1,18 +1,32 @@
 DOCKER_TARGET ?= build
 DOCKER_PLATFORM ?= $(shell uname -s | tr '[A-Z]' '[a-z]')/$(subst aarch64,arm64,$(subst x86_64,amd64,$(shell uname -m)))
-DOCKER_ARCH := $(word 2,$(subst /, ,$(DOCKER_PLATFORM)))
-LINUXKIT ?= linuxkit
 
+# Split comma-separated DOCKER_PLATFORM list into space-separated
+COMMA := ,
+EMPTY :=
+SPACE := $(EMPTY) $(EMPTY)
+DOCKER_PLATFORM_LIST := $(subst $(COMMA),$(SPACE),$(DOCKER_PLATFORM))
+
+# Generate target names like build-vm-img-linux-arm64 from DOCKER_PLATFORM_LIST
+DOCKER_PLATFORM_TARGETS := $(foreach platform,$(DOCKER_PLATFORM_LIST),build-vm-img-$(subst /,-,$(platform)))
+
+LINUXKIT ?= linuxkit
 SDN_REPO ?= "lfedge/eden-sdn"
-SDN_DIR=$(CURDIR)
-SDN_VM_DIR=$(SDN_DIR)/vm
-SDN_SERVICE_CONTAINER := $(shell $(LINUXKIT) pkg show-tag $(SDN_VM_DIR))-$(DOCKER_ARCH)
+SDN_DIR := $(CURDIR)
+SDN_VM_DIR := $(SDN_DIR)/vm
 SDN_VERSION := $(shell grep -v '^#' VERSION | head -n1)
 
-build:
-	@$(LINUXKIT) pkg build --platforms $(DOCKER_PLATFORM) --build-yml build.yml $(SDN_VM_DIR)
-	@sed 's|SDN_SERVICE_CONTAINER|$(SDN_SERVICE_CONTAINER)|g' $(SDN_VM_DIR)/sdn-vm.yml.in | \
-		$(LINUXKIT) build --docker --arch $(DOCKER_ARCH) --name sdn --format raw-bios --dir $(SDN_VM_DIR) -
-	@docker buildx build --$(DOCKER_TARGET) --platform $(DOCKER_PLATFORM) \
-		-f $(SDN_VM_DIR)/Dockerfile.vm --build-arg SDN_VERSION=$(SDN_VERSION) \
-		--tag $(SDN_REPO):$(SDN_VERSION) $(SDN_VM_DIR)
+build-vm-img-%:
+	PLATFORM=$(subst -,/,$*); \
+	ARCH=$$(echo $$PLATFORM | cut -d/ -f2); \
+	SDN_SVC_CONT_TAG=`$(LINUXKIT) pkg show-tag $(SDN_VM_DIR)`-$$ARCH; \
+	$(LINUXKIT) pkg build --platforms $$PLATFORM --build-yml build.yml $(SDN_VM_DIR); \
+	sed 's|SDN_SERVICE_CONTAINER|'"$$SDN_SVC_CONT_TAG"'|g' $(SDN_VM_DIR)/sdn-vm.yml.in | \
+		$(LINUXKIT) build --docker --arch $$ARCH --name sdn-$$ARCH --format raw-bios --dir $(SDN_VM_DIR) -
+
+build: $(DOCKER_PLATFORM_TARGETS)
+	docker buildx build --$(DOCKER_TARGET) --platform $(DOCKER_PLATFORM) \
+		-f $(SDN_VM_DIR)/Dockerfile.vm \
+		--build-arg SDN_VERSION=$(SDN_VERSION) \
+		--tag $(SDN_REPO):$(SDN_VERSION) \
+		$(SDN_VM_DIR)

--- a/sdn/README.md
+++ b/sdn/README.md
@@ -106,6 +106,15 @@ You can build this container using the following Makefile target:
 make DOCKER_TARGET=build DOCKER_PLATFORM=<os>/<arch> push-multi-arch-sdn
 ```
 
+It is also possible to build a multi-platform image by specifying multiple platforms
+in the `DOCKER_PLATFORM` variable:
+
+```shell
+make DOCKER_TARGET=build DOCKER_PLATFORM=<os1>/<arch1>,<os2>/<arch2>,... push-multi-arch-sdn
+```
+
+Replace `<os>/<arch>` entries with the desired target platforms (e.g., `linux/amd64,linux/arm64`).
+
 To additionally push the image to the `lfedge/eden-sdn` repository,
 run with `DOCKER_TARGET=push`.
 

--- a/sdn/vm/.gitignore
+++ b/sdn/vm/.gitignore
@@ -1,1 +1,2 @@
-sdn-bios.img
+sdn-arm64-bios.img
+sdn-amd64-bios.img

--- a/sdn/vm/Dockerfile.vm
+++ b/sdn/vm/Dockerfile.vm
@@ -7,7 +7,9 @@ FROM lfedge/eve-alpine:12.1.0
 
 COPY --from=tools /out/ /
 COPY entrypoint.sh /
-COPY sdn-bios.img /bits/
+
+ARG TARGETARCH
+COPY sdn-${TARGETARCH}-bios.img /bits/sdn-bios.img
 
 ARG SDN_VERSION
 RUN echo "$SDN_VERSION" > /bits/sdn-version


### PR DESCRIPTION
Refactored the `sdn/Makefile` to support building `eden-sdn` images for multiple platforms using Docker Buildx and LinuxKit. Each target architecture now produces a distinct `sdn-<arch>-bios.img` and is handled via dedicated Makefile targets (e.g., `build-vm-img-linux-arm64`).

`Dockerfile.vm` has been updated to use the correct image based on the target architecture at build time using the standard `TARGETARCH` argument.

With this patch it is now supported to specify multiple platforms, like we do in the publish workflow:
```
make DOCKER_TARGET=push LINUXKIT_TARGET=push DOCKER_PLATFORM=linux/arm64,linux/amd64 build-docker
```

(my [previous PR](https://github.com/lf-edge/eden/pull/1077) broke the multi-platform building/publishing: https://github.com/lf-edge/eden/actions/runs/16353910243/job/46207393649) 