### PR TITLE
ci: collect EVE coverage per matrix job in Eden CI

### DIFF
--- a/.github/actions/run-eden-test/action.yml
+++ b/.github/actions/run-eden-test/action.yml
@@ -47,6 +47,22 @@ runs:
       run: EDEN_TEST_STOP=n ./eden test ./tests/workflow -s ${{ inputs.suite }} -v debug
       shell: bash
       working-directory: "./eden"
+    - name: Collect coverage
+      if: always()
+      run: |
+        mkdir -p eden_coverage
+        ./eden eve collect-coverage --output-dir ./eden_coverage || true
+        ls -la eden_coverage/ || true
+      shell: bash
+      working-directory: "./eden"
+    - name: Upload coverage artifact
+      if: always() && hashFiles('./eden/eden_coverage/eden_e2e_coverage.txt') != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: covdata-${{ inputs.suite }}-fs-${{ inputs.file_system }}-tpm-${{ inputs.tpm_enabled }}-attempt-${{ github.run_attempt }}
+        path: ./eden/eden_coverage/
+        if-no-files-found: warn
+        retention-days: 7
     - name: Collect info
       if: failure()
       uses: ./eden/.github/actions/collect-info

--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -18,6 +18,7 @@ jobs:
   run_tests:
     name: Execute Eden test workflow
     uses: ./.github/workflows/test.yml
+    secrets: inherit
     with:
       eve_image: "lfedge/eve:16.6.0"
       eve_kubevirt_image: "lfedge/eve:0.0.0-master-75241279-kubevirt-amd64"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -393,3 +393,44 @@ jobs:
           eve_artifact_name: ${{ inputs.eve_artifact_name }}
           artifact_run_id: ${{ inputs.artifact_run_id }}
           require_virtualization: true
+
+  coverage-merge:
+    name: Merge coverage
+    needs: [smoke, networking, storage, lps-loc, eve-upgrade, user-apps, virtualization]
+    if: always()
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.24'
+      - name: Download per-job covdata artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: covdata-*
+          path: covdata-raw
+      - name: Merge covdata
+        run: |
+          set -e
+          mkdir -p covdata-merged
+          # Each artifact directory contains eden_e2e_coverage.txt and a
+          # covdata/coverage/ subtree with covmeta.* / covcounters.* files.
+          # Discover every GOCOVERDIR-shaped directory by looking for covmeta.*.
+          mapfile -t covdirs < <(find covdata-raw -name 'covmeta.*' -printf '%h\n' | sort -u)
+          if [ ${#covdirs[@]} -eq 0 ]; then
+            echo "::warning::No raw covdata found across jobs"
+            exit 0
+          fi
+          inputs=$(IFS=,; echo "${covdirs[*]}")
+          go tool covdata merge -i="$inputs" -o covdata-merged
+          go tool covdata textfmt -i=covdata-merged -o combined_coverage.txt
+          go tool cover -func=combined_coverage.txt | tee coverage-summary.txt
+      - name: Upload merged covdata
+        if: always() && hashFiles('combined_coverage.txt') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: covdata-merged
+          path: |
+            covdata-merged/
+            combined_coverage.txt
+            coverage-summary.txt
+          retention-days: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -434,3 +434,9 @@ jobs:
             combined_coverage.txt
             coverage-summary.txt
           retention-days: 30
+      - name: Upload coverage to Codecov
+        if: always() && hashFiles('combined_coverage.txt') != ''
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: combined_coverage.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -440,3 +440,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: combined_coverage.txt
+          fail_ci_if_error: false

--- a/pkg/openevec/coverage.go
+++ b/pkg/openevec/coverage.go
@@ -120,26 +120,28 @@ func (openEVEC *OpenEVEC) CollectEveCoverage(outputDir string) error {
 		log.Warnf("EVE coverage: %v; proceeding with whatever was written", err)
 	}
 
-	// Copy binary coverage files from EVE to a local temp directory.
-	tmpDir, err := os.MkdirTemp("", "eve-coverage-*")
-	if err != nil {
-		return fmt.Errorf("cannot create temp dir: %w", err)
+	// Copy binary coverage files from EVE into <outputDir>/covdata so that
+	// callers wanting to merge coverage across multiple runs (e.g. across
+	// the Eden CI matrix) have access to the raw covmeta.* / covcounters.*
+	// files needed by `go tool covdata merge`.
+	covdataDir := filepath.Join(outputDir, "covdata")
+	if err := os.MkdirAll(covdataDir, 0755); err != nil {
+		return fmt.Errorf("cannot create covdata dir %s: %w", covdataDir, err)
 	}
-	defer os.RemoveAll(tmpDir)
 
 	log.Infof("EVE coverage: copying %s from EVE to %s",
-		defaults.DefaultEveCoverageDir, tmpDir)
+		defaults.DefaultEveCoverageDir, covdataDir)
 	if err := openEVEC.SdnForwardSCPDirFromEve(
-		defaults.DefaultEveCoverageDir, tmpDir); err != nil {
+		defaults.DefaultEveCoverageDir, covdataDir); err != nil {
 		return fmt.Errorf("cannot copy coverage data from EVE: %w", err)
 	}
 
 	// The SCP copies the directory itself, so the files land under
-	// tmpDir/coverage/.  Point covdata at that sub-directory.
-	coverSubDir := filepath.Join(tmpDir, filepath.Base(defaults.DefaultEveCoverageDir))
+	// covdataDir/coverage/.  Point covdata at that sub-directory.
+	coverSubDir := filepath.Join(covdataDir, filepath.Base(defaults.DefaultEveCoverageDir))
 	if _, err := os.Stat(coverSubDir); os.IsNotExist(err) {
-		// Fallback: files landed directly in tmpDir.
-		coverSubDir = tmpDir
+		// Fallback: files landed directly in covdataDir.
+		coverSubDir = covdataDir
 	}
 
 	// Convert binary coverage format → Go text profile format.


### PR DESCRIPTION
# Description

Per-job coverage collection for the Eden test matrix plus a fan-in
merge job, intended to be consumed by a coverage-instrumented EVE
build on the lf-edge/eve side.

Each suite in the Eden test matrix expands into ~12 independent
runners with their own `./eden setup -> start -> stop -> make clean`
lifecycle, so per-job collection is the only point at which to
capture covdata. After `make clean` the runner is wiped — there is no
later opportunity.

Two commits:

### `collect-coverage: preserve raw covdata in output`

`CollectEveCoverage` SCP'd the raw `covmeta.*` / `covcounters.*`
files into a temp dir, ran `go tool covdata textfmt` on them, and
let the deferred cleanup wipe the binary files on return. Only the
text profile at `<output-dir>/eden_e2e_coverage.txt` survived.

Callers that want to merge coverage across multiple runs (e.g.
across the Eden test matrix) need the raw covdata so they can use
`go tool covdata merge`; the text profile alone only supports
concatenation, which is fine for a per-line summary but doesn't
aggregate the way merge does.

Copy the SCP target into `<output-dir>/covdata/` instead of an
auto-deleted temp dir. The text-profile output path is unchanged.

### `ci: collect eden e2e coverage per matrix job`

- `run-eden-test` composite action gains a Collect/Upload coverage
  pair, gated as best-effort (`if: always()` and `|| true`), that
  invokes `./eden eve collect-coverage` and uploads the resulting
  `eden_coverage/` directory (text profile + raw covdata subtree) as
  artifact `covdata-<suite>-fs-<fs>-tpm-<tpm>-attempt-<n>`.
- `test.yml` gains a `coverage-merge` job that downloads every
  `covdata-*` artifact, runs `go tool covdata merge` on the raw
  covmeta.* / covcounters.* files to produce a single merged covdata
  directory, converts it to a text profile via `covdata textfmt`,
  and runs `go tool cover -func` for a per-package summary.

## Companion PR

This change is the prerequisite for
[lf-edge/eve#5950](https://github.com/lf-edge/eve/pull/5950),
which adds an opt-in `COVER=y` EVE build (gated on a `coverage` PR
label) and wires `eden-trusted.yml` to consume the resulting
artifact. The EVE PR calls
`lf-edge/eden/.github/workflows/test.yml@master`, so this PR has to
land first; otherwise the `tests-master-cover` job on the EVE side
will run tests but emit no covdata-merged artifact.

## How to test and validate this PR

Without a coverage-instrumented EVE artifact, the new steps run as
no-ops:

1. Confirm `eden.yml` (the eden-only CI path that consumes
   `lfedge/eve:16.6.0`) still passes after this change. The
   `Collect coverage` step warns ("no covcounters appeared")
   because zedbox isn't built with `-cover`, and the
   `Upload coverage artifact` step skips because the
   `eden_e2e_coverage.txt` hashFiles check is false. No new artifact
   is uploaded.
2. Confirm the `coverage-merge` fan-in job runs to completion and
   emits the "No raw covdata found across jobs" warning instead of
   failing.
3. Locally: build EVE with `COVER=y` and run a single suite via
   `make eden-cover` (or by passing
   `--coverage-dir <dir>` to `eden test`); confirm
   `<dir>/eden_e2e_coverage.txt` AND `<dir>/covdata/coverage/`
   (containing `covmeta.*` and `covcounters.*`) both exist after
   the run.
4. Once the companion EVE PR lands on `master`, exercise the full
   path end-to-end by labelling a coverage-instrumented EVE PR with
   `coverage` and confirming the `covdata-merged` artifact is
   produced at the end of the workflow run.

## Notes

No user-facing changes. CI / dev-tooling only.
