### PR TITLE
tests: wait for EVE to publish info after restart

### DIFF
--- a/tests/workflow/testdata/eve_restart.txt
+++ b/tests/workflow/testdata/eve_restart.txt
@@ -10,6 +10,22 @@ exec sleep 60
 eden -t 2m eve start
 ! stderr .
 
-eden eve status
-stdout 'EVE on .* status: running'
-! stderr .
+# `eden eve status` only checks that qemu's PID is alive; that's not
+# enough — downstream tests in the smoke suite (info_test, metric_test,
+# ssh_test) assume EVE has finished attestation/onboard and is
+# publishing to the controller. On coverage-instrumented builds the
+# post-restart republish can take ~12 min, so wait up to 20 min for a
+# fresh ZiDevice. The epoch bump nudges EVE to republish info on its
+# next config poll once it's reachable.
+eden eve epoch
+test eden.lim.test -test.v -timewait 20m -test.run TestInfo -out InfoContent.dinfo.machineArch 'InfoContent.dinfo.machineArch:.+'
+stdout 'x86_64|aarch64'
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}


### PR DESCRIPTION
## Summary
- `eve_restart` scenario now waits for EVE to be back on the controller (a fresh `ZiDevice` info), not just for qemu's PID to be alive.
- Bounded at 20 min to accommodate slow / coverage-instrumented builds; ~minute on a vanilla EVE.

## Why
The previous `eden eve status` check only verifies qemu PID. Downstream tests in the `smoke` suite (`info_test`, `metric_test`, `ssh_test`) assume EVE has completed attestation/onboard and is publishing to the controller.

On coverage-instrumented builds the post-restart republish can take ~12 min, so the first downstream `info_test` (5-min `timewait`) fires before EVE has published any `ZiDevice` and times out, cascading into `failScenario`.

The fix waits for a fresh `ZiDevice.machineArch` value (a field that's always set, x86_64/aarch64). An `eden eve epoch` bump nudges EVE to republish info on its next config poll once it's reachable.

## Test plan
- [x] CI workflow/smoke suite passes on vanilla builds (wait returns in ~60 s)
- [x] Workflow/smoke suite passes on a coverage-instrumented eve build (wait completes within 20 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)