### PR TITLE
tests/baseosmgr: e2e coverage for force-fallback and retry-update

### DIFF
--- a/tests/baseosmgr/Makefile
+++ b/tests/baseosmgr/Makefile
@@ -1,0 +1,65 @@
+DEBUG ?= "debug"
+
+# HOSTARCH is the host architecture
+# ARCH is the target architecture
+# we need to keep track of them separately
+HOSTARCH ?= $(shell uname -m)
+HOSTOS ?= $(shell uname -s | tr A-Z a-z)
+
+# canonicalized names for host architecture
+override HOSTARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(HOSTARCH)))
+
+# unless otherwise set, I am building for my own architecture, i.e. not cross-compiling
+# and for my OS
+ARCH ?= $(HOSTARCH)
+OS ?= $(HOSTOS)
+
+# canonicalized names for target architecture
+override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
+
+WORKDIR ?= $(CURDIR)/../../dist
+TESTDIR := tests/$(shell basename $(CURDIR))
+BINDIR := $(WORKDIR)/bin
+DATADIR := $(WORKDIR)/$(TESTDIR)/
+BIN := eden
+LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
+TESTNAME := eden.escript
+TESTBIN := $(TESTNAME).test
+TESTSCN := eden.baseosmgr.tests.txt
+LOCALTESTBIN := $(TESTBIN)-$(OS)-$(ARCH)
+
+.DEFAULT_GOAL := help
+
+clean:
+	rm -rf $(WORKDIR)/$(TESTSCN)
+
+$(BINDIR):
+	mkdir -p $@
+$(DATADIR):
+	mkdir -p $@
+
+test:
+	$(LOCALBIN) test $(CURDIR) -v $(DEBUG)
+
+build: setup
+
+
+setup: $(BINDIR) $(DATADIR)
+	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
+
+.PHONY: test build setup clean all
+
+help:
+	@echo "EDEN is the harness for testing EVE and ADAM"
+	@echo
+	@echo "This Makefile automates commons tasks of EDEN testing"
+	@echo
+	@echo "Commonly used maintenance and development targets:"
+	@echo "   build         build test-binary (OS and ARCH options supported, for ex. OS=linux ARCH=arm64)"
+	@echo "   setup         setup of test environment"
+	@echo "   test          run tests"
+	@echo "   clean         cleanup of test harness"
+	@echo
+	@echo "You need install requirements for EVE (look at https://github.com/lf-edge/eve#install-dependencies)."
+	@echo "Also, you need to install 'uuidgen' utility."
+	@echo "You need access to docker socket and installed qemu packages."

--- a/tests/baseosmgr/eden-config.yml
+++ b/tests/baseosmgr/eden-config.yml
@@ -1,0 +1,5 @@
+---
+eden:
+
+    # test scenario
+    test-scenario: "eden.baseosmgr.tests.txt"

--- a/tests/baseosmgr/eden.baseosmgr.tests.txt
+++ b/tests/baseosmgr/eden.baseosmgr.tests.txt
@@ -1,2 +1,2 @@
-eden.escript.test -test.run TestEdenScripts/force_fallback -test.timeout 30m
-eden.escript.test -test.run TestEdenScripts/retry_update -test.timeout 60m
+eden.escript.test -test.run TestEdenScripts/force_fallback -test.timeout 45m
+eden.escript.test -test.run TestEdenScripts/retry_update -test.timeout 90m

--- a/tests/baseosmgr/eden.baseosmgr.tests.txt
+++ b/tests/baseosmgr/eden.baseosmgr.tests.txt
@@ -1,0 +1,2 @@
+eden.escript.test -test.run TestEdenScripts/force_fallback -test.timeout 30m
+eden.escript.test -test.run TestEdenScripts/retry_update -test.timeout 60m

--- a/tests/baseosmgr/testdata/force_fallback.txt
+++ b/tests/baseosmgr/testdata/force_fallback.txt
@@ -102,8 +102,12 @@ message 'Asserting rollback to previous version'
 eden -t 1m info --out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:active' --tail=1
 cmp stdout old_ver
 
-# Reset config and clear the leftover baseos config so subsequent
-# tests start clean.
+# Clear adam's leftover BaseOsConfig for the test version so subsequent
+# tests / suites start with a clean controller-side state.
+eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam:// --os-version={{$short_version}}
+exec sleep 10
+
+# Reset config back to defaults.
 eden eve reset
 
 -- eden-config.yml --

--- a/tests/baseosmgr/testdata/force_fallback.txt
+++ b/tests/baseosmgr/testdata/force_fallback.txt
@@ -1,0 +1,116 @@
+# baseosmgr force-fallback test
+#
+# Exercises the controller-driven roll-back to the previous image:
+#   handleForceFallback in pkg/pillar/cmd/baseosmgr/forcefallback.go.
+#
+# Sequence:
+#   1. Capture the version currently running (the OLD version).
+#   2. Trigger an EVE image update to a NEW version and wait for it
+#      to commit (active state).
+#      After commit baseosmgr's invariant for force-fallback holds:
+#      curr=active (new), other=unused (with the OLD version).
+#   3. Bump the global config knob force.fallback.counter. zedagent
+#      forwards the change to baseosmgr via ZedAgentStatus, which
+#      flips the OTHER partition to "updating". nodeagent observes
+#      the flip and reboots into the OTHER partition with
+#      BootReasonUpdate.
+#   4. After the reboot the active partition is the OLD partition,
+#      so SwList[0].ShortVersion equals the captured old_ver.
+#
+# Verifies, end-to-end:
+#   - readForceFallbackCounter / writeForceFallbackCounter persistence
+#   - handleForceFallback's preconditions (curr=active, other=unused
+#     with non-empty version) being met after a successful upgrade
+#   - the SetOtherPartitionStateUpdating → ZbootStatus republish path
+#   - that nodeagent reacts to the flip and reboots into the previous
+#     image
+#
+# This test does an end-to-end *upgrade then roll back* cycle, so it
+# is a long test (~10–20 min depending on host speed).
+
+# Default EVE version to upgrade *to* (i.e. the version we will then
+# fall back away from). Override via $EVE_VERSION as usual.
+{{$eve_ver := "12.1.0"}}
+{{$eve_registry := "lfedge/eve"}}
+{{$env := EdenGetEnv "EVE_VERSION"}}
+{{if $env}}{{$eve_ver = $env}}{{end}}
+{{$eve_hv := "kvm"}}
+{{$eve_arch := EdenConfig "eve.arch"}}
+{{$short_version := printf "%s-%s-%s" $eve_ver $eve_hv $eve_arch}}
+
+# Lim helper for waiting on Info messages.
+{{$test := "test eden.lim.test -test.v -timewait 30m -test.run TestInfo"}}
+
+# Configure timers:
+#   - test-success: 30s so the upgrade commits quickly
+#   - shorter controller polling so the new timers reach the device
+#     promptly and so the bumped force.fallback.counter propagates
+#   - shorter deviceinfo so post-rollback Info publishes promptly
+eden controller edge-node update --config timer.test.baseimage.update=30
+eden controller edge-node update --config timer.config.interval=10
+eden controller edge-node update --config timer.deviceinfo.interval=30
+
+# Default timer.config.interval is 60s, so wait long enough for the
+# device's next config poll to apply the shorter values.
+exec sleep 70
+
+# Capture the version we're starting from (the OLD version we will
+# roll back to in step 4).
+message 'Capturing pre-upgrade (old) version'
+eden -t 1m info --out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:active' --tail=1
+cp stdout old_ver
+
+# Pre-fetch the rootfs so eveimage-update doesn't depend on network.
+message 'EVE image download'
+eden -t 10m utils download eve-rootfs --eve-tag={{$eve_ver}} --eve-hv={{$eve_hv}} --eve-registry={{$eve_registry}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs'
+
+# If a prior run of this test left a stale BaseOsConfig on the
+# controller, EVE will refuse to reinstall the same version. Remove
+# + brief wait gives us a clean slate.
+message 'Clearing any stale baseos config from prior runs'
+eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam:// --os-version={{$short_version}}
+exec sleep 20
+
+# Step 2: trigger upgrade and wait for it to commit (active on new ver).
+message 'EVE update request'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam://
+! stderr .
+
+message 'Waiting for upgrade to commit (new partition active)'
+{{$test}} -out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:active InfoContent.dinfo.SwList[0].ShortVersion:{{ $short_version }}'
+stdout '{{ $short_version }}'
+
+# Step 3: bump force.fallback.counter. baseosmgr observes the change
+# via ZedAgentStatus, the precondition (curr=active, other=unused,
+# other has non-empty version) holds, so it flips the other partition
+# to "updating". nodeagent then reboots into it with BootReasonUpdate.
+message 'Bumping force.fallback.counter to roll back to previous image'
+eden controller edge-node update --config force.fallback.counter=1
+
+# Wait for: config push (~10s with the shorter interval),
+# baseosmgr's flip + ZbootStatus republish, nodeagent's
+# scheduleNodeOperation + minRebootDelay (30s) + boot, plus
+# a couple of ticks of slack.
+exec sleep 180
+
+# Step 4: verify the active partition is now the OLD version. We
+# read the latest active info and compare against the captured
+# old_ver.
+message 'Asserting rollback to previous version'
+{{$test}} -out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:active'
+eden -t 1m info --out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:active' --tail=1
+cmp stdout old_ver
+
+# Reset config and clear the leftover baseos config so subsequent
+# tests start clean.
+eden eve reset
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/baseosmgr/testdata/force_fallback.txt
+++ b/tests/baseosmgr/testdata/force_fallback.txt
@@ -70,6 +70,11 @@ stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs'
 # + brief wait gives us a clean slate.
 message 'Clearing any stale baseos config from prior runs'
 eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam:// --os-version={{$short_version}}
+
+# Verify the controller config no longer references the removed image
+eden controller edge-node get-config
+! stdout '{{ $short_version }}'
+
 exec sleep 20
 
 # Step 2: trigger upgrade and wait for it to commit (active on new ver).
@@ -105,6 +110,11 @@ cmp stdout old_ver
 # Clear adam's leftover BaseOsConfig for the test version so subsequent
 # tests / suites start with a clean controller-side state.
 eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam:// --os-version={{$short_version}}
+
+# Verify the controller config no longer references the removed image
+eden controller edge-node get-config
+! stdout '{{ $short_version }}'
+
 exec sleep 10
 
 # Reset config back to defaults.

--- a/tests/baseosmgr/testdata/retry_update.txt
+++ b/tests/baseosmgr/testdata/retry_update.txt
@@ -144,7 +144,37 @@ message 'Waiting for the retry to commit (new partition active again)'
 eden -t 1m info --out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:active' --tail=1
 stdout '{{ $short_version }}'
 
-# Reset config back to defaults.
+# Revert EVE back to the originally-configured version so the device
+# is left in a known state for downstream tests / suites. The retry
+# committed the NEW version onto the active partition, so without
+# this revert the device stays on $short_version forever.
+{{$orig_ver := EdenConfig "eve.tag"}}
+{{$orig_short := printf "%s-%s-%s" $orig_ver $eve_hv $eve_arch}}
+
+message 'Reverting EVE to original version ({{$orig_ver}})'
+# Clear the leftover BaseOsConfig so the next eveimage-update is a
+# fresh request (otherwise adam may treat the original-version push
+# as a no-op against the still-installed $short_version).
+eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam:// --os-version={{ $short_version }}
+exec sleep 20
+
+# Pre-fetch the original rootfs.
+eden -t 10m utils download eve-rootfs --eve-tag={{ $orig_ver }} --eve-hv={{ $eve_hv }} --eve-registry={{ $eve_registry }} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $orig_short }}.squashfs'
+
+# Push the downgrade and wait for it to commit (active on $orig_short).
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $orig_short }}.squashfs -m adam://
+! stderr .
+
+{{$test}} -out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:active InfoContent.dinfo.SwList[0].ShortVersion:{{ $orig_short }}'
+eden -t 1m info --out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:active' --tail=1
+stdout '{{ $orig_short }}'
+
+# Clear adam's BaseOsConfig (so it doesn't push the downgrade again
+# next session) and reset device config back to defaults.
+eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $orig_short }}.squashfs -m adam:// --os-version={{ $orig_short }}
+exec sleep 10
+
 eden eve reset
 
 {{else}}

--- a/tests/baseosmgr/testdata/retry_update.txt
+++ b/tests/baseosmgr/testdata/retry_update.txt
@@ -1,0 +1,163 @@
+# baseosmgr retry-update test
+#
+# Exercises the controller-driven retry of a failed update:
+#   handleUpdateRetryCounter + isImageInErrorState in
+#   pkg/pillar/cmd/baseosmgr/handlebaseos.go.
+#
+# Sequence:
+#   1. Configure a short test window (30s) and a short fallback timer
+#      (60s) so the failed-upgrade cycle finishes quickly.
+#   2. Trigger an EVE image update to the new version. Wait until the
+#      device is on the NEW partition in inprogress state (the
+#      post-update test window).
+#   3. Cut controller reachability so the device cannot reach Adam
+#      during the test window. After fallback timeout nodeagent
+#      reboots back to the OLD image with BootReasonFallback.
+#      Restore connectivity post-reboot.
+#   4. Bump RetryUpdateCounter via `eveimage-update-retry`. baseosmgr
+#      observes via the new BaseOsConfig: curr=active (old), other=
+#      inprogress (new, same as the retry attempt) → preconditions
+#      met. It flips the OTHER partition back to "updating".
+#      nodeagent reboots into it. The retry's test window (still 30s)
+#      now passes against a working controller, so the upgrade
+#      commits — active=NEW.
+#   4 verifies, end-to-end:
+#      - The "failed image" branch of isImageInErrorState (curr=active,
+#        other=inprogress with matching BaseOsConfig.Activate=true).
+#      - handleUpdateRetryCounter's
+#        SetOtherPartitionStateUpdating + saveConfigRetryUpdateCounter
+#        path.
+#      - That nodeagent re-boots into the same image and that
+#        baseosmgr commits the retry once it passes.
+#
+# Black-hole-on-iptables flavour: the device's controller IP is
+# silently dropped via in-EVE iptables (link, IP, lease all stay
+# valid so NIM is happy and only nodeagent's fallback timer fires).
+# After the fallback reboot the rule dies with the previous boot's
+# in-memory iptables, so connectivity restores naturally.
+#
+# Only meaningful on device models reachable via eden eve ssh
+# (ZedVirtual-4G, VBox).
+
+{{$devmodel := EdenConfig "eve.devmodel"}}
+{{$adam_ip  := EdenConfig "adam.ip"}}
+
+{{if or (eq $devmodel "ZedVirtual-4G") (eq $devmodel "VBox") }}
+
+{{$eve_ver := "12.1.0"}}
+{{$eve_registry := "lfedge/eve"}}
+{{$env := EdenGetEnv "EVE_VERSION"}}
+{{if $env}}{{$eve_ver = $env}}{{end}}
+{{$eve_hv := "kvm"}}
+{{$eve_arch := EdenConfig "eve.arch"}}
+{{$short_version := printf "%s-%s-%s" $eve_ver $eve_hv $eve_arch}}
+
+{{$test := "test eden.lim.test -test.v -timewait 30m -test.run TestInfo"}}
+
+# Step 1: configure timers.
+#   - fallback fires after 60s of cloud-gone (minimum allowed)
+#   - test-success deliberately long (default 10min) so the FIRST
+#     attempt fails via fallback rather than committing
+#   - shorter controller polling so subsequent config pushes (the
+#     retry counter bump) propagate promptly
+#   - shorter deviceinfo so post-reboot Infos publish promptly
+eden controller edge-node update --config timer.update.fallback.no.network=60
+eden controller edge-node update --config timer.test.baseimage.update=600
+eden controller edge-node update --config timer.config.interval=10
+eden controller edge-node update --config timer.deviceinfo.interval=30
+
+# Default timer.config.interval is 60s, so wait long enough for the
+# device's next config poll to apply the shorter values.
+exec sleep 70
+
+# Pre-fetch the rootfs so eveimage-update doesn't depend on network.
+message 'EVE image download'
+eden -t 10m utils download eve-rootfs --eve-tag={{$eve_ver}} --eve-hv={{$eve_hv}} --eve-registry={{$eve_registry}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs'
+
+# If a prior run left a stale BaseOsConfig, remove it so the retry
+# path actually re-attempts a fresh install.
+message 'Clearing any stale baseos config from prior runs'
+eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam:// --os-version={{$short_version}}
+exec sleep 20
+
+# Step 2: trigger the update.
+message 'EVE update request'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam://
+! stderr .
+
+message 'Waiting for new partition to be inprogress'
+{{$test}} -out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:inprogress InfoContent.dinfo.SwList[0].ShortVersion:{{ $short_version }}'
+stdout '{{ $short_version }}'
+
+# Step 3: black-hole the controller so the test window times out.
+# The link stays up (NIM is happy) and only nodeagent's fallback
+# timer fires.
+message 'Black-holing controller traffic to trigger fallback'
+# `--` terminates eden's flag parsing so the iptables flags pass
+# through unmolested to ssh.
+eden eve ssh -- iptables -A OUTPUT -d {{$adam_ip}} -j DROP
+
+# Sleep > timer.update.fallback.no.network (60s) + propagation +
+# minRebootDelay (30s) + boot, plus a couple of ticks of slack.
+# After the reboot the device is back on the previous partition;
+# the iptables rule (in-memory) is gone with it, so connectivity
+# restores naturally.
+exec sleep 180
+
+# Confirm the failure: nodeagent should have reported BootReasonFallback.
+message 'Asserting first cycle ended with BOOT_REASON_FALLBACK'
+{{$test}} -out InfoContent.dinfo.LastBootReason 'InfoContent.dinfo.LastBootReason:BOOT_REASON_FALLBACK'
+stdout 'BOOT_REASON_FALLBACK'
+
+# At this point: curr=active (OLD), other=inprogress (NEW with the
+# same version we just tried). baseosmgr's
+# updateBaseOsStatusOnReboot has stamped the previous reboot reason
+# onto the BaseOsStatus for that uuid, and the controller can see
+# the failure.
+
+# Step 4: bump RetryUpdateCounter. baseosmgr observes the change
+# via the new BaseOsConfig. handleUpdateRetryCounter sees
+# isImageInErrorState=true (curr=active, other=inprogress with
+# matching Activate=true config) and flips the other partition
+# back to "updating". nodeagent reboots into it.
+message 'Bumping RetryUpdateCounter to retry the failed update'
+eden -t 1m controller edge-node eveimage-update-retry
+! stderr .
+
+# Now the retry's test window can pass since connectivity is
+# restored. Allow time for: config push, baseosmgr flip, nodeagent
+# reboot (minRebootDelay + boot), test window (30s), commit.
+# That's roughly 30s+30s+60s+30s = ~3 min, plus slack. The lim.test
+# wait below has its own 30m budget, so a single sleep is enough
+# to clear the busy initial period.
+exec sleep 60
+
+# Step 4 assertion: active=NEW. If the retry never fired, the
+# active partition would remain the OLD version and the lim.test
+# wait would either match nothing (if the regex never sees the
+# new version active) or match a stale pre-retry sample. To handle
+# the latter, follow the lim.test wait with `eden info ... --tail=1`
+# to get the freshest sample.
+message 'Waiting for the retry to commit (new partition active again)'
+{{$test}} -out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:active InfoContent.dinfo.SwList[0].ShortVersion:{{ $short_version }}'
+eden -t 1m info --out InfoContent.dinfo.SwList[0].ShortVersion 'InfoContent.dinfo.SwList[0].PartitionState:active' --tail=1
+stdout '{{ $short_version }}'
+
+# Reset config back to defaults.
+eden eve reset
+
+{{else}}
+
+message 'retry_update: skipped — device model {{$devmodel}} not supported via eden eve ssh'
+
+{{end}}
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/baseosmgr/testdata/retry_update.txt
+++ b/tests/baseosmgr/testdata/retry_update.txt
@@ -79,6 +79,11 @@ stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs'
 # path actually re-attempts a fresh install.
 message 'Clearing any stale baseos config from prior runs'
 eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam:// --os-version={{$short_version}}
+
+# Verify the controller config no longer references the removed image
+eden controller edge-node get-config
+! stdout '{{ $short_version }}'
+
 exec sleep 20
 
 # Step 2: trigger the update.
@@ -156,6 +161,11 @@ message 'Reverting EVE to original version ({{$orig_ver}})'
 # fresh request (otherwise adam may treat the original-version push
 # as a no-op against the still-installed $short_version).
 eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $short_version }}.squashfs -m adam:// --os-version={{ $short_version }}
+
+# Verify the controller config no longer references the removed image
+eden controller edge-node get-config
+! stdout '{{ $short_version }}'
+
 exec sleep 20
 
 # Pre-fetch the original rootfs.
@@ -173,6 +183,11 @@ stdout '{{ $orig_short }}'
 # Clear adam's BaseOsConfig (so it doesn't push the downgrade again
 # next session) and reset device config back to defaults.
 eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $orig_short }}.squashfs -m adam:// --os-version={{ $orig_short }}
+
+# Verify the controller config no longer references the removed image
+eden controller edge-node get-config
+! stdout '{{ $orig_short }}'
+
 exec sleep 10
 
 eden eve reset


### PR DESCRIPTION
## Summary

Adds a new \`tests/baseosmgr/\` suite with **two e2e tests** that exercise the two controller-driven knobs in \`pkg/pillar/cmd/baseosmgr\` that are otherwise reachable only through real partition flips and a real controller round-trip:

| Test | Path tested | Failure / drive mode |
|---|---|---|
| \`force_fallback\` | \`handleForceFallback\` (\`forcefallback.go\`) | Bumps the global config knob \`force.fallback.counter\` after a successful upgrade and asserts the device reverts to the captured pre-upgrade version. |
| \`retry_update\` | \`handleUpdateRetryCounter\` + \`isImageInErrorState\` (\`handlebaseos.go\`) | Triggers an upgrade, black-holes the controller's IP via in-EVE \`iptables\` so the post-update test window times out (\`BootReasonFallback\`), then bumps \`RetryUpdateCounter\` via \`eveimage-update-retry\` and asserts the same image succeeds on the second attempt. |

These complement the existing \`tests/update_eve_image/\` suite (which already covers the happy upgrade path + simple revert) and the new \`tests/nodeagent/baseos_fallback_*\` (#1162, which covers the fallback-on-cloud-disconnect path from nodeagent's perspective).

## What's covered (and what isn't)

\`force_fallback\` exercises \`handleForceFallback\`'s precondition check
(curr=active, other=unused with non-empty \`ShortVersion\` — only true after a
prior successful upgrade), the
\`/persist/checkpoint/forceFallbackCounter\` plumbing, the
\`SetOtherPartitionStateUpdating\` path, and that nodeagent reacts to the
flip and reboots into the previous image. The version-based assertion
(\`cmp\` of the post-rollback active version against a captured \`old_ver\`
file) is unique to this path — only force-fallback can revert
\`SwList[0].ShortVersion\` to the pre-upgrade value.

\`retry_update\` exercises the "failed image" branch of
\`isImageInErrorState\` (curr=active, other=inprogress with a matching
\`BaseOsConfig.Activate=true\`), the
\`SetOtherPartitionStateUpdating\` + \`saveConfigRetryUpdateCounter\` path,
and the second \`BootReasonUpdate\` cycle that nodeagent issues into the
same partition. The black-hole is removed naturally by the post-fallback
reboot (in-memory iptables rule dies with the previous boot), so the
retry's test window passes against a working controller.

## Test plan

- [ ] Both tests run locally against a coverage-instrumented EVE under
      QEMU (\`ZedVirtual-4G\`). *(deferred: eden harness is busy)*
- [ ] CI run on lf-edge/eden's harness.

Per-test runtime estimate (laptop, KVM-accelerated):

- \`force_fallback\`: ~10–15 min (one full upgrade-then-rollback cycle).
- \`retry_update\`: ~12–18 min (one failed-attempt cycle + one retry cycle).

## Implementation notes

- **Capture-then-compare for the version assertion**: \`force_fallback\` runs
  \`eden info ... PartitionState:active --tail=1\` *before* the upgrade,
  saves the result to \`old_ver\`, and after the rollback runs the same
  command again and \`cmp\`s against \`old_ver\`. This is more robust than
  asserting \`! stdout '$short_version'\` because the post-fallback Info
  publish-cadence might still echo a stale pre-reboot sample if the
  assertion fires too early; the \`cmp\` is exact.
- **Idempotency across runs**: both tests issue \`eveimage-remove\` + brief
  wait before \`eveimage-update\`, so re-running with the same EVE version
  still triggers a fresh update.
- **Config-propagation timing**: \`timer.config.interval=10\` shortens
  controller polling so subsequent config pushes (the
  \`force.fallback.counter\` bump or the \`RetryUpdateCounter\` bump from
  \`eveimage-update-retry\`) propagate within ~10s. \`timer.deviceinfo.interval=30\`
  ensures post-rollback Info publishes promptly so \`lim.test\` doesn't
  wait 10 min for the next periodic push.
- **Black-hole mechanism (retry_update)**: \`eden eve ssh -- iptables -A OUTPUT -d <adam-ip> -j DROP\`,
  identical to the new \`tests/nodeagent/baseos_fallback_blackhole.txt\` in
  #1162. Device-model gating is the same (\`ZedVirtual-4G\` / \`VBox\` only).
- **Suite is not wired into broader workflows** — the two tests are
  addressable on their own (\`eden.escript.test -test.run TestEdenScripts/force_fallback -testdata tests/baseosmgr/testdata/\`).
  Folding them into a broader \`smoke\` / \`eve-upgrade\` workflow is a
  follow-up.

## Suite structure

\`\`\`
tests/baseosmgr/
├── Makefile               (boilerplate matching tests/nodeagent/)
├── eden-config.yml
├── eden.baseosmgr.tests.txt
└── testdata/
    ├── force_fallback.txt
    └── retry_update.txt
\`\`\`

## Why draft

Has not been run end-to-end yet (eden harness was busy at write time);
will be exercised on \`ZedVirtual-4G\` / \`VBox\` before marking ready.

The companion eve-side PRs that the unit-test side of this work is in:

- lf-edge/eve#5921 — \`docs(baseosmgr): add architecture document\`.
- lf-edge/eve#5922 — \`baseosmgr: add Phase-1 unit tests + pathConfig seam\`.
- lf-edge/eve#5923 — \`baseosmgr: Phase 2 — Zboot/kubeapi/HVType seams + tests\`
  (lifts package coverage from 0 % to ~75 %).

This PR is independent of those (it only touches eden), but the same
review eyes apply to the design.