### PR TITLE
tests/eclient: fix ctrl_cert_change log pattern after ReconnectApp rename

### DIFF
--- a/tests/eclient/testdata/ctrl_cert_change.txt
+++ b/tests/eclient/testdata/ctrl_cert_change.txt
@@ -26,7 +26,7 @@ eden utils gen-signing-cert -o /tmp/signing-new.pem
 eden adam change-signing-cert --cert-file /tmp/signing-new.pem
 
 # wait for changes to be applied
-test eden.lim.test -test.v -timewait 15m -test.run TestLog -out content 'content:Rebuilding.intended.global.config,.reasons:.reconnecting.app'
+test eden.lim.test -test.v -timewait 15m -test.run TestLog -out content 'content:Rebuilding.intended.global.config,.reasons:.updating.app.connectivity'
 
 eden pod deploy -n eclient2 --memory=512MB --networks=n1 {{template "eclient_image"}} --metadata={{$userdata}}
 


### PR DESCRIPTION
The ctrl_cert_change smoke test was timing out waiting for the log message "Rebuilding intended global config, reasons: reconnecting app", which no longer exists.

On EVE, when ReconnectApp() in nireconciler/linux_reconciler.go was renamed to UpdateAppConn() as part of the Kubernetes CNI plugin work, the reason string passed to scheduleGlobalCfgRebuild() changed from "reconnecting app (%v)" to "updating app connectivity (%v)".

The mechanism itself still works correctly: a controller cert change invalidates cipher contexts, which triggers AppNetworkConfig re-publication, which causes doUpdateActivatedAppNetwork to call UpdateAppConn in the NI reconciler, which logs the updated reason string.

Update the LIM test pattern to match the current reason string.

An example of the timeout error: https://github.com/lf-edge/eve/actions/runs/25115269940/job/73757607638#step:4:3029

The changes on EVE side: https://github.com/lf-edge/eve/commit/415d685992a428f3e5cac17363f48e477476eb2b