### PR TITLE
einfo,emetric: parse JSON from adam's redis stream

### DIFF
--- a/pkg/controller/einfo/einfo.go
+++ b/pkg/controller/einfo/einfo.go
@@ -18,7 +18,6 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 )
 
 // HandlerFunc must process info.ZInfoMsg and return true to exit
@@ -29,10 +28,15 @@ type HandlerFunc func(im *info.ZInfoMsg) bool
 // and return true to exit or false to continue
 type QHandlerFunc func(im *info.ZInfoMsg, query map[string]string) bool
 
-// ParseZInfoMsg unmarshal ZInfoMsg
+// ParseZInfoMsg unmarshal ZInfoMsg.
+//
+// Adam stores info messages as JSON in its redis stream (see adam commit
+// 3af1f41 "Store info and metrics as JSON, remove conversionFunc from
+// deviceDataGet", 2026-03-24); use protojson.Unmarshal to match — the
+// same decoder elog and eapps already use for log entries.
 func ParseZInfoMsg(data []byte) (ZInfoMsg *info.ZInfoMsg, err error) {
 	var zi info.ZInfoMsg
-	err = proto.Unmarshal(data, &zi)
+	err = protojson.Unmarshal(data, &zi)
 	return &zi, err
 }
 

--- a/pkg/controller/emetric/emetric.go
+++ b/pkg/controller/emetric/emetric.go
@@ -18,7 +18,6 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 )
 
 // MetricCheckerMode is MetricExist, MetricNew and MetricAny
@@ -36,10 +35,15 @@ const (
 	MetricAny   MetricCheckerMode = -1 //MetricAny use both mechanisms
 )
 
-// ParseMetricsBundle unmarshal LogBundle
+// ParseMetricsBundle unmarshal ZMetricMsg.
+//
+// Adam stores metric messages as JSON in its redis stream (see adam commit
+// 3af1f41 "Store info and metrics as JSON, remove conversionFunc from
+// deviceDataGet", 2026-03-24); use protojson.Unmarshal to match — the
+// same decoder elog and eapps already use for log entries.
 func ParseMetricsBundle(data []byte) (logBundle *metrics.ZMetricMsg, err error) {
 	var lb metrics.ZMetricMsg
-	err = proto.Unmarshal(data, &lb)
+	err = protojson.Unmarshal(data, &lb)
 	return &lb, err
 }
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -59,7 +59,7 @@ const (
 
 	//tags, versions, repos
 	DefaultEVETag               = "16.6.0" // DefaultEVETag tag for EVE image
-	DefaultAdamTag              = "0.0.65"
+	DefaultAdamTag              = "0.0.75"
 	DefaultRedisTag             = "7"
 	DefaultRegistryTag          = "2.7"
 	DefaultProcTag              = "83cfe07"


### PR DESCRIPTION
## Summary

Fixes a recent regression (which only appears when using adam master) due to switch from protobuf format to json which eden does not handle.

- `einfo,emetric: parse JSON from adam's redis stream` — switch `ParseZInfoMsg` and `ParseMetricsBundle` from `proto.Unmarshal` to `protojson.Unmarshal` so the eden side can read what adam now writes. Adam started storing info and metric messages as JSON in [`3af1f41`](https://github.com/lf-edge/adam/commit/3af1f41) (2026-03-24); the corresponding eden update was missed. Logs (`pkg/controller/elog`) and app logs (`pkg/controller/eapps`) already use `protojson.Unmarshal` and are unaffected. Flowlogs are unaffected because adam's `flowLogProcess` writes the EVE-side proto bytes through verbatim.
- `defaults: bump DefaultAdamTag from 0.0.65 to 0.0.75` — `0.0.65` was published ~2025-10, predates adam's JSON-storage change, and stores info/metrics as proto-binary; the patched einfo/emetric parser cannot read it. `0.0.75` is the latest auto-published tag (2026-05-03) and is post-`3af1f41`. Existing callers that pin a specific `adam.tag` (CI workflows, scripts, local user configs) are unaffected.

Fixes #1167.

## Test plan

- [x] `go build ./...` clean (no unused-import errors after dropping `google.golang.org/protobuf/proto` from einfo and emetric)
- [x] `go vet ./pkg/controller/einfo/... ./pkg/controller/emetric/...` clean
- [x] `gofmt -l` clean
- [x] End-to-end: built lim.test from this branch, ran against an adam built from current `lf-edge/adam` master (post-`3af1f41`):
  ```
  $ ./dist/bin/eden.lim.test -test.run TestInfo -test.v -timewait 60s \
      -out InfoContent.dinfo.machineArch 'InfoContent.dinfo.machineArch:.+'
  --- PASS: TestInfo (32.33s)
  ```
  Same query, same adam, **unpatched** `eden.lim.test` from master times out at 60s. Bumping the controller epoch (`eden eve epoch &`) reliably triggers a fresh `ZiDevice` publish that the patched lim.test matches.
- [ ] CI run on `lfedge/adam:0.0.75` (the new default) to confirm the workflow / smoke / lim suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
