### PR TITLE
tests: increase timeouts to handle slow CI environments

### DIFF
--- a/tests/inventory/inventory_test.go
+++ b/tests/inventory/inventory_test.go
@@ -125,7 +125,7 @@ func TestHWInventory(t *testing.T) {
 	steppy.AnnounceNext("check some fields in the HW inventory message")
 
 	steppy.AnnounceNext("reboot EVE node to generate new HW inventory")
-	if err := eveNode.EveRebootAndWait(5 * 60); err != nil {
+	if err := eveNode.EveRebootAndWait(10 * 60); err != nil {
 		logFatalf("Failed to reboot EVE node: %v", err)
 	}
 	time.Sleep(1 * time.Minute) // wait for a bit before checking logs

--- a/tests/volume/testdata/volumes_test.txt
+++ b/tests/volume/testdata/volumes_test.txt
@@ -26,10 +26,10 @@ source .env
 
 # allocate volume with size of half total space
 eden -t 1m volume create -n blank-vol-1 blank --disk-size=$half_total
-test eden.vol.test -test.v -timewait 3m CREATED_VOLUME blank-vol-1
+test eden.vol.test -test.v -timewait 10m CREATED_VOLUME blank-vol-1
 
 # allocate background info check for volumeErr contains Remaining word
-test eden.lim.test -test.v -timewait 3m -test.run TestInfo -out InfoContent.vinfo 'InfoContent.vinfo.volumeErr:Remaining' 'InfoContent.vinfo.displayName:blank-vol-2' &errorwait&
+test eden.lim.test -test.v -timewait 10m -test.run TestInfo -out InfoContent.vinfo 'InfoContent.vinfo.volumeErr:Remaining' 'InfoContent.vinfo.displayName:blank-vol-2' &errorwait&
 
 exec sleep 10
 


### PR DESCRIPTION
## Summary

- Increase volume test timeouts from 3m to 10m in \`tests/volume/testdata/volumes_test.txt\` — two \`eden.vol.test\` / \`eden.lim.test\` calls were timing out under CI load
- Increase HW inventory reboot wait from 5m to 10m in \`tests/inventory/inventory_test.go\` — \`TestHWInventory\` was timing out waiting for EVE to reboot and come back online

Both failures were observed in https://github.com/lf-edge/eve/actions/runs/24515821501.

Signed-off-by: eriknordmark <erik@zededa.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)