### PR TITLE
Stop reading network info from deprecated ZInfoDevice.Network

### DIFF
--- a/pkg/openevec/eve.go
+++ b/pkg/openevec/eve.go
@@ -299,7 +299,7 @@ func (openEVEC *OpenEVEC) GetEveIP(ifName string) string {
 		return ""
 	}
 	for _, nw := range networks {
-		if nw.LocalName == ifName {
+		if nw.Ifname == ifName {
 			if len(nw.IPAddrs) == 0 {
 				return ""
 			}
@@ -516,7 +516,7 @@ func (openEVEC *OpenEVEC) NewLinkEve(command, eveInterfaceName, vmName string) e
 	return nil
 }
 
-func (openEVEC *OpenEVEC) getEveNetworkInfo() (networks []*info.ZInfoNetwork, err error) {
+func (openEVEC *OpenEVEC) getEveNetworkInfo() (networks []*info.DevicePort, err error) {
 	changer := &adamChanger{}
 	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
@@ -530,7 +530,11 @@ func (openEVEC *OpenEVEC) getEveNetworkInfo() (networks []*info.ZInfoNetwork, er
 		return nil, fmt.Errorf("MetricLastCallback failed: %w", err)
 	}
 	if lastDInfo := eveState.InfoAndMetrics().GetDinfo(); lastDInfo != nil {
-		networks = append(networks, lastDInfo.Network...)
+		curIndex := int(lastDInfo.GetSystemAdapter().GetCurrentIndex())
+		netStatus := lastDInfo.GetSystemAdapter().GetStatus()
+		if curIndex < len(netStatus) {
+			networks = append(networks, netStatus[curIndex].Ports...)
+		}
 	}
 	return networks, nil
 }

--- a/pkg/openevec/status.go
+++ b/pkg/openevec/status.go
@@ -145,8 +145,12 @@ func (openEVEC *OpenEVEC) eveStatusRemote() error {
 	}
 	if lastDInfo := eveState.InfoAndMetrics().GetDinfo(); lastDInfo != nil {
 		var ips []string
-		for _, nw := range lastDInfo.Network {
-			ips = append(ips, nw.IPAddrs...)
+		curIndex := int(lastDInfo.GetSystemAdapter().GetCurrentIndex())
+		netStatus := lastDInfo.GetSystemAdapter().GetStatus()
+		if curIndex < len(netStatus) {
+			for _, port := range netStatus[curIndex].Ports {
+				ips = append(ips, port.IPAddrs...)
+			}
 		}
 		fmt.Printf("%s EVE REMOTE IPs: %s\n", statusOK(), strings.Join(ips, "; "))
 		var lastseen = time.Unix(eveState.InfoAndMetrics().GetLastInfoTime().GetSeconds(), 0)

--- a/tests/fsstress/fsstress_test.go
+++ b/tests/fsstress/fsstress_test.go
@@ -99,11 +99,18 @@ func checkAppRunning(appName string) testcontext.ProcInfoFunc {
 func getEVEIP(edgeNode *device.Ctx) testcontext.ProcTimerFunc {
 	return func() error {
 		if edgeNode.GetRemoteAddr() == "" { //no eve.remote-addr defined
-			eveIPCIDR, err := tc.GetState(edgeNode).LookUp("Dinfo.Network[0].IPAddrs[0]")
-			if err != nil {
+			sysAdapterInfo := tc.GetState(edgeNode).GetDinfo().GetSystemAdapter()
+			curIndex := int(sysAdapterInfo.GetCurrentIndex())
+			netStatus := sysAdapterInfo.GetStatus()
+			if curIndex >= len(netStatus) {
 				return nil
 			}
-			ip := net.ParseIP(eveIPCIDR.String())
+			ports := netStatus[curIndex].Ports
+			if len(ports) == 0 || len(ports[0].IPAddrs) == 0 {
+				return nil
+			}
+			eveIP := ports[0].IPAddrs[0]
+			ip := net.ParseIP(eveIP)
 			if ip == nil || ip.To4() == nil {
 				return nil
 			}

--- a/tests/lim/testdata/info_test.txt
+++ b/tests/lim/testdata/info_test.txt
@@ -6,8 +6,8 @@
 #eden eve onboard
 
 eden eve epoch &
-# Trying to find eth0 or eth1 in dinfo.network.devName.
-{{$test}} -out InfoContent.dinfo.network.devName 'InfoContent.dinfo.network.devName:.*eth[01].*'
+# Trying to find eth0 or eth1 in dinfo.systemAdapter.status.ports.ifname
+{{$test}} -out InfoContent.dinfo.systemAdapter.status.ports.ifname 'InfoContent.dinfo.systemAdapter.status.ports.ifname:.*eth[01].*'
 stdout 'eth[01]'
 
 {{$tpm := EdenConfig "eve.tpm"}}

--- a/tests/vnc/vnc_test.go
+++ b/tests/vnc/vnc_test.go
@@ -113,11 +113,18 @@ func checkAppRunning(t *testing.T, appName string) testcontext.ProcInfoFunc {
 func getEVEIP(edgeNode *device.Ctx) testcontext.ProcTimerFunc {
 	return func() error {
 		if edgeNode.GetRemoteAddr() == "" { //no eve.remote-addr defined
-			eveIPCIDR, err := tc.GetState(edgeNode).LookUp("Dinfo.Network[0].IPAddrs[0]")
-			if err != nil {
+			sysAdapterInfo := tc.GetState(edgeNode).GetDinfo().GetSystemAdapter()
+			curIndex := int(sysAdapterInfo.GetCurrentIndex())
+			netStatus := sysAdapterInfo.GetStatus()
+			if curIndex >= len(netStatus) {
 				return nil
 			}
-			ip := net.ParseIP(eveIPCIDR.String())
+			ports := netStatus[curIndex].Ports
+			if len(ports) == 0 || len(ports[0].IPAddrs) == 0 {
+				return nil
+			}
+			eveIP := ports[0].IPAddrs[0]
+			ip := net.ParseIP(eveIP)
 			if ip == nil || ip.To4() == nil {
 				return nil
 			}


### PR DESCRIPTION
[ZInfoDevice.Network](https://github.com/lf-edge/eve-api/blob/main/proto/info/info.proto#L596-L599) (ZInfoNetwork) has been obsolete for several years and [will soon no longer be published by EVE](https://github.com/lf-edge/eve/pull/5283). Network-related information is instead provided through [ZInfoDevice.SystemAdapter](https://github.com/lf-edge/eve-api/blob/main/proto/info/info.proto#L615) (SystemAdapterInfo), which includes additional and more up-to-date fields such as configuration source, MTU, domain name, etc.