### PR TITLE
tar the whole of /persist/eve-info

### DIFF
--- a/.github/actions/publish-logs/action.yml
+++ b/.github/actions/publish-logs/action.yml
@@ -48,6 +48,7 @@ runs:
       with:
         name: ${{ inputs.report_name }}
         path: |
+            ${{ github.workspace }}/eden/eve-info.tar
             ${{ github.workspace }}/eden/eve-info.tar.gz
             ${{ github.workspace }}/eden/trace.log
             ${{ github.workspace }}/eden/info.log

--- a/.github/workflows/eden_gcp.yml
+++ b/.github/workflows/eden_gcp.yml
@@ -167,6 +167,7 @@ jobs:
         with:
           name: eden-report-${{ matrix.hv }}-${{ matrix.fs }}
           path: |
+            ${{ github.workspace }}/eve-info.tar
             ${{ github.workspace }}/eve-info.tar.gz
             ${{ github.workspace }}/trace.log
             ${{ github.workspace }}/info.log

--- a/shell-scripts/collect-info-ssh.sh
+++ b/shell-scripts/collect-info-ssh.sh
@@ -1,7 +1,7 @@
-#/bin/sh
+#!/bin/sh
 
 # Use output filename without colon, otherwise Github action "upload-artifact" complains.
-OUTPUT="eve-info.tar.gz"
+OUTPUT="eve-info.tar"
 
 ssh() {
   ./eden sdn fwd eth0 22 --\
@@ -45,13 +45,7 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-TGZNAME="$(cat ssh.stdout  | sed -n "s/EVE info is collected '\(.*\)'/\1/p")"
-if [ -z "${TGZNAME}" ]; then
-  echo "Failed to parse eve-info tarball filename"
-  exit 1
-fi
-
-scp "${TGZNAME}" ${OUTPUT}
+ssh "tar -C /persist -cf - eve-info" > "${OUTPUT}"
 if [ $? -ne 0 ]; then
   echo "Failed to receive eve-info"
   exit 1


### PR DESCRIPTION
When an Eden CI workflow fails, we run collect-info.sh and include the tar ball in the CI artifacts. However, there might be many relevant collect-info archives in /persist/eve-info, so we need to tar the whole directory instead.

This fixes the issue raised by @OhmSpectator that collect-info tar ball is not uploaded due to changes in https://github.com/lf-edge/eve/pull/5079.

I tested `shell-scripts/collect-info-ssh.sh` locally and it works well.

I also tested `shell-scripts/collect-info-console.sh` and it works for small tar balls. However for big tar balls, the streaming over telnet takes too long and it times out. I'm not sure if we actually see this in the CI, so let's try it and fix it if we actually hit that problem.

@christoph-zededa has proposed to mount a 9p volume on EVE when starting it in QEMU and just move the collect-info tar ball there instead of copying it over ssh or streaming over telnet. We could implement in as a fix in another PR.