### PR TITLE
eclient,log_test,userdata: ssh robustness improvements

### DIFF
--- a/tests/eclient/testdata/eclient.txt
+++ b/tests/eclient/testdata/eclient.txt
@@ -40,10 +40,13 @@ test:
 
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-for i in `seq 20`
-do
-  sleep 20
+END=$(($(date +%s) + 18*60))
+i=0
+while [ "$(date +%s)" -lt "$END" ]; do
+  i=$((i+1))
   # Test SSH-access to container
   echo $i\) $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep Ubuntu /etc/issue
-  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep Ubuntu /etc/issue && break
+  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep Ubuntu /etc/issue && exit 0
+  sleep 10
 done
+exit 1

--- a/tests/eclient/testdata/metadata.txt
+++ b/tests/eclient/testdata/metadata.txt
@@ -17,12 +17,11 @@ eden pod deploy -n eclient --memory=512MB {{template "eclient_image"}} -p {{$por
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 
 message 'Waiting for AppInstMetadata'
-# Use eden.lim.test for access Infos with timewait 10m in background
-test eden.lim.test -test.v -timewait 10m -test.run TestInfo -out InfoContent.amdinfo.data 'InfoContent.amdinfo.data:world' &
+# Start listener before SSH so we capture the immediate info EVE sends on metadata receipt
+test eden.lim.test -test.v -timewait 20m -test.run TestInfo -out InfoContent.amdinfo.data 'InfoContent.amdinfo.data:world' &
 
 exec -t 20m bash ssh.sh
 
-# wait for detector
 wait
 stdout '{"hello":"world"}'
 
@@ -44,10 +43,13 @@ test:
 
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-for i in `seq 20`
-do
-  sleep 20
+END=$(($(date +%s) + 18*60))
+i=0
+while [ "$(date +%s)" -lt "$END" ]; do
+  i=$((i+1))
   # Test SSH-access to container
   echo $i\) $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} curl --header \"Content-Type: application/json\" --request POST -d \'{\"hello\":\"world\"}\' 169.254.169.254/eve/v1/kubeconfig
-  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} curl --header \"Content-Type: application/json\" --request POST -d \'{\"hello\":\"world\"}\' 169.254.169.254/eve/v1/kubeconfig && break
+  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} curl --header \"Content-Type: application/json\" --request POST -d \'{\"hello\":\"world\"}\' 169.254.169.254/eve/v1/kubeconfig && exit 0
+  sleep 10
 done
+exit 1

--- a/tests/eclient/testdata/userdata.txt
+++ b/tests/eclient/testdata/userdata.txt
@@ -38,14 +38,14 @@ exec -t 10s bash generate_userdata.sh
 eden pod deploy -n eclient --memory=512MB --networks=n1 {{template "eclient_image"}} -p {{$port}}:22 --metadata={{$userdata_file}}
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 
-exec -t 40s bash test_injected_file.sh "before_restart"
+exec -t 5m bash test_injected_file.sh "before_restart"
 
-exec -t 40s bash change_injected_file.sh "after_restart"
+exec -t 5m bash change_injected_file.sh "after_restart"
 
 eden pod restart eclient
 test eden.app.test -test.v -timewait 20m -check-new RUNNING eclient
 
-exec -t 100s bash test_injected_file.sh "after_restart"
+exec -t 5m bash test_injected_file.sh "after_restart"
 
 eden pod delete eclient
 
@@ -85,20 +85,28 @@ EOF
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 TEXT=$1
 
-echo $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep -q $TEXT /etc/injected_file.txt
-
-# Retry in case there are connectivity issues
-for i in `seq 30`
-do
-  echo Try $i
-  # The timeout for ssh trying to connect is 10 seconds
-  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep -q $TEXT /etc/injected_file.txt && echo "Success" && break
-  sleep 2
+# Retry until 30s before the exec timeout (exec -t 5m)
+END=$(($(date +%s) + 4*60 + 30))
+i=0
+while [ "$(date +%s)" -lt "$END" ]; do
+  i=$((i+1))
+  echo Try $i: $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep -q $TEXT /etc/injected_file.txt
+  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep -q $TEXT /etc/injected_file.txt && echo "Success" && exit 0
+  sleep 5
 done
+exit 1
 
 -- change_injected_file.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 TEXT=$1
 
-echo $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} "echo $TEXT > /etc/injected_file.txt"
-$EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} "echo $TEXT > /etc/injected_file.txt"
+# Retry until 30s before the exec timeout (exec -t 5m)
+END=$(($(date +%s) + 4*60 + 30))
+i=0
+while [ "$(date +%s)" -lt "$END" ]; do
+  i=$((i+1))
+  echo Try $i: $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} "echo $TEXT > /etc/injected_file.txt"
+  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} "echo $TEXT > /etc/injected_file.txt" && exit 0
+  sleep 5
+done
+exit 1

--- a/tests/lim/testdata/log_test.txt
+++ b/tests/lim/testdata/log_test.txt
@@ -9,6 +9,9 @@ eden -t 1m controller edge-node update --config agent.debug.debug.remote.logleve
 # wait for the config changes to apply
 exec sleep 15
 
+# wait for EVE's sshd to be ready before starting the log watcher
+exec -t 5m bash wait_ssh.sh
+
 # ssh into EVE to force log creation
 exec -t 5m bash ssh.sh &
 
@@ -28,6 +31,14 @@ test:
         onboard-cert: {{EdenConfigPath "eve.cert"}}
         serial: "{{EdenConfig "eve.serial"}}"
         model: {{EdenConfig "eve.devmodel"}}
+
+-- wait_ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+END=$(($(date +%s) + 5*60))
+until $EDEN eve ssh exit 2>/dev/null; do
+  [ "$(date +%s)" -lt "$END" ] || { echo "sshd not ready after 5m"; exit 1; }
+  sleep 5
+done
 
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}


### PR DESCRIPTION
metadata test: SSH retry robustness

Replace the iteration-bounded seq/sleep loop in ssh.sh with a
time-bounded while loop (18 min, explicit exit 1 on expiry) to reliably
fill the exec -t 20m budget.

---

eclient,log_test,userdata: ssh robustness improvements

Increase SSH timeouts, add failure indication and sshd readiness check

Replace iteration-bounded seq/sleep SSH retry loops in eclient.txt and
userdata.txt with time-bounded while loops, which exit 1 if it never
manages to connect.

In log_test.txt, add a foreground wait_ssh.sh step (5m timeout) that
polls `eden eve ssh` until EVE's sshd accepts a connection before the
background ssh.sh starts generating log entries.