### PR TITLE
ctrl_encrypt_cert_change: rotate ECDH cert without restart

### DIFF
--- a/cmd/adam.go
+++ b/cmd/adam.go
@@ -26,6 +26,7 @@ func newAdamCmd(configName, verbosity *string) *cobra.Command {
 				newStopAdamCmd(),
 				newStatusAdamCmd(),
 				newChangeCertCmd(),
+				newChangeEncryptCertCmd(),
 			},
 		},
 	}
@@ -128,4 +129,43 @@ signing-key.pem is reused.`,
 	changeCertCmd.Flags().StringVar(&keyFile, "key-file", "", "path to the new signing private key (optional; if omitted, the existing key is reused)")
 
 	return changeCertCmd
+}
+
+func newChangeEncryptCertCmd() *cobra.Command {
+	var certFile, keyFile string
+
+	var changeEncryptCertCmd = &cobra.Command{
+		Use:   "change-encrypt-cert",
+		Short: "change ECDH encryption certificate for adam",
+		Long: `Set adam's ECDH (encryption) certificate from a file. If --key-file is
+provided, the matching private key is also installed and adam re-encrypts
+configs whose CipherContext references the old encrypt cert with the new
+key. The signing cert and key are not touched, so auth-container envelopes
+continue to verify against the device's saved signing cert. Only configs
+deployed with --use-encrypt-cert are re-encrypted; everything else is left
+alone.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			certData, err := os.ReadFile(certFile)
+			if err != nil {
+				log.Fatalf("Failed to read certificate file: %s", err)
+			}
+
+			var keyData []byte
+			if keyFile != "" {
+				keyData, err = os.ReadFile(keyFile)
+				if err != nil {
+					log.Fatalf("Failed to read key file: %s", err)
+				}
+			}
+
+			if err := openEVEC.ChangeEncryptCert(certData, keyData); err != nil {
+				log.Fatalf("Failed to upload encrypt certificate to adam: %s", err)
+			}
+		},
+	}
+
+	changeEncryptCertCmd.Flags().StringVarP(&certFile, "cert-file", "", "", "path to the new encrypt certificate file")
+	changeEncryptCertCmd.Flags().StringVar(&keyFile, "key-file", "", "path to the new encrypt private key (optional; if omitted, the existing key is reused)")
+
+	return changeEncryptCertCmd
 }

--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -81,3 +81,37 @@ written to --out and the matching private key to --key-out.`,
 
 	return certsCmd
 }
+
+func newGenEncryptCertCmd() *cobra.Command {
+	var certPath, keyPath string
+
+	var certsCmd = &cobra.Command{
+		Use:   "gen-encrypt-cert",
+		Short: "generate new ECDH encryption certificate for controller",
+		Long: `Generate a fresh ECDSA P-256 key pair and an encryption (ECDH)
+certificate containing the new public key, signed by the eden root CA. The
+cert is written to --out and the matching private key to --key-out. This is
+the certificate adam serves as CERT_TYPE_CONTROLLER_ECDH_EXCHANGE on /certs
+and is used by EVE for cipher block decryption.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if keyPath == "" {
+				keyPath = strings.TrimSuffix(certPath, ".pem") + "-key.pem"
+			}
+			if err := utils.GenEncryptCertWithNewKey(certPath, keyPath); err != nil {
+				log.Errorf("cannot generate encrypt cert: %s", err)
+			} else {
+				log.Infof("Generated encrypt cert at %s and key at %s", certPath, keyPath)
+			}
+		},
+	}
+
+	edenHome, err := utils.DefaultEdenDir()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	certsCmd.Flags().StringVarP(&certPath, "out", "o", filepath.Join(edenHome, defaults.DefaultCertsDist, "encrypt-new.pem"), "certificate output path")
+	certsCmd.Flags().StringVar(&keyPath, "key-out", "", "private-key output path (default: <out> with .pem replaced by -key.pem)")
+
+	return certsCmd
+}

--- a/cmd/edenPod.go
+++ b/cmd/edenPod.go
@@ -120,6 +120,7 @@ To block all traffic define ACL with no endpoints: '<network_name>:'`)
 	podDeployCmd.Flags().StringSliceVar(&pc.Vlans, "vlan", nil, `Connect application to the (switch) network over an access port assigned to the given VLAN.
 You can set access VLAN ID (VID) for a particular network in the format '<network_name:VID>'`)
 	podDeployCmd.Flags().BoolVar(&pc.OpenStackMetadata, "openstack-metadata", false, "Use OpenStack metadata for VM")
+	podDeployCmd.Flags().BoolVar(&pc.UseEncryptCert, "use-encrypt-cert", false, "Encrypt user-data with the controller's ECDH (encrypt.pem) cert instead of the signing cert; the cipher context will reference CERT_TYPE_CONTROLLER_ECDH_EXCHANGE so it tracks change-encrypt-cert rotations.")
 	podDeployCmd.Flags().StringVar(&pc.DatastoreOverride, "datastoreOverride", "", "Override datastore path for disks (when we use different URL for Eden and EVE or for local datastore)")
 	podDeployCmd.Flags().Uint32Var(&pc.StartDelay, "start-delay", 0, "The amount of time (in seconds) that EVE waits (after boot finish) before starting application")
 	podDeployCmd.Flags().BoolVar(&pc.PinCpus, "pin-cpus", false, "Pin the CPUs used by the pod")

--- a/cmd/edenUtils.go
+++ b/cmd/edenUtils.go
@@ -31,6 +31,7 @@ func newUtilsCmd(configName, verbosity *string) *cobra.Command {
 				newOciImageCmd(),
 				newCertsCmd(cfg),
 				newGenSigningCertCmd(),
+				newGenEncryptCertCmd(),
 				newGcpCmd(cfg),
 				newSdInfoEveCmd(),
 				newDebugCmd(cfg),

--- a/pkg/controller/adam/adam.go
+++ b/pkg/controller/adam/adam.go
@@ -430,25 +430,33 @@ func (adam *Ctx) GetGlobalOptions() (*types.GlobalOptions, error) {
 
 // SigningCertGet gets signing certificate from Adam
 func (adam *Ctx) SigningCertGet() (signCert []byte, err error) {
+	return adam.controllerCertByType(certs.ZCertType_CERT_TYPE_CONTROLLER_SIGNING)
+}
+
+// EncryptCertGet gets the controller's ECDH encryption certificate from Adam.
+// This is the cert eve-side cipher.go uses as the ECDH peer when
+// CipherContext.ControllerCertHash refers to the encryption (not signing) cert.
+func (adam *Ctx) EncryptCertGet() (encCert []byte, err error) {
+	return adam.controllerCertByType(certs.ZCertType_CERT_TYPE_CONTROLLER_ECDH_EXCHANGE)
+}
+
+func (adam *Ctx) controllerCertByType(certType certs.ZCertType) ([]byte, error) {
 	certsData, err := adam.getObj("/api/v2/edgedevice/certs", mimeProto)
 	if err != nil {
 		return nil, err
 	}
 	zcloudMsg := &auth.AuthContainer{}
-	err = proto.Unmarshal([]byte(certsData), zcloudMsg)
-	if err != nil {
+	if err := proto.Unmarshal([]byte(certsData), zcloudMsg); err != nil {
 		return nil, err
 	}
 	ctrlCert := &certs.ZControllerCert{}
-	err = proto.Unmarshal(zcloudMsg.ProtectedPayload.Payload, ctrlCert)
-	if err != nil {
+	if err := proto.Unmarshal(zcloudMsg.ProtectedPayload.Payload, ctrlCert); err != nil {
 		return nil, err
 	}
 	for _, c := range ctrlCert.Certs {
-		// there should be only one signing certificate, so we return the first one we find
-		if c.Type == certs.ZCertType_CERT_TYPE_CONTROLLER_SIGNING {
+		if c.Type == certType {
 			return c.Cert, nil
 		}
 	}
-	return nil, fmt.Errorf("no signing certificate found")
+	return nil, fmt.Errorf("no controller certificate of type %s", certType)
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -19,6 +19,7 @@ import (
 type Controller interface {
 	GetECDHCert(devUUID uuid.UUID) ([]byte, error)
 	SigningCertGet() (signCert []byte, err error)
+	EncryptCertGet() (encCert []byte, err error)
 	ConfigGet(devUUID uuid.UUID) (out string, err error)
 	ConfigSet(devUUID uuid.UUID, devConfig []byte) (err error)
 	LogAppsChecker(devUUID uuid.UUID, appUUID uuid.UUID, q map[string]string, handler eapps.HandlerFunc, mode eapps.LogCheckerMode, timeout time.Duration) (err error)

--- a/pkg/expect/encrypt.go
+++ b/pkg/expect/encrypt.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/lf-edge/eden/pkg/controller"
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eden/pkg/utils"
 	"github.com/lf-edge/eve-api/go/config"
@@ -57,24 +58,13 @@ func (exp *AppExpectation) prepareCipherData(encBlock *evecommon.EncryptionBlock
 		return nil, nil
 	}
 
-	// get signing certificate from the controller
-	signCert, err := exp.ctrl.SigningCertGet()
+	ctrlCert, ctrlPrivKey, err := loadControllerCryptoMaterial(exp.ctrl, exp.useEncryptCert)
 	if err != nil {
-		log.Errorf("cannot get cloud's signing certificate. will use plaintext. error: %s", err)
+		log.Errorf("cannot load controller crypto material. will use plaintext. error: %s", err)
 		return nil, nil
 	}
 
-	edenHome, err := utils.DefaultEdenDir()
-	if err != nil {
-		return nil, fmt.Errorf("DefaultEdenDir: %w", err)
-	}
-	keyPath := filepath.Join(edenHome, defaults.DefaultCertsDist, "signing-key.pem")
-	ctrlPrivKey, err := os.ReadFile(keyPath)
-	if err != nil {
-		return nil, fmt.Errorf("cannot read %s: %w", keyPath, err)
-	}
-
-	cryptoConfig, err := utils.GetCommonCryptoConfig(devCert, signCert, ctrlPrivKey)
+	cryptoConfig, err := utils.GetCommonCryptoConfig(devCert, ctrlCert, ctrlPrivKey)
 	if err != nil {
 		return nil, fmt.Errorf("GetCommonCryptoConfig: %w", err)
 	}
@@ -87,4 +77,39 @@ func (exp *AppExpectation) prepareCipherData(encBlock *evecommon.EncryptionBlock
 	cipherCtx = utils.AddCipherCtxToDev(exp.device, cipherCtx)
 
 	return utils.CryptoConfigWrapper(encBlock, cryptoConfig, cipherCtx)
+}
+
+// loadControllerCryptoMaterial returns the controller cert + matching private
+// key to use for ECDH derivation. When useEncryptCert is true, encrypt.pem +
+// encrypt-key.pem are used so the resulting cipher context references the
+// controller's CONTROLLER_ECDH_EXCHANGE cert; otherwise signing.pem +
+// signing-key.pem are used (historical default).
+func loadControllerCryptoMaterial(ctrl controller.Cloud, useEncryptCert bool) ([]byte, []byte, error) {
+	edenHome, err := utils.DefaultEdenDir()
+	if err != nil {
+		return nil, nil, fmt.Errorf("DefaultEdenDir: %w", err)
+	}
+	var (
+		certBytes []byte
+		keyName   string
+	)
+	if useEncryptCert {
+		certBytes, err = ctrl.EncryptCertGet()
+		if err != nil {
+			return nil, nil, fmt.Errorf("EncryptCertGet: %w", err)
+		}
+		keyName = "encrypt-key.pem"
+	} else {
+		certBytes, err = ctrl.SigningCertGet()
+		if err != nil {
+			return nil, nil, fmt.Errorf("SigningCertGet: %w", err)
+		}
+		keyName = "signing-key.pem"
+	}
+	keyPath := filepath.Join(edenHome, defaults.DefaultCertsDist, keyName)
+	keyBytes, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot read %s: %w", keyPath, err)
+	}
+	return certBytes, keyBytes, nil
 }

--- a/pkg/expect/expectation.go
+++ b/pkg/expect/expectation.go
@@ -54,8 +54,8 @@ type AppExpectation struct {
 
 	baseOSVersion string
 
-	vncDisplay  int
-	vncPassword string
+	vncDisplay   int
+	vncPassword  string
 	vncForShimVM bool
 
 	netInstances []*NetInstanceExpectation
@@ -83,6 +83,7 @@ type AppExpectation struct {
 	vlans map[string]int // networkInstanceName -> VID
 
 	openStackMetadata bool
+	useEncryptCert    bool
 	profiles          []string
 	datastoreOverride string
 	startDelay        uint32

--- a/pkg/expect/options.go
+++ b/pkg/expect/options.go
@@ -281,6 +281,16 @@ func WithOpenStackMetadata(openStackMetadata bool) ExpectationOption {
 	}
 }
 
+// WithUseEncryptCert tells Eden to encrypt this app's user-data with
+// encrypt-key.pem and tag the cipher context with the controller's encryption
+// (ECDH) cert hash, instead of the signing cert. The default is false, which
+// preserves the historical behavior of using signing-key.pem for ECDH.
+func WithUseEncryptCert(useEncryptCert bool) ExpectationOption {
+	return func(expectation *AppExpectation) {
+		expectation.useEncryptCert = useEncryptCert
+	}
+}
+
 // WithProfiles set profileList for appInstance
 func WithProfiles(profiles []string) ExpectationOption {
 	return func(expectation *AppExpectation) {

--- a/pkg/openevec/adam.go
+++ b/pkg/openevec/adam.go
@@ -1,9 +1,11 @@
 package openevec
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/lf-edge/eden/pkg/controller"
 	"github.com/lf-edge/eden/pkg/defaults"
@@ -115,6 +117,187 @@ func (openEVEC *OpenEVEC) ChangeSigningCert(newSignCert, newSignKey []byte) erro
 	return nil
 }
 
+// ChangeEncryptCert rotates the controller's ECDH (encryption) cert and key in
+// adam, re-encrypting only those configs whose CipherContext references the
+// old encrypt cert hash. The signing cert and key are left untouched, so
+// auth-container envelopes continue to verify against the device's saved
+// signing cert. Configs encrypted with the signing key (the historical
+// default in this Eden setup) are left alone, so a rotation here is a no-op
+// for apps that were not deployed with --use-encrypt-cert.
+//
+// If newEncKey is non-nil it is treated as the private key matching newEncCert
+// and is installed alongside the cert. If newEncKey is nil the existing key is
+// reused (cert-only rotation).
+func (openEVEC *OpenEVEC) ChangeEncryptCert(newEncCert, newEncKey []byte) error {
+	changer := &adamChanger{}
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
+	if err != nil {
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
+	}
+
+	if err := reencryptConfigsForEncryptCert(ctrl, dev, newEncCert, newEncKey); err != nil {
+		return fmt.Errorf("failed to reencrypt existing configs: %w", err)
+	}
+
+	if err = changer.setControllerAndDev(ctrl, dev); err != nil {
+		return fmt.Errorf("setControllerAndDev: %w", err)
+	}
+
+	edenHome, err := utils.DefaultEdenDir()
+	if err != nil {
+		return err
+	}
+	globalCertsDir := filepath.Join(edenHome, defaults.DefaultCertsDist)
+	encryptCertPath := filepath.Join(globalCertsDir, "encrypt.pem")
+	encryptKeyPath := filepath.Join(globalCertsDir, "encrypt-key.pem")
+
+	if len(newEncKey) > 0 {
+		if err = atomicWriteFile(encryptKeyPath, newEncKey, 0600); err != nil {
+			return fmt.Errorf("cannot write encrypt key to %s: %w", encryptKeyPath, err)
+		}
+	}
+	if err = atomicWriteFile(encryptCertPath, newEncCert, 0644); err != nil {
+		if len(newEncKey) > 0 {
+			log.Errorf("INCONSISTENT STATE: encrypt-key.pem was rotated but encrypt.pem failed to write to %s. Re-run change-encrypt-cert to recover.", encryptCertPath)
+		}
+		return fmt.Errorf("cannot write encrypt cert to %s: %w", encryptCertPath, err)
+	}
+
+	log.Infof("Encrypt cert changed successfully")
+	return nil
+}
+
+// reencryptConfigsForEncryptCert re-encrypts only those app/datastore/wireless
+// cipher blocks whose owning CipherContext references the old encrypt cert -
+// i.e. only configs that were encrypted via WithUseEncryptCert. The new cipher
+// context is registered on the device and used as the destination for all
+// matching cipher blocks.
+func reencryptConfigsForEncryptCert(ctrl controller.Cloud, dev *device.Ctx, newEncCert, newEncKey []byte) error {
+	devCert, err := ctrl.GetECDHCert(dev.GetID())
+	if err != nil {
+		return fmt.Errorf("cannot get device certificate from cloud: %w", err)
+	}
+
+	oldEncCert, err := ctrl.EncryptCertGet()
+	if err != nil {
+		log.Error("cannot get cloud's encrypt certificate. nothing to re-encrypt")
+		return nil
+	}
+
+	edenHome, err := utils.DefaultEdenDir()
+	if err != nil {
+		return fmt.Errorf("DefaultEdenDir: %w", err)
+	}
+	keyPath := filepath.Join(edenHome, defaults.DefaultCertsDist, "encrypt-key.pem")
+	oldCtrlPrivBytes, err := os.ReadFile(keyPath)
+	if err != nil {
+		return fmt.Errorf("cannot read %s: %w", keyPath, err)
+	}
+
+	newCtrlPrivBytes := oldCtrlPrivBytes
+	if len(newEncKey) > 0 {
+		newCtrlPrivBytes = newEncKey
+	}
+
+	oldCryptoConfig, err := utils.GetCommonCryptoConfig(devCert, oldEncCert, oldCtrlPrivBytes)
+	if err != nil {
+		return fmt.Errorf("GetCommonCryptoConfig (old): %w", err)
+	}
+	newCryptoConfig, err := utils.GetCommonCryptoConfig(devCert, newEncCert, newCtrlPrivBytes)
+	if err != nil {
+		return fmt.Errorf("GetCommonCryptoConfig (new): %w", err)
+	}
+
+	newCipherCtx, err := utils.CreateCipherCtx(newCryptoConfig)
+	if err != nil {
+		return fmt.Errorf("CreateCipherCtx: %w", err)
+	}
+	newCipherCtx = utils.AddCipherCtxToDev(dev, newCipherCtx)
+
+	matchCtxIDs := map[string]struct{}{}
+	for _, c := range dev.GetCipherContexts() {
+		if controllerCertHashMatches(c.ControllerCertHash, oldEncCert) {
+			matchCtxIDs[c.ContextId] = struct{}{}
+		}
+	}
+
+	matches := func(holder utils.CipherDataHolder) bool {
+		cd := holder.GetCipherData()
+		if cd == nil {
+			return false
+		}
+		_, ok := matchCtxIDs[cd.CipherContextId]
+		return ok
+	}
+
+	for _, cfg := range ctrl.ListApplicationInstanceConfig() {
+		if !matches(cfg) {
+			continue
+		}
+		if err := utils.ReencryptConfigData(cfg, oldCryptoConfig, newCryptoConfig, newCipherCtx); err != nil {
+			return fmt.Errorf("reencryptConfigData (app): %w", err)
+		}
+	}
+	for _, cfg := range ctrl.ListDataStore() {
+		if !matches(cfg) {
+			continue
+		}
+		if err := utils.ReencryptConfigData(cfg, oldCryptoConfig, newCryptoConfig, newCipherCtx); err != nil {
+			return fmt.Errorf("reencryptConfigData (datastore): %w", err)
+		}
+	}
+	for _, networkConfigID := range dev.GetNetworks() {
+		networkConfig, err := ctrl.GetNetworkConfig(networkConfigID)
+		if err != nil {
+			return fmt.Errorf("GetNetworkConfig: %w", err)
+		}
+		if networkConfig == nil || networkConfig.Wireless == nil {
+			continue
+		}
+		for _, cfg := range networkConfig.Wireless.CellularCfg {
+			for _, ap := range cfg.AccessPoints {
+				if !matches(ap) {
+					continue
+				}
+				if err := utils.ReencryptConfigData(ap, oldCryptoConfig, newCryptoConfig, newCipherCtx); err != nil {
+					return fmt.Errorf("reencryptConfigData (cellular): %w", err)
+				}
+			}
+		}
+		for _, cfg := range networkConfig.Wireless.WifiCfg {
+			if !matches(cfg) {
+				continue
+			}
+			if err := utils.ReencryptConfigData(cfg, oldCryptoConfig, newCryptoConfig, newCipherCtx); err != nil {
+				return fmt.Errorf("reencryptConfigData (wifi): %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// controllerCertHashMatches returns true iff the first 16 bytes of the
+// CipherContext.ControllerCertHash equal the first 16 bytes of sha256 of the
+// trimmed PEM-encoded cert (the same way Eden computed it at encrypt time -
+// see utils.GetCommonCryptoConfig and utils.CreateCipherCtx).
+func controllerCertHashMatches(ctxHash []byte, certPEM []byte) bool {
+	if len(ctxHash) == 0 || len(certPEM) == 0 {
+		return false
+	}
+	sum := sha256.Sum256([]byte(strings.TrimSpace(string(certPEM))))
+	expect := sum[:16]
+	if len(ctxHash) < len(expect) {
+		return false
+	}
+	for i := range expect {
+		if ctxHash[i] != expect[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // atomicWriteFile writes data to path via a tmpfile in the same directory
 // followed by an atomic os.Rename. The tmpfile is fsynced before rename so
 // a crash post-rename cannot lose the new content. The destination's mode
@@ -202,9 +385,31 @@ func reencryptConfigs(ctrl controller.Cloud, dev *device.Ctx, newSignCert, newSi
 	// add cipher context to device or return a matching existing one
 	cipherCtx = utils.AddCipherCtxToDev(dev, cipherCtx)
 
+	// Only re-encrypt configs whose CipherContext references the OLD signing
+	// cert hash. Configs encrypted with the encrypt cert (--use-encrypt-cert)
+	// are owned by change-encrypt-cert and are left untouched here, so the
+	// two rotations can coexist without one breaking the other.
+	matchCtxIDs := map[string]struct{}{}
+	for _, c := range dev.GetCipherContexts() {
+		if controllerCertHashMatches(c.ControllerCertHash, oldSignCert) {
+			matchCtxIDs[c.ContextId] = struct{}{}
+		}
+	}
+	matches := func(holder utils.CipherDataHolder) bool {
+		cd := holder.GetCipherData()
+		if cd == nil {
+			return false
+		}
+		_, ok := matchCtxIDs[cd.CipherContextId]
+		return ok
+	}
+
 	// re-encrypt all app configs with the new signing certificate
 	appConfigs := ctrl.ListApplicationInstanceConfig()
 	for _, config := range appConfigs {
+		if !matches(config) {
+			continue
+		}
 		if err = utils.ReencryptConfigData(config, oldCryptoConfig, newCryptoConfig, cipherCtx); err != nil {
 			return fmt.Errorf("reencryptConfigData: %w", err)
 		}
@@ -213,6 +418,9 @@ func reencryptConfigs(ctrl controller.Cloud, dev *device.Ctx, newSignCert, newSi
 	// re-encrypt all datastore configs with the new signing certificate
 	dsConfigs := ctrl.ListDataStore()
 	for _, config := range dsConfigs {
+		if !matches(config) {
+			continue
+		}
 		if err = utils.ReencryptConfigData(config, oldCryptoConfig, newCryptoConfig, cipherCtx); err != nil {
 			return fmt.Errorf("reencryptConfigData: %w", err)
 		}
@@ -227,12 +435,18 @@ func reencryptConfigs(ctrl controller.Cloud, dev *device.Ctx, newSignCert, newSi
 		if networkConfig != nil && networkConfig.Wireless != nil {
 			for _, config := range networkConfig.Wireless.CellularCfg {
 				for _, ap := range config.AccessPoints {
+					if !matches(ap) {
+						continue
+					}
 					if err = utils.ReencryptConfigData(ap, oldCryptoConfig, newCryptoConfig, cipherCtx); err != nil {
 						return fmt.Errorf("reencryptConfigData: %w", err)
 					}
 				}
 			}
 			for _, config := range networkConfig.Wireless.WifiCfg {
+				if !matches(config) {
+					continue
+				}
 				if err = utils.ReencryptConfigData(config, oldCryptoConfig, newCryptoConfig, cipherCtx); err != nil {
 					return fmt.Errorf("reencryptConfigData: %w", err)
 				}

--- a/pkg/openevec/config.go
+++ b/pkg/openevec/config.go
@@ -233,6 +233,7 @@ type PodConfig struct {
 	SftpLoad          bool
 	DirectLoad        bool
 	OpenStackMetadata bool
+	UseEncryptCert    bool
 	DatastoreOverride string
 	ACLOnlyHost       bool
 }

--- a/pkg/openevec/pod.go
+++ b/pkg/openevec/pod.go
@@ -136,6 +136,7 @@ func (openEVEC *OpenEVEC) PodDeploy(appLink string, pc PodConfig, cfg *EdenSetup
 		opts = append(opts, expect.WithVirtualizationMode(config.VmMode_NOHYPER))
 	}
 	opts = append(opts, expect.WithOpenStackMetadata(pc.OpenStackMetadata))
+	opts = append(opts, expect.WithUseEncryptCert(pc.UseEncryptCert))
 	opts = append(opts, expect.WithProfiles(pc.Profiles))
 	opts = append(opts, expect.WithDatastoreOverride(pc.DatastoreOverride))
 	opts = append(opts, expect.WithStartDelay(pc.StartDelay))

--- a/pkg/utils/x509.go
+++ b/pkg/utils/x509.go
@@ -117,6 +117,17 @@ func GenServerCertElliptic(cert *x509.Certificate, key *rsa.PrivateKey, serial *
 // number is randomized so two consecutive calls always produce two distinct
 // certs even within the same second.
 func GenServerCertWithNewKey(certPath, keyPath string) error {
+	return genServerCertFromTemplate("signing.pem", certPath, keyPath)
+}
+
+// GenEncryptCertWithNewKey is GenServerCertWithNewKey for the controller's
+// ECDH encryption cert: the new cert's template is copied from encrypt.pem,
+// not signing.pem, so the rotated cert preserves the encrypt-cert subject.
+func GenEncryptCertWithNewKey(certPath, keyPath string) error {
+	return genServerCertFromTemplate("encrypt.pem", certPath, keyPath)
+}
+
+func genServerCertFromTemplate(srcCertName, certPath, keyPath string) error {
 	edenHome, err := DefaultEdenDir()
 	if err != nil {
 		return err
@@ -130,7 +141,7 @@ func GenServerCertWithNewKey(certPath, keyPath string) error {
 	if err != nil {
 		return err
 	}
-	oldServerCert, err := ParseCertificate(filepath.Join(edenHome, defaults.DefaultCertsDist, "signing.pem"))
+	oldServerCert, err := ParseCertificate(filepath.Join(edenHome, defaults.DefaultCertsDist, srcCertName))
 	if err != nil {
 		return err
 	}

--- a/tests/eclient/testdata/ctrl_encrypt_cert_change.txt
+++ b/tests/eclient/testdata/ctrl_encrypt_cert_change.txt
@@ -1,0 +1,220 @@
+# Test of controller encryption (ECDH) certificate change.
+#
+# Companion to ctrl_cert_change.txt: that test rotates the signing cert while
+# Eden uses the *signing* key for ECDH derivation, so it incidentally
+# exercises the encryption path too. This test deploys apps with
+# --use-encrypt-cert so their cipher contexts reference the controller's
+# CERT_TYPE_CONTROLLER_ECDH_EXCHANGE cert (Type=3) instead of the signing
+# cert, and verifies that those cipher blocks stay decryptable across cert
+# rotations.
+#
+# Why every rotation rotates *both* certs:
+#
+#   The only fast trigger for a /certs refetch on the device is a
+#   signing-cert mismatch in the auth-envelope's SenderCertHash
+#   (controllerconn/authen.go: SenderStatusCertMiss). The cipher decrypt
+#   path returns "Controller Certificate get fail" when the encrypt cert
+#   hash isn't in pubControllerCert but does NOT trigger a /certs refetch.
+#   handleControllerCertsSha could trigger one if adam populated
+#   EdgeDevConfig.controllercert_confighash, but it doesn't. The periodic
+#   controllerCertsTask defaults to CertInterval=24h. So pure encrypt-cert
+#   rotation has no fast trigger, and the only practical way to land a new
+#   ECDH cert on the device today is to rotate the signing cert alongside
+#   it. See lf-edge/eve#5926.
+#
+#   Order matters: change-encrypt-cert first, then change-signing-cert.
+#   change-encrypt-cert re-encrypts the encrypt-tagged cipher blocks and
+#   writes the new encrypt files on adam's disk. change-signing-cert is a
+#   no-op for those cipher blocks (its reencryptConfigs filter skips
+#   cipher contexts that don't reference the signing cert hash), but its
+#   on-disk signing-key swap is what makes adam sign the next auth
+#   envelope with a key the device hasn't seen, triggering
+#   SenderStatusCertMiss. By the time the device refetches /certs, both
+#   new certs are on adam's disk and arrive in a single round-trip.
+#
+# Two rotations are exercised so both controllercerts.bak code paths are
+# hit:
+#   1. First rotation: .bak does not exist yet for either cert.
+#   2. Second rotation: .bak now exists for both, exercising the
+#      backup-fallback path inside VerifyAuthContainerHeader and the .bak
+#      atomic-rename refresh inside MaybeSaveControllerCerts.
+#
+# reencryptConfigs' cipher-context-cert-hash filter is exercised
+# implicitly by the encrypt+signing rotation steps: eclient1 keeps
+# running through change-signing-cert because the filter correctly
+# skips its encrypt-cert-tagged cipher block. ctrl_cert_change.txt
+# covers the signing-only rotation case independently.
+
+{{$port := "2223"}}
+
+{{$userdata := "marker=encrypt-cert-rotation-test"}}
+
+{{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+
+[!exec:bash] stop
+[!exec:sleep] stop
+[!exec:chmod] stop
+
+exec chmod 600 {{EdenConfig "eden.tests"}}/eclient/image/cert/id_rsa
+
+eden network create 10.11.12.0/24 -n n1
+eden pod deploy -n eclient1 --memory=512MB --networks=n1 --use-encrypt-cert {{template "eclient_image"}} -p {{$port}}:22 --metadata={{$userdata}}
+
+test eden.app.test -test.v -timewait 20m RUNNING eclient1
+
+# --- First rotation: encrypt + signing ---
+
+eden utils gen-encrypt-cert -o /tmp/encrypt-new.pem --key-out /tmp/encrypt-new-key.pem
+eden utils gen-signing-cert -o /tmp/signing-new.pem --key-out /tmp/signing-new-key.pem
+eden adam change-encrypt-cert --cert-file /tmp/encrypt-new.pem --key-file /tmp/encrypt-new-key.pem
+eden adam change-signing-cert --cert-file /tmp/signing-new.pem --key-file /tmp/signing-new-key.pem
+
+# Wait for the device-side reconcile log line that fires once zedmanager has
+# republished AppNetworkConfig with the new cipher block (same trigger as
+# ctrl_cert_change.txt - this is one synchronization barrier confirming the
+# new cipher block is now live in the device's pubsub state).
+test eden.lim.test -test.v -timewait 15m -test.run TestLog -out content 'content:Rebuilding.intended.global.config,.reasons:.updating.app.connectivity'
+
+# Deploy a fresh app *after* the rotation: its cipher block is encrypted
+# against the new ECDH key from the start, so reaching RUNNING proves the
+# device received the new encrypt cert via the signing-cert-triggered
+# /certs refetch and the new ECDH key decrypts the new cipher block.
+eden pod deploy -n eclient2 --memory=512MB --networks=n1 --use-encrypt-cert {{template "eclient_image"}} --metadata={{$userdata}}
+
+test eden.app.test -test.v -timewait 20m RUNNING eclient2
+
+# eclient2 RUNNING is the primary success signal - the cert chain must have
+# settled in pubsub for activate to have decrypted the cipher block. The
+# script-level check below cross-verifies that the cert advertised on the
+# device matches encrypt-new.pem byte-for-byte.
+exec -t 2m bash check_encrypt_cert.sh /tmp/encrypt-new.pem
+
+# --- Second rotation: encrypt + signing (exercises .bak fallback) ---
+
+eden utils gen-encrypt-cert -o /tmp/encrypt-new.pem --key-out /tmp/encrypt-new-key.pem
+eden utils gen-signing-cert -o /tmp/signing-new.pem --key-out /tmp/signing-new-key.pem
+eden adam change-encrypt-cert --cert-file /tmp/encrypt-new.pem --key-file /tmp/encrypt-new-key.pem
+eden adam change-signing-cert --cert-file /tmp/signing-new.pem --key-file /tmp/signing-new-key.pem
+
+test eden.lim.test -test.v -timewait 15m -test.run TestLog -out content 'content:Rebuilding.intended.global.config,.reasons:.updating.app.connectivity'
+
+eden pod deploy -n eclient3 --memory=512MB --networks=n1 --use-encrypt-cert {{template "eclient_image"}} --metadata={{$userdata}}
+
+test eden.app.test -test.v -timewait 20m RUNNING eclient3
+
+exec -t 2m bash check_encrypt_cert.sh /tmp/encrypt-new.pem
+
+# --- Reboot and verify reboot-survival of the rotated encrypt cert ---
+#
+# /tmp/encrypt-new.pem holds the most recent rotated encrypt cert (from
+# the second encrypt+signing rotation). After EVE reboots we expect:
+#   * all three apps to come back RUNNING - their cipher blocks are
+#     persisted on adam; EVE pulls them post-reboot and decrypts with the
+#     post-reboot ECDH key.
+#   * /run/zedagent/ControllerCert/ to again advertise that same cert as
+#     Type=3 (rebuilt either from /persist/checkpoint/controllercerts on
+#     the device or re-fetched from adam; in both cases the cert chain
+#     must roundtrip the reboot intact).
+test eden.reboot.test -test.v -timewait=20m -reboot=1 -count=1 &
+
+test eden.app.test -test.v -timewait 20m -check-new RUNNING eclient1 eclient2 eclient3
+
+exec -t 2m bash check_encrypt_cert.sh /tmp/encrypt-new.pem
+
+# cleanup
+eden pod delete eclient1
+eden pod delete eclient2
+eden pod delete eclient3
+eden network delete n1
+
+test eden.app.test -test.v -timewait 10m - eclient1
+test eden.app.test -test.v -timewait 10m - eclient2
+test eden.app.test -test.v -timewait 10m - eclient3
+test eden.network.test -test.v -timewait 10m - n1
+
+-- eden-config.yml --
+{{/* Test's config. file */}}
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- check_encrypt_cert.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+EXPECTED_CERT="$1"
+
+# CERT_TYPE_CONTROLLER_ECDH_EXCHANGE = 3 (eve-api/proto/certs/certs.proto).
+# /run/zedagent/ControllerCert/ (or /persist/status/zedagent/ControllerCert/
+# on older EVE where pubControllerCert is Persistent: true) contains one
+# JSON file per controller cert the device has received via /certs. Find a
+# Type=3 entry whose Cert field (base64-encoded PEM) matches the newly-
+# rotated encrypt-new.pem.
+
+# Adam runs the cert through strings.TrimSpace before computing CertHash
+# and before storing it in the ZCert.Cert field that EVE base64-encodes
+# into the JSON pubsub file (apiHandlerv2.go:221-226). The PEM file
+# pem.Encode wrote to disk has a trailing newline; the device-side bytes
+# don't. Compare the *trimmed* file content to match adam's normalization.
+# bash's $(<file) command substitution strips trailing newlines, which
+# matches TrimSpace for well-formed PEM files (no leading whitespace).
+expected_content=$(<"$EXPECTED_CERT")
+expected_sha=$(printf '%s' "$expected_content" | sha256sum | awk '{print $1}')
+
+echo "EXPECTED_CERT $EXPECTED_CERT trimmed-sha256: $expected_sha" >&2
+
+# scan_dir <ssh_path> <local_prefix>
+# - lists json files in the device-side pubsub directory
+# - cats each, dumps its Type field (and Cert sha256) for diagnostics
+# - returns 0 if a Type=3 entry matched EXPECTED_CERT byte-for-byte
+scan_dir() {
+    local ssh_path="$1" local_prefix="$2"
+    local listing="/tmp/${local_prefix}-files"
+    $EDEN eve ssh ls "$ssh_path" 2>/dev/null >"$listing" || true
+    if ! [ -s "$listing" ] || ! grep -q json "$listing"; then
+        echo "  $ssh_path: no json files" >&2
+        return 1
+    fi
+    for f in $(cat "$listing"); do
+        local local_file="/tmp/${local_prefix}-${f}"
+        $EDEN eve ssh cat "$ssh_path/$f" > "$local_file" 2>/dev/null
+        local typ
+        typ=$(grep -oE '"Type":[ ]?[0-9]+' "$local_file" 2>/dev/null | head -n1 | tr -dc 0-9)
+        if [ -z "$typ" ]; then
+            echo "  $ssh_path/$f: <no Type field>" >&2
+            continue
+        fi
+        if [ "$typ" != "3" ]; then
+            echo "  $ssh_path/$f: Type=$typ (skip)" >&2
+            continue
+        fi
+        # Type=3 entry; extract base64 PEM and compare. The decoded bytes
+        # are adam's TrimSpace'd cert (no trailing newline), so compare
+        # against expected_sha computed from the same normalization.
+        grep -oE '"Cert":"[^"]*"' "$local_file" | head -n1 | sed 's/^"Cert":"//;s/"$//' \
+            | base64 -d > /tmp/server-encrypt-cert.pem 2>/dev/null
+        local got
+        got=$(sha256sum /tmp/server-encrypt-cert.pem 2>/dev/null | awk '{print $1}')
+        if [ "$got" = "$expected_sha" ]; then
+            echo "  $ssh_path/$f: Type=3, sha256=$got MATCH" >&2
+            return 0
+        fi
+        echo "  $ssh_path/$f: Type=3, sha256=$got (expected $expected_sha)" >&2
+    done
+    return 1
+}
+
+while true; do
+    echo "Scan /run/zedagent/ControllerCert/" >&2
+    if scan_dir /run/zedagent/ControllerCert/ run; then
+        exit 0
+    fi
+    echo "Scan /persist/status/zedagent/ControllerCert/" >&2
+    if scan_dir /persist/status/zedagent/ControllerCert/ persist; then
+        exit 0
+    fi
+    echo "Encrypt cert not yet matching, retrying in 10s..." >&2
+    sleep 10
+done

--- a/tests/workflow/smoke.tests.txt
+++ b/tests/workflow/smoke.tests.txt
@@ -1,5 +1,5 @@
 # Number of tests
-{{$tests := 25}}
+{{$tests := 26}}
 # EDEN_TEST_SETUP env. var. -- "y"(default) performs the EDEN setup steps
 {{$setup := "n"}}
 {{$setup_env := EdenGetEnv "EDEN_TEST_SETUP"}}
@@ -78,9 +78,11 @@ eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/userd
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/app_logs
 /bin/echo Eden change controller certificate test (23/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/ctrl_cert_change
+/bin/echo Eden change controller encrypt certificate test (24/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/ctrl_encrypt_cert_change
 
-/bin/echo Eden Shutdown test (24/{{$tests}})
+/bin/echo Eden Shutdown test (25/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/shutdown_test
 
-/bin/echo EVE reset (25/{{$tests}})
+/bin/echo EVE reset (26/{{$tests}})
 eden.escript.test -test.run TestEdenScripts/eden_reset


### PR DESCRIPTION
## Summary

End-to-end test for rotation of the controller's ECDH encryption certificate (`CERT_TYPE_CONTROLLER_ECDH_EXCHANGE`, `encrypt.pem`), independent of the signing cert. Two commits:

1. **Plumbing** — `eden utils gen-encrypt-cert`, `eden adam change-encrypt-cert`, `eden pod deploy --use-encrypt-cert`. The `--use-encrypt-cert` flag makes `prepareCipherData` derive ECDH from `encrypt-key.pem` and tag the cipher context with the encrypt cert hash, mirroring production controller layouts where signing and ECDH are distinct certs with independent lifetimes. A new cipher-context-cert-hash filter in `reencryptConfigs` (and the new `reencryptConfigsForEncryptCert`) lets the two rotation commands coexist: each only re-encrypts cipher blocks whose context references the cert it owns.

2. **Test** — `ctrl_encrypt_cert_change.txt`, registered as smoke step 24/26. Deploys three eclient apps with `--use-encrypt-cert`, rotates encrypt + signing certs twice, verifies fresh-app deployment after each rotation, cross-checks the rotated cert is advertised in pubsub, and confirms reboot survival.

## Why each rotation rotates *both* signing and encrypt

EVE's only fast trigger for `/certs` refetch is signing-cert mismatch in the auth-envelope `SenderCertHash` (`controllerconn/authen.go:152-162`). The cipher decrypt path returns "Controller Certificate get fail" without triggering refetch, adam doesn't populate `EdgeDevConfig.controllercert_confighash` so `handleControllerCertsSha` is dead, and the periodic `controllerCertsTask` defaults to `CertInterval = 24h`. See [lf-edge/eve#5926](https://github.com/lf-edge/eve/issues/5926) for the gap analysis and [lf-edge/adam#152](https://github.com/lf-edge/adam/pull/152) for the fix; once that adam patch ships in an Eden-tracked release, the test can be extended with a pure encrypt-cert rotation.

## Verification approach

1. **Fresh-app deployment** is the primary signal. After each rotation, eclient2/eclient3 is deployed with `--use-encrypt-cert` — the cipher block uses the just-rotated ECDH key. Reaching `RUNNING` means EVE pulled `/certs` (triggered by the paired signing rotation), published the new Type=3 cert into `pubControllerCert`, and decrypted the cipher block.

2. **Cert-chain cross-check.** `check_encrypt_cert.sh` walks `/run/zedagent/ControllerCert/` (or `/persist/...` on EVE where that pubsub is `Persistent: true`), filters for `Type=3`, and byte-matches the decoded PEM against `encrypt-new.pem` (normalized for adam's `strings.TrimSpace`).

3. **Reboot survival.** After both rotations + a reboot, all three apps come back `RUNNING` and the cert chain still has the rotated encrypt cert.

## Test plan

- [x] CI smoke matrix — 3 of 4 entries reach the test and pass; the fourth (`Smoke (ext4, false)`) hits the upstream `log_test` flake that #1156 addresses, before reaching step 24.
- [x] `gofmt -l pkg/ cmd/` clean
- [x] `go build ./...` clean
- [x] `go test ./pkg/openevec/...` passes
- [x] Existing `ctrl_cert_change.txt` continues to pass (the new `reencryptConfigs` filter is a no-op for it — its cipher contexts all reference the signing cert hash, which is what the filter selects).

## Notes for reviewers

- This branch is rebased onto [lf-edge/eden#1156](https://github.com/lf-edge/eden/pull/1156)'s log_test fix (`4b0a8cd`). That commit will fall away naturally once #1156 merges and we rebase onto upstream master.
- adam #152 is a separate PR that this Eden PR does not depend on — adam #152 enables a future Eden test enhancement, not a current requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
