### PR TITLE
Add test for LPS /api/v1/network endpoint

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -19,7 +19,7 @@ jobs:
     name: Execute Eden test workflow
     uses: ./.github/workflows/test.yml
     with:
-      eve_image: "lfedge/eve:15.8.0"
+      eve_image: "lfedge/eve:15.11.0"
       eve_kubevirt_image: "lfedge/eve:0.0.0-master-75241279-kubevirt-amd64"
       eden_version: ${{ github.event.pull_request.head.sha }}
     secrets: inherit

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/lf-edge/eden/eserver v0.0.0-20220711180217-6e2bfa9c3f67
 	github.com/lf-edge/eden/sdn/vm v0.0.0-20250314212201-6f1e0716172f
 	github.com/lf-edge/edge-containers v0.0.0-20240207093504-5dfda0619b80
-	github.com/lf-edge/eve-api/go v0.0.0-20240829123634-7c8ebda876ff
+	github.com/lf-edge/eve-api/go v0.0.0-20250922144401-abfd2fa2b728
 	github.com/lf-edge/eve/pkg/pillar v0.0.0-20240923082146-6d403aaa5513
 	github.com/mcuadros/go-lookup v0.0.0-20200831155250-80f87a4fa5ee
 	github.com/moby/term v0.5.0
@@ -42,7 +42,7 @@ require (
 	golang.org/x/term v0.18.0
 	golang.org/x/text v0.14.0
 	google.golang.org/api v0.160.0
-	google.golang.org/protobuf v1.33.0
+	google.golang.org/protobuf v1.36.3
 	gopkg.in/errgo.v2 v2.1.0
 	gopkg.in/yaml.v2 v2.4.0
 	oras.land/oras-go v1.2.5

--- a/go.sum
+++ b/go.sum
@@ -1370,8 +1370,8 @@ github.com/lf-edge/eden/eserver v0.0.0-20220711180217-6e2bfa9c3f67 h1:lUJ/IASqGL
 github.com/lf-edge/eden/eserver v0.0.0-20220711180217-6e2bfa9c3f67/go.mod h1:D8XwIk3t45EzFr7Yxf4EE3G9H+4H2nEkvte/2ItzkNk=
 github.com/lf-edge/edge-containers v0.0.0-20240207093504-5dfda0619b80 h1:kiqB1Rk8fmWci0idN68azRDJfPxCivD3zNDddWZocFw=
 github.com/lf-edge/edge-containers v0.0.0-20240207093504-5dfda0619b80/go.mod h1:4yXdumKdTzF0URMtxOl8Xnzdxnoy1QR+2dzfOr4CIZY=
-github.com/lf-edge/eve-api/go v0.0.0-20240829123634-7c8ebda876ff h1:3uGTOvWQFQkIrlkFalmzUmXINnzmVOAn5Zx0ryBSzxQ=
-github.com/lf-edge/eve-api/go v0.0.0-20240829123634-7c8ebda876ff/go.mod h1:ot6MhAhBXapUDl/hXklaX4kY88T3uC4PTg0D2wD8DzA=
+github.com/lf-edge/eve-api/go v0.0.0-20250922144401-abfd2fa2b728 h1:MieVGF6Sp12dcgBBZPG7GODDBSIEQF2vOfio3qQ/UVE=
+github.com/lf-edge/eve-api/go v0.0.0-20250922144401-abfd2fa2b728/go.mod h1:6HxNA/qKJVEqwpuOFkcQ0h3QyotvAs/cjHLC961FPOY=
 github.com/lf-edge/eve/libs/depgraph v0.0.0-20220711144346-0659e3b03496 h1:txHCOKhVsKIZKvKWzyIMe3J+ATKk61o4bADhsdLk42Y=
 github.com/lf-edge/eve/libs/depgraph v0.0.0-20220711144346-0659e3b03496/go.mod h1:8gtCaEwMJftnaP8PjjgRStLhOoHquzzlmYzj441QwpU=
 github.com/lf-edge/eve/pkg/pillar v0.0.0-20240923082146-6d403aaa5513 h1:6eoKsOh15KAIGzZbLNlMhsOoPiMgoD6+VeuKsYsbqHY=
@@ -2787,8 +2787,8 @@ google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.29.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.29.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
-google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.36.3 h1:82DV7MYdb8anAVi3qge1wSnMDrnKK7ebr+I0hHRN1BU=
+google.golang.org/protobuf v1.36.3/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -53,8 +53,8 @@ const (
 	DefaultRegistryPort         = 5050
 
 	//tags, versions, repos
-	DefaultEVETag               = "15.8.0" // DefaultEVETag tag for EVE image
-	DefaultAdamTag              = "0.0.57"
+	DefaultEVETag               = "15.11.0" // DefaultEVETag tag for EVE image
+	DefaultAdamTag              = "0.0.65"
 	DefaultRedisTag             = "7"
 	DefaultRegistryTag          = "2.7"
 	DefaultProcTag              = "83cfe07"
@@ -82,7 +82,7 @@ const (
 	DefaultEServerTag          = "4b71e2c"
 	DefaultEServerContainerRef = "lfedge/eden-http-server"
 
-	DefaultEClientTag          = "b1c1de6"
+	DefaultEClientTag          = "070b10b"
 	DefaultEClientContainerRef = "lfedge/eden-eclient"
 
 	//DefaultRepeatCount is repeat count for requests

--- a/pkg/expect/networkInstance.go
+++ b/pkg/expect/networkInstance.go
@@ -66,7 +66,7 @@ func (exp *AppExpectation) createNetworkInstance(instanceExpect *NetInstanceExpe
 		Port:           adapter,
 		Cfg:            &config.NetworkInstanceOpaqueConfig{},
 		IpType:         config.AddressType_IPV4,
-		Ip:             &config.Ipspec{},
+		Ip:             &evecommon.Ipspec{},
 		DisableFlowlog: !instanceExpect.enableFlowlog,
 	}
 	if instanceExpect.netInstType == "switch" {
@@ -76,11 +76,11 @@ func (exp *AppExpectation) createNetworkInstance(instanceExpect *NetInstanceExpe
 		if err != nil {
 			return nil, err
 		}
-		netInst.Ip = &config.Ipspec{
+		netInst.Ip = &evecommon.Ipspec{
 			Subnet:  instanceExpect.subnet,
 			Gateway: gwIP.String(),
 			Dns:     []string{gwIP.String()},
-			DhcpRange: &config.IpRange{
+			DhcpRange: &evecommon.IpRange{
 				Start: dhcpStart.String(),
 				End:   dhcpEnd.String(),
 			},
@@ -92,7 +92,7 @@ func (exp *AppExpectation) createNetworkInstance(instanceExpect *NetInstanceExpe
 	}
 	netInst.Displayname = instanceExpect.name
 	for hostname, ipAddrs := range instanceExpect.staticDNSEntries {
-		netInst.Dns = append(netInst.Dns, &config.ZnetStaticDNSEntry{
+		netInst.Dns = append(netInst.Dns, &evecommon.ZnetStaticDNSEntry{
 			HostName: hostname,
 			Address:  ipAddrs,
 		})

--- a/pkg/models/common.go
+++ b/pkg/models/common.go
@@ -14,10 +14,10 @@ func generateNetworkConfigs(ethCount, wifiCount uint) []*config.NetworkConfig {
 		networkConfigs = append(networkConfigs,
 			&config.NetworkConfig{
 				Id:   defaults.NetDHCPID,
-				Type: config.NetworkType_V4,
-				Ip: &config.Ipspec{
-					Dhcp:      config.DHCPType_Client,
-					DhcpRange: &config.IpRange{},
+				Type: evecommon.NetworkType_V4,
+				Ip: &evecommon.Ipspec{
+					Dhcp:      evecommon.DHCPType_Client,
+					DhcpRange: &evecommon.IpRange{},
 				},
 				Wireless: nil,
 			})
@@ -25,10 +25,10 @@ func generateNetworkConfigs(ethCount, wifiCount uint) []*config.NetworkConfig {
 			networkConfigs = append(networkConfigs,
 				&config.NetworkConfig{
 					Id:   defaults.NetDHCPID2,
-					Type: config.NetworkType_V4,
-					Ip: &config.Ipspec{
-						Dhcp:      config.DHCPType_Client,
-						DhcpRange: &config.IpRange{},
+					Type: evecommon.NetworkType_V4,
+					Ip: &evecommon.Ipspec{
+						Dhcp:      evecommon.DHCPType_Client,
+						DhcpRange: &evecommon.IpRange{},
 					},
 					Wireless: nil,
 				})
@@ -37,10 +37,10 @@ func generateNetworkConfigs(ethCount, wifiCount uint) []*config.NetworkConfig {
 			networkConfigs = append(networkConfigs,
 				&config.NetworkConfig{
 					Id:   defaults.NetSwitch,
-					Type: config.NetworkType_V4,
-					Ip: &config.Ipspec{
-						Dhcp:      config.DHCPType_DHCPNone,
-						DhcpRange: &config.IpRange{},
+					Type: evecommon.NetworkType_V4,
+					Ip: &evecommon.Ipspec{
+						Dhcp:      evecommon.DHCPType_DHCPNone,
+						DhcpRange: &evecommon.IpRange{},
 					},
 					Wireless: nil,
 				})
@@ -50,13 +50,13 @@ func generateNetworkConfigs(ethCount, wifiCount uint) []*config.NetworkConfig {
 		networkConfigs = append(networkConfigs,
 			&config.NetworkConfig{
 				Id:   defaults.NetWiFiID,
-				Type: config.NetworkType_V4,
-				Ip: &config.Ipspec{
-					Dhcp:      config.DHCPType_Client,
-					DhcpRange: &config.IpRange{},
+				Type: evecommon.NetworkType_V4,
+				Ip: &evecommon.Ipspec{
+					Dhcp:      evecommon.DHCPType_Client,
+					DhcpRange: &evecommon.IpRange{},
 				},
 				Wireless: &config.WirelessConfig{
-					Type:        config.WirelessType_WiFi,
+					Type:        evecommon.WirelessType_WiFi,
 					CellularCfg: nil,
 					WifiCfg:     nil,
 				},

--- a/pkg/models/rpi.go
+++ b/pkg/models/rpi.go
@@ -84,7 +84,7 @@ func (ctx *DevModelRpi) SetWiFiParams(ssid string, psk string) {
 			if el.Wireless != nil {
 				el.Wireless.WifiCfg = []*config.WifiConfig{{
 					WifiSSID:  ssid,
-					KeyScheme: config.WiFiKeyScheme_WPAPSK,
+					KeyScheme: evecommon.WiFiKeyScheme_WPAPSK,
 					Password:  psk,
 				}}
 			}

--- a/tests/eclient/testdata/dev_local_info.txt
+++ b/tests/eclient/testdata/dev_local_info.txt
@@ -65,7 +65,9 @@ exec -t 10m bash wait-for-dev-state.sh ONLINE
 # STEP 4: Request for shutdown. Check that app1 stops before local_manager
 exec -t 15m bash wait-for-app-state.sh app1 HALTED &app1halted&
 exec -t 1m bash put-devinfo-cmd.sh COMMAND_SHUTDOWN &
-exec -t 5m bash wait-for-dev-state.sh SHUTTING_DOWN &
+# Device state during shutdown used to be called SHUTTING_DOWN, but later was renamed
+# to PREPARING_POWEROFF, see: https://github.com/lf-edge/eve-api/commit/12c71e9526c87b107e67b4e5decd6411248856ff
+exec -t 5m bash wait-for-dev-state.sh PREPARING_POWEROFF &
 # Could it already have HALTED? Match HALTING or HALTED
 exec -t 5m bash wait-for-app-state.sh app1 HALT
 exec -t 2m bash wait-for-app-state.sh local-manager RUNNING &
@@ -110,7 +112,9 @@ skip 'The rest of the test is supported only on QEMU'
 {{end}}
 
 # STEP 6: Request for poweroff. Check that app1 stops before local_manager
-exec -t 1m bash put-devinfo-cmd.sh COMMAND_SHUTDOWN_POWEROFF &
+# This command used to be called COMMAND_SHUTDOWN_POWEROFF, but later was renamed
+# to COMMAND_GRACEFUL_POWEROFF, see: https://github.com/lf-edge/eve-api/commit/44ba9892be84814edc36b851314e56f0461dbbaa
+exec -t 1m bash put-devinfo-cmd.sh COMMAND_GRACEFUL_POWEROFF &
 exec -t 5m bash wait-for-dev-state.sh POWERING_OFF &
 # Could it already have HALTED? Match HALTING or HALTED
 exec -t 5m bash wait-for-app-state.sh app1 HALT

--- a/tests/eclient/testdata/network_local_changes.txt
+++ b/tests/eclient/testdata/network_local_changes.txt
@@ -1,0 +1,241 @@
+# Test local network configuration submitted via LPS.
+
+{{define "port"}}2223{{end}}
+{{define "token"}}server_token_123{{end}}
+{{define "network_info_file"}}/mnt/network-info.json{{end}}
+{{define "local_network_config_file"}}/mnt/local-network-config.json{{end}}
+{{define "network"}}n1{{end}}
+{{define "ssh"}}ssh -q -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa root@FWD_IP -p FWD_PORT{{end}}
+{{define "scp"}}scp -i {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa -P FWD_PORT{{end}}
+{{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+{{define "jq_path_eth0_latest_cfg"}}.latestConfig[] | select(.logicalLabel=="eth0"){{end}}
+{{define "jq_path_eth1_latest_cfg"}}.latestConfig[] | select(.logicalLabel=="eth1"){{end}}
+{{define "jq_path_eth0_local_cfg"}}.localConfig.ports[] | select(.logicalLabel=="eth0"){{end}}
+{{define "jq_path_eth1_local_cfg"}}.localConfig.ports[] | select(.logicalLabel=="eth1"){{end}}
+{{define "jq_path_eth0_has_local_cfg"}}any(.localConfig.ports[]?; .logicalLabel=="eth0"){{end}}
+{{define "jq_path_eth1_has_local_cfg"}}any(.localConfig.ports[]?; .logicalLabel=="eth1"){{end}}
+{{define "jq_arg_cfg_applied"}}.configApplied // false{{end}}
+{{define "jq_arg_err_msg"}}.errorMessage // ""{{end}}
+{{define "jq_arg_cfg_origin"}}.configSource.origin // "NETWORK_CONFIG_ORIGIN_UNSPECIFIED"{{end}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:ssh] stop
+[!exec:chmod] stop
+[!exec:jq] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
+
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait 100m -reboot=0 -count=1 &
+
+message 'Resetting of EVE'
+eden eve reset
+exec sleep 30
+
+# Enable local configuration changes for eth1.
+exec -t 2m bash allow_lps_config.sh eth1
+! stderr .
+
+# Create n1 network
+eden -t 1m network create 10.11.12.0/24 -n {{template "network"}}
+test eden.network.test -test.v -timewait 10m ACTIVATED {{template "network"}}
+
+# Deploy local-manager
+eden pod deploy -n local-manager --memory=512MB {{template "eclient_image"}} -p {{template "port"}}:22 --networks={{template "network"}}
+test eden.app.test -test.v -timewait 10m RUNNING local-manager
+
+# Wait for ssh access
+exec -t 5m bash wait-ssh.sh {{template "port"}}
+
+# Start local manager application
+exec -t 1m bash local-manager-start.sh
+
+# Obtain local-manager IP address
+exec -t 2m bash get-app-ip.sh local-manager
+source .env
+
+# Configure local server
+eden controller edge-node update --device profile_server_token={{template "token"}}
+eden controller edge-node update --device local_profile_server=$app_ip:8888
+
+# Wait for network info
+exec -t 5m bash wait-for-network-info.sh '{{template "jq_path_eth0_latest_cfg"}} | {{template "jq_arg_cfg_origin"}}' NETWORK_CONFIG_ORIGIN_CONTROLLER
+exec -t 1m bash wait-for-network-info.sh '{{template "jq_path_eth1_latest_cfg"}} | {{template "jq_arg_cfg_origin"}}' NETWORK_CONFIG_ORIGIN_CONTROLLER
+exec -t 1m bash wait-for-network-info.sh '.configTesting.controllerReachable' true
+exec -t 1m bash wait-for-network-info.sh '.configTesting.testingPhase' 'DPC verification succeeded'
+
+# Apply local network configuration:
+#   - Override DNS servers for eth0
+#   - Override MTU value for eth1
+exec -t 1m bash apply-local-network-config.sh $WORK/local-config.json
+
+# Local changes to eth0 should be rejected, since LPS is not permitted to modify eth0 configuration.
+exec -t 5m bash wait-for-network-info.sh '{{template "jq_path_eth0_local_cfg"}} | {{template "jq_arg_err_msg"}}' 'local modifications not permitted for port "eth0"'
+exec -t 1m bash wait-for-network-info.sh '{{template "jq_path_eth0_local_cfg"}} | {{template "jq_arg_cfg_applied"}}' false
+exec -t 1m bash wait-for-network-info.sh '{{template "jq_path_eth0_latest_cfg"}} | {{template "jq_arg_cfg_applied"}}' true
+eden eve ssh cat /etc/resolv.conf
+! stdout 'nameserver 8.8.8.8'
+! stdout 'nameserver 1.1.1.1'
+
+# Local changes to eth1 should be successfully applied.
+exec -t 5m bash wait-for-network-info.sh '{{template "jq_path_eth1_local_cfg"}} | {{template "jq_arg_cfg_applied"}}' true
+exec -t 5m bash wait-for-network-info.sh '{{template "jq_path_eth1_local_cfg"}} | {{template "jq_arg_err_msg"}}' ''
+exec -t 1m bash wait-for-network-info.sh '{{template "jq_path_eth1_local_cfg"}} | .mtu' 9000
+exec -t 1m bash wait-for-network-info.sh '{{template "jq_path_eth1_latest_cfg"}} | {{template "jq_arg_cfg_applied"}}' false
+eden eve ssh ifconfig eth1
+stdout 'MTU:9000'
+
+# Enable local configuration changes for eth0.
+exec -t 2m bash allow_lps_config.sh eth0
+! stderr .
+
+# Local changes to eth0 should be now permitted and successfully applied.
+exec -t 5m bash wait-for-network-info.sh '{{template "jq_path_eth0_local_cfg"}} | {{template "jq_arg_cfg_applied"}}' true
+exec -t 5m bash wait-for-network-info.sh '{{template "jq_path_eth0_local_cfg"}} | {{template "jq_arg_err_msg"}}' ''
+exec -t 1m bash wait-for-network-info.sh '{{template "jq_path_eth0_local_cfg"}} | .dnsServers | index("8.8.8.8") != null' true
+exec -t 1m bash wait-for-network-info.sh '{{template "jq_path_eth0_local_cfg"}} | .dnsServers | index("1.1.1.1") != null' true
+exec -t 1m bash wait-for-network-info.sh '{{template "jq_path_eth0_latest_cfg"}} | {{template "jq_arg_cfg_applied"}}' false
+eden eve ssh cat /etc/resolv.conf
+stdout 'nameserver 8.8.8.8'
+stdout 'nameserver 1.1.1.1'
+
+# Apply empty local config to revert all local changes.
+exec -t 1m bash apply-local-network-config.sh $WORK/empty-config.json
+
+# eth0 configuration should be reverted back to controller-provided config.
+exec -t 5m bash wait-for-network-info.sh '{{template "jq_path_eth0_has_local_cfg"}}' false
+exec -t 1m bash wait-for-network-info.sh '{{template "jq_path_eth0_latest_cfg"}} | {{template "jq_arg_cfg_applied"}}' true
+eden eve ssh cat /etc/resolv.conf
+! stdout 'nameserver 8.8.8.8'
+! stdout 'nameserver 1.1.1.1'
+
+# eth1 configuration should be reverted back to controller-provided config.
+exec -t 1m bash wait-for-network-info.sh '{{template "jq_path_eth1_has_local_cfg"}}' false
+exec -t 1m bash wait-for-network-info.sh '{{template "jq_path_eth1_latest_cfg"}} | {{template "jq_arg_cfg_applied"}}' true
+eden eve ssh ifconfig eth1
+stdout 'MTU:1500'
+
+# Undeploy local-manager
+eden pod delete local-manager
+test eden.app.test -test.v -timewait 15m - local-manager
+eden network delete {{template "network"}}
+test eden.network.test -test.v -timewait 10m - {{template "network"}}
+
+-- wait-ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+for p in $*
+do
+  for i in `seq 20`
+  do
+    sleep 20
+    # Test SSH-access to container
+    echo $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue
+    $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue && break
+  done
+done
+
+-- local-manager-start.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+ARGS="--token={{template "token"}}"
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "/root/local_manager $ARGS &>/proc/1/fd/1 &"
+
+-- get-app-ip.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+IP=$($EDEN pod ps | grep $1 | awk '{print $4}' | cut -d ":" -f 1)
+echo app_ip=$IP>>.env
+
+-- wait-for-network-info.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+NETWORK_INFO_FILE={{template "network_info_file"}}
+JQ_PATH="$1"
+EXPECTED="$2"
+
+# Strip double quotes from EXPECTED to simplify matching
+EXPECTED=$(echo "$EXPECTED" | tr -d '"')
+
+printf 'Waiting for JQ_PATH=[%q], EXPECTED=[%q] in file=[%q]\n' "$JQ_PATH" "$EXPECTED" "$NETWORK_INFO_FILE"
+
+CMDS=$(cat <<EOF
+until test -f "$NETWORK_INFO_FILE"; do
+  sleep 5
+done
+while true; do
+  VALUE=\$(jq -r '$JQ_PATH' '$NETWORK_INFO_FILE' 2>/dev/null || echo "")
+  VALUE=\$(echo "\$VALUE" | tr -d '"' | tr '\n' ' ' | sed 's/[[:space:]]*$//')
+  if [ "\$VALUE" = "$EXPECTED" ]; then
+    echo "Condition met: $JQ_PATH: \$VALUE == $EXPECTED"
+    break
+  else
+    echo "Condition NOT met: $JQ_PATH: \$VALUE == $EXPECTED"
+  fi
+  sleep 5
+done
+EOF
+)
+
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "ssh"}} "sh -s" <<EOF
+$CMDS
+EOF
+
+-- apply-local-network-config.sh --
+CONFIG_FILE="${1}"
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+$EDEN sdn fwd eth0 {{template "port"}} -- {{template "scp"}} "$CONFIG_FILE" root@FWD_IP:/mnt/local-network-config.json
+
+-- allow_lps_config.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+PORT="${1}"
+ENABLE="${2:-true}"
+
+TMPCFG=eve.cfg
+$EDEN controller edge-node get-config --file $TMPCFG
+
+jq --arg port "$PORT" --argjson enable "$ENABLE" '
+  .systemAdapterList |= map(
+    if .name == $port then
+      . + {allowLocalModifications: $enable}
+    else
+      .
+    end
+  )
+' < $TMPCFG > $TMPCFG.new
+
+$EDEN controller edge-node set-config --file $TMPCFG.new
+echo "Setting allowLocalModifications=$ENABLE for adapter $PORT"
+
+-- local-config.json --
+{
+  "ports": [
+    {
+      "logicalLabel": "eth0",
+      "ipVersion": "IP_VERSION_IPV4_ONLY",
+      "useDhcp": true,
+      "dhcpOptionsIgnore":  {
+        "dnsConfigExclusively": true
+      },
+      "dnsServers": ["8.8.8.8", "1.1.1.1"]
+    },
+    {
+      "logicalLabel": "eth1",
+      "ipVersion": "IP_VERSION_IPV4_ONLY",
+      "useDhcp": true,
+      "mtu": 9000
+    }
+  ]
+}
+
+-- empty-config.json --
+{}
+
+-- eden-config.yml --
+{{/* Test's config file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/workflow/lps-loc.tests.txt
+++ b/tests/workflow/lps-loc.tests.txt
@@ -1,5 +1,5 @@
 # Number of tests
-{{$tests := 9}}
+{{$tests := 10}}
 # EDEN_TEST_SETUP env. var. -- "y"(default) performs the EDEN setup steps
 {{$setup := "n"}}
 {{$setup_env := EdenGetEnv "EDEN_TEST_SETUP"}}
@@ -43,3 +43,5 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/app_l
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/dev_local_info
 /bin/echo Eden location publish test (9/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/publish_location
+/bin/echo Eden location publish test (10/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/network_local_changes


### PR DESCRIPTION
This test validates local network configuration changes via the [LPS network endpoint](https://github.com/lf-edge/eve-api/blob/main/PROFILE.md#network) in the `eclient/local_manager` application.
It covers:

- Enabling local modifications on specific adapters (`eth0`/`eth1`)
- Applying local MTU and DNS overrides (as an example of a local config change)
- Verifying that modifications are rejected when disallowed by controller
- Confirming local changes are correctly applied when allowed
- Reverting local changes to controller-provided configuration

I used escript and not neoeden since the existing LPS test suite is written in escript and I'm not sure if the two can be combined under the same workflow.

For now this PR is Draft -- the EVE-side implementation of the LPS network endpoint is not yet merged and released (PR with part I is open here: https://github.com/lf-edge/eve/pull/5237; part II will follow) 