### PR TITLE
add tests for remote levels of newlogd

### DIFF
--- a/tests/newlogd/Makefile
+++ b/tests/newlogd/Makefile
@@ -1,0 +1,77 @@
+DEBUG ?= "debug"
+
+# HOSTARCH is the host architecture
+# ARCH is the target architecture
+# we need to keep track of them separately
+HOSTARCH ?= $(shell uname -m)
+HOSTOS ?= $(shell uname -s | tr A-Z a-z)
+
+# canonicalized names for host architecture
+override HOSTARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(HOSTARCH)))
+
+# unless otherwise set, I am building for my own architecture, i.e. not cross-compiling
+# and for my OS
+ARCH ?= $(HOSTARCH)
+OS ?= $(HOSTOS)
+
+# canonicalized names for target architecture
+override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
+
+WORKDIR ?= $(CURDIR)/../../dist
+TESTDIR := tests/$(shell basename $(CURDIR))
+BINDIR := $(WORKDIR)/bin
+DATADIR := $(WORKDIR)/$(TESTDIR)/
+BIN := eden
+LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
+TESTNAME := eden.newlogd
+TESTBIN := $(TESTNAME).test
+TESTSCN := $(TESTNAME).tests.txt
+LOCALTESTBIN := $(TESTBIN)-$(OS)-$(ARCH)
+SCRIPTDIR := scripts
+LINKDIR := ../../tests/newlogd
+
+.DEFAULT_GOAL := help
+
+clean:
+	rm -rf $(LOCALTESTBIN) $(BINDIR)/$(TESTBIN) $(WORKDIR)/$(TESTSCN) $(CURDIR)/$(TESTBIN) $(BINDIR)/$(TESTBIN)
+
+$(BINDIR):
+	mkdir -p $@
+$(DATADIR):
+	mkdir -p $@
+
+test:
+	$(LOCALBIN) test $(CURDIR) -v $(DEBUG)
+
+build: setup
+
+testbin: $(TESTBIN)
+$(LOCALTESTBIN): $(BINDIR) *.go
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -ldflags "-s -w" -o $@ *.go
+
+$(TESTBIN): $(LOCALTESTBIN)
+	ln -sf $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN)
+
+setup: testbin $(BINDIR) $(DATADIR)
+	cp -a $(LOCALTESTBIN) $(CURDIR)/$(TESTBIN) $(BINDIR)
+	cp -a *.yml $(TESTSCN) $(DATADIR)
+
+debug:
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go test -c -gcflags "all=-N -l" -o $@ *.go
+	dlv dap --listen=:12345 --headless=true --api-version=2 exec ./debug -- -test.v
+
+.PHONY: test build setup clean all testbin debug
+
+help:
+	@echo "EDEN is the harness for testing EVE and ADAM"
+	@echo
+	@echo "This Makefile automates commons tasks of EDEN testing"
+	@echo
+	@echo "Commonly used maintenance and development targets:"
+	@echo "   build         build test-binary (OS and ARCH options supported, for ex. OS=linux ARCH=arm64)"
+	@echo "   setup         setup of test environment"
+	@echo "   test          run tests"
+	@echo "   clean         cleanup of test harness"
+	@echo
+	@echo "You need install requirements for EVE (look at https://github.com/lf-edge/eve#install-dependencies)."
+	@echo "You need access to docker socket and installed qemu packages."

--- a/tests/newlogd/eden-config.yml
+++ b/tests/newlogd/eden-config.yml
@@ -1,0 +1,7 @@
+---
+eden:
+    # test binary
+    test-bin: "eden.newlogd.test"
+
+    # test scenario
+    test-scenario: "eden.newlogd.tests.txt"

--- a/tests/newlogd/eden.newlogd.tests.txt
+++ b/tests/newlogd/eden.newlogd.tests.txt
@@ -1,0 +1,1 @@
+eden.newlogd.test

--- a/tests/newlogd/newlogd_test.go
+++ b/tests/newlogd/newlogd_test.go
@@ -1,0 +1,114 @@
+package newlogd
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eden/pkg/controller/elog"
+	tk "github.com/lf-edge/eden/pkg/evetestkit"
+	"github.com/lf-edge/eden/pkg/utils"
+)
+
+var eveNode *tk.EveNode
+var logT *testing.T
+
+const (
+	projectName = "newlogd"
+	logTimeout  = 2 * time.Minute
+)
+
+func logFatalf(format string, args ...interface{}) {
+	out := utils.AddTimestampf(format+"\n", args...)
+	if logT != nil {
+		logT.Fatal(out)
+	} else {
+		fmt.Print(out)
+		os.Exit(1)
+	}
+}
+
+func logInfof(format string, args ...interface{}) {
+	out := utils.AddTimestampf(format+"\n", args...)
+	if logT != nil {
+		logT.Log(out)
+	} else {
+		fmt.Print(out)
+	}
+}
+
+type stepCounter struct {
+	count int
+}
+
+func (s *stepCounter) AnnounceNext(msg string) {
+	s.count++
+	logInfof("STEP %d: %s", s.count, msg)
+}
+
+func TestMain(m *testing.M) {
+	logInfof("%s Test started", projectName)
+	defer logInfof("%s Test finished", projectName)
+
+	node, err := tk.InitializeTest(projectName, tk.WithControllerVerbosity("debug"))
+	if err != nil {
+		logFatalf("Failed to initialize test: %v", err)
+	}
+
+	eveNode = node
+	res := m.Run()
+	os.Exit(res)
+}
+
+func TestLogLevelsDifferent(t *testing.T) {
+	logT = t
+	steppy := &stepCounter{}
+
+	logInfof("TestLogLevelsDifferent started")
+	defer logInfof("TestLogLevelsDifferent finished")
+
+	steppy.AnnounceNext("secure the initial config")
+	if err := eveNode.GetConfig("/tmp/initial_config"); err != nil {
+		logFatalf("Failed to get initial config: %v", err)
+	}
+	defer func() {
+		logInfof("revert to the initial config")
+		if err := eveNode.SetConfig("/tmp/initial_config"); err != nil {
+			logFatalf("Failed to get back to the initial config: %v", err)
+		}
+	}()
+
+	steppy.AnnounceNext("set log levels")
+	localLogLevel := "debug"
+	remoteLogLevel := "none"
+	eveNode.UpdateNodeGlobalConfig(
+		nil,
+		map[string]string{
+			"debug.default.loglevel":        localLogLevel,
+			"debug.default.remote.loglevel": remoteLogLevel,
+			"debug.syslog.loglevel":         localLogLevel,
+			"debug.syslog.remote.loglevel":  remoteLogLevel,
+			"debug.kernel.loglevel":         localLogLevel,
+			"debug.kernel.remote.loglevel":  remoteLogLevel,
+		},
+	)
+	if err := eveNode.WaitForConfigApplied(60 * time.Second); err != nil {
+		logFatalf("Failed to wait for config to be applied: %v", err)
+	}
+
+	steppy.AnnounceNext("reboot EVE to generate fresh logs")
+	if err := eveNode.EveRebootAndWait(180); err != nil {
+		logFatalf("Failed to reboot EVE: %v", err)
+	}
+
+	steppy.AnnounceNext(fmt.Sprintf("check for undesired logs (timeout %v)", logTimeout))
+	query := map[string]string{
+		"severity": ".*",
+	}
+	if err := eveNode.FindLogOnAdam(query, elog.LogNew, logTimeout); err != nil {
+		logInfof("No logs found, as expected")
+	} else {
+		logFatalf("Logs found, but they should not be present with the remote log level '%s'", remoteLogLevel)
+	}
+}


### PR DESCRIPTION
The added test sets the remote log levels of EVE and checks the logs that arrive at the controller after a certain period of time. The test succeeds unless logs below the set remote log level are detected.

I didn't include it in the smoke suite so far, because this test will fail (at least sometimes) with the current version of EVE. The fix for EVE is already under way https://github.com/lf-edge/eve/pull/5242.