### PR TITLE
ci: switch eden.yml from pull_request_target to pull_request

### DIFF
--- a/.github/actions/run-eden-test/action.yml
+++ b/.github/actions/run-eden-test/action.yml
@@ -23,12 +23,6 @@ inputs:
     type: string
   require_virtualization:
     type: bool
-  aziot_id_scope:
-    description: 'Azure IoT ID scope'
-    required: false
-  aziot_connection_string:
-    description: 'Azure IoT connection string'
-    required: false
 
 
 runs:
@@ -53,9 +47,6 @@ runs:
       run: EDEN_TEST_STOP=n ./eden test ./tests/workflow -s ${{ inputs.suite }} -v debug
       shell: bash
       working-directory: "./eden"
-      env:
-        AZIOT_ID_SCOPE: ${{ inputs.aziot_id_scope }}
-        AZIOT_CONNECTION_STRING: ${{ inputs.aziot_connection_string }}
     - name: Collect info
       if: failure()
       uses: ./eden/.github/actions/collect-info

--- a/.github/actions/run-neoeden-test/action.yml
+++ b/.github/actions/run-neoeden-test/action.yml
@@ -22,12 +22,6 @@ inputs:
     type: bool
   test_suite:
     type: string
-  aziot_id_scope:
-    description: 'Azure IoT ID scope'
-    required: false
-  aziot_connection_string:
-    description: 'Azure IoT connection string'
-    required: false
 
 
 runs:
@@ -52,9 +46,6 @@ runs:
       run: go test -timeout 30m
       shell: bash
       working-directory: ${{ inputs.test_suite }}
-      env:
-        AZIOT_ID_SCOPE: ${{ inputs.aziot_id_scope }}
-        AZIOT_CONNECTION_STRING: ${{ inputs.aziot_connection_string }}
     - name: Collect info
       if: failure()
       uses: ./eden/.github/actions/collect-info

--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -2,11 +2,11 @@
 name: Eden
 on: # yamllint disable-line rule:truthy
   push:
-    branches: [master]
+    branches: [master, 'EVE-*-stable']
     paths-ignore:
       - 'docs/**'
-  pull_request_target:
-    branches: [master]
+  pull_request:
+    branches: [master, 'EVE-*-stable']
     paths-ignore:
       - 'docs/**'
 
@@ -22,4 +22,3 @@ jobs:
       eve_image: "lfedge/eve:16.6.0"
       eve_kubevirt_image: "lfedge/eve:0.0.0-master-75241279-kubevirt-amd64"
       eden_version: ${{ github.event.pull_request.head.sha }}
-    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,8 +96,6 @@ jobs:
           eve_log_level: ${{ inputs.eve_log_level }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
-          aziot_id_scope: ${{ secrets.AZIOT_ID_SCOPE }}
-          aziot_connection_string: ${{ secrets.AZIOT_CONNECTION_STRING }}
 
   networking:
     name: Networking


### PR DESCRIPTION
## Summary
- Switch Eden workflow trigger from `pull_request_target` to `pull_request` so each branch uses its own workflow file (with its hardcoded `eve_image`), enabling stable/backport branches (`EVE-*-stable`) to work correctly
- Add `EVE-*-stable` to both `push` and `pull_request` branch filters
- Remove unused Azure IoT secrets (`AZIOT_ID_SCOPE`, `AZIOT_CONNECTION_STRING`) from the workflow and both composite actions — no tests ever consumed them
- Remove `secrets: inherit` from `eden.yml` since no secrets are needed anymore

## Test plan
- [ ] Verify the Eden workflow triggers on PRs to master
- [ ] Verify the Eden workflow triggers on PRs to an `EVE-*-stable` branch
- [ ] Confirm smoke tests still pass without the aziot env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)