### PR TITLE
tests/workflow: split radio_silence_persistence into its own slot

### DIFF
--- a/tests/workflow/lps-loc.tests.txt
+++ b/tests/workflow/lps-loc.tests.txt
@@ -1,5 +1,5 @@
 # Number of tests
-{{$tests := 10}}
+{{$tests := 11}}
 # EDEN_TEST_SETUP env. var. -- "y"(default) performs the EDEN setup steps
 {{$setup := "n"}}
 {{$setup_env := EdenGetEnv "EDEN_TEST_SETUP"}}
@@ -36,12 +36,17 @@ eden.escript.test -test.run TestEdenScripts/template_check
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/profile
 
 /bin/echo Eden test radio silence (6/{{$tests}})
-eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/radio_silence
+# Anchor with trailing '$' so this only runs the radio_silence subtest;
+# radio_silence_persistence runs as test 11 below so a failure there no
+# longer fail-fast-aborts the rest of the suite.
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/radio_silence$
 /bin/echo Eden test app info (7/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/app_local_info
 /bin/echo Eden test dev info (8/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/dev_local_info
 /bin/echo Eden location publish test (9/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/publish_location
-/bin/echo Eden location publish test (10/{{$tests}})
+/bin/echo Eden network local changes test (10/{{$tests}})
 eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/network_local_changes
+/bin/echo Eden test radio silence persistence (11/{{$tests}})
+eden.escript.test -testdata ../eclient/testdata/ -test.run TestEdenScripts/radio_silence_persistence


### PR DESCRIPTION
## Summary
The `lps-loc` scenario invokes `eden.escript.test -test.run TestEdenScripts/radio_silence`, which is a Go regex *prefix* match — it picks up both the `radio_silence` and `radio_silence_persistence` subtests at scenario slot 6/10. When `radio_silence_persistence` fails (e.g. NIM never settles `RadioSilence.Imposed=true`), the testscript runner's fail-fast policy aborts the whole suite and the remaining 4 `lps_loc` tests (`app_local_info`, `dev_local_info`, `publish_location`, `network_local_changes`) never run.

Split them:
- Slot 6 now anchors with `^radio_silence$` and only runs the passing `radio_silence` subtest.
- A new slot 11/11 at the end runs `radio_silence_persistence`; a failure there no longer blocks any other test.

Also fixes a label typo: slot 10's `/bin/echo` originally said `"Eden location publish test"` (same as slot 9). Renamed to `"Eden network local changes test"` to match the actual test invoked on that line.

## Test plan
- [ ] `lps_loc` suite reaches slots 7–10 even when `radio_silence_persistence` fails
- [ ] `radio_silence` (the passing one) still runs at slot 6 as before
- [ ] `radio_silence_persistence` runs and reports its actual outcome at slot 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)