### PR TITLE
eden: rotate ECDSA keypair on controller signing-cert change

### DIFF
--- a/cmd/adam.go
+++ b/cmd/adam.go
@@ -95,25 +95,37 @@ func newStatusAdamCmd() *cobra.Command {
 }
 
 func newChangeCertCmd() *cobra.Command {
-	var certFile string
+	var certFile, keyFile string
 
 	var changeCertCmd = &cobra.Command{
 		Use:   "change-signing-cert",
 		Short: "change signing certificate for adam",
-		Long:  `Set Adam's signing certificate from a file.`,
+		Long: `Set Adam's signing certificate from a file. If --key-file is
+provided, the matching private key is also installed and used to re-encrypt
+configs; otherwise only the certificate is rotated and the existing
+signing-key.pem is reused.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			certData, err := os.ReadFile(certFile)
 			if err != nil {
 				log.Fatalf("Failed to read certificate file: %s", err)
 			}
 
-			if err := openEVEC.ChangeSigningCert(certData); err != nil {
+			var keyData []byte
+			if keyFile != "" {
+				keyData, err = os.ReadFile(keyFile)
+				if err != nil {
+					log.Fatalf("Failed to read key file: %s", err)
+				}
+			}
+
+			if err := openEVEC.ChangeSigningCert(certData, keyData); err != nil {
 				log.Fatalf("Failed to upload certificate to adam: %s", err)
 			}
 		},
 	}
 
-	changeCertCmd.Flags().StringVarP(&certFile, "cert-file", "", "", "path to the signing certificate file")
+	changeCertCmd.Flags().StringVarP(&certFile, "cert-file", "", "", "path to the new signing certificate file")
+	changeCertCmd.Flags().StringVar(&keyFile, "key-file", "", "path to the new signing private key (optional; if omitted, the existing key is reused)")
 
 	return changeCertCmd
 }

--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eden/pkg/eden"
@@ -50,17 +51,22 @@ func newCertsCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 }
 
 func newGenSigningCertCmd() *cobra.Command {
-	var certPath string
+	var certPath, keyPath string
 
 	var certsCmd = &cobra.Command{
 		Use:   "gen-signing-cert",
 		Short: "generate new signing certificate for controller",
-		Long:  `Generate a new signing certificate for the controller using the same signing key`,
+		Long: `Generate a fresh ECDSA P-256 key pair and a signing certificate
+containing the new public key, signed by the eden root CA. The cert is
+written to --out and the matching private key to --key-out.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := utils.GenServerCertFromPrevCertAndKey(certPath); err != nil {
+			if keyPath == "" {
+				keyPath = strings.TrimSuffix(certPath, ".pem") + "-key.pem"
+			}
+			if err := utils.GenServerCertWithNewKey(certPath, keyPath); err != nil {
 				log.Errorf("cannot generate signing cert: %s", err)
 			} else {
-				log.Info("GenServerCertEllipticFromPrevCertAndKey done")
+				log.Infof("Generated signing cert at %s and key at %s", certPath, keyPath)
 			}
 		},
 	}
@@ -71,6 +77,7 @@ func newGenSigningCertCmd() *cobra.Command {
 	}
 
 	certsCmd.Flags().StringVarP(&certPath, "out", "o", filepath.Join(edenHome, defaults.DefaultCertsDist, "signing-new.pem"), "certificate output path")
+	certsCmd.Flags().StringVar(&keyPath, "key-out", "", "private-key output path (default: <out> with .pem replaced by -key.pem)")
 
 	return certsCmd
 }

--- a/pkg/openevec/adam.go
+++ b/pkg/openevec/adam.go
@@ -33,8 +33,15 @@ func (openEVEC *OpenEVEC) AdamStart() error {
 	return nil
 }
 
-// ChangeSigningCert uploads the provided signing certificate to the OpenEVEC controller.
-func (openEVEC *OpenEVEC) ChangeSigningCert(newSignCert []byte) error {
+// ChangeSigningCert uploads the provided signing certificate to the OpenEVEC
+// controller and re-encrypts existing configs against the new cipher context.
+//
+// If newSignKey is non-nil it is treated as the private key matching
+// newSignCert: re-encryption uses the new key for the new cipher context, and
+// the new key is installed on disk as signing-key.pem after re-encryption
+// completes. If newSignKey is nil the existing on-disk key is reused, which
+// matches the historical "rotate cert metadata only" behavior.
+func (openEVEC *OpenEVEC) ChangeSigningCert(newSignCert, newSignKey []byte) error {
 	changer := &adamChanger{}
 	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
 	if err != nil {
@@ -42,11 +49,20 @@ func (openEVEC *OpenEVEC) ChangeSigningCert(newSignCert []byte) error {
 	}
 
 	// we need to re-encrypt existing configs with the new certificate because EVE has support only for one server signing certificate
-	err = reencryptConfigs(ctrl, dev, newSignCert)
+	err = reencryptConfigs(ctrl, dev, newSignCert, newSignKey)
 	if err != nil {
 		return fmt.Errorf("failed to reencrypt existing configs: %w", err)
 	}
 
+	// Push the re-encrypted configs to adam *before* rotating signing.pem /
+	// signing-key.pem on disk. Adam's redis now holds cipher contexts that
+	// reference the new cert hash, while adam still signs auth-containers
+	// with the old key/cert. EVE's next config pull verifies the auth
+	// container against its saved cert and then sees a cipher-context that
+	// references an unknown cert hash, which is what triggers
+	// SenderStatusCertMiss and the /certs fetch on the device side. The
+	// on-disk swap below makes adam's subsequent responses use the new
+	// signing material.
 	if err = changer.setControllerAndDev(ctrl, dev); err != nil {
 		return fmt.Errorf("setControllerAndDev: %w", err)
 	}
@@ -57,8 +73,41 @@ func (openEVEC *OpenEVEC) ChangeSigningCert(newSignCert []byte) error {
 	}
 	globalCertsDir := filepath.Join(edenHome, defaults.DefaultCertsDist)
 	signingCertPath := filepath.Join(globalCertsDir, "signing.pem")
+	signingKeyPath := filepath.Join(globalCertsDir, "signing-key.pem")
 
-	if err = os.WriteFile(signingCertPath, newSignCert, 0644); err != nil {
+	// Both writes go through atomicWriteFile so a crash mid-write cannot
+	// leave a truncated signing.pem or signing-key.pem on disk; each file
+	// is either fully old or fully new.
+	//
+	// The two files are still rotated independently, so there is a brief
+	// window where adam may serve a (new key, old cert) pair: adam's
+	// prepareEnvelope reads the cert and the key from disk in two separate
+	// os.ReadFile calls (apiHandlerv2.go:364 and :376). A request that
+	// races between our two renames below can therefore produce an
+	// auth-container whose signature does not verify against the cert hash
+	// it claims. EVE retries config requests on signature mismatch, so a
+	// single dropped response is recoverable, but the residual race is
+	// real and worth documenting.
+	//
+	// Writing the key before the cert means adam never serves (new cert,
+	// old key) - the inverse skew - which would have the same effect; the
+	// ordering choice is largely cosmetic given the residual race above.
+	if len(newSignKey) > 0 {
+		if err = atomicWriteFile(signingKeyPath, newSignKey, 0600); err != nil {
+			return fmt.Errorf("cannot write signing key to %s: %w", signingKeyPath, err)
+		}
+	}
+	if err = atomicWriteFile(signingCertPath, newSignCert, 0644); err != nil {
+		// The key on disk is now the new key but the cert is the old one.
+		// A subsequent ChangeSigningCert call will read this stale cert as
+		// "old" while reading the new key as the "old" controller key,
+		// which silently produces a wrong oldCryptoConfig. Surface the
+		// inconsistency loudly so the operator knows manual recovery
+		// (re-running the full rotation, or reverting signing-key.pem) is
+		// required.
+		if len(newSignKey) > 0 {
+			log.Errorf("INCONSISTENT STATE: signing-key.pem was rotated but signing.pem failed to write to %s. Re-run change-signing-cert to recover.", signingCertPath)
+		}
 		return fmt.Errorf("cannot write signing cert to %s: %w", signingCertPath, err)
 	}
 
@@ -66,7 +115,45 @@ func (openEVEC *OpenEVEC) ChangeSigningCert(newSignCert []byte) error {
 	return nil
 }
 
-func reencryptConfigs(ctrl controller.Cloud, dev *device.Ctx, newSignCert []byte) error {
+// atomicWriteFile writes data to path via a tmpfile in the same directory
+// followed by an atomic os.Rename. The tmpfile is fsynced before rename so
+// a crash post-rename cannot lose the new content. The destination's mode
+// is set to perm regardless of umask.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create tmp in %s: %w", dir, err)
+	}
+	tmpName := tmp.Name()
+	// On any error below, ensure the tmpfile is cleaned up.
+	defer func() {
+		// os.Remove on a non-existent file (after a successful rename)
+		// returns ENOENT, which we ignore.
+		_ = os.Remove(tmpName)
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write %s: %w", tmpName, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("sync %s: %w", tmpName, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", tmpName, err)
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return fmt.Errorf("chmod %s to %o: %w", tmpName, perm, err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename %s to %s: %w", tmpName, path, err)
+	}
+	return nil
+}
+
+func reencryptConfigs(ctrl controller.Cloud, dev *device.Ctx, newSignCert, newSignKey []byte) error {
 	// get device certificate from the controller
 	devCert, err := ctrl.GetECDHCert(dev.GetID())
 	if err != nil {
@@ -85,19 +172,27 @@ func reencryptConfigs(ctrl controller.Cloud, dev *device.Ctx, newSignCert []byte
 		return fmt.Errorf("DefaultEdenDir: %w", err)
 	}
 	keyPath := filepath.Join(edenHome, defaults.DefaultCertsDist, "signing-key.pem")
-	ctrlPrivKey, err := os.ReadFile(keyPath)
+	oldCtrlPrivBytes, err := os.ReadFile(keyPath)
 	if err != nil {
 		return fmt.Errorf("cannot read %s: %w", keyPath, err)
 	}
 
-	oldCryptoConfig, err := utils.GetCommonCryptoConfig(devCert, oldSignCert, ctrlPrivKey)
-	if err != nil {
-		return fmt.Errorf("GetCommonCryptoConfig: %w", err)
+	// The new ECDH shared secret must be derived from the *new* private key
+	// when a key rotation is requested; otherwise the cipher context written
+	// for the new cert would still be readable with the previous key.
+	newCtrlPrivBytes := oldCtrlPrivBytes
+	if len(newSignKey) > 0 {
+		newCtrlPrivBytes = newSignKey
 	}
 
-	newCryptoConfig, err := utils.GetCommonCryptoConfig(devCert, newSignCert, ctrlPrivKey)
+	oldCryptoConfig, err := utils.GetCommonCryptoConfig(devCert, oldSignCert, oldCtrlPrivBytes)
 	if err != nil {
-		return fmt.Errorf("GetCommonCryptoConfig: %w", err)
+		return fmt.Errorf("GetCommonCryptoConfig (old): %w", err)
+	}
+
+	newCryptoConfig, err := utils.GetCommonCryptoConfig(devCert, newSignCert, newCtrlPrivBytes)
+	if err != nil {
+		return fmt.Errorf("GetCommonCryptoConfig (new): %w", err)
 	}
 
 	cipherCtx, err := utils.CreateCipherCtx(newCryptoConfig)

--- a/pkg/utils/x509.go
+++ b/pkg/utils/x509.go
@@ -107,62 +107,51 @@ func GenServerCertElliptic(cert *x509.Certificate, key *rsa.PrivateKey, serial *
 
 }
 
-// GenServerCertFromPrevCertAndKey generate new signing certificate for the controller using the same signing key and saves it to give path
-func GenServerCertFromPrevCertAndKey(writePath string) error {
+// GenServerCertWithNewKey generates a fresh ECDSA P-256 key pair and a signing
+// certificate containing the new public key, signed by the eden root CA. The
+// cert is written to certPath; the private key is written to keyPath in the
+// same PEM format used by signing-key.pem (EC PARAMETERS + EC PRIVATE KEY).
+//
+// Subject and other template fields are copied from the existing signing.pem
+// so the controller's identity is preserved across the rotation. The serial
+// number is randomized so two consecutive calls always produce two distinct
+// certs even within the same second.
+func GenServerCertWithNewKey(certPath, keyPath string) error {
 	edenHome, err := DefaultEdenDir()
 	if err != nil {
 		return err
 	}
 
-	// Read root cert
 	rootCert, err := ParseCertificate(filepath.Join(edenHome, defaults.DefaultCertsDist, "root-certificate.pem"))
 	if err != nil {
 		return err
 	}
-
-	// Read root key
 	rootKey, err := ParsePrivateKey(filepath.Join(edenHome, defaults.DefaultCertsDist, "root-certificate-key.pem"))
 	if err != nil {
 		return err
 	}
-
-	// Read server cert
 	oldServerCert, err := ParseCertificate(filepath.Join(edenHome, defaults.DefaultCertsDist, "signing.pem"))
 	if err != nil {
 		return err
 	}
 
-	// Read ecdsa server key
-	serverKeyBytes, err := os.ReadFile(filepath.Join(edenHome, defaults.DefaultCertsDist, "signing-key.pem"))
+	newKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return err
-	}
-	var serverKey *ecdsa.PrivateKey
-	for block, rest := pem.Decode(serverKeyBytes); block != nil; block, rest = pem.Decode(rest) {
-		if block.Type == "EC PRIVATE KEY" {
-			serverKey, err = x509.ParseECPrivateKey(block.Bytes)
-			if err != nil {
-				return err
-			}
-			break
-		}
+		return fmt.Errorf("ecdsa.GenerateKey: %w", err)
 	}
 
-	// keep all the same except for dates
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return fmt.Errorf("generate serial number: %w", err)
+	}
+
 	serverTemplate := *oldServerCert
+	serverTemplate.SerialNumber = serial
 	serverTemplate.NotBefore = time.Now().Add(-10 * time.Second)
 	serverTemplate.NotAfter = time.Now().AddDate(10, 0, 0)
 
-	// create new certificate and write it to file
-	serverCert := genCertECDSA(&serverTemplate, rootCert, &serverKey.PublicKey, rootKey)
-	certOut, err := os.Create(writePath)
-	if err != nil {
-		return err
-	}
-	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: serverCert.Raw}); err != nil {
-		return err
-	}
-	return certOut.Close()
+	serverCert := genCertECDSA(&serverTemplate, rootCert, &newKey.PublicKey, rootKey)
+	return WriteToFiles(serverCert, newKey, certPath, keyPath)
 }
 
 // WriteToFiles write cert and key

--- a/tests/eclient/testdata/ctrl_cert_change.txt
+++ b/tests/eclient/testdata/ctrl_cert_change.txt
@@ -32,13 +32,16 @@ eden pod deploy -n eclient1 --memory=512MB --networks=n1 {{template "eclient_ima
 test eden.app.test -test.v -timewait 20m RUNNING eclient1
 
 # first rotation: at this point /persist/checkpoint/controllercerts.bak
-# does not exist on the device.
+# does not exist on the device. Each gen-signing-cert invocation produces
+# a fresh ECDSA P-256 key pair, and change-signing-cert installs both the
+# cert and the matching private key, so this is a real key rotation - not
+# just a refresh of the cert envelope around an unchanged key pair.
 
-# generate new controller certificate
-eden utils gen-signing-cert -o /tmp/signing-new.pem
+# generate new controller signing key pair and certificate
+eden utils gen-signing-cert -o /tmp/signing-new.pem --key-out /tmp/signing-new-key.pem
 
-# upload new certificate to controller, resign old config and reapply it
-eden adam change-signing-cert --cert-file /tmp/signing-new.pem
+# upload new certificate and key to controller, resign old config and reapply it
+eden adam change-signing-cert --cert-file /tmp/signing-new.pem --key-file /tmp/signing-new-key.pem
 
 # wait for changes to be applied
 test eden.lim.test -test.v -timewait 15m -test.run TestLog -out content 'content:Rebuilding.intended.global.config,.reasons:.updating.app.connectivity'
@@ -48,11 +51,11 @@ test eden.lim.test -test.v -timewait 15m -test.run TestLog -out content 'content
 # VerifyAuthContainerHeader as well as the .bak refresh inside
 # MaybeSaveControllerCerts.
 
-# generate another new controller certificate (overwrites /tmp/signing-new.pem)
-eden utils gen-signing-cert -o /tmp/signing-new.pem
+# generate another fresh key pair and certificate (overwrites the files)
+eden utils gen-signing-cert -o /tmp/signing-new.pem --key-out /tmp/signing-new-key.pem
 
-# upload the second new certificate to the controller and reapply config
-eden adam change-signing-cert --cert-file /tmp/signing-new.pem
+# upload the second new certificate and key to the controller and reapply config
+eden adam change-signing-cert --cert-file /tmp/signing-new.pem --key-file /tmp/signing-new-key.pem
 
 # wait for the second rotation to be applied
 test eden.lim.test -test.v -timewait 15m -test.run TestLog -out content 'content:Rebuilding.intended.global.config,.reasons:.updating.app.connectivity'


### PR DESCRIPTION
## Summary

Stacks on top of #1153. Turns \`gen-signing-cert\` from a cert-envelope refresh
into a real signing-key rotation, so the \`ctrl_cert_change\` smoke test
exercises the full controller-key change rather than just a cert-hash
mismatch on EVE.

Today \`GenServerCertFromPrevCertAndKey\`
([\`pkg/utils/x509.go\`](https://github.com/lf-edge/eden/blob/master/pkg/utils/x509.go))
reuses the existing \`signing-key.pem\` and only varies \`NotBefore\`/\`NotAfter\`,
so the new cert ends up with the same \`SubjectPublicKeyInfo\` as the old one.
The ECDH shared secret derived in \`calculateSymmetricKeyForEcdhAES\` is
therefore identical before and after - rotating the cert on adam changes the
cert-hash that EVE sees, but does not actually rotate the controller signing
key. An attacker holding the previous key would still be able to read freshly
re-encrypted ciphertexts.

## Changes

- **\`pkg/utils/x509.go\`**: replace \`GenServerCertFromPrevCertAndKey\` with
  \`GenServerCertWithNewKey(certPath, keyPath string)\`. Generates a fresh
  ECDSA P-256 keypair, picks a random 128-bit serial, copies the subject
  and other template fields from the existing \`signing.pem\`, signs with
  the eden root CA, and writes the cert plus the matching key (in the
  same \`EC PARAMETERS\` + \`EC PRIVATE KEY\` PEM form used by
  \`signing-key.pem\`, mode 0600) via the existing \`WriteToFiles\` helper.
- **\`cmd/certs.go\`**: \`gen-signing-cert\` gains a \`--key-out\` flag. If
  unset, the path is derived from \`--out\` by replacing the trailing
  \`.pem\` with \`-key.pem\`.
- **\`cmd/adam.go\`**: \`change-signing-cert\` gains an optional \`--key-file\`
  flag. When omitted, the historical cert-only rotation is preserved for
  any external caller.
- **\`pkg/openevec/adam.go\`**: \`ChangeSigningCert\` and \`reencryptConfigs\`
  now thread an optional new private key through. \`oldCryptoConfig\`
  keeps using the on-disk key; \`newCryptoConfig\` uses the new key when
  supplied, so the cipher contexts written for newly-encrypted blocks
  rely on a genuinely different ECDH secret. The new key is written to
  \`signing-key.pem\` _before_ the new cert is written to \`signing.pem\`,
  so adam never observes a (new cert, old key) pair.
- **\`tests/eclient/testdata/ctrl_cert_change.txt\`**: both rotations now
  pass \`--key-out\` to \`gen-signing-cert\` and \`--key-file\` to
  \`change-signing-cert\`.

## Test plan

- [x] Smoke (ext4, true) on EVE master with the upstream
      \`SenderStatusCertMiss\`-preservation fix in \`authen.go\`. Both
      rotations should complete inside the 15m TestLog windows, the
      "Rebuilding intended global config, reasons: updating app
      connectivity" log should fire after each, and \`check_sign_cert.sh\`
      should still succeed because \`/tmp/signing-new.pem\` holds the
      most recent rotation.
- [x] Smoke (zfs, true), Smoke (ext4, false), Smoke (zfs, false) for
      parity with the existing matrix.
- [x] Local: \`go build ./...\`, \`go vet ./...\`, \`gofmt -l\` on the
      touched files (all clean).

## Risks / open questions for reviewers

1. **Adam key-cache behavior.** This change is sound only if adam
   re-reads \`signing-key.pem\` from disk per request (which the
   single-key cert-rotation flow has been quietly relying on for
   \`signing.pem\`). If adam pins the key in memory at startup, the first
   TestLog after the first key rotation will time out with a signature
   verification failure on EVE rather than a cert-miss, and we will
   need to add an adam restart (or a key-reload signal) inside
   \`ChangeSigningCert\`. Filing this PR as draft so this can be
   confirmed in CI. I'm investigating the adam side separately.
2. **Exported Go signature change.** \`ChangeSigningCert\` changes from
   \`(newSignCert []byte)\` to \`(newSignCert, newSignKey []byte)\`. The
   only in-tree caller is the eden CLI itself; no other consumer should
   be affected, but a heads-up in release notes seems prudent.
3. **\`gen-signing-cert\` semantic shift.** Anyone who relied on the
   "preserve the same controller key" behavior will now silently get a
   key rotation. Flag set is back-compat (no flags removed), but the
   underlying behavior is not.

## Stacking

Built on \`ctrl-cert-change-twice\` (PR #1153). Once that lands this can
be rebased onto master; until then please review on top of #1153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)