### PR TITLE
[14.5-stable] fix some tests

### DIFF
--- a/.github/actions/run-eden-test/action.yml
+++ b/.github/actions/run-eden-test/action.yml
@@ -23,12 +23,6 @@ inputs:
     type: string
   require_virtualization:
     type: bool
-  aziot_id_scope:
-    description: 'Azure IoT ID scope'
-    required: false
-  aziot_connection_string:
-    description: 'Azure IoT connection string'
-    required: false
 
 
 runs:
@@ -53,9 +47,6 @@ runs:
       run: EDEN_TEST_STOP=n ./eden test ./tests/workflow -s ${{ inputs.suite }} -v debug
       shell: bash
       working-directory: "./eden"
-      env:
-        AZIOT_ID_SCOPE: ${{ inputs.aziot_id_scope }}
-        AZIOT_CONNECTION_STRING: ${{ inputs.aziot_connection_string }}
     - name: Collect info
       if: failure()
       uses: ./eden/.github/actions/collect-info

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -94,10 +94,10 @@ runs:
           echo "Setting up eve image ${image}"
           eve_pr_registry=$(echo "$image" |  cut -d ':' -f 1)
           eve_pr=$(echo "$image" |  cut -d ':' -f 2 | cut -d "-" -f1)
-          # this will be empty if there is no rc in the tag
-          eve_rc=$(echo "$image" |  cut -d ':' -f 2 | grep -Eo "\-rc[0-9]+" || printf "")
+          # this will be empty if there is no rc or lts suffix in the tag
+          eve_suffix=$(echo "$image" |  cut -d ':' -f 2 | grep -Eo "\-(rc[0-9]+|lts)" || printf "")
           ./eden config set default --key=eve.registry --value="$eve_pr_registry"
-          ./eden config set default --key=eve.tag --value="$eve_pr$eve_rc"
+          ./eden config set default --key=eve.tag --value="$eve_pr$eve_suffix"
         else
           echo "Skipping setting up eve image ${image}"
         fi

--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -19,5 +19,5 @@ jobs:
     name: Execute Eden test workflow
     uses: ./.github/workflows/test.yml
     with:
-      eve_image: "lfedge/eve:13.3.0"
+      eve_image: "lfedge/eve:14.5.3-lts"
       eden_version: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -1,8 +1,12 @@
 ---
 name: Eden
 on: # yamllint disable-line rule:truthy
-  pull_request_target:
-    branches: [master]
+  push:
+    branches: [master, 'EVE-*-stable']
+    paths-ignore:
+      - 'docs/**'
+  pull_request:
+    branches: [master, 'EVE-*-stable']
     paths-ignore:
       - 'docs/**'
 
@@ -17,4 +21,3 @@ jobs:
     with:
       eve_image: "lfedge/eve:13.3.0"
       eden_version: ${{ github.event.pull_request.head.sha }}
-    secrets: inherit

--- a/.github/workflows/eden_setup.yml
+++ b/.github/workflows/eden_setup.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           go-version: '1.22'
       - name: Login to DockerHub (Pull)
-        if: ${{ github.event.repository.full_name }} == 'lf-edge/eden'
+        if: ${{ github.event.repository.full_name == 'lf-edge/eden' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_PULL_USER }}
@@ -60,7 +60,7 @@ jobs:
         with:
           go-version: '1.22'
       - name: Login to DockerHub (Pull)
-        if: ${{ github.event.repository.full_name }} == 'lf-edge/eden'
+        if: ${{ github.event.repository.full_name == 'lf-edge/eden' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_PULL_USER }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,8 +88,6 @@ jobs:
           eve_log_level: ${{ inputs.eve_log_level }}
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
-          aziot_id_scope: ${{ secrets.AZIOT_ID_SCOPE }}
-          aziot_connection_string: ${{ secrets.AZIOT_CONNECTION_STRING }}
 
   networking:
     name: Networking

--- a/pkg/openevec/eve.go
+++ b/pkg/openevec/eve.go
@@ -346,29 +346,10 @@ func (openEVEC *OpenEVEC) ConsoleEve(host string) error {
 
 func (openEVEC *OpenEVEC) SSHEve(commandToRun string) error {
 	cfg := openEVEC.cfg
-	if _, err := os.Stat(cfg.Eden.SSHKey); !os.IsNotExist(err) {
-		changer := &adamChanger{}
-		ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
-		if err != nil {
-			return fmt.Errorf("cannot get controller or dev, please start them and onboard: %w", err)
-		}
-		b, err := os.ReadFile(ctrl.GetVars().SSHKey)
-		switch {
-		case err != nil:
-			return fmt.Errorf("error reading sshKey file %s: %w", ctrl.GetVars().SSHKey, err)
-		}
-		dev.SetConfigItem("debug.enable.ssh", string(b))
-		if err = ctrl.ConfigSync(dev); err != nil {
-			return err
-		}
-		if err = openEVEC.SdnForwardSSHToEve(commandToRun); err != nil {
-			return err
-		}
-	} else {
+	if _, err := os.Stat(cfg.Eden.SSHKey); os.IsNotExist(err) {
 		return fmt.Errorf("SSH key problem: %w", err)
 	}
-
-	return nil
+	return openEVEC.SdnForwardSSHToEve(commandToRun)
 }
 
 func (openEVEC *OpenEVEC) ResetEve() error {

--- a/tests/eclient/testdata/ctrl_cert_change.txt
+++ b/tests/eclient/testdata/ctrl_cert_change.txt
@@ -72,10 +72,53 @@ test:
 
 -- check_sign_cert.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-$EDEN eve ssh cat /persist/certs/server-signing-cert.pem > /tmp/server-signing-cert.pem
-diff -Z /tmp/signing-new.pem /tmp/server-signing-cert.pem
-status=$?
-if [ $status -ne 0 ]; then
-    echo "Error: Current server signing certificate does not match the uploaded one." >&2
-fi
-exit $status
+# In older versions the signing cert was stored in a PEM file in /persist/certs/, and also in a JSON file in /persist/status/zedagent/ControllerCert/.
+# In newer EVE versions it is available as a JSON file in /run/zedagent/ControllerCert/.
+# We look in the new directory (/run/zedagent) and fallback to the old (/persist/status/zedagent).
+# The signing cert has Type=1 (CERT_TYPE_CONTROLLER_SIGNING) and the PEM-encoded
+# cert bytes are base64-encoded in the "Cert" field.
+#
+# Extract the signing cert (Type=1) from a JSON file and compare it against
+# the expected cert. Returns 0 if it matches.
+try_extract_and_match() {
+    local json_file="$1"
+    if grep -q "\"Type\":1" "$json_file" 2>/dev/null; then
+        grep -o "\"Cert\":\"[^\"]*\"" "$json_file" | tr -d "\"" | cut -d: -f2 | base64 -d > /tmp/server-signing-cert.pem
+        if diff -qZ /tmp/signing-new.pem /tmp/server-signing-cert.pem >/dev/null 2>&1; then
+            return 0
+        fi
+        rm -f /tmp/server-signing-cert.pem
+    fi
+    return 1
+}
+
+while true; do
+    echo "Try fetching ControllerCert - from /run" >&2
+    $EDEN eve ssh ls /run/zedagent/ControllerCert/ 2>/dev/null >/tmp/certfiles
+    if [ -s /tmp/certfiles ] && grep -q json /tmp/certfiles; then
+        echo "Found in /run: $(cat /tmp/certfiles)" >&2
+        for f in $(cat /tmp/certfiles); do
+            $EDEN eve ssh cat "/run/zedagent/ControllerCert/$f" > "/tmp/$f"
+            if try_extract_and_match "/tmp/$f"; then
+                echo "Matched signing cert in /run/$f" >&2
+                exit 0
+            fi
+        done
+    fi
+
+    echo "Try fetching ControllerCert - from /persist" >&2
+    $EDEN eve ssh ls /persist/status/zedagent/ControllerCert/ 2>/dev/null >/tmp/certfiles.old
+    if [ -s /tmp/certfiles.old ] && grep -q json /tmp/certfiles.old; then
+        echo "Found in /persist: $(cat /tmp/certfiles.old)" >&2
+        for f in $(cat /tmp/certfiles.old); do
+            $EDEN eve ssh cat "/persist/status/zedagent/ControllerCert/$f" > "/tmp/$f.old"
+            if try_extract_and_match "/tmp/$f.old"; then
+                echo "Matched signing cert in /persist/$f" >&2
+                exit 0
+            fi
+        done
+    fi
+
+    echo "Signing cert not yet matching, retrying in 10s..." >&2
+    sleep 10
+done

--- a/tests/eclient/testdata/metadata.txt
+++ b/tests/eclient/testdata/metadata.txt
@@ -20,7 +20,7 @@ message 'Waiting for AppInstMetadata'
 # Use eden.lim.test for access Infos with timewait 10m in background
 test eden.lim.test -test.v -timewait 10m -test.run TestInfo -out InfoContent.amdinfo.data 'InfoContent.amdinfo.data:world' &
 
-exec -t 5m bash ssh.sh
+exec -t 20m bash ssh.sh
 
 # wait for detector
 wait

--- a/tests/eclient/testdata/networking_light.txt
+++ b/tests/eclient/testdata/networking_light.txt
@@ -82,7 +82,20 @@ done
 -- eserver_ip.sh --
 IP_NUM="$1"
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-echo export ESERVER_IP=$(grep '^eserver\s' pod_ps | cut -f 4|tr -d ' '|cut -d";" -f"$IP_NUM") > env
+# Retry until eserver has real IPs (not just "-")
+for i in $(seq 30); do
+  $EDEN pod ps > pod_ps_live
+  IP=$(grep '^eserver\s' pod_ps_live | cut -f 4 | tr -d ' ' | cut -d";" -f"$IP_NUM")
+  if [ -n "$IP" ] && [ "$IP" != "-" ]; then
+    echo "eserver IP[$IP_NUM] = $IP (attempt $i)"
+    echo "export ESERVER_IP=$IP" > env
+    exit 0
+  fi
+  echo "Waiting for eserver IP (attempt $i, got '$IP')..."
+  sleep 10
+done
+echo "ERROR: eserver never got an IP after 30 attempts" >&2
+exit 1
 
 -- setup_srv.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}

--- a/tests/eclient/testdata/userdata.txt
+++ b/tests/eclient/testdata/userdata.txt
@@ -45,7 +45,7 @@ exec -t 40s bash change_injected_file.sh "after_restart"
 eden pod restart eclient
 test eden.app.test -test.v -timewait 20m -check-new RUNNING eclient
 
-exec -t 40s bash test_injected_file.sh "after_restart"
+exec -t 100s bash test_injected_file.sh "after_restart"
 
 eden pod delete eclient
 

--- a/tests/lim/testdata/log_test.txt
+++ b/tests/lim/testdata/log_test.txt
@@ -31,4 +31,12 @@ test:
 
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-until timeout 10 $EDEN eve ssh exit; do sleep 10; done
+# Keep generating SSH connections so the log watcher catches a
+# "Disconnected" message regardless of startup timing.
+# Use a finite loop so the script exits cleanly before the
+# background timeout — testscript treats a killed background
+# process as a test failure.
+for i in $(seq 1 15); do
+    timeout 10 $EDEN eve ssh exit || true
+    sleep 10
+done


### PR DESCRIPTION
Backport of
https://github.com/lf-edge/eden/pull/1123
https://github.com/lf-edge/eden/pull/1137

Same fixes as https://github.com/lf-edge/eden/pull/1136 (16.0-stable), adapted for the 14.5-stable branch.

Cherry-picked commits:
- userdata: increase timeout for injected file test after restart
- fix flaky SSH-based tests by removing ConfigSync from SSHEve (vector_test.go skipped — doesn't exist in this branch)
- fix flaky ctrl_cert_change test by matching cert in retry loop
- fix flaky metadata test by increasing SSH timeout to 20m
- tests: fix networking_light flakiness when eserver IP is not ready
- fix: correct conditional syntax for DockerHub login in workflow
- ci: switch eden.yml from pull_request_target to pull_request (neoeden action skipped — doesn't exist in this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)