### PR TITLE
einfo,emetric,elog,eapps: ignore unknown JSON fields on decode

### DIFF
--- a/pkg/controller/eapps/eappslog.go
+++ b/pkg/controller/eapps/eappslog.go
@@ -38,7 +38,7 @@ const (
 // ParseLogEntry unmarshal LogEntry
 func ParseLogEntry(data []byte) (logEntry *logs.LogEntry, err error) {
 	var le logs.LogEntry
-	err = protojson.Unmarshal(data, &le)
+	err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(data, &le)
 	return &le, err
 }
 

--- a/pkg/controller/einfo/einfo.go
+++ b/pkg/controller/einfo/einfo.go
@@ -36,7 +36,7 @@ type QHandlerFunc func(im *info.ZInfoMsg, query map[string]string) bool
 // same decoder elog and eapps already use for log entries.
 func ParseZInfoMsg(data []byte) (ZInfoMsg *info.ZInfoMsg, err error) {
 	var zi info.ZInfoMsg
-	err = protojson.Unmarshal(data, &zi)
+	err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(data, &zi)
 	return &zi, err
 }
 

--- a/pkg/controller/elog/elog.go
+++ b/pkg/controller/elog/elog.go
@@ -45,7 +45,7 @@ const (
 // ParseFullLogEntry unmarshal FullLogEntry
 func ParseFullLogEntry(data []byte) (fullLogEntry *FullLogEntry, err error) {
 	var lb FullLogEntry
-	err = protojson.Unmarshal(data, &lb)
+	err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(data, &lb)
 	return &lb, err
 }
 

--- a/pkg/controller/emetric/emetric.go
+++ b/pkg/controller/emetric/emetric.go
@@ -43,7 +43,7 @@ const (
 // same decoder elog and eapps already use for log entries.
 func ParseMetricsBundle(data []byte) (logBundle *metrics.ZMetricMsg, err error) {
 	var lb metrics.ZMetricMsg
-	err = protojson.Unmarshal(data, &lb)
+	err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(data, &lb)
 	return &lb, err
 }
 


### PR DESCRIPTION
## Summary

Running with adam master and eden master branch this einfo code barfed on the new and unknown field related to pnac hence didn't "see" any device info messages. Presumably because eden doesn't have the latest eve-api vendored in. But the code should be made robust against that.

Switch eden's four JSON proto decoders (einfo / emetric / elog / eapps) to `protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal` so eden tolerates field-set drift between EVE and the vendored eve-api module.

## Why
PR #1168 migrated these decoders from `proto.Unmarshal` (binary wire format) to `protojson.Unmarshal` to match adam's post-3af1f41 redis-stream storage. By default `protojson.Unmarshal` rejects unknown fields. Any time EVE emits a field that the eden-vendored `eve-api` module hasn't caught up to yet, decoding fails silently and the entire message is dropped from the test framework's match pipeline.

Concrete reproduction (caught by instrumenting `einfo.infoProcess` against the eve-coverage-allprs test environment):

```
DBG-IPROC: parse error: proto: (line 1:1570): unknown field "pnacStatus"
```

Newer EVE versions emit `pnacStatus` on `SystemAdapter.Status.Ports`. The eden module currently in this repo doesn't have it. Every `ZiDevice` info message fails to decode; `lim.test`'s `TestInfo` (used by `tests/lim/testdata/info_test.txt`) has nothing to match and times out at its full `timewait`. Same shape applies to any future EVE-side field addition.

With `DiscardUnknown: true`, unknown fields are silently ignored — the rest of the message decodes cleanly and the test framework matches against the known fields.

## Test plan
- [x] CI smoke suite passes (`info_test` no longer times out on newer EVE images)
- [ ] Coverage-instrumented build: `eden info --tail 1 'ztype:ZiDevice'` returns immediately instead of dropping every message

🤖 Generated with [Claude Code](https://claude.com/claude-code)