### PR TITLE
tests/eclient: rotate controller cert twice in ctrl_cert_change

### DIFF
--- a/tests/eclient/testdata/ctrl_cert_change.txt
+++ b/tests/eclient/testdata/ctrl_cert_change.txt
@@ -2,6 +2,18 @@
 # This test validates the re-encryption of an application's user data
 # following a change in the controller's certificate, accompanied by an edge node reboot.
 # The test involves deploying three applications to make sure the config is (re)applied to all of them.
+#
+# The controller signing certificate is rotated twice so that both states of
+# /persist/checkpoint/controllercerts.bak on the device are exercised:
+#   1. First rotation: .bak does not yet exist. EVE's first auth-verify
+#      fallback in VerifyAuthContainerHeader cannot find the backup file,
+#      and EVE must fall through to fetching the new cert via /certs.
+#      Saving the new chain via MaybeSaveControllerCerts populates .bak
+#      with the previous controllercerts as a side effect.
+#   2. Second rotation: .bak now exists, so the backup-fallback code path
+#      actually loads a cert (the previous-but-one cert) and only after
+#      that fails does EVE trigger /certs again. Also exercises the .bak
+#      atomic-rename refresh inside MaybeSaveControllerCerts.
 
 {{$port := "2223"}}
 
@@ -19,6 +31,9 @@ eden pod deploy -n eclient1 --memory=512MB --networks=n1 {{template "eclient_ima
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient1
 
+# first rotation: at this point /persist/checkpoint/controllercerts.bak
+# does not exist on the device.
+
 # generate new controller certificate
 eden utils gen-signing-cert -o /tmp/signing-new.pem
 
@@ -26,6 +41,20 @@ eden utils gen-signing-cert -o /tmp/signing-new.pem
 eden adam change-signing-cert --cert-file /tmp/signing-new.pem
 
 # wait for changes to be applied
+test eden.lim.test -test.v -timewait 15m -test.run TestLog -out content 'content:Rebuilding.intended.global.config,.reasons:.updating.app.connectivity'
+
+# second rotation: the cert installed by the first rotation is now in
+# controllercerts.bak, so this exercises the backup-fallback path in
+# VerifyAuthContainerHeader as well as the .bak refresh inside
+# MaybeSaveControllerCerts.
+
+# generate another new controller certificate (overwrites /tmp/signing-new.pem)
+eden utils gen-signing-cert -o /tmp/signing-new.pem
+
+# upload the second new certificate to the controller and reapply config
+eden adam change-signing-cert --cert-file /tmp/signing-new.pem
+
+# wait for the second rotation to be applied
 test eden.lim.test -test.v -timewait 15m -test.run TestLog -out content 'content:Rebuilding.intended.global.config,.reasons:.updating.app.connectivity'
 
 eden pod deploy -n eclient2 --memory=512MB --networks=n1 {{template "eclient_image"}} --metadata={{$userdata}}


### PR DESCRIPTION
## Summary

Extend `ctrl_cert_change` to perform two consecutive controller signing
certificate rotations between the initial `eclient1` deploy and the
`eclient2` deploy, so that both cases of `/persist/checkpoint/controllercerts.bak`
on the device are covered.

1. A brand new device (or just updated to EVE post PR https://github.com/lf-edge/eve/pull/5584) does not have a controllercerts. bak, and the controller signing cert is rotated on the controller.
2. A device (running post EVE PR https://github.com/lf-edge/eve/pull/5584) with a controllercerts.bak (e.g., due to having already gone through one cert rotation) sees a signing cert rotation.

## Motivation

The first form of this test detecting a real EVE bug:
when `.bak` does not exist, the backup attempt in
`VerifyAuthContainerHeader` returned `SenderStatusNone` from
`LoadSavedServerSigningCert` (file-not-found), which clobbers the
original `SenderStatusCertMiss` produced by the primary attempt.
Callers in zedagent then fall through to the `default` case instead
of `case types.SenderStatusCertMiss:`, so `triggerControllerCertEvent`
never fires, EVE never fetches the rotated cert, and the test ends up
timing out waiting for the rebuild log. See
[run 25392481670](https://github.com/lf-edge/eve/actions/runs/25392481670/job/74470441520)
for an example failure.

The fix is on the EVE side (https://github.com/lf-edge/eve/pull/5906). With both
rotations in place, this test will:

- exercise the cert-fetch trigger path (the first form) **and**
- exercise the backup-cert-load path (the second form)

so that any future regression that breaks either branch fails the
test rather than silently passing.

## Test plan

- [x] Smoke (ext4, true) on EVE master with the `authen.go`
      `SenderStatusCertMiss`-preservation fix applied — both rotations
      should complete inside the 15m windows.
- [x] Smoke (ext4, true) on EVE master *without* the fix — rotation 1
      should still time out (regression confirmation).
- [x] Smoke (zfs, true) and Smoke (\*, false) for parity with the
      existing matrix entries.
- [ ] Confirm in the captured device logs that
      `MaybeSaveControllerCerts updated the certs` appears after each
      rotation and that `controllercerts.bak worked` appears on the
      second rotation (or, equivalently, that the `controllercerts.bak`
      file size is non-zero after the run).

## Notes for reviewers

- `gen-signing-cert` always reads `signing.pem`/`signing-key.pem` from
  edenHome and only varies `NotBefore`/`NotAfter`
  (`pkg/utils/x509.go:GenServerCertFromPrevCertAndKey`). Two
  back-to-back invocations produce two distinct certs because the
  timestamps differ, so the second `change-signing-cert` is a real
  rotation, not a no-op.
- `check_sign_cert.sh` is unchanged. It compares EVE's installed
  cert against `/tmp/signing-new.pem`, which after the second
  rotation holds the second new cert (overwritten by the second
  `gen-signing-cert -o /tmp/signing-new.pem`), so the existing check
  still validates the correct end state.
- Total test runtime grows by up to one extra 15m TestLog window in
  the worst case. The window can be tightened later if warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)