### PR TITLE
Fix Eden workflow schema and drop redundant IP logging.

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -12,16 +12,9 @@ concurrency:
 
 jobs:
   run_tests:
-    steps:
-      - name: Print Public IP Address
-        run: |
-          echo "Public IP Address of the runner:"
-          curl -s https://api.ipify.org
-        shell: bash
-
-      - name: Execute Eden test workflow
-        uses: ./.github/workflows/test.yml
-        with:
-          eve_image: "lfedge/eve:13.3.0"
-          eden_version: ${{ github.event.pull_request.head.sha }}
-        secrets: inherit
+    name: Execute Eden test workflow
+    uses: ./.github/workflows/test.yml
+    with:
+      eve_image: "lfedge/eve:13.3.0"
+      eden_version: ${{ github.event.pull_request.head.sha }}
+    secrets: inherit


### PR DESCRIPTION
Declare the Eden test workflow call at the job level instead of nesting it inside steps, correcting the GitHub Actions schema that had broken the job.  Remove the temporary “Print Public IP Address” command, now handled centrally across all Eden jobs in test.yml.

These changes restore a valid workflow file and re-enable automatic Eden tests for pull-request builds.

It partially reverts 1bfe493516af8358849699ebed191366ee193bae from #1080