### PR TITLE
eve-coverage: collect basic-block coverage from instrumented EVE

### DIFF
--- a/cmd/edenTest.go
+++ b/cmd/edenTest.go
@@ -66,9 +66,16 @@ test <test_dir> -r <regexp> [-t <timewait>] [-v <level>]
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-
 			if err := openevec.Test(&tstCfg); err != nil {
 				log.Fatal(err)
+			}
+			// After all tests complete, collect coverage if requested.
+			// This requires EVE to have been built with COVER=y.
+			if tstCfg.CoverageDir != "" {
+				openEVEC := openevec.CreateOpenEVEC(cfg)
+				if err := openEVEC.CollectEveCoverage(tstCfg.CoverageDir); err != nil {
+					log.Errorf("EVE coverage collection failed: %v", err)
+				}
 			}
 		},
 	}
@@ -82,6 +89,8 @@ test <test_dir> -r <regexp> [-t <timewait>] [-v <level>]
 	testCmd.Flags().StringVarP(&tstCfg.TestScenario, "scenario", "s", "", "scenario for tests bunch running")
 	testCmd.Flags().StringVarP(&tstCfg.FailScenario, "fail_scenario", "f", "cfg.FailScenario.txt", "scenario for test failing")
 	testCmd.Flags().BoolVarP(&tstCfg.TestOpts, "opts", "o", false, "Options description for test binary which may be used in test scenarious and '-a|--args' option")
+	testCmd.Flags().StringVar(&tstCfg.CoverageDir, "coverage-dir", "",
+		"collect EVE code coverage after tests and write eden_e2e_coverage.txt to this directory (requires EVE built with COVER=y)")
 
 	return testCmd
 }

--- a/cmd/eve.go
+++ b/cmd/eve.go
@@ -34,6 +34,7 @@ func newEveCmd(configName, verbosity *string) *cobra.Command {
 				newVersionEveCmd(),
 				newEpochEveCmd(),
 				newLinkEveCmd(cfg),
+				newCollectCoverageEveCmd(cfg),
 			},
 		},
 	}
@@ -285,4 +286,47 @@ func newLinkEveCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 	linkEveCmd.Flags().StringVarP(&eveInterfaceName, "interface-name", "i", "", "EVE interface to get/change the link state of")
 
 	return linkEveCmd
+}
+
+// newCollectCoverageEveCmd returns the "eden eve collect-coverage" command.
+// It collects Go basic-block coverage data from a coverage-instrumented EVE
+// image (built with COVER=y) and writes a text profile to --output-dir.
+// The resulting file can be merged with "make test" unit-test coverage using
+// "make coverage-merge" from the EVE repository root.
+func newCollectCoverageEveCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
+	var outputDir string
+
+	var collectCoverageCmd = &cobra.Command{
+		Use:   "collect-coverage",
+		Short: "collect code coverage from a coverage-instrumented EVE image",
+		Long: `Dump in-memory coverage counters from all running zedbox processes on EVE
+(via SIGUSR2), copy the binary coverage files to the host, and convert them
+to a Go text coverage profile at <output-dir>/eden_e2e_coverage.txt.
+
+Requires EVE to have been built with COVER=y so that zedbox is instrumented
+(go build -cover -covermode=atomic) and registers a SIGUSR2 handler that
+writes coverage data to /persist/coverage without terminating.
+
+The text profile uses the same format as "go test -coverprofile" so it can
+be concatenated with unit-test coverage to produce a combined report:
+
+    head -1 pkg/pillar/coverage.txt > combined.txt
+    tail -n +2 pkg/pillar/coverage.txt >> combined.txt
+    tail -n +2 <output-dir>/eden_e2e_coverage.txt >> combined.txt
+    go tool cover -func=combined.txt
+
+Or use "make coverage-merge" from the EVE repository root.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			openEVEC := openevec.CreateOpenEVEC(cfg)
+			if outputDir == "" {
+				return fmt.Errorf("--output-dir is required")
+			}
+			return openEVEC.CollectEveCoverage(outputDir)
+		},
+	}
+
+	collectCoverageCmd.Flags().StringVar(&outputDir, "output-dir", "",
+		"directory to write eden_e2e_coverage.txt (required)")
+
+	return collectCoverageCmd
 }

--- a/cmd/eve.go
+++ b/cmd/eve.go
@@ -316,6 +316,7 @@ be concatenated with unit-test coverage to produce a combined report:
     go tool cover -func=combined.txt
 
 Or use "make coverage-merge" from the EVE repository root.`,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			openEVEC := openevec.CreateOpenEVEC(cfg)
 			if outputDir == "" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"os"
 	"reflect"
 
 	"github.com/lf-edge/eden/pkg/defaults"
@@ -85,5 +86,7 @@ func preRunViperLoadFunction(cfg *openevec.EdenSetupArgs, configName, verbosity 
 // Execute primary function for cobra
 func Execute() {
 	rootCmd := NewEdenCommand()
-	_ = rootCmd.Execute()
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -35,6 +35,10 @@ const (
 	DefaultConfigEnv   = "EDEN_CONFIG"    //default env for set config
 	DefaultEdenHomeEnv = "EDEN_HOME"      //default env for overriding eden home directory
 	DefaultTestArgsEnv = "EDEN_TEST_ARGS" //default env for test arguments
+
+	// DefaultEveCoverageDir is the directory inside EVE where coverage-instrumented
+	// zedbox binaries write their coverage data (via GOCOVERDIR).
+	DefaultEveCoverageDir = "/persist/coverage"
 )
 
 // domains, ips, ports

--- a/pkg/openevec/coverage.go
+++ b/pkg/openevec/coverage.go
@@ -14,13 +14,31 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// waitForEveSSH polls until EVE accepts an SSH connection or the timeout
+// expires.  Tests that reboot EVE leave SSH temporarily unreachable; retrying
+// here avoids a spurious coverage-collection failure.
+func (openEVEC *OpenEVEC) waitForEveSSH(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	interval := 10 * time.Second
+	for {
+		if err := openEVEC.sshEveProbe(); err == nil {
+			return nil
+		}
+		if time.Now().Add(interval).After(deadline) {
+			return fmt.Errorf("EVE SSH not available after %v", timeout)
+		}
+		log.Infof("EVE coverage: waiting for SSH to become available...")
+		time.Sleep(interval)
+	}
+}
+
 // CollectEveCoverage dumps coverage counters from coverage-instrumented EVE
 // binaries (built with COVER=y / go build -cover -covermode=atomic) and
 // converts the result to a Go coverage text profile at
 // <outputDir>/eden_e2e_coverage.txt.
 //
 // The function:
-//  1. Creates /persist/coverage inside EVE (if not present).
+//  1. Waits for EVE SSH to be ready (EVE may be rebooting after tests).
 //  2. Sends SIGUSR2 to all running zedbox processes so they write their
 //     in-memory coverage counters to GOCOVERDIR without terminating.
 //  3. Copies the binary coverage files to a local temporary directory.
@@ -37,10 +55,11 @@ func (openEVEC *OpenEVEC) CollectEveCoverage(outputDir string) error {
 		return fmt.Errorf("cannot create coverage output dir %s: %w", outputDir, err)
 	}
 
-	// Ensure the coverage directory exists inside EVE.
-	log.Infof("EVE coverage: creating %s on EVE", defaults.DefaultEveCoverageDir)
-	if err := openEVEC.SSHEve(fmt.Sprintf("mkdir -p %s", defaults.DefaultEveCoverageDir)); err != nil {
-		return fmt.Errorf("cannot create coverage dir on EVE: %w", err)
+	// Wait for EVE SSH to be ready.  A test may have rebooted EVE and SSH
+	// might not be accepting connections immediately after tests complete.
+	log.Infof("EVE coverage: waiting for EVE SSH (up to 5 min)...")
+	if err := openEVEC.waitForEveSSH(5 * time.Minute); err != nil {
+		return fmt.Errorf("cannot reach EVE via SSH: %w", err)
 	}
 
 	// Send SIGUSR2 to all zedbox processes to dump live coverage counters.

--- a/pkg/openevec/coverage.go
+++ b/pkg/openevec/coverage.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package openevec
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/lf-edge/eden/pkg/defaults"
+	log "github.com/sirupsen/logrus"
+)
+
+// CollectEveCoverage dumps coverage counters from coverage-instrumented EVE
+// binaries (built with COVER=y / go build -cover -covermode=atomic) and
+// converts the result to a Go coverage text profile at
+// <outputDir>/eden_e2e_coverage.txt.
+//
+// The function:
+//  1. Creates /persist/coverage inside EVE (if not present).
+//  2. Sends SIGUSR2 to all running zedbox processes so they write their
+//     in-memory coverage counters to GOCOVERDIR without terminating.
+//  3. Copies the binary coverage files to a local temporary directory.
+//  4. Converts them to text profile format with "go tool covdata textfmt".
+//
+// Requirements:
+//   - EVE must have been built with COVER=y so that zedbox is instrumented
+//     and its init() sets GOCOVERDIR=/persist/coverage and registers a
+//     SIGUSR2 handler that calls runtime/coverage.WriteCountersDir.
+//   - SSH access to EVE must be configured (eden.ssh-key must exist and
+//     debug.enable.ssh must be set in the EVE config item).
+func (openEVEC *OpenEVEC) CollectEveCoverage(outputDir string) error {
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("cannot create coverage output dir %s: %w", outputDir, err)
+	}
+
+	// Ensure the coverage directory exists inside EVE.
+	log.Infof("EVE coverage: creating %s on EVE", defaults.DefaultEveCoverageDir)
+	if err := openEVEC.SSHEve(fmt.Sprintf("mkdir -p %s", defaults.DefaultEveCoverageDir)); err != nil {
+		return fmt.Errorf("cannot create coverage dir on EVE: %w", err)
+	}
+
+	// Send SIGUSR2 to all zedbox processes to dump live coverage counters.
+	// The SIGUSR2 handler (registered in zedbox when built with -cover) calls
+	// runtime/coverage.WriteCountersDir(GOCOVERDIR) without exiting.
+	log.Infof("EVE coverage: sending SIGUSR2 to zedbox processes")
+	sigCmd := fmt.Sprintf("kill -USR2 $(pgrep -x zedbox) 2>/dev/null; true")
+	if err := openEVEC.SdnForwardSSHToEve(sigCmd); err != nil {
+		log.Warnf("EVE coverage: SIGUSR2 delivery failed (%v); "+
+			"coverage may be incomplete", err)
+	}
+
+	// Give zedbox processes a moment to finish writing the files.
+	log.Infof("EVE coverage: waiting for coverage data to be written")
+	time.Sleep(3 * time.Second)
+
+	// Copy binary coverage files from EVE to a local temp directory.
+	tmpDir, err := os.MkdirTemp("", "eve-coverage-*")
+	if err != nil {
+		return fmt.Errorf("cannot create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	log.Infof("EVE coverage: copying %s from EVE to %s",
+		defaults.DefaultEveCoverageDir, tmpDir)
+	if err := openEVEC.SdnForwardSCPDirFromEve(
+		defaults.DefaultEveCoverageDir, tmpDir); err != nil {
+		return fmt.Errorf("cannot copy coverage data from EVE: %w", err)
+	}
+
+	// The SCP copies the directory itself, so the files land under
+	// tmpDir/coverage/.  Point covdata at that sub-directory.
+	coverSubDir := filepath.Join(tmpDir, filepath.Base(defaults.DefaultEveCoverageDir))
+	if _, err := os.Stat(coverSubDir); os.IsNotExist(err) {
+		// Fallback: files landed directly in tmpDir.
+		coverSubDir = tmpDir
+	}
+
+	// Convert binary coverage format → Go text profile format.
+	outputFile := filepath.Join(outputDir, "eden_e2e_coverage.txt")
+	log.Infof("EVE coverage: converting to text profile %s", outputFile)
+	cmd := exec.Command("go", "tool", "covdata", "textfmt",
+		"-i="+coverSubDir,
+		"-o="+outputFile)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("go tool covdata textfmt failed: %w\nOutput: %s",
+			err, string(out))
+	}
+
+	log.Infof("EVE coverage: written to %s", outputFile)
+	return nil
+}

--- a/pkg/openevec/sdn.go
+++ b/pkg/openevec/sdn.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -49,7 +52,33 @@ func sdnSSHKeyPath(sdnSourceDir string) string {
 	return filepath.Join(sdnSourceDir, "vm/cert/ssh/id_rsa")
 }
 
+// stdinOpt connects the subprocess stdin to the parent process stdin,
+// matching the behaviour of utils.RunCommandForeground.
+var stdinOpt utils.CommandOpt = func(cmd *exec.Cmd) {
+	cmd.Stdin = os.Stdin
+}
+
+// silentOpt discards subprocess stdout and stderr.
+// Used for availability probes where output noise is not wanted.
+var silentOpt utils.CommandOpt = func(cmd *exec.Cmd) {
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+}
+
 func (openEVEC *OpenEVEC) SdnForwardCmd(fromEp string, eveIfName string, targetPort int, cmd string, args ...string) error {
+	return openEVEC.sdnForwardCmdWithOpts(fromEp, eveIfName, targetPort, []utils.CommandOpt{stdinOpt}, cmd, args...)
+}
+
+// sshEveProbe runs "ssh ... true" against EVE with all output discarded.
+// Used by waitForEveSSH to poll SSH availability without noisy stderr.
+func (openEVEC *OpenEVEC) sshEveProbe() error {
+	cfg := openEVEC.cfg
+	arguments := fmt.Sprintf("-o IdentitiesOnly=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i %s "+
+		"-p FWD_PORT root@FWD_IP true", sdnSSSHKeyPrivate(cfg.Eden.SSHKey))
+	return openEVEC.sdnForwardCmdWithOpts("", "eth0", 22, []utils.CommandOpt{silentOpt}, "ssh", strings.Fields(arguments)...)
+}
+
+func (openEVEC *OpenEVEC) sdnForwardCmdWithOpts(fromEp string, eveIfName string, targetPort int, cmdOpts []utils.CommandOpt, cmd string, args ...string) error {
 	cfg := openEVEC.cfg
 	const fwdIPLabel = "FWD_IP"
 	const fwdPortLabel = "FWD_PORT"
@@ -66,7 +95,7 @@ func (openEVEC *OpenEVEC) SdnForwardCmd(fromEp string, eveIfName string, targetP
 			args[i] = strings.ReplaceAll(args[i], fwdIPLabel, ip)
 			args[i] = strings.ReplaceAll(args[i], fwdPortLabel, strconv.Itoa(targetPort))
 		}
-		err := utils.RunCommandForeground(cmd, args...)
+		err := utils.RunCommandForegroundWithOpts(cmd, args, cmdOpts...)
 		if err != nil {
 			return fmt.Errorf("command %s failed: %w", cmd, err)
 		}
@@ -116,7 +145,7 @@ func (openEVEC *OpenEVEC) SdnForwardCmd(fromEp string, eveIfName string, targetP
 			args[i] = strings.ReplaceAll(args[i], fwdIPLabel, "127.0.0.1")
 			args[i] = strings.ReplaceAll(args[i], fwdPortLabel, fwdPort)
 		}
-		err := utils.RunCommandForeground(cmd, args...)
+		err := utils.RunCommandForegroundWithOpts(cmd, args, cmdOpts...)
 		if err != nil {
 			return fmt.Errorf("command %s failed: %w", cmd, err)
 		}
@@ -168,7 +197,7 @@ func (openEVEC *OpenEVEC) SdnForwardCmd(fromEp string, eveIfName string, targetP
 		args[i] = strings.ReplaceAll(args[i], fwdIPLabel, "127.0.0.1")
 		args[i] = strings.ReplaceAll(args[i], fwdPortLabel, fwdPort)
 	}
-	err = utils.RunCommandForeground(cmd, args...)
+	err = utils.RunCommandForegroundWithOpts(cmd, args, cmdOpts...)
 	if err != nil {
 		return fmt.Errorf("command %s %s failed: %w", cmd, strings.Join(args, " "), err)
 	}

--- a/pkg/openevec/sdn.go
+++ b/pkg/openevec/sdn.go
@@ -28,6 +28,14 @@ func (openEVEC *OpenEVEC) SdnForwardSCPFromEve(remoteFilePath, localFilePath str
 	return openEVEC.SdnForwardCmd("", "eth0", 22, "scp", strings.Fields(arguments)...)
 }
 
+// SdnForwardSCPDirFromEve copies a directory recursively from EVE to the host using scp -r.
+func (openEVEC *OpenEVEC) SdnForwardSCPDirFromEve(remoteDirPath, localDirPath string) error {
+	cfg := openEVEC.cfg
+	arguments := fmt.Sprintf("-r -o IdentitiesOnly=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no -i %s "+
+		"-P FWD_PORT root@FWD_IP:%s %s", sdnSSSHKeyPrivate(cfg.Eden.SSHKey), remoteDirPath, localDirPath)
+	return openEVEC.SdnForwardCmd("", "eth0", 22, "scp", strings.Fields(arguments)...)
+}
+
 func sdnSSSHKeyPrivate(sshKeyPub string) string {
 	extension := filepath.Ext(sshKeyPub)
 	// we store the pub key in config

--- a/pkg/openevec/test.go
+++ b/pkg/openevec/test.go
@@ -25,6 +25,10 @@ type TestArgs struct {
 	CurDir       string
 	ConfigFile   string
 	Verbosity    string
+	// CoverageDir, when non-empty, triggers EVE coverage collection after all
+	// tests complete.  EVE must have been built with COVER=y.  The text profile
+	// is written to CoverageDir/eden_e2e_coverage.txt.
+	CoverageDir string
 }
 
 func InitVarsFromConfig(cfg *EdenSetupArgs) (*utils.ConfigVars, error) {


### PR DESCRIPTION
Add support for collecting Go basic-block code coverage from a running EVE instance that was built with COVER=y (go build -cover -covermode=atomic).

Changes:
- pkg/defaults: add DefaultEveCoverageDir (/persist/coverage)
- pkg/openevec/coverage.go: new CollectEveCoverage() that sends SIGUSR2 to zedbox processes, copies binary coverage files via SCP, and converts them to text profile format with "go tool covdata textfmt"
- pkg/openevec/sdn.go: add SdnForwardSCPDirFromEve() for recursive SCP
- pkg/openevec/test.go: add CoverageDir field to TestArgs
- cmd/edenTest.go: add --coverage-dir flag; collect coverage after tests
- cmd/eve.go: add "eden eve collect-coverage" subcommand

The resulting eden_e2e_coverage.txt uses the same -covermode=atomic text profile format as "go test -coverprofile" so it can be concatenated with unit-test coverage from "make test" to produce a combined report.