### PR TITLE
[13.4-stable] backport test robustness fixes from master

### DIFF
--- a/tests/app/testdata/purge_not_activated_test.txt
+++ b/tests/app/testdata/purge_not_activated_test.txt
@@ -1,0 +1,164 @@
+# Test that purge succeeds for an app that was never activated (image download failed).
+#
+# Regression test for EVE commit a1582bb40 ("zedmanager: fix purge stuck when app
+# was never activated").
+#
+# The bug: when a purge was triggered for an app whose image failed to download
+# (so no domain was ever created), the old code left PurgeInprogress=BringDown
+# without calling purgeCmdDone.  This caused the app to get stuck at LOADED with
+# VerifyOnly=true indefinitely because volumemgr was never told to create the
+# volume.
+#
+# Test sequence:
+#   1. Deploy an app with a nonexistent image tag so the download fails and the
+#      app never activates (no domain is created).
+#   2. After confirming the app is not RUNNING, apply a single atomic config
+#      update that fixes the image tag, generates fresh volume/content-tree UUIDs
+#      (as "eden pod purge" would), and increments the purge counter.
+#   3. Verify the app eventually reaches RUNNING state.  Without the fix the app
+#      would remain stuck at LOADED indefinitely.
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:grep] stop
+[!exec:jq] stop
+[!exec:uuidgen] stop
+
+# Starting of reboot detector with a 1 reboot limit
+! test eden.reboot.test -test.v -timewait=0 -reboot=0 -count=1 &
+
+message 'Resetting of EVE'
+eden eve reset
+exec sleep 30
+
+# Deploy an app with a deliberately invalid image tag.
+# The tag "purge-test-nonexistent-99999" does not exist, so EVE will fail to
+# resolve the manifest and the app will never be activated.
+eden -t 1m pod deploy -n bad-image-app docker://nginx:purge-test-nonexistent-99999 --memory 512MB
+stdout 'deploy pod bad-image-app'
+
+# Give EVE time to attempt manifest resolution and fail.
+# We intentionally do NOT wait for RUNNING – that would defeat the test.
+exec sleep 90
+
+# Confirm the app is not RUNNING (it never activated).
+eden pod ps
+cp stdout pod_ps
+! grep '^bad-image-app\s.*RUNNING' pod_ps
+
+# Apply the fix atomically:
+#   - fix the image tag (nginx:stable instead of the nonexistent one)
+#   - generate fresh ContentTree and Volume UUIDs (forces EVE to create new volumes)
+#   - increment the purge counter
+# This replicates what "eden pod purge" does while simultaneously fixing the
+# image URL, exactly matching the bug scenario.
+exec -t 2m bash fix-and-purge.sh bad-image-app
+
+# With the EVE fix, the purge completes and the app reaches RUNNING.
+# Without the fix the app would remain stuck at LOADED indefinitely (the test
+# would time out here).
+test eden.app.test -test.v -timewait 15m RUNNING bad-image-app
+
+# Cleanup.
+eden pod delete bad-image-app
+test eden.app.test -test.v -timewait 5m - bad-image-app
+
+-- fix-and-purge.sh --
+#!/bin/sh
+# fix-and-purge.sh <app-name>
+#
+# Atomically update the EVE device config to:
+#   1. Replace the failing ContentTree with a new one (same repo, tag "stable",
+#      new UUID so EVE treats it as a fresh download).
+#   2. Assign a new UUID to the app's volume (as "eden pod purge" does).
+#   3. Increment the purge counter on the app.
+#
+# This is the minimal combination needed to reproduce and verify the fix for EVE
+# commit a1582bb40: purge of an app that was never activated (no domain created).
+
+APP="${1:-bad-image-app}"
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+$EDEN controller edge-node get-config --file device.cfg
+
+# --- locate old UUIDs ---
+OLD_VOL_UUID=$(jq -r --arg app "$APP" \
+    '.apps[] | select(.displayname == $app) | .volumeRefList[0].uuid' device.cfg)
+
+if [ -z "$OLD_VOL_UUID" ] || [ "$OLD_VOL_UUID" = "null" ]; then
+    echo "ERROR: could not find volume UUID for app '$APP'" >&2
+    exit 1
+fi
+
+OLD_CT_UUID=$(jq -r --arg vuuid "$OLD_VOL_UUID" \
+    '.volumes[] | select(.uuid == $vuuid) | .origin.downloadContentTreeID' device.cfg)
+
+if [ -z "$OLD_CT_UUID" ] || [ "$OLD_CT_UUID" = "null" ]; then
+    echo "ERROR: could not find ContentTree UUID for volume $OLD_VOL_UUID" >&2
+    exit 1
+fi
+
+# --- derive fixed image URL (keep the repo, switch to tag "stable") ---
+OLD_URL=$(jq -r --arg ctuuid "$OLD_CT_UUID" \
+    '.contentInfo[] | select(.uuid == $ctuuid) | .URL' device.cfg)
+
+REPO_BASE="${OLD_URL%:*}"   # e.g. "library/nginx"
+GOOD_URL="${REPO_BASE}:stable"
+
+# --- generate fresh UUIDs ---
+NEW_VOL_UUID=$(uuidgen)
+NEW_CT_UUID=$(uuidgen)
+
+echo "fix-and-purge: old vol=$OLD_VOL_UUID  old ct=$OLD_CT_UUID"
+echo "fix-and-purge: new vol=$NEW_VOL_UUID  new ct=$NEW_CT_UUID"
+echo "fix-and-purge: old URL=$OLD_URL  good URL=$GOOD_URL"
+
+# --- build updated config in a single jq pass ---
+#
+# Four changes:
+#   a) contentInfo: replace old ContentTree entry with new UUID + fixed URL + cleared sha256.
+#      All other fields (dsId, iformat, etc.) are preserved via ". + {...}" merge.
+#   b) volumes: give the app's volume a new UUID and point it at the new ContentTree.
+#   c) apps.volumeRefList: update the volume reference to the new UUID.
+#   d) apps.purge.counter: increment so EVE enters PurgeInprogress=DownloadAndVerify.
+jq --arg app       "$APP" \
+   --arg old_vuuid  "$OLD_VOL_UUID" \
+   --arg new_vuuid  "$NEW_VOL_UUID" \
+   --arg old_ctuuid "$OLD_CT_UUID" \
+   --arg new_ctuuid "$NEW_CT_UUID" \
+   --arg good_url   "$GOOD_URL" \
+   '
+   .contentInfo = (.contentInfo | map(
+     if .uuid == $old_ctuuid then
+       . + {"uuid": $new_ctuuid, "URL": $good_url, "sha256": ""}
+     else . end
+   )) |
+   .volumes = (.volumes | map(
+     if .uuid == $old_vuuid then
+       . + {"uuid": $new_vuuid,
+            "origin": (.origin + {"downloadContentTreeID": $new_ctuuid})}
+     else . end
+   )) |
+   .apps = (.apps | map(
+     if .displayname == $app then
+       .volumeRefList = (.volumeRefList | map(
+         if .uuid == $old_vuuid then .uuid = $new_vuuid else . end
+       )) |
+       .purge = {"counter": ((.purge.counter // 0) + 1)}
+     else . end
+   ))
+   ' device.cfg > device_fixed.cfg
+
+$EDEN controller edge-node set-config --file device_fixed.cfg
+echo "fix-and-purge: config updated, purge counter incremented"
+
+-- eden-config.yml --
+{{/* Test's config file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/eclient/testdata/ctrl_cert_change.txt
+++ b/tests/eclient/testdata/ctrl_cert_change.txt
@@ -26,7 +26,7 @@ eden utils gen-signing-cert -o /tmp/signing-new.pem
 eden adam change-signing-cert --cert-file /tmp/signing-new.pem
 
 # wait for changes to be applied
-test eden.lim.test -test.v -timewait 15m -test.run TestLog -out content 'content:Rebuilding.intended.global.config,.reasons:.reconnecting.app'
+test eden.lim.test -test.v -timewait 15m -test.run TestLog -out content 'content:Rebuilding.intended.global.config,.reasons:.updating.app.connectivity'
 
 eden pod deploy -n eclient2 --memory=512MB --networks=n1 {{template "eclient_image"}} --metadata={{$userdata}}
 

--- a/tests/eclient/testdata/eclient.txt
+++ b/tests/eclient/testdata/eclient.txt
@@ -40,10 +40,13 @@ test:
 
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-for i in `seq 20`
-do
-  sleep 20
+END=$(($(date +%s) + 18*60))
+i=0
+while [ "$(date +%s)" -lt "$END" ]; do
+  i=$((i+1))
   # Test SSH-access to container
   echo $i\) $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep Ubuntu /etc/issue
-  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep Ubuntu /etc/issue && break
+  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep Ubuntu /etc/issue && exit 0
+  sleep 10
 done
+exit 1

--- a/tests/eclient/testdata/metadata.txt
+++ b/tests/eclient/testdata/metadata.txt
@@ -17,12 +17,11 @@ eden pod deploy -n eclient --memory=512MB {{template "eclient_image"}} -p {{$por
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 
 message 'Waiting for AppInstMetadata'
-# Use eden.lim.test for access Infos with timewait 10m in background
-test eden.lim.test -test.v -timewait 10m -test.run TestInfo -out InfoContent.amdinfo.data 'InfoContent.amdinfo.data:world' &
+# Start listener before SSH so we capture the immediate info EVE sends on metadata receipt
+test eden.lim.test -test.v -timewait 20m -test.run TestInfo -out InfoContent.amdinfo.data 'InfoContent.amdinfo.data:world' &
 
 exec -t 20m bash ssh.sh
 
-# wait for detector
 wait
 stdout '{"hello":"world"}'
 
@@ -44,10 +43,13 @@ test:
 
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-for i in `seq 20`
-do
-  sleep 20
+END=$(($(date +%s) + 18*60))
+i=0
+while [ "$(date +%s)" -lt "$END" ]; do
+  i=$((i+1))
   # Test SSH-access to container
   echo $i\) $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} curl --header \"Content-Type: application/json\" --request POST -d \'{\"hello\":\"world\"}\' 169.254.169.254/eve/v1/kubeconfig
-  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} curl --header \"Content-Type: application/json\" --request POST -d \'{\"hello\":\"world\"}\' 169.254.169.254/eve/v1/kubeconfig && break
+  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} curl --header \"Content-Type: application/json\" --request POST -d \'{\"hello\":\"world\"}\' 169.254.169.254/eve/v1/kubeconfig && exit 0
+  sleep 10
 done
+exit 1

--- a/tests/eclient/testdata/nginx.txt
+++ b/tests/eclient/testdata/nginx.txt
@@ -52,7 +52,7 @@ done
 -- server_ip.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 for i in $(seq 30); do
-  IP=$($EDEN pod ps | grep "^$1[[:space:]]" | awk '{print $4}')
+  IP=$($EDEN pod ps | grep "^$1[[:space:]]" | awk '{print $4}' | cut -d: -f1)
   if [ -n "$IP" ] && [ "$IP" != "-" ]; then
     echo "Server IP = $IP (attempt $i)"
     echo "export ESERVER_IP=$IP" > env

--- a/tests/eclient/testdata/nginx.txt
+++ b/tests/eclient/testdata/nginx.txt
@@ -19,7 +19,7 @@ exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
 
 eden pod deploy -n eclient --memory=512MB {{template "eclient_image"}} -p {{template "port"}}:22
 
-eden pod deploy -n {{$server}} --memory=512MB docker://nginx:latest
+eden pod deploy -n {{$server}} --memory=512MB docker://nginx:latest -p 8080:80
 
 test eden.app.test -test.v -timewait 20m RUNNING eclient {{$server}}
 
@@ -27,10 +27,10 @@ exec -t 20m bash wait_ssh.sh
 
 eden pod ps
 cp stdout pod_ps
-exec bash server_ip.sh {{$server}}
+exec -t 5m bash server_ip.sh {{$server}}
 
 exec sleep 10
-exec -t 1m bash run_client.sh
+exec -t 2m bash run_client.sh
 stdout '{{$test_msg}}'
 
 eden pod delete eclient
@@ -51,7 +51,18 @@ done
 
 -- server_ip.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-echo export ESERVER_IP=$(grep "^$1\s" pod_ps | awk '{print $4}') > env
+for i in $(seq 30); do
+  IP=$($EDEN pod ps | grep "^$1[[:space:]]" | awk '{print $4}')
+  if [ -n "$IP" ] && [ "$IP" != "-" ]; then
+    echo "Server IP = $IP (attempt $i)"
+    echo "export ESERVER_IP=$IP" > env
+    exit 0
+  fi
+  echo "Waiting for server IP (attempt $i, got '$IP')..."
+  sleep 10
+done
+echo "ERROR: Server $1 never got an IP after 30 attempts" >&2
+exit 1
 
 -- run_client.sh --
 . ./env

--- a/tests/eclient/testdata/userdata.txt
+++ b/tests/eclient/testdata/userdata.txt
@@ -38,14 +38,14 @@ exec -t 10s bash generate_userdata.sh
 eden pod deploy -n eclient --memory=512MB --networks=n1 {{template "eclient_image"}} -p {{$port}}:22 --metadata={{$userdata_file}}
 test eden.app.test -test.v -timewait 20m RUNNING eclient
 
-exec -t 40s bash test_injected_file.sh "before_restart"
+exec -t 5m bash test_injected_file.sh "before_restart"
 
-exec -t 40s bash change_injected_file.sh "after_restart"
+exec -t 5m bash change_injected_file.sh "after_restart"
 
 eden pod restart eclient
 test eden.app.test -test.v -timewait 20m -check-new RUNNING eclient
 
-exec -t 100s bash test_injected_file.sh "after_restart"
+exec -t 5m bash test_injected_file.sh "after_restart"
 
 eden pod delete eclient
 
@@ -85,19 +85,28 @@ EOF
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 TEXT=$1
 
-echo $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep -q $TEXT /etc/injected_file.txt
-
-# Retry in case there are connectivity issues
-for i in `seq 30`
-do
-  echo Try $i
-  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep -q $TEXT /etc/injected_file.txt && echo "Success" && break
-  sleep 2
+# Retry until 30s before the exec timeout (exec -t 5m)
+END=$(($(date +%s) + 4*60 + 30))
+i=0
+while [ "$(date +%s)" -lt "$END" ]; do
+  i=$((i+1))
+  echo Try $i: $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep -q $TEXT /etc/injected_file.txt
+  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} grep -q $TEXT /etc/injected_file.txt && echo "Success" && exit 0
+  sleep 5
 done
+exit 1
 
 -- change_injected_file.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 TEXT=$1
 
-echo $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} "echo $TEXT > /etc/injected_file.txt"
-$EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} "echo $TEXT > /etc/injected_file.txt"
+# Retry until 30s before the exec timeout (exec -t 5m)
+END=$(($(date +%s) + 4*60 + 30))
+i=0
+while [ "$(date +%s)" -lt "$END" ]; do
+  i=$((i+1))
+  echo Try $i: $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} "echo $TEXT > /etc/injected_file.txt"
+  $EDEN sdn fwd eth0 {{$port}} -- {{template "ssh"}} "echo $TEXT > /etc/injected_file.txt" && exit 0
+  sleep 5
+done
+exit 1

--- a/tests/flir/image/Dockerfile
+++ b/tests/flir/image/Dockerfile
@@ -1,62 +1,180 @@
-FROM ubuntu:18.04
+# syntax=docker/dockerfile:1
+FROM ubuntu:20.04
 
-ARG ARCHITECTURE="x86_64"
-ARG FLEDGEVERSION="1.8.2"
-ARG OPERATINGSYSTEM="ubuntu1804"
-ARG FLEDGELINK="http://archives.fledge-iot.org/${FLEDGEVERSION}/${OPERATINGSYSTEM}/${ARCHITECTURE}/"
+ARG FLEDGEVERSION="3.1.0"
 
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y \
-    rsyslog=8.32.* \
-    curl=7.58.* \
-    wget=1.19.* \
-    jq=1.5* \
-    procps=2:3.3.* \
-    python3-wheel=0.30.* \
-    automake=1:1.15.* \
-    make=4.1-9* && \
-    wget ${FLEDGELINK}/fledge-${FLEDGEVERSION}-${ARCHITECTURE}.deb && \
-    wget ${FLEDGELINK}/fledge-gui-${FLEDGEVERSION}.deb && \
-    wget ${FLEDGELINK}/fledge-south-modbus-${FLEDGEVERSION}-${ARCHITECTURE}.deb && \
-    wget ${FLEDGELINK}/fledge-south-flirax8-${FLEDGEVERSION}-${ARCHITECTURE}.deb && \
-    wget ${FLEDGELINK}/fledge-south-sinusoid-${FLEDGEVERSION}-${ARCHITECTURE}.deb && \
-    wget ${FLEDGELINK}/fledge-south-opcua-${FLEDGEVERSION}-${ARCHITECTURE}.deb && \
-    wget ${FLEDGELINK}/fledge-south-http-south-${FLEDGEVERSION}-${ARCHITECTURE}.deb && \
-    wget ${FLEDGELINK}/fledge-filter-flirvalidity-${FLEDGEVERSION}-${ARCHITECTURE}.deb && \
-    wget ${FLEDGELINK}/fledge-filter-asset-${FLEDGEVERSION}-${ARCHITECTURE}.deb && \
-    wget ${FLEDGELINK}/fledge-service-notification-${FLEDGEVERSION}-${ARCHITECTURE}.deb && \
-    wget ${FLEDGELINK}/fledge-rule-average-${FLEDGEVERSION}-${ARCHITECTURE}.deb && \
-    wget ${FLEDGELINK}/fledge-rule-outofbound-${FLEDGEVERSION}-${ARCHITECTURE}.deb && \
-    wget ${FLEDGELINK}/fledge-rule-simple-expression-${FLEDGEVERSION}-${ARCHITECTURE}.deb && \
-    wget ${FLEDGELINK}/fledge-notify-asset-${FLEDGEVERSION}-${ARCHITECTURE}.deb && \
-    wget ${FLEDGELINK}/fledge-notify-email-${FLEDGEVERSION}-${ARCHITECTURE}.deb && \
-    wget ${FLEDGELINK}/fledge-north-gcp-${FLEDGEVERSION}-${ARCHITECTURE}.deb && \
-    wget ${FLEDGELINK}/fledge-north-httpc-${FLEDGEVERSION}-${ARCHITECTURE}.deb && \
-    echo '==============================================' && \
-    dpkg-deb -R fledge-${FLEDGEVERSION}-${ARCHITECTURE}.deb fledge-${FLEDGEVERSION}-${ARCHITECTURE} && \
-    sed -i 's/systemctl/echo/g' ./fledge-${FLEDGEVERSION}-${ARCHITECTURE}/DEBIAN/postinst && \
-    dpkg-deb -b fledge-${FLEDGEVERSION}-${ARCHITECTURE} fledge-${FLEDGEVERSION}-${ARCHITECTURE}.deb && \
-    dpkg-deb -R fledge-gui-${FLEDGEVERSION}.deb fledge-gui-${FLEDGEVERSION} && \
-    sed -i 's/service/echo/g' ./fledge-gui-${FLEDGEVERSION}/DEBIAN/preinst && \
-    sed -i 's/service/echo/g' ./fledge-gui-${FLEDGEVERSION}/DEBIAN/postinst && \
-    sed -i 's/grep/echo/g' ./fledge-gui-${FLEDGEVERSION}/DEBIAN/postinst && \
-    sed -i 's/service/echo/g' ./fledge-gui-${FLEDGEVERSION}/DEBIAN/postrm && \
-    dpkg-deb -b fledge-gui-${FLEDGEVERSION} fledge-gui-${FLEDGEVERSION}.deb && \
-    echo '==============================================' && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y ./*.deb && \
-    rm -rf ./*deb
+ENV DEBIAN_FRONTEND=noninteractive \
+    FLEDGE_ROOT=/usr/local/fledge
 
-RUN echo "service rsyslog start" > start.sh && \
-    echo "/etc/init.d/nginx start" >> start.sh && \
-    echo "/usr/local/fledge/bin/fledge start" >> start.sh && \
-    echo "tail -f /dev/null" >> start.sh && \
-    chmod +x start.sh
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+
+# Install dependencies
+RUN apt-get update && apt-get install --no-install-recommends -y curl
+RUN apt-get install --no-install-recommends -y \
+        sudo git ca-certificates curl gnupg lsb-release \
+        libssl-dev avahi-daemon \
+        rsyslog nginx postgresql wget jq procps \
+        libmodbus-dev libmbedtls-dev libjwt-dev \
+        libboost-filesystem-dev libboost-program-options-dev
+RUN apt-get remove -y nodejs npm && \
+    apt-get autoremove -y && \
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install --no-install-recommends -y nodejs && \
+    npm install -g yarn@1.22.22
+
+# Build and install fledge core.
+# requirements.sh installs all C++ and Python build dependencies for the core
+# (cmake, g++, boost, libpq-dev, sqlite3 custom build, krb5, etc.).
+ADD https://github.com/fledge-iot/fledge.git#v${FLEDGEVERSION} /tmp/fledge
+WORKDIR /tmp/fledge
+RUN ./requirements.sh && \
+    env -u FLEDGE_ROOT make -j "$(nproc)" && \
+    env -u FLEDGE_ROOT make install && \
+    cp -r cmake_build /usr/local/fledge/ && \
+    cp -r C /usr/local/fledge/ && \
+    rm -rf /tmp/fledge /tmp/sqlite3-pkg
+
+# Build the Free OPC-UA library as a static library.
+# fledge-south-opcua's requirements.sh references this Dianomic/Kapsch fork.
+# Static build avoids shipping .so files at runtime.
+ADD https://github.com/dianomic/freeopcua.git#Kapsch /tmp/freeopcua
+WORKDIR /tmp/freeopcua
+RUN sed -i 's/SHARED/STATIC/g' CMakeLists.txt && \
+    cmake -S . -B build && \
+    cmake --build build -j "$(nproc)"
+
+ENV FREEOPCUA=/tmp/freeopcua
+
+# Build and install fledge-south-modbus-c
+# (the deb was named fledge-south-modbus; the GitHub repo is fledge-south-modbus-c)
+ADD https://github.com/fledge-iot/fledge-south-modbus-c.git#v${FLEDGEVERSION} /tmp/fledge-south-modbus-c
+RUN cmake -S /tmp/fledge-south-modbus-c -B /tmp/fledge-south-modbus-c/build \
+          -DFLEDGE_INSTALL="${FLEDGE_ROOT}" && \
+    cmake --build /tmp/fledge-south-modbus-c/build -j "$(nproc)" --target install && \
+    rm -rf /tmp/fledge-south-modbus-c
+
+# Build and install fledge-south-FlirAX8 (depends on modbus-c)
+# (capitalization matters: FlirAX8, not flirax8)
+ADD https://github.com/fledge-iot/fledge-south-FlirAX8.git#v${FLEDGEVERSION} /tmp/fledge-south-FlirAX8
+RUN cmake -S /tmp/fledge-south-FlirAX8 -B /tmp/fledge-south-FlirAX8/build \
+          -DFLEDGE_INSTALL="${FLEDGE_ROOT}" && \
+    cmake --build /tmp/fledge-south-FlirAX8/build -j "$(nproc)" --target install && \
+    rm -rf /tmp/fledge-south-FlirAX8
+
+# Build and install fledge-south-opcua (uses FREEOPCUA env set above)
+ADD https://github.com/fledge-iot/fledge-south-opcua.git#v${FLEDGEVERSION} /tmp/fledge-south-opcua
+RUN cmake -S /tmp/fledge-south-opcua -B /tmp/fledge-south-opcua/build \
+          -DFLEDGE_INSTALL="${FLEDGE_ROOT}" && \
+    cmake --build /tmp/fledge-south-opcua/build -j "$(nproc)" --target install && \
+    rm -rf /tmp/fledge-south-opcua /tmp/freeopcua
+
+# Build and install fledge-filter-asset
+# NOTE: fledge-filter-flirvalidity has no public GitHub repo and is omitted.
+ADD https://github.com/fledge-iot/fledge-filter-asset.git#v${FLEDGEVERSION} /tmp/fledge-filter-asset
+RUN cmake -S /tmp/fledge-filter-asset -B /tmp/fledge-filter-asset/build \
+          -DFLEDGE_INSTALL="${FLEDGE_ROOT}" && \
+    cmake --build /tmp/fledge-filter-asset/build -j "$(nproc)" --target install && \
+    rm -rf /tmp/fledge-filter-asset
+
+# Build and install fledge-service-notification.
+# Must be built before rule/notify plugins so its headers are available.
+ADD https://github.com/fledge-iot/fledge-service-notification.git#v${FLEDGEVERSION} /tmp/fledge-service-notification
+RUN cmake -S /tmp/fledge-service-notification -B /tmp/fledge-service-notification/build \
+          -DFLEDGE_INSTALL="${FLEDGE_ROOT}" && \
+    cmake --build /tmp/fledge-service-notification/build -j "$(nproc)" --target install && \
+    cp -r /tmp/fledge-service-notification/C/services/notification/include \
+        /usr/local/fledge/notification-service-include && \
+    rm -rf /tmp/fledge-service-notification
+
+ENV NOTIFICATION_SERVICE_INCLUDE_DIRS=/usr/local/fledge/notification-service-include
+
+# Build and install notification rule plugins
+ADD https://github.com/fledge-iot/fledge-rule-average.git#v${FLEDGEVERSION} /tmp/fledge-rule-average
+RUN cmake -S /tmp/fledge-rule-average -B /tmp/fledge-rule-average/build \
+          -DFLEDGE_INSTALL="${FLEDGE_ROOT}" && \
+    cmake --build /tmp/fledge-rule-average/build -j "$(nproc)" --target install && \
+    rm -rf /tmp/fledge-rule-average
+
+ADD https://github.com/fledge-iot/fledge-rule-outofbound.git#v${FLEDGEVERSION} /tmp/fledge-rule-outofbound
+RUN cmake -S /tmp/fledge-rule-outofbound -B /tmp/fledge-rule-outofbound/build \
+          -DFLEDGE_INSTALL="${FLEDGE_ROOT}" && \
+    cmake --build /tmp/fledge-rule-outofbound/build -j "$(nproc)" --target install && \
+    rm -rf /tmp/fledge-rule-outofbound
+
+ADD https://github.com/fledge-iot/fledge-rule-simple-expression.git#v${FLEDGEVERSION} /tmp/fledge-rule-simple-expression
+RUN cmake -S /tmp/fledge-rule-simple-expression -B /tmp/fledge-rule-simple-expression/build \
+          -DFLEDGE_INSTALL="${FLEDGE_ROOT}" && \
+    cmake --build /tmp/fledge-rule-simple-expression/build -j "$(nproc)" --target install && \
+    rm -rf /tmp/fledge-rule-simple-expression
+
+# Build and install notification delivery plugins
+ADD https://github.com/fledge-iot/fledge-notify-asset.git#v${FLEDGEVERSION} /tmp/fledge-notify-asset
+RUN cmake -S /tmp/fledge-notify-asset -B /tmp/fledge-notify-asset/build \
+          -DFLEDGE_INSTALL="${FLEDGE_ROOT}" && \
+    cmake --build /tmp/fledge-notify-asset/build -j "$(nproc)" --target install && \
+    rm -rf /tmp/fledge-notify-asset
+
+ADD https://github.com/fledge-iot/fledge-notify-email.git#v${FLEDGEVERSION} /tmp/fledge-notify-email
+RUN cmake -S /tmp/fledge-notify-email -B /tmp/fledge-notify-email/build \
+          -DFLEDGE_INSTALL="${FLEDGE_ROOT}" && \
+    cmake --build /tmp/fledge-notify-email/build -j "$(nproc)" --target install && \
+    rm -rf /tmp/fledge-notify-email
+
+# Build and install north plugins
+# (the deb was named fledge-north-httpc; the GitHub repo is fledge-north-http-c)
+ADD https://github.com/eclipse/paho.mqtt.c.git#v1.3.16 /paho.mqtt
+WORKDIR /paho.mqtt
+RUN make PAHO_WITH_SSL=1 && \
+    make install && \
+    ldconfig
+
+ADD https://github.com/fledge-iot/fledge-north-gcp.git#v2.1.0 /tmp/fledge-north-gcp
+RUN cmake -S /tmp/fledge-north-gcp -B /tmp/fledge-north-gcp/build \
+          -DFLEDGE_INSTALL="${FLEDGE_ROOT}" && \
+    cmake --build /tmp/fledge-north-gcp/build -j "$(nproc)" --target install && \
+    rm -rf /tmp/fledge-north-gcp
+
+ADD https://github.com/fledge-iot/fledge-north-http-c.git#v${FLEDGEVERSION} /tmp/fledge-north-http-c
+RUN cmake -S /tmp/fledge-north-http-c -B /tmp/fledge-north-http-c/build \
+          -DFLEDGE_INSTALL="${FLEDGE_ROOT}" && \
+    cmake --build /tmp/fledge-north-http-c/build -j "$(nproc)" --target install && \
+    rm -rf /tmp/fledge-north-http-c
+
+# Install Python south plugins by copying into the fledge plugin tree
+ADD https://github.com/fledge-iot/fledge-south-sinusoid.git#v${FLEDGEVERSION} /tmp/fledge-south-sinusoid
+RUN cp -r /tmp/fledge-south-sinusoid/python/fledge/plugins/south/sinusoid \
+        "${FLEDGE_ROOT}/python/fledge/plugins/south/" && \
+    rm -rf /tmp/fledge-south-sinusoid
+
+# fledge-south-http replaces the discontinued fledge-south-http-south deb package
+ADD https://github.com/fledge-iot/fledge-south-http.git#v${FLEDGEVERSION} /tmp/fledge-south-http
+RUN cp -r /tmp/fledge-south-http/python/fledge/plugins/south/http_south \
+        "${FLEDGE_ROOT}/python/fledge/plugins/south/" && \
+    rm -rf /tmp/fledge-south-http
+
+# Build and deploy fledge-gui
+ADD https://github.com/fledge-iot/fledge-gui.git#v${FLEDGEVERSION} /tmp/fledge-gui
+WORKDIR /tmp/fledge-gui
+RUN yarn install && \
+    ./build --clean-start && \
+    mkdir -p /var/www/html && \
+    cp -r dist/* /var/www/html/ && \
+    cp nginx.conf /etc/nginx/sites-available/fledge-gui && \
+    ln -sf /etc/nginx/sites-available/fledge-gui /etc/nginx/sites-enabled/fledge-gui && \
+    yarn cache clean && \
+    rm -f /etc/nginx/sites-enabled/default && \
+    rm -rf /tmp/fledge-gui /root/.cache /root/.yarn
+
+WORKDIR /
+RUN echo "service rsyslog start" > /start.sh && \
+    echo "/etc/init.d/nginx start" >> /start.sh && \
+    echo "${FLEDGE_ROOT}/bin/fledge start" >> /start.sh && \
+    echo "tail -f /dev/null" >> /start.sh && \
+    chmod +x /start.sh
 
 ENV FLEDGE_ROOT=/usr/local/fledge
 
-# Fledge API and Fledge GUI ports
+# Fledge API, fledge alternate port, nginx (GUI), and fledge GUI port
 EXPOSE 8081 1995 80 6683
 
-
-CMD ["bash", "./start.sh"]
-
+CMD ["bash", "/start.sh"]

--- a/tests/lim/lim_test.go
+++ b/tests/lim/lim_test.go
@@ -59,7 +59,7 @@ func mkquery() error {
 		// we use & to indicate background process
 		a := strings.TrimSuffix(arg, "&")
 		for _, f := range strings.Split(a, " ") {
-			s := strings.Split(f, ":")
+			s := strings.SplitN(f, ":", 2)
 			if len(s) == 1 {
 				if s[0] == "" {
 					continue

--- a/tests/lim/testdata/log_test.txt
+++ b/tests/lim/testdata/log_test.txt
@@ -9,6 +9,9 @@ eden -t 1m controller edge-node update --config agent.debug.debug.remote.logleve
 # wait for the config changes to apply
 exec sleep 15
 
+# wait for EVE's sshd to be ready before starting the log watcher
+exec -t 5m bash wait_ssh.sh
+
 # ssh into EVE to force log creation
 exec -t 5m bash ssh.sh &
 
@@ -28,6 +31,14 @@ test:
         onboard-cert: {{EdenConfigPath "eve.cert"}}
         serial: "{{EdenConfig "eve.serial"}}"
         model: {{EdenConfig "eve.devmodel"}}
+
+-- wait_ssh.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+END=$(($(date +%s) + 5*60))
+until $EDEN eve ssh exit 2>/dev/null; do
+  [ "$(date +%s)" -lt "$END" ] || { echo "sshd not ready after 5m"; exit 1; }
+  sleep 5
+done
 
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}

--- a/tests/lim/testdata/log_test.txt
+++ b/tests/lim/testdata/log_test.txt
@@ -1,5 +1,4 @@
-{{$test1 := "test eden.lim.test -test.v -timewait 25m -test.run TestLog"}}
-{{$test2 := "test eden.lim.test -test.v -timewait 7m -test.run TestLog"}}
+{{$test := "test eden.lim.test -test.v -timewait 25m -test.run TestLog"}}
 
 # save the current config before changing it
 eden -t 1m controller edge-node get-config --file /tmp/full-config.json
@@ -7,23 +6,17 @@ eden -t 1m controller edge-node get-config --file /tmp/full-config.json
 # set the remote log level to info, because the expected message is logged with info level
 eden -t 1m controller edge-node update --config agent.debug.debug.loglevel=info
 eden -t 1m controller edge-node update --config agent.debug.debug.remote.loglevel=info
-# wait for the config changes to apply
-exec sleep 15
 
 # wait for EVE's sshd to be ready before starting the log watcher
 exec -t 5m bash wait_ssh.sh
 
-# Phase 1: wait for EVE's log delivery pipeline to become active (any log entry).
-# After a reboot, the pipeline can be silent for 15+ minutes while startup logs
-# queue up ahead of new entries; we must not start looking for Disconnected until
-# we know fresh entries are reaching the controller.
-{{$test1}} -out content 'content:.+'
+# Give EVE time to fetch and apply the updated config.  On TPM-enabled devices the
+# controller config must pass TPM signature verification before EVE applies it; this
+# can take several minutes, far longer than a short fixed sleep.
+exec sleep 60
 
-# ssh into EVE to force log creation (pipeline is now confirmed active)
-exec -t 8m bash ssh.sh &
-
-# Phase 2: look for the Disconnected message now that the pipeline is known-good
-{{$test2}} -out content 'content:.*Disconnected.*'
+exec -t 27m bash ssh.sh &
+{{$test}} -out content 'content:.*Disconnected.*'
 stdout 'Disconnected from'
 
 # restore the original config
@@ -50,10 +43,11 @@ done
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 # Keep generating SSH connections so the log watcher catches a "Disconnected"
-# message. Run for ~7 minutes (under the 7m timewait for phase 2). testscript
-# sends SIGINT at script end; trap it so the process exits cleanly.
+# message. The exec -t timeout in the caller controls the effective duration;
+# this loop runs until killed. testscript sends SIGINT at script end; trap it
+# so the process exits cleanly.
 trap 'exit 0' TERM INT
-END=$(($(date +%s) + 7*60))
+END=$(($(date +%s) + 60*60))
 while [ "$(date +%s)" -lt "$END" ]; do
     timeout 10 $EDEN eve ssh exit || true
     sleep 10

--- a/tests/lim/testdata/log_test.txt
+++ b/tests/lim/testdata/log_test.txt
@@ -1,4 +1,4 @@
-{{$test1 := "test eden.lim.test -test.v -timewait 10m -test.run TestLog"}}
+{{$test1 := "test eden.lim.test -test.v -timewait 15m -test.run TestLog"}}
 
 # save the current config before changing it
 eden -t 1m controller edge-node get-config --file /tmp/full-config.json
@@ -13,7 +13,7 @@ exec sleep 15
 exec -t 5m bash wait_ssh.sh
 
 # ssh into EVE to force log creation
-exec -t 5m bash ssh.sh &
+exec -t 16m bash ssh.sh &
 
 # Trying to find messages about ssh in log
 {{$test1}} -out content 'content:.*Disconnected.*'
@@ -42,12 +42,15 @@ done
 
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-# Keep generating SSH connections so the log watcher catches a
-# "Disconnected" message regardless of startup timing.
-# Use a finite loop so the script exits cleanly before the
-# background timeout — testscript treats a killed background
-# process as a test failure.
-for i in $(seq 1 15); do
+# Keep generating SSH connections throughout the test window so the log
+# watcher catches a "Disconnected" message regardless of log-delivery
+# delay (e.g. after an EVE restart the first upload batch can be delayed
+# 10+ minutes). Run for ~14 minutes, just under the 15m timewait, so the
+# loop exits before the exec -t deadline. testscript sends SIGINT at
+# script end; trap it so the process exits cleanly with status 0.
+trap 'exit 0' TERM INT
+END=$(($(date +%s) + 14*60))
+while [ "$(date +%s)" -lt "$END" ]; do
     timeout 10 $EDEN eve ssh exit || true
     sleep 10
 done

--- a/tests/lim/testdata/log_test.txt
+++ b/tests/lim/testdata/log_test.txt
@@ -1,4 +1,5 @@
-{{$test1 := "test eden.lim.test -test.v -timewait 15m -test.run TestLog"}}
+{{$test1 := "test eden.lim.test -test.v -timewait 25m -test.run TestLog"}}
+{{$test2 := "test eden.lim.test -test.v -timewait 7m -test.run TestLog"}}
 
 # save the current config before changing it
 eden -t 1m controller edge-node get-config --file /tmp/full-config.json
@@ -12,11 +13,17 @@ exec sleep 15
 # wait for EVE's sshd to be ready before starting the log watcher
 exec -t 5m bash wait_ssh.sh
 
-# ssh into EVE to force log creation
-exec -t 16m bash ssh.sh &
+# Phase 1: wait for EVE's log delivery pipeline to become active (any log entry).
+# After a reboot, the pipeline can be silent for 15+ minutes while startup logs
+# queue up ahead of new entries; we must not start looking for Disconnected until
+# we know fresh entries are reaching the controller.
+{{$test1}} -out content 'content:.+'
 
-# Trying to find messages about ssh in log
-{{$test1}} -out content 'content:.*Disconnected.*'
+# ssh into EVE to force log creation (pipeline is now confirmed active)
+exec -t 8m bash ssh.sh &
+
+# Phase 2: look for the Disconnected message now that the pipeline is known-good
+{{$test2}} -out content 'content:.*Disconnected.*'
 stdout 'Disconnected from'
 
 # restore the original config
@@ -42,14 +49,11 @@ done
 
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-# Keep generating SSH connections throughout the test window so the log
-# watcher catches a "Disconnected" message regardless of log-delivery
-# delay (e.g. after an EVE restart the first upload batch can be delayed
-# 10+ minutes). Run for ~14 minutes, just under the 15m timewait, so the
-# loop exits before the exec -t deadline. testscript sends SIGINT at
-# script end; trap it so the process exits cleanly with status 0.
+# Keep generating SSH connections so the log watcher catches a "Disconnected"
+# message. Run for ~7 minutes (under the 7m timewait for phase 2). testscript
+# sends SIGINT at script end; trap it so the process exits cleanly.
 trap 'exit 0' TERM INT
-END=$(($(date +%s) + 14*60))
+END=$(($(date +%s) + 7*60))
 while [ "$(date +%s)" -lt "$END" ]; do
     timeout 10 $EDEN eve ssh exit || true
     sleep 10

--- a/tests/network/testdata/switch_net_vlans.txt
+++ b/tests/network/testdata/switch_net_vlans.txt
@@ -62,7 +62,7 @@ grep 'app2_ip=10.2.100.\d+' .env
 source .env
 
 # Wait for app2 to obtain test_data from app1
-exec -t 5m bash wait_and_get_recv_data.sh app2 8029
+exec -t 7m bash wait_and_get_recv_data.sh app2 8029
 stdout '{{$test_data}}'
 
 eden pod delete app2
@@ -76,7 +76,7 @@ grep 'app3_ip=10.2.200.\d+' .env
 source .env
 
 # app3 will try to obtain test_data from app1, but it should fail because they are in different VLANs
-exec -t 5m bash wait_and_get_recv_data.sh app3 8030
+exec -t 7m bash wait_and_get_recv_data.sh app3 8030
 ! stdout '{{$test_data}}'
 
 eden pod delete app3
@@ -90,7 +90,7 @@ grep 'app4_ip=10.2.0.\d+' .env
 source .env
 
 # app4 will try to obtain test_data from app1, but it should fail because app1 is inside VLAN while app4 is not
-exec -t 5m bash wait_and_get_recv_data.sh app4 8031
+exec -t 7m bash wait_and_get_recv_data.sh app4 8031
 ! stdout '{{$test_data}}'
 
 # Modify app4 and move it to the VLAN 100
@@ -102,7 +102,7 @@ grep 'app4_ip=10.2.100.\d+' .env
 source .env
 
 # app4 should now be able to obtain test_data from app1
-exec -t 5m bash wait_and_get_recv_data.sh app4 8031
+exec -t 7m bash wait_and_get_recv_data.sh app4 8031
 stdout '{{$test_data}}'
 
 # Cleanup - undeploy applications
@@ -185,14 +185,15 @@ EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "ede
 
 address=http://FWD_IP:FWD_PORT/received-data.html
 
-# wait at most 1 minute for received-data.html to be available
-for i in `seq 12`
-do
-    sleep 5
-    recv_data=$($EDEN sdn fwd eth0 $PORT -- curl -m 10 $address)
-    if [ ! -z "$recv_data" ]; then
+# Wait up to ~4.5 minutes for received-data.html to contain data.
+# The original 1-minute window was insufficient under CI load.
+END=$(($(date +%s) + 4*60 + 30))
+while [ "$(date +%s)" -lt "$END" ]; do
+    recv_data=$($EDEN sdn fwd eth0 $PORT -- curl -m 10 $address 2>/dev/null)
+    if [ -n "$recv_data" ]; then
         break
     fi
+    sleep 5
 done
 $EDEN sdn fwd eth0 $PORT -- curl -m 10 $address
 

--- a/tests/volume/testdata/volumes_test.txt
+++ b/tests/volume/testdata/volumes_test.txt
@@ -20,13 +20,14 @@ stdout 'create volume v-vhdx with file://{{EdenConfig "eden.root"}}/empty.vhdx r
 # Wait for ready
 test eden.vol.test -test.v -timewait 15m DELIVERED v-qcow2 v-docker v-qcow v-vmdk v-vhdx
 
-# measure reported total space of persist
+# measure reported space of persist
 exec -t 5m bash wait-and-get-persist-fractions.sh
 source .env
 
-# allocate volume with 3/4 of total persist space; this guarantees blank-vol-2 (half
-# total) cannot fit regardless of pool size or ZFS thin-provisioning overhead.
-eden -t 1m volume create -n blank-vol-1 blank --disk-size=$three_quarter_total
+# allocate volume sized so persist's free space drops just below half_total;
+# guarantees blank-vol-2 (half_total) cannot fit, but blank-vol-1 itself still
+# does — even on ZFS where reservations consume real pool space.
+eden -t 1m volume create -n blank-vol-1 blank --disk-size=$blank_vol_1_size
 test eden.vol.test -test.v -timewait 10m CREATED_VOLUME blank-vol-1
 
 # allocate background info check for volumeErr contains Remaining word
@@ -34,7 +35,7 @@ test eden.lim.test -test.v -timewait 20m -test.run TestInfo -out InfoContent.vin
 
 exec sleep 10
 
-# this volume expected to fail: blank-vol-1 holds 3/4 of persist, leaving less than half
+# this volume expected to fail: free space after blank-vol-1 is below half_total
 eden -t 1m volume create -n blank-vol-2 blank --disk-size=$half_total
 
 # wait for error from the second volume creation process
@@ -116,11 +117,31 @@ cp stdout vol_ls
 
 -- wait-and-get-persist-fractions.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+# Margin (in MB) to leave between blank-vol-1's footprint and the half_total
+# threshold, so ZFS overhead/metadata cannot push the remaining free space
+# back above half_total — which would let blank-vol-2 fit unexpectedly.
+SAFETY_MARGIN_MB=200
 while true; do
-    TOTAL=$($EDEN metric --tail=1 --format=json|jq -r '.dm.disk[] | select(.mountPath=="/persist") | .total')
-    if [ "$TOTAL" -gt 0 ]; then
-        echo half_total="$(( TOTAL*1024*1024/2 ))">>.env
-        echo three_quarter_total="$(( TOTAL*1024*1024*3/4 ))">>.env
+    JSON=$($EDEN metric --tail=1 --format=json)
+    TOTAL_MB=$(echo "$JSON" | jq -r '.dm.disk[] | select(.mountPath=="/persist") | .total')
+    FREE_MB=$(echo "$JSON" | jq -r '.dm.disk[] | select(.mountPath=="/persist") | .free')
+    if [ "$TOTAL_MB" -gt 0 ] && [ "$FREE_MB" -gt 0 ]; then
+        # half_total: blank-vol-2 (and the eclient-mount volume) are sized at
+        # half the pool, which the test expects not to fit alongside blank-vol-1.
+        half_total_mb=$(( TOTAL_MB / 2 ))
+        echo half_total=$(( half_total_mb*1024*1024 ))>>.env
+        # blank_vol_1_size: large enough that the free space remaining after
+        # blank-vol-1 is below half_total (so blank-vol-2 cannot fit), but
+        # bounded by current free space so blank-vol-1 itself still fits.
+        # Require at least one safety margin of headroom over half_total —
+        # so blank_vol_1 ends up with >= 2*SAFETY_MARGIN_MB MB to absorb
+        # zedmanager/ZFS overhead during creation.
+        if [ "$(( FREE_MB - half_total_mb ))" -lt "$SAFETY_MARGIN_MB" ]; then
+            echo "wait-and-get-persist-fractions.sh: insufficient /persist free space for test (free=${FREE_MB} MB, half_total=${half_total_mb} MB, need free >= half_total + ${SAFETY_MARGIN_MB} MB)" >&2
+            exit 1
+        fi
+        blank_vol_1_mb=$(( FREE_MB - half_total_mb + SAFETY_MARGIN_MB ))
+        echo blank_vol_1_size=$(( blank_vol_1_mb*1024*1024 ))>>.env
         exit 0
     fi
     sleep 10

--- a/tests/volume/testdata/volumes_test.txt
+++ b/tests/volume/testdata/volumes_test.txt
@@ -21,19 +21,20 @@ stdout 'create volume v-vhdx with file://{{EdenConfig "eden.root"}}/empty.vhdx r
 test eden.vol.test -test.v -timewait 15m DELIVERED v-qcow2 v-docker v-qcow v-vmdk v-vhdx
 
 # measure reported total space of persist
-exec -t 5m bash wait-and-get-half-total.sh
+exec -t 5m bash wait-and-get-persist-fractions.sh
 source .env
 
-# allocate volume with size of half total space
-eden -t 1m volume create -n blank-vol-1 blank --disk-size=$half_total
-test eden.vol.test -test.v -timewait 3m CREATED_VOLUME blank-vol-1
+# allocate volume with 3/4 of total persist space; this guarantees blank-vol-2 (half
+# total) cannot fit regardless of pool size or ZFS thin-provisioning overhead.
+eden -t 1m volume create -n blank-vol-1 blank --disk-size=$three_quarter_total
+test eden.vol.test -test.v -timewait 10m CREATED_VOLUME blank-vol-1
 
 # allocate background info check for volumeErr contains Remaining word
-test eden.lim.test -test.v -timewait 3m -test.run TestInfo -out InfoContent.vinfo 'InfoContent.vinfo.volumeErr:Remaining' 'InfoContent.vinfo.displayName:blank-vol-2' &errorwait&
+test eden.lim.test -test.v -timewait 20m -test.run TestInfo -out InfoContent.vinfo 'InfoContent.vinfo.volumeErr:Remaining' 'InfoContent.vinfo.displayName:blank-vol-2' &errorwait&
 
 exec sleep 10
 
-# this volume expected to fail because we cannot create two volumes with half of total persist space
+# this volume expected to fail: blank-vol-1 holds 3/4 of persist, leaving less than half
 eden -t 1m volume create -n blank-vol-2 blank --disk-size=$half_total
 
 # wait for error from the second volume creation process
@@ -113,12 +114,13 @@ cp stdout vol_ls
 ! grep '^blank-vol-2\s*' vol_ls
 ! grep '^eclient-mount\s*' vol_ls
 
--- wait-and-get-half-total.sh --
+-- wait-and-get-persist-fractions.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 while true; do
     TOTAL=$($EDEN metric --tail=1 --format=json|jq -r '.dm.disk[] | select(.mountPath=="/persist") | .total')
     if [ "$TOTAL" -gt 0 ]; then
         echo half_total="$(( TOTAL*1024*1024/2 ))">>.env
+        echo three_quarter_total="$(( TOTAL*1024*1024*3/4 ))">>.env
         exit 0
     fi
     sleep 10

--- a/tests/workflow/user-apps.tests.txt
+++ b/tests/workflow/user-apps.tests.txt
@@ -1,5 +1,5 @@
 # Number of tests
-{{$tests := 8}}
+{{$tests := 9}}
 # EDEN_TEST_SETUP env. var. -- "y"(default) performs the EDEN setup steps
 {{$setup := "n"}}
 {{$setup_env := EdenGetEnv "EDEN_TEST_SETUP"}}
@@ -43,3 +43,6 @@ eden.escript.test -testdata ../app/testdata/ -test.run TestEdenScripts/app_repla
 
 /bin/echo Eden nodered (8/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/nodered
+
+/bin/echo Testing purge of an app that was never activated (9/{{$tests}})
+eden.escript.test -testdata ../app/testdata/ -test.run TestEdenScripts/purge_not_activated_test


### PR DESCRIPTION
Backport of test robustness fixes and a regression test from master.
Same set as #1159 ([14.5-stable]).

## PRs included

- #1143 — eclient/log_test/userdata SSH robustness (2 commits)
- #1144 — log pipeline delays + VLAN retry (4 commits)
- #1149 — nginx server_ip.sh handle IP:PORT format
- #1150 — ctrl_cert_change pattern after `ReconnectApp` → `UpdateAppConn` rename (the EVE-side rename is on 12.0+)
- #1151 — mkquery query-value truncation + ZFS storage-full + log_test TPM delay (3 commits)
- #1133 — `purge_not_activated_test` regression test (regression was introduced after 16.0, so the test serves as a regression-prevention guard here)
- #1146 — rebuild fledge Docker image from GitHub sources (manual port — see below)
- #1155 — size `blank-vol-1` from free space

## Not backported

- #1116 (vector test) — `tests/vector/` does not exist on 13.4.
- newlogd bundle (`18508e6` + #1142 + #1147) — EVE 13.4 lacks `8411d8701` "add support for remote log level to newlogd", so newlogd does not enforce `remote.loglevel = none`; the test would correctly fail. The Eden testkit API the test depends on is also missing on 13.4.

## Conflict resolutions

1. `tests/eclient/testdata/userdata.txt` (#1143 d976210): existing 60s `seq 30 / sleep 2` retry on stable replaced by master's 4m30s time-bounded loop with explicit `exit 1`. Master version strictly better. The same patch also bumps the `exec -t` timeouts from 40s/100s to 5m, applied as part of the same commit.
2. `tests/volume/testdata/volumes_test.txt` (#1151 c76eb7e): `half_total` → `three_quarter_total`. Took master version.

## Manual port: #1146 fledge

The `c42bb5e` cherry-pick does not apply cleanly because the stable
branch had `ubuntu:18.04 / FLEDGEVERSION 1.8.2` while master is now
`ubuntu:20.04 / FLEDGEVERSION 3.1.0`. Adopted master's Dockerfile
verbatim, since the old Dockerfile no longer builds anywhere now that
fledge-iot.org is decommissioned.