### PR TITLE
Disable vComLink test temporarily

### DIFF
--- a/tests/workflow/virtualization.tests.txt
+++ b/tests/workflow/virtualization.tests.txt
@@ -52,5 +52,6 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/air-g
 /bin/echo Test VNC access (11/{{$tests}})
 eden.escript.test -testdata ../vnc/testdata/ -test.run TestEdenScripts/vnc_test
 
-/bin/echo EVE VcomLink tests (12/{{$tests}})
-eden.escript.test -test.run TestEdenScripts/eden_vcom
+# revert back when we have a eve release that contains lf-edge/eve#4502
+#/bin/echo EVE VcomLink tests (12/{{$tests}})
+#eden.escript.test -test.run TestEdenScripts/eden_vcom


### PR DESCRIPTION
Disable vComLink test temporarily until we have an EVE release that includes the changes introduced in lf-edge/eve#4502.