### PR TITLE
Centralize EDEN_HOME handling and make retry count configurable

### DIFF
--- a/cmd/edenSetup.go
+++ b/cmd/edenSetup.go
@@ -78,6 +78,7 @@ func newSetupCmd(configName, verbosity *string) *cobra.Command {
 
 	setupCmd.Flags().BoolVarP(&cfg.Eden.EnableIPv6, "enable-ipv6", "", false, "enable IPv6 connectivity for the Eden docker network")
 	setupCmd.Flags().StringVarP(&cfg.Eden.IPv6Subnet, "ipv6-subnet", "", defaults.DefaultDockerNetIPv6Subnet, "IPv6 subnet for the Eden docker network")
+	setupCmd.Flags().IntVarP(&cfg.Eden.RepeatCount, "repeat-count", "", defaults.DefaultRepeatCount, "number of retry attempts for controller connections")
 
 	addSdnConfigDirOpt(setupCmd, cfg)
 	addSdnImageOpt(setupCmd, cfg)

--- a/pkg/controller/adam/adam.go
+++ b/pkg/controller/adam/adam.go
@@ -47,6 +47,7 @@ type Ctx struct {
 	AdamCaching       bool   // enable caching of adam`s logs/info
 	AdamCachingRedis  bool   // caching to redis instead of files
 	AdamCachingPrefix string // custom prefix for file or stream naming for cache
+	repeatCount       int
 }
 
 // parseRedisURL try to use string from config to obtain redis url
@@ -97,7 +98,7 @@ func (adam *Ctx) getLoader() (loader loaders.Loader) {
 				URLMetrics: adam.getMetricsURL,
 				URLRequest: adam.getRequestURL,
 			}
-			loader = loaders.NewRemoteLoader(adam.getHTTPClient, urlGetters)
+			loader = loaders.NewRemoteLoader(adam.getHTTPClient, urlGetters, adam.repeatCount)
 		}
 	} else {
 		log.Debug("will use local adam loader")
@@ -149,6 +150,7 @@ func (adam *Ctx) InitWithVars(vars *utils.ConfigVars) error {
 	adam.AdamCachingRedis = vars.AdamCachingRedis
 	adam.AdamCachingPrefix = vars.AdamCachingPrefix
 	adam.AdamRedisURLEden = vars.AdamRedisURLEden
+	adam.repeatCount = vars.RepeatCount
 	return nil
 }
 

--- a/pkg/controller/adam/httpclient.go
+++ b/pkg/controller/adam/httpclient.go
@@ -53,7 +53,7 @@ func (adam *Ctx) deleteObj(path string) (err error) {
 		return fmt.Errorf("unable to create new http request: %v", err)
 	}
 
-	response, err := utils.RepeatableAttempt(client, req)
+	response, err := utils.RepeatableAttempt(client, req, adam.repeatCount)
 	if err != nil {
 		return fmt.Errorf("unable to send request: %v", err)
 	}
@@ -78,7 +78,7 @@ func (adam *Ctx) getObj(path string, acceptMime string) (out string, err error) 
 		req.Header.Set("Accept", acceptMime)
 	}
 
-	response, err := utils.RepeatableAttempt(client, req)
+	response, err := utils.RepeatableAttempt(client, req, adam.repeatCount)
 	if err != nil {
 		log.Fatalf("unable to send request: %v", err)
 	}
@@ -105,7 +105,7 @@ func (adam *Ctx) getList(path string, acceptMime string) (out []string, err erro
 		req.Header.Set("Accept", acceptMime)
 	}
 
-	response, err := utils.RepeatableAttempt(client, req)
+	response, err := utils.RepeatableAttempt(client, req, adam.repeatCount)
 	if err != nil {
 		log.Fatalf("unable to send request: %v", err)
 	}
@@ -130,7 +130,7 @@ func (adam *Ctx) postObj(path string, obj []byte, mimeType string) (err error) {
 	}
 	req.Header.Set("Content-Type", mimeType)
 
-	_, err = utils.RepeatableAttempt(client, req)
+	_, err = utils.RepeatableAttempt(client, req, adam.repeatCount)
 	if err != nil {
 		log.Fatalf("unable to send request: %v", err)
 	}
@@ -149,7 +149,7 @@ func (adam *Ctx) putObj(path string, obj []byte, mimeType string) (err error) {
 		log.Fatalf("unable to create new http request: %v", err)
 	}
 	req.Header.Set("Content-Type", mimeType)
-	_, err = utils.RepeatableAttempt(client, req)
+	_, err = utils.RepeatableAttempt(client, req, adam.repeatCount)
 	if err != nil {
 		log.Fatalf("unable to send request: %v", err)
 	}

--- a/pkg/controller/loaders/remoteLoader.go
+++ b/pkg/controller/loaders/remoteLoader.go
@@ -39,17 +39,22 @@ type RemoteLoader struct {
 	getClient    getClient
 	client       *http.Client
 	cache        cachers.CacheProcessor
+	repeatCount  int
 }
 
 // NewRemoteLoader return loader from files
-func NewRemoteLoader(getClient getClient, urlGetters types.URLGetters) *RemoteLoader {
+func NewRemoteLoader(getClient getClient, urlGetters types.URLGetters, repeatCount int) *RemoteLoader {
 	log.Debugf("HTTP NewRemoteLoader init")
+	if repeatCount <= 0 {
+		repeatCount = defaults.DefaultRepeatCount
+	}
 	return &RemoteLoader{
 		urlGetters:   urlGetters,
 		getClient:    getClient,
 		firstLoad:    true,
 		lastTimesamp: nil,
 		client:       getClient(),
+		repeatCount:  repeatCount,
 	}
 }
 
@@ -176,7 +181,7 @@ func (loader *RemoteLoader) repeatableConnection(process ProcessFunction, typeTo
 	} else {
 		loader.client.Timeout = 0
 	}
-	maxRepeat := defaults.DefaultRepeatCount
+	maxRepeat := loader.repeatCount
 	delayTime := defaults.DefaultRepeatTimeout
 
 repeatLoop:

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -33,6 +33,7 @@ const (
 	DefaultContext = "default" //default context name
 
 	DefaultConfigEnv   = "EDEN_CONFIG"    //default env for set config
+	DefaultEdenHomeEnv = "EDEN_HOME"      //default env for overriding eden home directory
 	DefaultTestArgsEnv = "EDEN_TEST_ARGS" //default env for test arguments
 )
 

--- a/pkg/eden/eden.go
+++ b/pkg/eden/eden.go
@@ -1075,7 +1075,7 @@ func (server *EServer) EServerAddFileURL(url string) (name string) {
 		log.Fatalf("EServerAddFileURL: unable to create new http request: %v", err)
 	}
 
-	response, err := utils.RepeatableAttempt(client, req)
+	response, err := utils.RepeatableAttempt(client, req, defaults.DefaultRepeatCount)
 	if err != nil {
 		log.Fatalf("EServerAddFileURL: unable to send request: %v", err)
 	}
@@ -1098,7 +1098,7 @@ func (server *EServer) EServerCheckStatus(name string) (fileInfo *api.FileInfo) 
 		log.Fatalf("EServerAddFileURL: unable to create new http request: %v", err)
 	}
 
-	response, err := utils.RepeatableAttempt(client, req)
+	response, err := utils.RepeatableAttempt(client, req, defaults.DefaultRepeatCount)
 	if err != nil {
 		log.Fatalf("EServerAddFileURL: unable to send request: %v", err)
 	}

--- a/pkg/openevec/config.go
+++ b/pkg/openevec/config.go
@@ -44,6 +44,7 @@ type EdenConfig struct {
 	TestBin      string `mapstructure:"test-bin"`
 	TestScenario string `mapstructure:"test-scenario"`
 	Tests        string `mapstructure:"tests"`
+	RepeatCount  int    `mapstructure:"repeat-count" cobraflag:"repeat-count"`
 	EnableIPv6   bool   `mapstructure:"enable-ipv6" cobraflag:"enable-ipv6"`
 	IPv6Subnet   string `mapstructure:"ipv6-subnet" cobraflag:"ipv6-subnet"`
 
@@ -301,6 +302,7 @@ func LoadConfig(configFile string) (*EdenSetupArgs, error) {
 		return nil, fmt.Errorf("viper cannot be loaded")
 	}
 	viper.SetDefault("eve.uefi-tag", defaults.DefaultEVETag)
+	viper.SetDefault("eden.repeat-count", defaults.DefaultRepeatCount)
 
 	cfg := &EdenSetupArgs{}
 

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -151,13 +151,13 @@ func InitVars() (*ConfigVars, error) {
 
 // DefaultEdenDir returns path to default directory
 func DefaultEdenDir() (string, error) {
+	edenHome := strings.TrimSpace(os.Getenv(defaults.DefaultEdenHomeEnv))
+	if edenHome != "" {
+		return edenHome, nil
+	}
 	usr, err := user.Current()
 	if err != nil {
 		return "", err
-	}
-	edenHome := strings.TrimSpace(os.Getenv("EDEN_HOME"))
-	if edenHome != "" {
-		return edenHome, nil
 	}
 	return filepath.Join(usr.HomeDir, defaults.DefaultEdenHomeDir), nil
 }

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -65,6 +65,7 @@ type ConfigVars struct {
 	RegistryMirror    string
 	LogLevel          string
 	RemoteLogLevel    string
+	RepeatCount       int
 }
 
 // InitVars loads vars from viper
@@ -134,6 +135,7 @@ func InitVars() (*ConfigVars, error) {
 			RegistryMirror:    viper.GetString("registry.mirror"),
 			LogLevel:          viper.GetString("eve.log-level"),
 			RemoteLogLevel:    viper.GetString("eve.remote-log-level"),
+			RepeatCount:       viper.GetInt("eden.repeat-count"),
 		}
 		viperAccessMutex.RUnlock()
 		redisPasswordFile := filepath.Join(globalCertsDir, defaults.DefaultRedisPasswordFile)
@@ -489,6 +491,8 @@ func generateConfigFileFromTemplate(filePath string, templateString string, cont
 			return false
 		case "eden.ipv6-subnet":
 			return defaults.DefaultDockerNetIPv6Subnet
+		case "eden.repeat-count":
+			return defaults.DefaultRepeatCount
 
 		case "gcp.key":
 			return ""

--- a/pkg/utils/networking.go
+++ b/pkg/utils/networking.go
@@ -203,8 +203,10 @@ func GetFileSizeURL(url string) int64 {
 }
 
 // RepeatableAttempt do request several times waiting for nil error and expected status code
-func RepeatableAttempt(client *http.Client, req *http.Request) (response *http.Response, err error) {
-	maxRepeat := defaults.DefaultRepeatCount
+func RepeatableAttempt(client *http.Client, req *http.Request, maxRepeat int) (response *http.Response, err error) {
+	if maxRepeat <= 0 {
+		maxRepeat = defaults.DefaultRepeatCount
+	}
 	delayTime := defaults.DefaultRepeatTimeout
 
 	for i := 0; i < maxRepeat; i++ {

--- a/tests/escript/go-internal/testscript/testscript.go
+++ b/tests/escript/go-internal/testscript/testscript.go
@@ -326,6 +326,9 @@ func (ts *TestScript) setup() string {
 	if configEnv := os.Getenv(defaults.DefaultConfigEnv); configEnv != "" {
 		env.Vars = append(env.Vars, fmt.Sprintf("%s=%s", defaults.DefaultConfigEnv, configEnv))
 	}
+	if edenHomeEnv := os.Getenv(defaults.DefaultEdenHomeEnv); edenHomeEnv != "" {
+		env.Vars = append(env.Vars, fmt.Sprintf("%s=%s", defaults.DefaultEdenHomeEnv, edenHomeEnv))
+	}
 	// MacOS envs set
 	if runtime.GOOS == "darwin" {
 		env.Vars = append(env.Vars,


### PR DESCRIPTION
This PR improves two areas of Eden's configuration:

#### EDEN_HOME in test harness
The test script setup now propagates the EDEN_HOME environment variable into child script environments alongside EDEN_CONFIG (missed in https://github.com/lf-edge/eden/pull/1127)

#### Configurable connection retry count
The hardcoded DefaultRepeatCount (20) used by RepeatableAttempt and RemoteLoader.repeatableConnection can now be overridden via the --repeat-count CLI flag or the eden.repeat-count config key.