### PR TITLE
eclient: add LPS network endpoint

### DIFF
--- a/tests/eclient/image/Dockerfile
+++ b/tests/eclient/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine AS build
+FROM golang:1.23-alpine AS build
 
 WORKDIR /go/src/local_manager
 COPY pkg .

--- a/tests/eclient/image/pkg/go.mod
+++ b/tests/eclient/image/pkg/go.mod
@@ -1,8 +1,10 @@
 module github.com/lf-edge/eden/tests/eclient/image/pgk
 
-go 1.14
+go 1.23
 
 require (
-	github.com/lf-edge/eve-api/go v0.0.0-20231214160111-99ce4e43be4b
-	google.golang.org/protobuf v1.33.0
+	github.com/lf-edge/eve-api/go v0.0.0-20250922144401-abfd2fa2b728
+	google.golang.org/protobuf v1.36.3
 )
+
+require github.com/google/go-cmp v0.6.0 // indirect

--- a/tests/eclient/image/pkg/go.sum
+++ b/tests/eclient/image/pkg/go.sum
@@ -1,11 +1,6 @@
-github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
-github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/lf-edge/eve-api/go v0.0.0-20231214160111-99ce4e43be4b h1:uxB8HRp0NgOf8tb9nSoVEcMOo8TQ8YdohfSX+q91vnI=
-github.com/lf-edge/eve-api/go v0.0.0-20231214160111-99ce4e43be4b/go.mod h1:6XqpOM8p1HsluNIGw2ihYPYsaAisQ5CuJpbIKHXQo5w=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
-google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/lf-edge/eve-api/go v0.0.0-20250922144401-abfd2fa2b728 h1:MieVGF6Sp12dcgBBZPG7GODDBSIEQF2vOfio3qQ/UVE=
+github.com/lf-edge/eve-api/go v0.0.0-20250922144401-abfd2fa2b728/go.mod h1:6HxNA/qKJVEqwpuOFkcQ0h3QyotvAs/cjHLC961FPOY=
+google.golang.org/protobuf v1.36.3 h1:82DV7MYdb8anAVi3qge1wSnMDrnKK7ebr+I0hHRN1BU=
+google.golang.org/protobuf v1.36.3/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=


### PR DESCRIPTION
Implement the recently introduced LPS `/api/v1/network` endpoint in `local_manager` (part of the `eclient` application) to support local network configuration changes.

The endpoint:
- Accepts `NetworkInfo` from EVE, saves it into `/mnt/network-info.json`.
- Optionally reads and returns `LocalNetworkConfig` from `/mnt/local-network-config.json` if present.
- Handles empty config file as a throttling request.

The formal definition of the LPS network endpoint can be found here: https://github.com/lf-edge/eve-api/blob/main/PROFILE.md#network

This will be used in a new LPS test for the network endpoint. 
However, this PR must be merged first so that a new version of `eclient` is built and pushed to Docker Hub, 
which the test will then reference.