### PR TITLE
tests/nodeagent: e2e coverage for reboot paths, restart counter, and disk-space maintenance

### DIFF
--- a/tests/nodeagent/Makefile
+++ b/tests/nodeagent/Makefile
@@ -1,0 +1,65 @@
+DEBUG ?= "debug"
+
+# HOSTARCH is the host architecture
+# ARCH is the target architecture
+# we need to keep track of them separately
+HOSTARCH ?= $(shell uname -m)
+HOSTOS ?= $(shell uname -s | tr A-Z a-z)
+
+# canonicalized names for host architecture
+override HOSTARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(HOSTARCH)))
+
+# unless otherwise set, I am building for my own architecture, i.e. not cross-compiling
+# and for my OS
+ARCH ?= $(HOSTARCH)
+OS ?= $(HOSTOS)
+
+# canonicalized names for target architecture
+override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
+
+WORKDIR ?= $(CURDIR)/../../dist
+TESTDIR := tests/$(shell basename $(CURDIR))
+BINDIR := $(WORKDIR)/bin
+DATADIR := $(WORKDIR)/$(TESTDIR)/
+BIN := eden
+LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
+TESTNAME := eden.escript
+TESTBIN := $(TESTNAME).test
+TESTSCN := eden.nodeagent.tests.txt
+LOCALTESTBIN := $(TESTBIN)-$(OS)-$(ARCH)
+
+.DEFAULT_GOAL := help
+
+clean:
+	rm -rf $(WORKDIR)/$(TESTSCN)
+
+$(BINDIR):
+	mkdir -p $@
+$(DATADIR):
+	mkdir -p $@
+
+test:
+	$(LOCALBIN) test $(CURDIR) -v $(DEBUG)
+
+build: setup
+
+
+setup: $(BINDIR) $(DATADIR)
+	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
+
+.PHONY: test build setup clean all
+
+help:
+	@echo "EDEN is the harness for testing EVE and ADAM"
+	@echo
+	@echo "This Makefile automates commons tasks of EDEN testing"
+	@echo
+	@echo "Commonly used maintenance and development targets:"
+	@echo "   build         build test-binary (OS and ARCH options supported, for ex. OS=linux ARCH=arm64)"
+	@echo "   setup         setup of test environment"
+	@echo "   test          run tests"
+	@echo "   clean         cleanup of test harness"
+	@echo
+	@echo "You need install requirements for EVE (look at https://github.com/lf-edge/eve#install-dependencies)."
+	@echo "Also, you need to install 'uuidgen' utility."
+	@echo "You need access to docker socket and installed qemu packages."

--- a/tests/nodeagent/eden-config.yml
+++ b/tests/nodeagent/eden-config.yml
@@ -1,0 +1,5 @@
+---
+eden:
+
+    # test scenario
+    test-scenario: "eden.nodeagent.tests.txt"

--- a/tests/nodeagent/eden.nodeagent.tests.txt
+++ b/tests/nodeagent/eden.nodeagent.tests.txt
@@ -1,6 +1,6 @@
-eden.escript.test -test.run TestEdenScripts/reset_on_disconnect_link_down -test.timeout 15m
-eden.escript.test -test.run TestEdenScripts/reset_on_disconnect_blackhole -test.timeout 15m
-eden.escript.test -test.run TestEdenScripts/baseos_fallback_link_down -test.timeout 30m
-eden.escript.test -test.run TestEdenScripts/baseos_fallback_blackhole -test.timeout 30m
-eden.escript.test -test.run TestEdenScripts/restart_counter_monotonic -test.timeout 10m
-eden.escript.test -test.run TestEdenScripts/maintenance_no_disk_space -test.timeout 20m
+eden.escript.test -test.run TestEdenScripts/reset_on_disconnect_link_down -test.timeout 45m
+eden.escript.test -test.run TestEdenScripts/reset_on_disconnect_blackhole -test.timeout 45m
+eden.escript.test -test.run TestEdenScripts/baseos_fallback_link_down -test.timeout 45m
+eden.escript.test -test.run TestEdenScripts/baseos_fallback_blackhole -test.timeout 45m
+eden.escript.test -test.run TestEdenScripts/restart_counter_monotonic -test.timeout 20m
+eden.escript.test -test.run TestEdenScripts/maintenance_no_disk_space -test.timeout 40m

--- a/tests/nodeagent/eden.nodeagent.tests.txt
+++ b/tests/nodeagent/eden.nodeagent.tests.txt
@@ -1,0 +1,4 @@
+eden.escript.test -test.run TestEdenScripts/reset_on_disconnect_link_down -test.timeout 15m
+eden.escript.test -test.run TestEdenScripts/reset_on_disconnect_blackhole -test.timeout 15m
+eden.escript.test -test.run TestEdenScripts/baseos_fallback_link_down -test.timeout 30m
+eden.escript.test -test.run TestEdenScripts/baseos_fallback_blackhole -test.timeout 30m

--- a/tests/nodeagent/eden.nodeagent.tests.txt
+++ b/tests/nodeagent/eden.nodeagent.tests.txt
@@ -2,3 +2,5 @@ eden.escript.test -test.run TestEdenScripts/reset_on_disconnect_link_down -test.
 eden.escript.test -test.run TestEdenScripts/reset_on_disconnect_blackhole -test.timeout 15m
 eden.escript.test -test.run TestEdenScripts/baseos_fallback_link_down -test.timeout 30m
 eden.escript.test -test.run TestEdenScripts/baseos_fallback_blackhole -test.timeout 30m
+eden.escript.test -test.run TestEdenScripts/restart_counter_monotonic -test.timeout 10m
+eden.escript.test -test.run TestEdenScripts/maintenance_no_disk_space -test.timeout 20m

--- a/tests/nodeagent/testdata/baseos_fallback_blackhole.txt
+++ b/tests/nodeagent/testdata/baseos_fallback_blackhole.txt
@@ -104,7 +104,12 @@ message 'Asserting last_boot_reason'
 {{$test}} -out InfoContent.dinfo.LastBootReason 'InfoContent.dinfo.LastBootReason:BOOT_REASON_FALLBACK'
 stdout 'BOOT_REASON_FALLBACK'
 
-# Reset config and clear the leftover update.
+# Clear adam's leftover BaseOsConfig for the test version so subsequent
+# tests / suites start with a clean controller-side state.
+eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam:// --os-version={{$short_version}}
+exec sleep 10
+
+# Reset config back to defaults.
 eden eve reset
 
 {{else}}

--- a/tests/nodeagent/testdata/baseos_fallback_blackhole.txt
+++ b/tests/nodeagent/testdata/baseos_fallback_blackhole.txt
@@ -70,6 +70,11 @@ stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs'
 # update path.
 message 'Clearing any stale baseos config from prior runs'
 eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam:// --os-version={{$short_version}}
+
+# Verify the controller config no longer references the removed image
+eden controller edge-node get-config
+! stdout '{{ $short_version }}'
+
 exec sleep 20
 
 # Trigger the update.
@@ -107,6 +112,11 @@ stdout 'BOOT_REASON_FALLBACK'
 # Clear adam's leftover BaseOsConfig for the test version so subsequent
 # tests / suites start with a clean controller-side state.
 eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam:// --os-version={{$short_version}}
+
+# Verify the controller config no longer references the removed image
+eden controller edge-node get-config
+! stdout '{{ $short_version }}'
+
 exec sleep 10
 
 # Reset config back to defaults.

--- a/tests/nodeagent/testdata/baseos_fallback_blackhole.txt
+++ b/tests/nodeagent/testdata/baseos_fallback_blackhole.txt
@@ -1,0 +1,123 @@
+# nodeagent baseos fallback — black-hole variant
+#
+# Companion to baseos_fallback_link_down. Same upgrade-rollback path
+# being tested (BootReasonFallback / handleFallbackOnCloudDisconnect),
+# but the disconnect mechanism is silent packet drop on the controller
+# IP — the more realistic real-world upgrade-rollback trigger, since a
+# fresh EVE image usually does come up with a working interface; what
+# fails is reachability to the controller.
+#
+# Sequence:
+#   1. Trigger an EVE image update.
+#   2. Wait for the device to reboot into the new partition (inprogress).
+#   3. SSH into the new EVE and install an iptables OUTPUT DROP rule
+#      for Adam's IP — link stays up, NIM stays happy, only the
+#      controller goes silent.
+#   4. After timer.update.fallback.no.network elapses, nodeagent
+#      schedules a fallback reboot with BootReasonFallback.
+#   5. Device reboots back to the previous partition; the iptables
+#      rule (in-memory) is gone, so connectivity restores naturally.
+#   6. Assert last_boot_reason=BOOT_REASON_FALLBACK.
+#
+# Only meaningful on device models reachable via eden eve ssh
+# (ZedVirtual-4G, VBox).
+
+{{$devmodel := EdenConfig "eve.devmodel"}}
+{{$adam_ip  := EdenConfig "adam.ip"}}
+
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") }}
+
+# Default EVE version to update to.
+{{$eve_ver := "12.1.0"}}
+{{$eve_registry := "lfedge/eve"}}
+{{$env := EdenGetEnv "EVE_VERSION"}}
+{{if $env}}{{$eve_ver = $env}}{{end}}
+{{$eve_hv := "kvm"}}
+{{$eve_arch := EdenConfig "eve.arch"}}
+{{$short_version := printf "%s-%s-%s" $eve_ver $eve_hv $eve_arch}}
+
+{{$test := "test eden.lim.test -test.v -timewait 30m -test.run TestInfo"}}
+
+# Configure the timers:
+#   - fallback fires after 60s of cloud-gone (minimum allowed)
+#   - test-success deliberately long (default 10min) so fallback wins
+#   - shorten controller polling so the new timer reaches the device
+eden controller edge-node update --config timer.update.fallback.no.network=60
+eden controller edge-node update --config timer.test.baseimage.update=600
+eden controller edge-node update --config timer.config.interval=10
+# Shorten timer.deviceinfo.interval so the device publishes a fresh
+# info to Adam soon after the post-fallback reboot — lim.test's final
+# assertion uses einfo.InfoNew and otherwise waits up to 10min for the
+# next periodic info push.
+eden controller edge-node update --config timer.deviceinfo.interval=30
+
+# Default timer.config.interval is 60s, so wait long enough for the
+# device's next config poll to apply our shorter value. Subsequent
+# config pushes (including eveimage-remove / eveimage-update below)
+# can then rely on 10s polling.
+exec sleep 70
+
+# Pre-fetch the rootfs so the eveimage-update step does not need network.
+message 'EVE image download'
+eden -t 10m utils download eve-rootfs --eve-tag={{$eve_ver}} --eve-hv={{$eve_hv}} --eve-registry={{$eve_registry}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs'
+
+# If a previous test (or a prior run of this one) already attempted an
+# update to the same version and rolled back, EVE will refuse to retry
+# the same version unless we either bump the retry counter or remove
+# the baseos config first. Remove + brief wait gives us a clean state
+# so re-running the test with the same version still exercises the
+# update path.
+message 'Clearing any stale baseos config from prior runs'
+eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam:// --os-version={{$short_version}}
+exec sleep 20
+
+# Trigger the update.
+message 'EVE update request'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam://
+! stderr .
+
+# Wait for the device to come up on the new partition in inprogress state.
+# This is the *post-update test window*; nodeagent has updateInprogress=true.
+message 'Waiting for new partition to be inprogress'
+{{$test}} -out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:inprogress InfoContent.dinfo.SwList[0].ShortVersion:{{ $short_version }}'
+stdout '{{ $short_version }}'
+
+# Black-hole controller traffic on the freshly-booted partition. Link
+# stays up, NIM is happy, only the controller goes silent — exactly
+# the failure mode handleFallbackOnCloudDisconnect is designed for.
+message 'Black-holing controller traffic to trigger fallback'
+# `--` terminates eden's flag parsing so the iptables flags below pass
+# through unmolested to the SSH command.
+eden eve ssh -- iptables -A OUTPUT -d {{$adam_ip}} -j DROP
+
+# Sleep > timer.update.fallback.no.network (60s) + the propagation +
+# minRebootDelay + boot. After the reboot the device is back on the
+# previous partition; the iptables rule (in-memory) is gone with it.
+exec sleep 180
+
+# Verify: nodeagent reported BOOT_REASON_FALLBACK on the next boot.
+# This boot reason is set exclusively by handleFallbackOnCloudDisconnect,
+# so this single assertion is sufficient signal that the upgrade-window
+# fallback path executed end-to-end.
+message 'Asserting last_boot_reason'
+{{$test}} -out InfoContent.dinfo.LastBootReason 'InfoContent.dinfo.LastBootReason:BOOT_REASON_FALLBACK'
+stdout 'BOOT_REASON_FALLBACK'
+
+# Reset config and clear the leftover update.
+eden eve reset
+
+{{else}}
+
+message 'baseos_fallback_blackhole: skipped — device model {{$devmodel}} not supported via eden eve ssh'
+
+{{end}}
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/nodeagent/testdata/baseos_fallback_link_down.txt
+++ b/tests/nodeagent/testdata/baseos_fallback_link_down.txt
@@ -99,7 +99,12 @@ message 'Asserting last_boot_reason'
 {{$test}} -out InfoContent.dinfo.LastBootReason 'InfoContent.dinfo.LastBootReason:BOOT_REASON_FALLBACK'
 stdout 'BOOT_REASON_FALLBACK'
 
-# Reset config back to defaults and clear the leftover update.
+# Clear adam's leftover BaseOsConfig for the test version so subsequent
+# tests / suites start with a clean controller-side state.
+eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam:// --os-version={{$short_version}}
+exec sleep 10
+
+# Reset config back to defaults.
 eden eve reset
 
 {{else}}

--- a/tests/nodeagent/testdata/baseos_fallback_link_down.txt
+++ b/tests/nodeagent/testdata/baseos_fallback_link_down.txt
@@ -61,6 +61,11 @@ stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs'
 # update path.
 message 'Clearing any stale baseos config from prior runs'
 eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam:// --os-version={{$short_version}}
+
+# Verify the controller config no longer references the removed image
+eden controller edge-node get-config
+! stdout '{{ $short_version }}'
+
 exec sleep 20
 
 # Trigger the update.
@@ -102,6 +107,11 @@ stdout 'BOOT_REASON_FALLBACK'
 # Clear adam's leftover BaseOsConfig for the test version so subsequent
 # tests / suites start with a clean controller-side state.
 eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam:// --os-version={{$short_version}}
+
+# Verify the controller config no longer references the removed image
+eden controller edge-node get-config
+! stdout '{{ $short_version }}'
+
 exec sleep 10
 
 # Reset config back to defaults.

--- a/tests/nodeagent/testdata/baseos_fallback_link_down.txt
+++ b/tests/nodeagent/testdata/baseos_fallback_link_down.txt
@@ -1,0 +1,118 @@
+# nodeagent baseos fallback test
+#
+# Exercises BootReasonFallback (handleFallbackOnCloudDisconnect):
+#   1. Trigger an EVE image update.
+#   2. Wait for the device to reboot into the new partition (PartitionState:inprogress).
+#   3. Drop the controller link before the post-update test window expires.
+#   4. After timer.update.fallback.no.network elapses, nodeagent
+#      schedules a fallback reboot with BootReasonFallback.
+#   5. Bring the link back up; the device publishes
+#      last_boot_reason=BOOT_REASON_FALLBACK and lastRebootReason
+#      mentioning the fallback timeout.
+#
+# Only meaningful on device models where Eden can drop the link
+# (ZedVirtual-4G, VBox).
+
+{{$devmodel := EdenConfig "eve.devmodel"}}
+
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") }}
+
+# Default EVE version to update to.
+{{$eve_ver := "12.1.0"}}
+{{$eve_registry := "lfedge/eve"}}
+{{$env := EdenGetEnv "EVE_VERSION"}}
+{{if $env}}{{$eve_ver = $env}}{{end}}
+{{$eve_hv := "kvm"}}
+{{$eve_arch := EdenConfig "eve.arch"}}
+{{$short_version := printf "%s-%s-%s" $eve_ver $eve_hv $eve_arch}}
+
+{{$test := "test eden.lim.test -test.v -timewait 30m -test.run TestInfo"}}
+
+# Configure the timers:
+#   - fallback fires after 60s of cloud-gone (minimum allowed)
+#   - test-success deliberately long (default 10min) so fallback wins
+#   - shorten controller polling so the new timers reach the device
+#     promptly after the post-update reboot.
+eden controller edge-node update --config timer.update.fallback.no.network=60
+eden controller edge-node update --config timer.test.baseimage.update=600
+eden controller edge-node update --config timer.config.interval=10
+# Shorten timer.deviceinfo.interval so the device publishes a fresh
+# info to Adam soon after the post-fallback reboot — lim.test's final
+# assertion uses einfo.InfoNew and otherwise waits up to 10min for the
+# next periodic info push.
+eden controller edge-node update --config timer.deviceinfo.interval=30
+
+# Default timer.config.interval is 60s, so wait long enough for the
+# device's next config poll to apply our shorter value. Subsequent
+# config pushes (including eveimage-remove / eveimage-update below)
+# can then rely on 10s polling.
+exec sleep 70
+
+# Pre-fetch the rootfs so the eveimage-update step does not need network.
+message 'EVE image download'
+eden -t 10m utils download eve-rootfs --eve-tag={{$eve_ver}} --eve-hv={{$eve_hv}} --eve-registry={{$eve_registry}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs'
+
+# If a previous test (or a prior run of this one) already attempted an
+# update to the same version and rolled back, EVE will refuse to retry
+# the same version unless we either bump the retry counter or remove
+# the baseos config first. Remove + brief wait gives us a clean state
+# so re-running the test with the same version still exercises the
+# update path.
+message 'Clearing any stale baseos config from prior runs'
+eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam:// --os-version={{$short_version}}
+exec sleep 20
+
+# Trigger the update.
+message 'EVE update request'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam://
+! stderr .
+
+# Wait for the device to come up on the new partition in inprogress state.
+# This is the *post-update test window*; nodeagent has updateInprogress=true.
+message 'Waiting for new partition to be inprogress'
+{{$test}} -out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:inprogress InfoContent.dinfo.SwList[0].ShortVersion:{{ $short_version }}'
+stdout '{{ $short_version }}'
+
+# Drop the controller link. From this point the device cannot reach
+# Adam, so nodeagent's lastControllerReachableTime stops advancing.
+message 'Dropping controller link to trigger fallback'
+eden eve link down
+
+# Sleep for longer than timer.update.fallback.no.network (60s).
+# A few extra ticks of slack: nodeagent's tick is 10s, and it needs
+# at least one full "still unreachable" tick to cross the threshold,
+# plus minRebootDelay (30s) before zboot.Reset, plus boot.
+exec sleep 180
+
+# Bring the link back up so the device can re-publish its info.
+# By this time the device should already have rebooted into the
+# previous partition.
+message 'Restoring controller link'
+eden eve link up
+
+# Verify: nodeagent reported BOOT_REASON_FALLBACK on the next boot.
+# This boot reason is set exclusively by handleFallbackOnCloudDisconnect,
+# so this single assertion is sufficient signal that the upgrade-window
+# fallback path executed end-to-end.
+message 'Asserting last_boot_reason'
+{{$test}} -out InfoContent.dinfo.LastBootReason 'InfoContent.dinfo.LastBootReason:BOOT_REASON_FALLBACK'
+stdout 'BOOT_REASON_FALLBACK'
+
+# Reset config back to defaults and clear the leftover update.
+eden eve reset
+
+{{else}}
+
+message 'baseos_fallback_test: skipped — device model {{$devmodel}} does not support eden eve link down'
+
+{{end}}
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/nodeagent/testdata/maintenance_no_disk_space.txt
+++ b/tests/nodeagent/testdata/maintenance_no_disk_space.txt
@@ -1,0 +1,181 @@
+# nodeagent maintenance mode on no disk space
+#
+# Exercises MaintenanceModeReasonNoDiskSpace
+# (handleVolumeMgrStatusImpl in pkg/pillar/cmd/nodeagent), end-to-end
+# from volumemgr's RemainingSpace=0 publication through nodeagent's
+# maintenance-mode aggregation, into zedagent's info message, to the
+# controller's view of MaintenanceMode + MaintenanceModeReasons.
+#
+# Mechanism (from the getRemainingDiskSpace formula in
+# pkg/pillar/cmd/volumemgr/sizemgmt.go):
+#
+#   - reservedAppDiskUsage is the sum of declared (max-)sizes of all
+#     volumes in state >= CREATING_VOLUME. A "blank" volume contributes
+#     its --disk-size even though it consumes only sparse on-disk.
+#     We declare one large blank volume sized close to /persist total.
+#
+#   - allowedDeviceDiskSize = deviceDiskSize - Dom0DiskReservedSize.
+#     Dom0DiskReservedSize uses dynamicUsedByDom0 = device.Used -
+#     appDiskUsage when that exceeds the static cap. So filling
+#     /persist/newlog/ with non-app data pushes the dom0 reservation
+#     up dynamically.
+#
+#   - When allowedDeviceDiskSize < reservedAppDiskUsage, volumemgr
+#     publishes VolumeMgrStatus{RemainingSpace: 0}. nodeagent's
+#     handleVolumeMgrStatusImpl then adds
+#     MaintenanceModeReasonNoDiskSpace to the multi-reason set and
+#     publishes NodeAgentStatus{LocalMaintenanceMode: true}.
+#     zedagent forwards this as info.maintenance_mode +
+#     info.maintenance_mode_reasons.
+#
+# Only meaningful on device models reachable via eden eve ssh
+# (ZedVirtual-4G, VBox).
+
+{{$devmodel := EdenConfig "eve.devmodel"}}
+
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") }}
+
+{{$info := "test eden.lim.test -test.v -timewait 10m -test.run TestInfo"}}
+
+# Speed up the test:
+#   - timer.config.interval=10 so subsequent config pushes propagate fast
+#   - timer.deviceinfo.interval=30 so info messages with the new
+#     MaintenanceMode value reach Adam quickly
+#   - timer.metric.diskscan.interval=30 so volumemgr recomputes
+#     RemainingSpace within ~30s of disk usage changing
+eden controller edge-node update --config timer.config.interval=10
+eden controller edge-node update --config timer.deviceinfo.interval=30
+eden controller edge-node update --config timer.metric.diskscan.interval=30
+
+# Default timer.config.interval is 60s; let the new shorter value
+# take effect before relying on it.
+exec sleep 70
+
+# Capture /persist's total size (in bytes) and compute the volume +
+# filler sizes we need. We use ~60% of /persist for the blank volume
+# (must stay below the system-overhead-adjusted limit; observed
+# empirically at ~78% of total) and ~30% for the /persist/newlog
+# filler. With the default 2GB Dom0DiskUsageMaxBytes + 2GB
+# LogRemainToSendMBytes, pushing dynamicUsedByDom0 past the static cap
+# is what tips allowedDeviceDiskSize below reservedAppDiskUsage.
+exec -t 5m bash get-persist-size.sh
+stdout 'three_fifths_total set'
+source .env
+
+# Run the volume-create / fill / assert sequence inside a bash
+# wrapper so cleanup of the multi-GiB filler at /persist/log/ and
+# the blank volume happens unconditionally (via `trap ... EXIT`).
+# The escript dialect has no defer, so without this wrapper a
+# failed assertion would halt the script and leave the filler on
+# disk — wedging /persist for any subsequent test or run.
+exec -t 30m bash run_test.sh
+
+# Give volumemgr a tick + info publish to recompute and clear the
+# maintenance-mode state.
+exec sleep 90
+
+# Assert the device returned to ZDEVICE_STATE_ONLINE. The bool
+# MaintenanceMode field is omitted from proto3 when false, so we
+# don't try to match it directly; the device-state transition is the
+# practical clear-side signal.
+message 'Asserting device returned to ONLINE'
+{{$info}} -out InfoContent.dinfo.state 'InfoContent.dinfo.state:ZDEVICE_STATE_ONLINE'
+
+# Reset config back to defaults.
+eden eve reset
+
+{{else}}
+
+message 'maintenance_no_disk_space: skipped — device model {{$devmodel}} not supported (no eden eve ssh path)'
+
+{{end}}
+
+-- get-persist-size.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+# Wait for at least one device-metric report so we can read /persist's
+# total. Modeled after tests/volume/testdata/volumes_test.txt. TOTAL
+# is reported in MiB.
+for i in $(seq 30); do
+    TOTAL=$($EDEN metric --tail=1 --format=json 2>/dev/null | jq -r '.dm.disk[] | select(.mountPath=="/persist") | .total' 2>/dev/null)
+    if [ -n "$TOTAL" ] && [ "$TOTAL" -gt 0 ] 2>/dev/null; then
+        # Volume disk-size in bytes (3/5 of /persist).
+        echo three_fifths_total="$(( TOTAL * 1024 * 1024 * 3 / 5 ))" > .env
+        # Filler size in MiB (70% of /persist) — fed to dd's count=.
+        # We want a generous margin: empirically 35 % missed by 33 MiB
+        # because dynamicUsedByDom0 depends on EVE's other dom0 overhead
+        # which varies by build / environment. 70 % (~2× the originally
+        # estimated requirement) puts allowed well below the volume's
+        # 60 %-of-/persist MaxVolSize even with significant variance.
+        echo filler_mb="$(( TOTAL * 7 / 10 ))" >> .env
+        echo "three_fifths_total set"
+        exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: never got /persist total"
+exit 1
+
+-- run_test.sh --
+# Disk-pressure test body with unconditional cleanup.
+#
+# Invoked from maintenance_no_disk_space.txt via
+# `exec -t 30m bash run_test.sh`. We declare a blank volume and
+# write a multi-GiB filler at /persist/log/test_filler; both must
+# be torn down whether the assertions pass or fail. The escript
+# dialect has no defer/finally of its own, so the trap below is
+# the cleanup hook of last resort.
+#
+# Env vars $three_fifths_total and $filler_mb come from
+# get-persist-size.sh's .env, picked up by the `source .env`
+# step in the parent testscript (testscript propagates its env
+# to exec children).
+set -euo pipefail
+
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+LIMTEST={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden.lim.test
+VOLTEST={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/eden.vol.test
+
+cleanup() {
+    rc=$?
+    set +e
+    echo "=== cleanup (test rc=$rc) ==="
+    # `rm -f` is a no-op if the filler was never written.
+    # `volume delete` is best-effort: under disk pressure EVE can
+    # take many minutes to finish processing, and the critical
+    # assertions are already done by the time we get here.
+    timeout 30s "$EDEN" eve ssh -- rm -f /persist/log/test_filler
+    timeout 60s "$EDEN" volume delete nodeagent-disk-test
+    exit "$rc"
+}
+trap cleanup EXIT
+
+echo "=== Creating blank nodeagent-disk-test volume ==="
+"$EDEN" volume create -n nodeagent-disk-test blank --disk-size="$three_fifths_total"
+"$VOLTEST" -test.v -timewait 5m CREATED_VOLUME nodeagent-disk-test
+
+echo "=== Inflating dom0 dynamic usage ==="
+"$EDEN" eve ssh -- dd if=/dev/zero of=/persist/log/test_filler bs=1M count="$filler_mb"
+
+echo "=== Waiting for volumemgr/zedagent/info to propagate ==="
+sleep 90
+
+echo "=== Asserting MaintenanceMode:true ==="
+"$LIMTEST" -test.v -timewait 10m -test.run TestInfo \
+    -out InfoContent.dinfo.MaintenanceMode \
+    'InfoContent.dinfo.MaintenanceMode:true'
+
+echo "=== Asserting MAINTENANCE_MODE_REASON_LOW_DISK_SPACE ==="
+"$LIMTEST" -test.v -timewait 10m -test.run TestInfo \
+    -out InfoContent.dinfo.MaintenanceModeReasons \
+    'InfoContent.dinfo.MaintenanceModeReasons:.*MAINTENANCE_MODE_REASON_LOW_DISK_SPACE.*'
+
+echo "=== Test body succeeded; trap will run cleanup ==="
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/nodeagent/testdata/reset_on_disconnect_blackhole.txt
+++ b/tests/nodeagent/testdata/reset_on_disconnect_blackhole.txt
@@ -1,0 +1,98 @@
+# nodeagent reset-on-disconnect — black-hole variant
+#
+# Companion to reset_on_disconnect_link_down. The link-down variant
+# tests the "cable yanked" failure mode where eth0 loses its IP and
+# NIM's DPC verification trips. This variant tests the more common
+# real-world failure: link is up, IP is valid, the interface looks
+# healthy, but only controller-bound packets are silently dropped
+# (e.g. ISP routing change, controller IP migration, upstream firewall
+# change between device and controller). Here nodeagent's reset-on-
+# disconnect timer is the *primary* defence — NIM stays happy because
+# the interface itself is fine.
+#
+# Mechanism:
+#   eden eve ssh "iptables -A OUTPUT -d <adam-ip> -j DROP"
+#
+# After the reboot the rule is gone (it was in the previous boot's
+# in-memory iptables), so connectivity restores naturally.
+#
+# Only meaningful on device models reachable via eden eve ssh
+# (ZedVirtual-4G, VBox).
+
+{{$devmodel := EdenConfig "eve.devmodel"}}
+{{$adam_ip  := EdenConfig "adam.ip"}}
+
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") }}
+
+{{$test := "test eden.lim.test -test.v -timewait 30m -test.run TestInfo"}}
+
+# Establish a clean baseline by rebooting via controller command. After
+# this step LastBootReason is BOOT_REASON_REBOOT_CMD; the assertion at
+# the end then proves that a *fresh* reboot fired during the test
+# (changing it to BOOT_REASON_DISCONNECT), not a stale value left from
+# whatever booted the device before.
+message 'Establishing reboot baseline'
+eden controller edge-node reboot
+# Give the controller-issued reboot enough time to actually fire
+# (minRebootDelay 30s + boot ~30s) before we start matching the
+# resulting LastBootReason — otherwise lim.test could match a stale
+# REBOOT_CMD value from an earlier run.
+exec sleep 90
+{{$test}} -out InfoContent.dinfo.LastBootReason 'InfoContent.dinfo.LastBootReason:BOOT_REASON_REBOOT_CMD'
+
+# Shorten timer.reboot.no.network to its minimum (120s) and shorten
+# the controller-config polling interval so the new value reaches the
+# device promptly. Also shorten timer.deviceinfo.interval so the
+# device publishes a fresh info to Adam soon after each boot — the
+# final lim.test assertion uses einfo.InfoNew (only new messages
+# trigger the match), so without this it can wait up to 10min for
+# the next periodic info push after the post-disconnect reboot.
+eden controller edge-node update --config timer.reboot.no.network=120
+eden controller edge-node update --config timer.config.interval=10
+eden controller edge-node update --config timer.deviceinfo.interval=30
+
+# Wait long enough for the device to fetch and apply the new config.
+exec sleep 90
+
+# Black-hole controller traffic. Link stays up, lease persists, NIM
+# considers the interface healthy — only nodeagent's reset-on-
+# disconnect timer should react.
+# `--` terminates eden's flag parsing so the iptables flags below pass
+# through unmolested to the SSH command.
+message 'Black-holing controller traffic to trigger reset-on-disconnect'
+eden eve ssh -- iptables -A OUTPUT -d {{$adam_ip}} -j DROP
+
+# Sleep long enough that:
+#   ~10s for zedagent to flip ConfigGetStatus to Fail,
+#   120s for timer.reboot.no.network to elapse,
+#   30s for nodeagent's minRebootDelay,
+#   30-60s for the device to reboot.
+# After the reboot the iptables rule is gone (it was per-boot state),
+# so no explicit cleanup is required.
+exec sleep 360
+
+# Verify: nodeagent reported BOOT_REASON_DISCONNECT on the next boot.
+# This boot reason is set exclusively by handleResetOnCloudDisconnect,
+# so this single assertion is sufficient signal that the timer-driven
+# reset path executed end-to-end.
+message 'Asserting last_boot_reason'
+{{$test}} -out InfoContent.dinfo.LastBootReason 'InfoContent.dinfo.LastBootReason:BOOT_REASON_DISCONNECT'
+stdout 'BOOT_REASON_DISCONNECT'
+
+# Reset config back to defaults.
+eden eve reset
+
+{{else}}
+
+message 'reset_on_disconnect_blackhole: skipped — device model {{$devmodel}} not supported via eden eve ssh'
+
+{{end}}
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/nodeagent/testdata/reset_on_disconnect_link_down.txt
+++ b/tests/nodeagent/testdata/reset_on_disconnect_link_down.txt
@@ -1,0 +1,91 @@
+# nodeagent reset-on-disconnect test
+#
+# Exercises BootReasonDisconnect (handleResetOnCloudDisconnect):
+#   1. With no upgrade in progress, set timer.reboot.no.network to a
+#      short value.
+#   2. Drop the controller link for longer than that timer.
+#   3. nodeagent observes the controller as unreachable past the
+#      threshold and schedules a reboot with BootReasonDisconnect.
+#   4. Bring the link back up; the device publishes
+#      last_boot_reason=BOOT_REASON_DISCONNECT and lastRebootReason
+#      mentioning the controller-outage timeout.
+#
+# Only meaningful on device models where Eden can drop the link
+# (ZedVirtual-4G, VBox).
+
+{{$devmodel := EdenConfig "eve.devmodel"}}
+
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") }}
+
+{{$test := "test eden.lim.test -test.v -timewait 30m -test.run TestInfo"}}
+
+# Establish a clean baseline by rebooting via controller command. After
+# this step LastBootReason is BOOT_REASON_REBOOT_CMD; the assertion at
+# the end then proves that a *fresh* reboot fired during the test
+# (changing it to BOOT_REASON_DISCONNECT), not a stale value left from
+# whatever booted the device before.
+message 'Establishing reboot baseline'
+eden controller edge-node reboot
+# Give the controller-issued reboot enough time to actually fire
+# (minRebootDelay 30s + boot ~30s) before we start matching the
+# resulting LastBootReason — otherwise lim.test could match a stale
+# REBOOT_CMD value from an earlier run.
+exec sleep 90
+{{$test}} -out InfoContent.dinfo.LastBootReason 'InfoContent.dinfo.LastBootReason:BOOT_REASON_REBOOT_CMD'
+
+# Shorten timer.reboot.no.network to its minimum (120s) and shorten
+# the controller-config polling interval so the new value reaches the
+# device promptly. Also shorten timer.deviceinfo.interval so the
+# device publishes a fresh info to Adam soon after each boot — the
+# final lim.test assertion uses einfo.InfoNew (only new messages
+# trigger the match), so without this it can wait up to 10min for
+# the next periodic info push after the post-disconnect reboot.
+eden controller edge-node update --config timer.reboot.no.network=120
+eden controller edge-node update --config timer.config.interval=10
+eden controller edge-node update --config timer.deviceinfo.interval=30
+
+# Wait long enough for the device to fetch and apply the new config.
+# timer.config.interval defaults to 60s, so 90s is conservative even
+# before the new shorter interval takes effect.
+exec sleep 90
+
+# Drop the controller link.
+message 'Dropping controller link to trigger reset-on-disconnect'
+eden eve link down
+
+# Sleep long enough that:
+#   ~60s for zedagent to flip ConfigGetStatus to Fail,
+#   120s for timer.reboot.no.network to elapse,
+#   30s for nodeagent's minRebootDelay,
+#   30-60s for the device to reboot.
+exec sleep 360
+
+# Bring the link back up so the device can re-publish its info.
+message 'Restoring controller link'
+eden eve link up
+
+# Verify: nodeagent reported BOOT_REASON_DISCONNECT on the next boot.
+# This boot reason is set exclusively by handleResetOnCloudDisconnect,
+# so this single assertion is sufficient signal that the timer-driven
+# reset path executed end-to-end.
+message 'Asserting last_boot_reason'
+{{$test}} -out InfoContent.dinfo.LastBootReason 'InfoContent.dinfo.LastBootReason:BOOT_REASON_DISCONNECT'
+stdout 'BOOT_REASON_DISCONNECT'
+
+# Reset config back to defaults.
+eden eve reset
+
+{{else}}
+
+message 'reset_on_disconnect_test: skipped — device model {{$devmodel}} does not support eden eve link down'
+
+{{end}}
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/nodeagent/testdata/restart_counter_monotonic.txt
+++ b/tests/nodeagent/testdata/restart_counter_monotonic.txt
@@ -1,0 +1,93 @@
+# nodeagent restart counter monotonicity test
+#
+# Verifies that nodeagent's persistent RestartCounter (read+incremented
+# at startup, persisted in /persist/status/restartcounter, surfaced in
+# NodeAgentStatus and forwarded to the controller via zedagent's info
+# message) increments by exactly 1 across each EVE reboot.
+#
+# The unit tests in pkg/pillar/cmd/nodeagent cover the in-memory
+# read+increment+write logic against a temp file. This e2e adds the
+# pieces only an integration test can exercise:
+#   - the persistence path is actually /persist/status/restartcounter
+#     (not just whatever the unit test passed),
+#   - the value survives an actual EVE reboot,
+#   - the value reaches the controller through the
+#     NodeAgentStatus → zedagent → info chain.
+
+{{$devmodel := EdenConfig "eve.devmodel"}}
+
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") }}
+
+{{$info := "test eden.lim.test -test.v -timewait 10m -test.run TestInfo"}}
+
+# Shorten the controller-config polling so the post-reboot config push
+# (via eden eve reset at the end) propagates quickly. Shorten device-info
+# publishing too so the post-reboot RestartCounter shows up in Adam's
+# stream within ~30s rather than waiting up to 10min for the next
+# periodic push.
+eden controller edge-node update --config timer.config.interval=10
+eden controller edge-node update --config timer.deviceinfo.interval=30
+
+# Default timer.config.interval is 60s; let the new shorter value take
+# effect before relying on it.
+exec sleep 70
+
+# Capture the current RestartCounter value from Adam's latest info.
+message 'Capturing RestartCounter before reboot'
+eden -t 30s info --tail 1 --out InfoContent.dinfo.RestartCounter 'InfoContent.dinfo.RestartCounter:.+'
+cp stdout before_count.txt
+stdout '[0-9]+'
+
+# Trigger a clean controller-issued reboot.
+message 'Issuing controller reboot'
+eden controller edge-node reboot
+
+# Wait for the reboot to fire (minRebootDelay 30s) and the device to
+# come back online + publish at least one fresh info message.
+exec sleep 90
+{{$info}} -out InfoContent.dinfo.LastBootReason 'InfoContent.dinfo.LastBootReason:BOOT_REASON_REBOOT_CMD'
+
+# Capture the new RestartCounter value.
+message 'Capturing RestartCounter after reboot'
+eden -t 30s info --tail 1 --out InfoContent.dinfo.RestartCounter 'InfoContent.dinfo.RestartCounter:.+'
+cp stdout after_count.txt
+stdout '[0-9]+'
+
+# Assert the counter increased by exactly 1.
+message 'Asserting RestartCounter advanced by exactly 1'
+exec bash compare.sh
+stdout 'OK'
+
+# Reset config back to defaults.
+eden eve reset
+
+{{else}}
+
+message 'restart_counter_monotonic: skipped — device model {{$devmodel}} not supported (no eden eve reset path used here, but the test relies on a controller-driven reboot timing window)'
+
+{{end}}
+
+-- compare.sh --
+set -e
+before=$(grep -oE '[0-9]+' before_count.txt | tail -1)
+after=$(grep -oE '[0-9]+' after_count.txt | tail -1)
+if [ -z "$before" ] || [ -z "$after" ]; then
+  echo "FAIL: could not parse counters: before='$before' after='$after'"
+  exit 1
+fi
+diff=$((after - before))
+if [ "$diff" -eq 1 ]; then
+  echo "OK before=$before after=$after"
+else
+  echo "FAIL: expected after = before+1, got before=$before after=$after diff=$diff"
+  exit 1
+fi
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}


### PR DESCRIPTION
## Summary

Adds a new `tests/nodeagent/` suite with **six e2e tests** that exercise nodeagent's safety-net reboot paths, restart-counter persistence, and the maintenance-mode-on-no-disk-space chain.

### Cloud-disconnect reboot paths

Each in two distinct network-failure modes:

| Test | Path tested | Failure mode |
|---|---|---|
| `reset_on_disconnect_link_down` | `BootReasonDisconnect` | eth0 link-down (`eden eve link down` / QEMU `set_link off`) |
| `reset_on_disconnect_blackhole` | `BootReasonDisconnect` | controller IP silently dropped via in-EVE `iptables -A OUTPUT -d <adam-ip> -j DROP`; link, IP and lease all stay valid |
| `baseos_fallback_link_down` | `BootReasonFallback` | eth0 link-down during the post-update test window |
| `baseos_fallback_blackhole` | `BootReasonFallback` | controller IP black-holed during the test window |

The two failure modes exercise *different* code paths: link-down trips NIM's DPC verification first; the black-hole keeps the interface healthy so nodeagent's reset / fallback timer is the primary defence. The black-hole case is closer to common real-world failures (ISP routing change, controller IP migration, upstream firewall) than yanking the cable.

### Restart counter + disk-space maintenance

| Test | Path tested |
|---|---|
| `restart_counter_monotonic` | `RestartCounter` increments by exactly +1 across an actual EVE reboot, end-to-end through `/persist/status/restartcounter` → `NodeAgentStatus` → zedagent info → controller |
| `maintenance_no_disk_space` | `RemainingSpace=0` (driven by a blank volume + filler outside AppPersistPaths) propagates through `volumemgr → nodeagent → zedagent → controller` as `MaintenanceMode:true` + `MaintenanceModeReasons:[LOW_DISK_SPACE]`, and clears cleanly when pressure is removed |

## Test plan

- [x] All six tests pass locally against a coverage-instrumented EVE under QEMU (`ZedVirtual-4G`).
- [x] Each black-hole rule is wiped naturally on the post-disconnect reboot — no cleanup needed.
- [x] Disk-space maintenance test cleans up filler + volume; device returns to `ZDEVICE_STATE_ONLINE`.
- [ ] CI run on lf-edge/eden's harness.

Per-test runtime (laptop, KVM-accelerated): 4–8 min each.

## Implementation notes

- **Freshness guard for reboot tests**: each `reset_on_disconnect_*` prefixes with `eden controller edge-node reboot` to establish a known `LastBootReason` baseline. The final `lim.test` match thus cannot succeed against stale info from a prior run. The `baseos_fallback_*` tests get the same freshness for free since the upgrade flow always transits `BootReasonUpdate` before reaching `BootReasonFallback`.
- **Info publish cadence**: `timer.deviceinfo.interval=30` so the rebooted device publishes a fresh info message quickly. `lim.test`'s `TestInfo` matches only *new* info (`einfo.InfoNew`), so without this it can wait up to 10 min for the next periodic push.
- **Config propagation timing**: `timer.config.interval=10` shortens the controller-config polling. The fallback tests then `exec sleep 70` so the new shorter interval has time to take effect under the default 60 s polling, before any subsequent config push.
- **Idempotency across runs (fallback tests)**: `eveimage-remove` + brief wait *before* `eveimage-update`, so re-running with the same EVE version still triggers a fresh update. (EVE refuses to retry a previously-failed version unless the retry counter is bumped or the baseos config is removed first.)
- **Black-hole mechanism**: `eden eve ssh -- iptables -A OUTPUT -d <adam-ip> -j DROP`. The `--` terminates eden's cobra flag parsing so the `iptables` flags pass through cleanly. Empirically verified the rule lands in pillar/zedbox's network namespace (it shares `net:[4026531840]` with the dom0 shell), so it does silently drop zedagent's controller-bound traffic.
- **Disk-pressure mechanism**: blank volume at 60 % of `/persist` (sparse — declared size feeds `reservedAppDiskUsage`, on-disk cost is small) + 70 % filler in `/persist/log/` to push `dynamicUsedByDom0` past the 2 GiB `Dom0DiskUsageMaxBytes` static cap. The filler MUST NOT go to `/persist/newlog/` — that directory is in volumemgr's `excludeDirs` and so cancels out in `usedByDom0 = device.Used - appUsage`. `timer.metric.diskscan.interval=30` makes volumemgr's recompute window a tractable test duration.
- **Disk-pressure cleanup**: the volume-create / fill / assert sequence runs inside a bash wrapper invoked via `exec -t 30m bash run_test.sh`, with `trap cleanup EXIT` tearing down the multi-GiB filler and the blank volume regardless of which assertion fails. The escript dialect has no `defer` of its own, so without the wrapper a flaky `MaintenanceMode:true` match (info-publish lag, propagation timeout) would halt the script with the filler still pinned to disk and wedge `/persist` for any subsequent run.
- **Device-model gating**: tests skip with a `message` line on device models other than `ZedVirtual-4G` / `VBox` (no `eden eve link` / `eden eve ssh` support).

## Suite structure

```
tests/nodeagent/
├── Makefile
├── eden-config.yml
├── eden.nodeagent.tests.txt
└── testdata/
    ├── baseos_fallback_blackhole.txt
    ├── baseos_fallback_link_down.txt
    ├── maintenance_no_disk_space.txt
    ├── reset_on_disconnect_blackhole.txt
    ├── reset_on_disconnect_link_down.txt
    └── restart_counter_monotonic.txt
```

The suite is **not** wired into `tests/workflow/smoke.tests.txt` or `eve-upgrade.tests.txt` in this PR — the six tests are addressable on their own (e.g. `eden.escript.test -test.run TestEdenScripts/reset_on_disconnect_link_down -testdata tests/nodeagent/testdata/`). Folding them into a broader suite is a follow-up after we see how they behave under CI.

## Why draft

Want a chance for someone familiar with eden's harness to look at the patterns before marking ready — particularly the per-test timer tuning, the idempotency dance for the fallback tests, and the blank-volume-plus-filler trick for the disk-space test.
