### PR TITLE
Change default EVE disk image size to 16GB

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -112,7 +112,7 @@ default described below) please use several options before run of `eden setup`:
 
 * `eden config set default --key=eve.cpu --value=2` - to set 2 virtual CPUs for EVE (default is 4)
 * `eden config set default --key=eve.ram --value=8096` - to set 8096 MB of ram for EVE (default is 4096)
-* `eden config set default --key=eve.disk --value=65536` - to set 65536 MB of disk space for EVE (default is 8192)
+* `eden config set default --key=eve.disk --value=65536` - to set 65536 MB of disk space for EVE (default is 16384)
 
 ## Modifying of EVE config
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -154,7 +154,7 @@ const (
 
 	DefaultEVERemote = false
 
-	DefaultEVEImageSize = 8192
+	DefaultEVEImageSize = 16384
 
 	DefaultTPMEnabled       = false
 	DefaultCanEnabled       = false


### PR DESCRIPTION
This commit updates the EVE default image size from 8GB to 16GB. This increase is needed for future usage, eve-k already uses a bigger partition layout and eve-kvm will eventually be updated as well.