### PR TITLE
tests/eclient: fix nginx server_ip.sh to handle IP:PORT format

### DIFF
--- a/tests/eclient/testdata/nginx.txt
+++ b/tests/eclient/testdata/nginx.txt
@@ -52,7 +52,7 @@ done
 -- server_ip.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 for i in $(seq 30); do
-  IP=$($EDEN pod ps | grep "^$1[[:space:]]" | awk '{print $4}')
+  IP=$($EDEN pod ps | grep "^$1[[:space:]]" | awk '{print $4}' | cut -d: -f1)
   if [ -n "$IP" ] && [ "$IP" != "-" ]; then
     echo "Server IP = $IP (attempt $i)"
     echo "export ESERVER_IP=$IP" > env


### PR DESCRIPTION
When a pod has a port mapping (e.g. -p 8080:80), eden pod ps reports the INTERNAL column as "IP:PORT". With an unassigned IP the value is "-:80", not just "-", so the existing [ "$IP" != "-" ] guard was bypassed and the placeholder "-:80" was stored as ESERVER_IP, causing curl to fail with "missing URL before --next".

Strip the port suffix with cut -d: -f1 before the validity check so "-:80" reduces to "-" and triggers the retry loop as intended.

Example of the error: https://github.com/lf-edge/eve/actions/runs/25041346515/job/73345126272#step:4:5052