### PR TITLE
eclient: fix ctrl_cert_change test for EVE persist2memory branch

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -82,7 +82,7 @@ const (
 	DefaultEServerTag          = "4b71e2c"
 	DefaultEServerContainerRef = "lfedge/eden-http-server"
 
-	DefaultEClientTag          = "070b10b"
+	DefaultEClientTag          = "7a72275"
 	DefaultEClientContainerRef = "lfedge/eden-eclient"
 
 	//DefaultRepeatCount is repeat count for requests

--- a/tests/eclient/testdata/ctrl_cert_change.txt
+++ b/tests/eclient/testdata/ctrl_cert_change.txt
@@ -72,7 +72,53 @@ test:
 
 -- check_sign_cert.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-$EDEN eve ssh cat /persist/certs/server-signing-cert.pem > /tmp/server-signing-cert.pem
+# In older versions the signing cert was stored in a PEM file in /persist/certs/, and also in a JSON file in /persist/status/zedagent/ControllerCert/.
+# In newer EVE versions it is available as a JSON file in /run/zedagent/ControllerCert/.
+# We look in the new directory (/run/zedagent) and fallback to the old (/persist/status/zedagent).
+# The signing cert has Type=1 (CERT_TYPE_CONTROLLER_SIGNING) and the PEM-encoded
+# cert bytes are base64-encoded in the "Cert" field.
+while true; do
+    echo "Try fetching ControllerCert loop - from /run" >&2
+    $EDEN eve ssh ls /run/zedagent/ControllerCert/ >/tmp/certfiles
+    # Guard against an error string in stdout by checking for "json"
+    if [ -s /tmp/certfiles ] && grep -q json /tmp/certfiles ; then
+        echo "Found in /run $(cat /tmp/certfiles)" >&2
+        break
+    fi
+    echo "Try fetching ControllerCert loop - from /persist" >&2
+    $EDEN eve ssh ls /persist/status/zedagent/ControllerCert/ >/tmp/certfiles.old
+    # Guard against an error string in stdout by checking for "json"
+    if [ -s /tmp/certfiles.old ] && grep -q json /tmp/certfiles.old ; then
+        echo "Found in /persist $(cat /tmp/certfiles.old)" >&2
+        break
+    fi
+done
+for f in $(cat /tmp/certfiles); do
+    $EDEN eve ssh cat "/run/zedagent/ControllerCert/$f" > "/tmp/$f"
+    if grep -q "\"Type\":1" "/tmp/$f" 2>/dev/null; then
+        grep -o "\"Cert\":\"[^\"]*\"" "/tmp/$f" | tr -d "\"" | cut -d: -f2 | base64 -d > /tmp/server-signing-cert.pem
+        echo "Found in /tmp/$f" >&2
+        break
+    fi
+done
+if [ ! -f /tmp/server-signing-cert.pem ]; then
+    echo "Could not find signing certificate in /run/zedagent/ControllerCert/" >&2
+    for f in $(cat /tmp/certfiles.old); do
+        $EDEN eve ssh cat "/persist/status/zedagent/ControllerCert/$f" > "/tmp/$f.old"
+        if grep -q "\"Type\":1" "/tmp/$f.old" 2>/dev/null; then
+            grep -o "\"Cert\":\"[^\"]*\"" "/tmp/$f.old" | tr -d "\"" | cut -d: -f2 | base64 -d > /tmp/server-signing-cert.pem
+            echo "Found in /tmp/$f.old" >&2
+            # In case we have multiple old ones, we continue so we log their
+            # existence and as a result pick the numerically last one.
+            # TBD whether we should look at the modification time of the files
+            # on EVE to pick the most recent.
+        fi
+    done
+fi
+if [ ! -f /tmp/server-signing-cert.pem ]; then
+    echo "Error: Could not find signing certificate in /run/zedagent/ControllerCert/ nor in /persist/status/zedagent" >&2
+    exit 1
+fi
 diff -Z /tmp/signing-new.pem /tmp/server-signing-cert.pem
 status=$?
 if [ $status -ne 0 ]; then


### PR DESCRIPTION
## Summary

Fixes one issue in `tests/eclient/testdata/ctrl_cert_change.txt` needed to handle the EVE changes where signing certs are no longer persisted to `/persist/certs/server-signing-cert.pem` and are instead kept in memory (checkpointed to `/persist/checkpoint/controllercerts`).

**`check_sign_cert.sh`**:  In older versions the signing cert was stored in a PEM file in /persist/certs/, and also in a JSON file in /persist/status/zedagent/ControllerCert/. In newer EVE versions it is available as a JSON file in /run/zedagent/ControllerCert/. We look in the new directory (/run/zedagent) and fallback to the old (/persist/status/zedagent). The signing cert has Type=1 (CERT_TYPE_CONTROLLER_SIGNING) and the PEM-encoded cert bytes are base64-encoded in the "Cert" field.

## Test plan

- [X] Run `TestEdenScripts/ctrl_cert_change` against  EVE master
- [ ] Run `TestEdenScripts/ctrl_cert_change` against an EVE build from the persist2memory branch (post merge)
- [X] Confirm `check_sign_cert.sh` correctly extracts and compares the signing cert from `/run/zedagent/ControllerCerts/`