### PR TITLE
.github: Fix typo in calculation of previous attempt in test workflow.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -457,8 +457,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           FULL_JOB_NAME: ${{ env.JOB_NAME }}
-          PREV_ATTEMPT: ${{ github.run_attempt - 1 }}
         run: |
+            PREV_ATTEMPT=$((${{ github.run_attempt }} - 1 ))
             # For the first attempt, we don't need to check the previous attempt, just set conclusion to 'skipped'
             if [ "$PREV_ATTEMPT" -le 0 ]; then
                 echo "conclusion=skipped" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Correct the calculation of the previous attempt value in the Eden test workflow. This change ensures that the PREV_ATTEMPT variable is properly set using shell arithmetic, preventing errors in job execution logic.