### PR TITLE
tests/network: cross-version ConfigItemValueMap paths

### DIFF
--- a/tests/network/testdata/nim_diag_remote_endpoints.txt
+++ b/tests/network/testdata/nim_diag_remote_endpoints.txt
@@ -47,9 +47,11 @@ stdout 'snapshot taken'
 # Set a distinctive endpoint value through the controller config.
 eden controller edge-node update --config diag.probe.remote.http.endpoint=http://nim-test-diag.example.test/
 
-# Poll /run/zedagent/ConfigItemValueMap/global.json on EVE for the new
-# value to appear. zedagent's config-fetch interval is short, but adam
-# round-trips can take ~30s.
+# Poll the effective ConfigItemValueMap on EVE for the new value to
+# appear. zedagent's config-fetch interval is short, but adam
+# round-trips can take ~30s. (Path is EVE-version-dependent —
+# /run/zedagent/ConfigItemValueMap/global.json on master,
+# /persist/status/zedagent/ConfigItemValueMap/global.json on 16.6.0.)
 exec -t 3m bash wait-cfg-item.sh
 stdout 'diag endpoint propagated'
 
@@ -99,19 +101,28 @@ echo "snapshot taken"
 
 -- wait-cfg-item.sh --
 #!/bin/bash
-# Poll /run/zedagent/ConfigItemValueMap/global.json on EVE until the
-# distinctive endpoint shows up under
-# .GlobalSettings."diag.probe.remote.http.endpoint".StrValue.
+# Poll the effective ConfigItemValueMap on EVE until the distinctive
+# endpoint shows up under
+# .GlobalSettings["diag.probe.remote.http.endpoint"].StrValue.
+# Path is EVE-version-dependent — /run-resident on master,
+# /persist-resident on 16.6.0 — so probe /run first and fall back to
+# /persist. The ssh command must be a single line; `eden eve ssh`
+# collapses newlines into spaces. Fetch verbatim, then parse with
+# local jq (avoids shell-quoting issues with bracket-quoted jq
+# expressions through ssh).
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 WANT='http://nim-test-diag.example.test/'
 expr='.GlobalSettings["diag.probe.remote.http.endpoint"].StrValue'
 for i in $(seq 1 36); do
-    val=$($EDEN eve ssh "eve exec pillar jq -r '$expr' /run/zedagent/ConfigItemValueMap/global.json 2>/dev/null" 2>/dev/null)
-    val=${val//$'\r'/}
-    val=$(echo "$val" | tr -d '[:space:]')
-    if [ "$val" = "$WANT" ]; then
-        echo "diag endpoint propagated"
-        exit 0
+    "$EDEN" eve ssh 'f=/run/zedagent/ConfigItemValueMap/global.json; [ -s "$f" ] || f=/persist/status/zedagent/ConfigItemValueMap/global.json; [ -s "$f" ] && cat "$f"' 2>/dev/null > "$WORK/cfg.json"
+    if [ -s "$WORK/cfg.json" ]; then
+        val=$(jq -r "$expr" "$WORK/cfg.json" 2>/dev/null)
+        val=${val//$'\r'/}
+        val=$(echo "$val" | tr -d '[:space:]')
+        if [ "$val" = "$WANT" ]; then
+            echo "diag endpoint propagated"
+            exit 0
+        fi
     fi
     sleep 5
 done

--- a/tests/network/testdata/nim_globalconfig_only_preonboard.txt
+++ b/tests/network/testdata/nim_globalconfig_only_preonboard.txt
@@ -173,16 +173,18 @@ exit 1
 
 -- check-globalconfig-marker.sh --
 #!/bin/bash
-# Effective ConfigItemValueMap is pubsub-published by zedagent to
-# /run/zedagent/ConfigItemValueMap/global.json (not /persist — the
-# topic is /run-resident by default). Fetch the file verbatim via ssh
-# (avoids shell-quoting issues that bite when sending bracket-quoted
-# jq expressions through `eden eve ssh`), then parse locally with jq.
+# Effective ConfigItemValueMap pubsub topic location depends on EVE
+# version: master/HEAD has it /run-resident
+# (/run/zedagent/ConfigItemValueMap/global.json); 16.6.0 has it
+# /persist-resident (/persist/status/zedagent/ConfigItemValueMap/global.json).
+# Fetch from whichever exists; both carry the same JSON shape.
+# Cat-via-ssh + local jq avoids shell-quoting issues that bite when
+# sending bracket-quoted jq expressions through `eden eve ssh`.
 set -eu
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-"$EDEN" eve ssh 'cat /run/zedagent/ConfigItemValueMap/global.json' 2>/dev/null > "$WORK/effective-global.json"
+"$EDEN" eve ssh 'f=/run/zedagent/ConfigItemValueMap/global.json; [ -s "$f" ] || f=/persist/status/zedagent/ConfigItemValueMap/global.json; [ -s "$f" ] && cat "$f"' 2>/dev/null > "$WORK/effective-global.json"
 if [ ! -s "$WORK/effective-global.json" ]; then
-    echo "could not fetch /run/zedagent/ConfigItemValueMap/global.json from device"
+    echo "could not fetch ConfigItemValueMap/global.json from /run or /persist on device"
     exit 1
 fi
 val=$(jq -r '.GlobalSettings["timer.config.interval"].IntValue' "$WORK/effective-global.json")


### PR DESCRIPTION
Makes the `ConfigItemValueMap` marker checks in two `tests/network` testdata scripts work across EVE releases. The effective `ConfigItemValueMap` pubsub topic is `/run`-resident on current master (`/run/zedagent/ConfigItemValueMap/global.json`) but `/persist`-resident on 16.6.0 (`/persist/status/zedagent/ConfigItemValueMap/global.json`), because the topic's Persistent flag is not stable across releases. Both `nim_diag_remote_endpoints` and `nim_globalconfig_only_preonboard` previously hardcoded the `/run` path and failed on 16.6.0.

The polling/marker helpers now probe `/run` first and fall back to `/persist`, fetching the file over a single-line `eden eve ssh` command (`eden eve ssh` collapses newlines into spaces, which mangled an earlier multi-line form) and parsing locally with `jq` to avoid shell-quoting trouble with the bracket-quoted jq path.

## Test plan
- [x] `nim_globalconfig_only_preonboard` validated end-to-end against EVE tag 16.6.0 (passes ~103s).
- [ ] CI green on lf-edge/eden.
