### PR TITLE
Increase disk size on ZFS Tests from GH action

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -116,7 +116,7 @@ runs:
       if: inputs.file_system == 'zfs'
       run: |
         ./eden config set default --key=eve.disks --value=4
-        ./eden config set default --key=eve.disk --value=4096
+        ./eden config set default --key=eve.disk --value=16384
         ./eden setup -v debug --grub-options='set_global dom0_extra_args "$dom0_extra_args eve_install_zfs_with_raid_level "'
       shell: bash
       working-directory: "./eden"


### PR DESCRIPTION
Commit cd853ca4d4c360c4a7d2658d622c275091e8eaaa changed the default disk size from 4GB to 16GB. However, ZFS tests have a specific setup on GH actions. This commit changes the disk size on this setup from 4GB to 16GB as well.