### PR TITLE
tests/volume: size blank-vol-1 from free space

### DIFF
--- a/tests/volume/testdata/volumes_test.txt
+++ b/tests/volume/testdata/volumes_test.txt
@@ -20,13 +20,14 @@ stdout 'create volume v-vhdx with file://{{EdenConfig "eden.root"}}/empty.vhdx r
 # Wait for ready
 test eden.vol.test -test.v -timewait 15m DELIVERED v-qcow2 v-docker v-qcow v-vmdk v-vhdx
 
-# measure reported total space of persist
+# measure reported space of persist
 exec -t 5m bash wait-and-get-persist-fractions.sh
 source .env
 
-# allocate volume with 3/4 of total persist space; this guarantees blank-vol-2 (half
-# total) cannot fit regardless of pool size or ZFS thin-provisioning overhead.
-eden -t 1m volume create -n blank-vol-1 blank --disk-size=$three_quarter_total
+# allocate volume sized so persist's free space drops just below half_total;
+# guarantees blank-vol-2 (half_total) cannot fit, but blank-vol-1 itself still
+# does — even on ZFS where reservations consume real pool space.
+eden -t 1m volume create -n blank-vol-1 blank --disk-size=$blank_vol_1_size
 test eden.vol.test -test.v -timewait 10m CREATED_VOLUME blank-vol-1
 
 # allocate background info check for volumeErr contains Remaining word
@@ -34,7 +35,7 @@ test eden.lim.test -test.v -timewait 20m -test.run TestInfo -out InfoContent.vin
 
 exec sleep 10
 
-# this volume expected to fail: blank-vol-1 holds 3/4 of persist, leaving less than half
+# this volume expected to fail: free space after blank-vol-1 is below half_total
 eden -t 1m volume create -n blank-vol-2 blank --disk-size=$half_total
 
 # wait for error from the second volume creation process
@@ -116,11 +117,31 @@ cp stdout vol_ls
 
 -- wait-and-get-persist-fractions.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+# Margin (in MB) to leave between blank-vol-1's footprint and the half_total
+# threshold, so ZFS overhead/metadata cannot push the remaining free space
+# back above half_total — which would let blank-vol-2 fit unexpectedly.
+SAFETY_MARGIN_MB=200
 while true; do
-    TOTAL=$($EDEN metric --tail=1 --format=json|jq -r '.dm.disk[] | select(.mountPath=="/persist") | .total')
-    if [ "$TOTAL" -gt 0 ]; then
-        echo half_total="$(( TOTAL*1024*1024/2 ))">>.env
-        echo three_quarter_total="$(( TOTAL*1024*1024*3/4 ))">>.env
+    JSON=$($EDEN metric --tail=1 --format=json)
+    TOTAL_MB=$(echo "$JSON" | jq -r '.dm.disk[] | select(.mountPath=="/persist") | .total')
+    FREE_MB=$(echo "$JSON" | jq -r '.dm.disk[] | select(.mountPath=="/persist") | .free')
+    if [ "$TOTAL_MB" -gt 0 ] && [ "$FREE_MB" -gt 0 ]; then
+        # half_total: blank-vol-2 (and the eclient-mount volume) are sized at
+        # half the pool, which the test expects not to fit alongside blank-vol-1.
+        half_total_mb=$(( TOTAL_MB / 2 ))
+        echo half_total=$(( half_total_mb*1024*1024 ))>>.env
+        # blank_vol_1_size: large enough that the free space remaining after
+        # blank-vol-1 is below half_total (so blank-vol-2 cannot fit), but
+        # bounded by current free space so blank-vol-1 itself still fits.
+        # Require at least one safety margin of headroom over half_total —
+        # so blank_vol_1 ends up with >= 2*SAFETY_MARGIN_MB MB to absorb
+        # zedmanager/ZFS overhead during creation.
+        if [ "$(( FREE_MB - half_total_mb ))" -lt "$SAFETY_MARGIN_MB" ]; then
+            echo "wait-and-get-persist-fractions.sh: insufficient /persist free space for test (free=${FREE_MB} MB, half_total=${half_total_mb} MB, need free >= half_total + ${SAFETY_MARGIN_MB} MB)" >&2
+            exit 1
+        fi
+        blank_vol_1_mb=$(( FREE_MB - half_total_mb + SAFETY_MARGIN_MB ))
+        echo blank_vol_1_size=$(( blank_vol_1_mb*1024*1024 ))>>.env
         exit 0
     fi
     sleep 10


### PR DESCRIPTION
## Summary

- Storage (zfs) Eden test has been failing across PRs because \`blank-vol-1\` sometimes can't be created and sticks in \`INITIAL\` until the 10-minute timeout. Same signature shows up on completely unrelated PRs (e.g. CI workflow-only changes), confirming it's not caused by any specific PR.
- Root cause: after [c76eb7e](https://github.com/lf-edge/eden/commit/c76eb7e) sized \`blank-vol-1\` at \`3/4 * total\`, the v-* volumes that run earlier in the suite have already consumed pool space on ZFS, so 3/4 of the original total can exceed actual free space. ext4 is unaffected because its volumes are sparse qcow2 files.
- Fix: query \`free\` (in addition to \`total\`) from \`eden metric\` at the moment the script runs. Compute \`blank_vol_1_size = free - half_total + 200 MB\` so:
  - blank-vol-1 itself fits (\`blank_vol_1_size <= free\`),
  - the remaining free is just below \`half_total\` (\`free - blank_vol_1_size = half_total - 200 MB\`), so blank-vol-2 (\`half_total\`) cannot fit — independent of pool size or ZFS reservation overhead.
- Bail out with a clear message if free \\<= half_total at script time, since the test isn't meaningful then.

## Test plan

- [ ] Storage (zfs) job passes on a re-run of an open eve PR that previously hit the \`blank-vol-1 stuck in INITIAL\` failure.
- [ ] Storage (ext4) job continues to pass (still uses sparse qcow2; unaffected).
- [ ] EVE Upgrade (zfs) and Smoke (zfs, true/false) — sanity check, since they share the runner pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)