### PR TITLE
fix: skip pre-reboot buffered logs in TestLogLevelsDifferent

### DIFF
--- a/pkg/evetestkit/utils.go
+++ b/pkg/evetestkit/utils.go
@@ -673,6 +673,13 @@ func (node *EveNode) FindLogOnAdam(query map[string]string, mode elog.LogChecker
 	return node.controller.EdenFindLogs(query, mode, timeout)
 }
 
+// FindLogOnAdamAfter queries Adam for a log entry generated at or after the given time.
+// Log entries with timestamps before 'after' are silently skipped and do not count as a match.
+// Returns nil if a matching post-'after' entry is found, or an error (e.g. timeout) if not found.
+func (node *EveNode) FindLogOnAdamAfter(query map[string]string, mode elog.LogCheckerMode, timeout time.Duration, after time.Time) error {
+	return node.controller.EdenFindLogsAfter(query, mode, timeout, after)
+}
+
 // GetDefaultVMConfig returns a default configuration for a VM
 func GetDefaultVMConfig(appName, cloudConfig string, portPub []string) openevec.PodConfig {
 	var pc openevec.PodConfig

--- a/pkg/openevec/eden.go
+++ b/pkg/openevec/eden.go
@@ -607,6 +607,27 @@ func (openEVEC *OpenEVEC) EdenFindLogs(query map[string]string, mode elog.LogChe
 	return ctrl.LogChecker(devUUID, query, handler, mode, timeout)
 }
 
+// EdenFindLogsAfter finds logs in the controller generated at or after the given time.
+// Log entries with timestamps before 'after' are silently skipped and do not count as a match.
+// This is useful after a reboot to avoid false positives from pre-reboot logs that EVE's
+// newlogd persisted to disk and uploads to Adam after coming back up.
+func (openEVEC *OpenEVEC) EdenFindLogsAfter(query map[string]string, mode elog.LogCheckerMode, timeout time.Duration, after time.Time) error {
+	changer := &adamChanger{}
+	ctrl, devFirst, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
+	if err != nil {
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
+	}
+	devUUID := devFirst.GetID()
+	handler := func(logEntry *elog.FullLogEntry) bool {
+		if logEntry.Timestamp == nil || logEntry.Timestamp.AsTime().Before(after) {
+			return false // skip pre-'after' entries, keep watching
+		}
+		elog.LogPrint(logEntry, types.OutputFormatLines)
+		return true
+	}
+	return ctrl.LogChecker(devUUID, query, handler, mode, timeout)
+}
+
 func (openEVEC *OpenEVEC) EdenNetStat(outputFormat types.OutputFormat, follow bool, logTail uint, printFields, args []string) error {
 	changer := &adamChanger{}
 	ctrl, devFirst, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)

--- a/tests/newlogd/newlogd_test.go
+++ b/tests/newlogd/newlogd_test.go
@@ -96,6 +96,11 @@ func TestLogLevelsDifferent(t *testing.T) {
 	if err := eveNode.WaitForConfigApplied(60 * time.Second); err != nil {
 		logFatalf("Failed to wait for config to be applied: %v", err)
 	}
+	// Record the time after the new log levels were confirmed applied on EVE.
+	// Any log entry with a timestamp before this point was generated under the
+	// old log level (or during the apply transition) and should not count as a
+	// violation of the remote.loglevel=none policy.
+	configAppliedAt := time.Now()
 
 	steppy.AnnounceNext("reboot EVE to generate fresh logs")
 	if err := eveNode.EveRebootAndWait(5 * 60); err != nil {
@@ -106,7 +111,10 @@ func TestLogLevelsDifferent(t *testing.T) {
 	query := map[string]string{
 		"severity": ".*",
 	}
-	if err := eveNode.FindLogOnAdam(query, elog.LogNew, logTimeout); err != nil {
+	// Use FindLogOnAdamAfter to skip pre-reboot logs that EVE's newlogd persisted
+	// to disk and replays to Adam after coming back up. Those logs were generated
+	// before remote.loglevel=none was applied and must not be treated as violations.
+	if err := eveNode.FindLogOnAdamAfter(query, elog.LogNew, logTimeout, configAppliedAt); err != nil {
 		logInfof("No logs found, as expected")
 	} else {
 		logFatalf("Logs found, but they should not be present with the remote log level '%s'", remoteLogLevel)


### PR DESCRIPTION
# Description

This is a trial to fix the flakiness of smoke tests.

Root cause
----------
TestLogLevelsDifferent (eden_newlogd smoke test) was flaky with a false failure: "Logs found, but they should not be present with the remote log level 'none'".

The test flow is:
1. Set remote.loglevel=none on EVE.
2. WaitForConfigApplied polls EVE via SSH (stat -c %Y /persist/checkpoint) until the checkpoint file changes.
3. Each SSH poll session that disconnects writes a "Received disconnect" entry into EVE's sshd log — at this point the new log level is not yet applied on EVE, so newlogd persists those entries to disk.
4. Reboot EVE.
5. After reboot, newlogd replays all persisted pre-reboot logs to Adam.
6. `FindLogOnAdam(LogNew)` calls `XRead($)` on the Redis stream, blocking for the next entry after the current stream head.  The replayed log from step 3 arrives in Redis just after `XRead($)` starts → the watcher sees it as a new, post-config-change log → test fails.

Observed in CI (Smoke ext4,false):
  content: Received disconnect from 192.168.0.2 port 56928
  timestamp: 2026-04-15 12:33:48  (generated during WaitForConfigApplied)
  arrived in Adam at 12:36:20      (replayed by newlogd post-reboot)
  XRead($) started at 12:36:19    → race lost by 1 second

Fix
---
* Add EdenFindLogsAfter (openevec/eden.go) and FindLogOnAdamAfter (evetestkit/utils.go): same as the existing Find* pair but the match handler returns false (skip, keep watching) for any log entry whose Timestamp is before the supplied 'after' time.  Only entries at or after that timestamp trigger a match.

* In TestLogLevelsDifferent, record configAppliedAt := time.Now() immediately after WaitForConfigApplied returns (the moment EVE has confirmed the new log level), then pass it to FindLogOnAdamAfter. Pre-reboot logs replayed by newlogd are silently ignored; only a log generated *after* the new config was applied counts as a violation.