### PR TITLE
Fix LPS/LOC job restart logic in test workflow.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -268,7 +268,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           FULL_JOB_NAME: ${{ env.JOB_NAME }}
         run: |
-            PREV_ATTEMPT=$(($PREV_ATTEMPT - 1 ))
+            PREV_ATTEMPT=$((${{ github.run_attempt }} - 1 ))
             # For the first attempt, we don't need to check the previous attempt, just set conclusion to 'skipped'
             if [ "$PREV_ATTEMPT" -le 0 ]; then
                 echo "conclusion=skipped" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Update the calculation of the previous attempt count to use the built-in `github.run_attempt` variable instead of a custom one.