### PR TITLE
[13.4-stable] backport more test robustness fixes from master

### DIFF
--- a/tests/lim/testdata/log_test.txt
+++ b/tests/lim/testdata/log_test.txt
@@ -3,17 +3,24 @@
 # save the current config before changing it
 eden -t 1m controller edge-node get-config --file /tmp/full-config.json
 
+# wait for EVE's sshd before we capture the pre-update lastconfig mtime
+exec -t 5m bash wait_ssh.sh
+
+# snapshot /persist/checkpoint/lastconfig mtime *before* pushing the log-level
+# update so the subsequent active wait can detect when EVE has actually applied
+# the new config
+exec bash capture_checkpoint.sh
+
 # set the remote log level to info, because the expected message is logged with info level
 eden -t 1m controller edge-node update --config agent.debug.debug.loglevel=info
 eden -t 1m controller edge-node update --config agent.debug.debug.remote.loglevel=info
 
-# wait for EVE's sshd to be ready before starting the log watcher
-exec -t 5m bash wait_ssh.sh
-
-# Give EVE time to fetch and apply the updated config.  On TPM-enabled devices the
-# controller config must pass TPM signature verification before EVE applies it; this
-# can take several minutes, far longer than a short fixed sleep.
-exec sleep 60
+# Wait for EVE to fetch and apply the new config (lastconfig mtime advances).
+# This replaces a previous fixed `sleep 60` that intermittently raced with config
+# apply on slower runs (e.g. issue #1156: ext4 + TPM-off Smoke matrix entry).
+# TPM-enabled devices may need extra time for signature verification; a 10m
+# ceiling absorbs that without making the happy path slower.
+exec -t 10m bash wait_config_applied.sh
 
 exec -t 27m bash ssh.sh &
 {{$test}} -out content 'content:.*Disconnected.*'
@@ -39,6 +46,38 @@ until $EDEN eve ssh exit 2>/dev/null; do
   [ "$(date +%s)" -lt "$END" ] || { echo "sshd not ready after 5m"; exit 1; }
   sleep 5
 done
+
+-- capture_checkpoint.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+# Read the mtime of EVE's applied-device-config file; zedagent rewrites this
+# file each time it accepts and applies a new device config, so its mtime is
+# the same signal evetestkit.WaitForConfigApplied uses.  Watching the file
+# directly (rather than the /persist/checkpoint directory) avoids false
+# positives from unrelated touches on sibling files like lastradioconfig.
+TS=$($EDEN eve ssh 'stat -c %Y /persist/checkpoint/lastconfig' 2>/dev/null | tr -d '\r' | tail -n 1)
+case "$TS" in
+  ''|*[!0-9]*) echo "could not read /persist/checkpoint/lastconfig mtime (got: '$TS')"; exit 1 ;;
+esac
+echo "$TS" > checkpoint_ts
+echo "captured initial lastconfig mtime: $TS"
+
+-- wait_config_applied.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+INIT=$(cat checkpoint_ts 2>/dev/null)
+case "$INIT" in
+  ''|*[!0-9]*) echo "no initial lastconfig mtime captured"; exit 1 ;;
+esac
+END=$(($(date +%s) + 10*60))
+while [ "$(date +%s)" -lt "$END" ]; do
+  CUR=$($EDEN eve ssh 'stat -c %Y /persist/checkpoint/lastconfig' 2>/dev/null | tr -d '\r' | tail -n 1)
+  case "$CUR" in
+    ''|*[!0-9]*) ;;            # transient SSH/stat failure -- keep polling
+    *) [ "$CUR" != "$INIT" ] && { echo "config applied (lastconfig mtime: $INIT -> $CUR)"; exit 0; } ;;
+  esac
+  sleep 5
+done
+echo "timeout: /persist/checkpoint/lastconfig mtime did not advance from $INIT within 10m"
+exit 1
 
 -- ssh.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}

--- a/tests/zfs/testdata/state_and_layout_check.txt
+++ b/tests/zfs/testdata/state_and_layout_check.txt
@@ -10,6 +10,21 @@
 eden info --out InfoContent.dinfo.StorageInfo.StorageType 'InfoContent.dinfo.StorageInfo.StorageType:\w+' --tail 1
 [!stdout:STORAGE_TYPE_INFO_ZFS] skip 'No zfs type storage'
 
+# Speed up EVE's disk-metric sampling. The persist pool grows as `eden disks
+# set` adds vdevs, but EVE's disk usage is sampled by a flextimer keyed off
+# timer.metric.diskscan.interval (default 5 min, range 1.5–5 min) — far too
+# slow to observe within a CI test. Reduce it so the post-perturbation pool
+# size is reported in the next metric tick rather than several minutes later.
+eden controller edge-node update --config timer.metric.diskscan.interval=15
+
+# Snapshot the current /persist size from the disk metric before any
+# perturbation. The end-of-test wait below uses this baseline to detect the
+# post-resize reading by requiring a strictly larger total — that's the
+# direct property we care about ("metric now reflects the grown pool"),
+# not a stability proxy that would happily accept the stale cached value.
+exec -t 1m bash capture-persist-baseline.sh
+source .env
+
 # check for storage state
 eden info --out InfoContent.dinfo.StorageInfo.StorageState 'InfoContent.dinfo.StorageInfo.StorageState:\w+' --tail 1
 stdout 'STORAGE_STATUS_ONLINE'
@@ -77,5 +92,60 @@ eden eve epoch &
 {{$info_test}} -out InfoContent.dinfo.StorageInfo 'InfoContent.dinfo.StorageInfo:sde' 'InfoContent.dinfo.StorageInfo[].StorageState:STORAGE_STATUS_ONLINE'
 ! stdout '/dev/sda'
 
+# Wait until the /persist disk metric reflects the now-grown pool, so
+# subsequent tests don't compute volume sizes from a pre-resize cached
+# metric. Storage info already confirmed the final layout above, but the
+# disk-metric collector samples on its own ticker — verify the reported
+# total is strictly larger than the pre-perturbation baseline before
+# yielding to the next test.
+exec -t 5m bash wait-for-persist-grew.sh
 eden eve reset
 exec sleep 10
+
+-- capture-persist-baseline.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+# Read the current /persist total and write it to .env for the end-of-test
+# growth check. Whatever the controller currently reports is fine as a
+# baseline: at least one `eden disks set` will run between this script and
+# the wait below (the skip points return earlier when the host has too few
+# disks), so the post-perturbation total will be strictly larger.
+DEADLINE=$(( $(date +%s) + 60 ))
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    TOTAL=$($EDEN metric --tail=1 --format=json | jq -r '.dm.disk[]? | select(.mountPath=="/persist") | .total // empty')
+    if [ -n "$TOTAL" ] && [ "$TOTAL" -gt 0 ]; then
+        echo persist_total_baseline=$TOTAL>>.env
+        echo "/persist baseline ${TOTAL} MB"
+        exit 0
+    fi
+    sleep 5
+done
+echo "capture-persist-baseline.sh: no /persist metric within 1 min" >&2
+exit 1
+
+-- wait-for-persist-grew.sh --
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+# Poll the /persist disk metric until the reported total is strictly larger
+# than the baseline captured before perturbations. That's a definitive
+# signal that the disk-scan has run since the pool grew — unlike a "value
+# is stable" check, which would happily accept the stale pre-resize value.
+if [ -z "$persist_total_baseline" ]; then
+    echo "wait-for-persist-grew.sh: persist_total_baseline not set" >&2
+    exit 1
+fi
+DEADLINE=$(( $(date +%s) + 240 ))
+LAST=
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    JSON=$($EDEN metric --tail=1 --format=json)
+    TOTAL=$(echo "$JSON" | jq -r '.dm.disk[]? | select(.mountPath=="/persist") | .total // empty')
+    if [ -n "$TOTAL" ] && [ "$TOTAL" -gt 0 ]; then
+        if [ "$TOTAL" -gt "$persist_total_baseline" ]; then
+            TS=$(echo "$JSON" | jq -r '.atTimeStamp // empty')
+            echo "/persist grew to ${TOTAL} MB (baseline ${persist_total_baseline} MB, atTimeStamp ${TS})"
+            exit 0
+        fi
+        LAST=$TOTAL
+    fi
+    sleep 5
+done
+echo "wait-for-persist-grew.sh: /persist did not exceed baseline ${persist_total_baseline} MB within 4 min (last=${LAST} MB)" >&2
+exit 1


### PR DESCRIPTION
Companion to #1174 (16.0-stable) and #1175 (14.5-stable). Two
test-robustness fixes landed on master after the last backport pass;
both apply cleanly here.

## PRs / commits included

- `e81ba0b` — tests/zfs: wait for /persist metric to reflect grown pool
- `095d266` — tests/lim: log_test waits for config apply

Both are pure testscript changes — no Go / no eden infra changes —
and the pre-fix surrounding context in
`tests/zfs/testdata/state_and_layout_check.txt` and
`tests/lim/testdata/log_test.txt` is identical to master at the point
the fixes were authored, so the cherry-picks apply without conflict.

## Why these are safe on 13.4-stable

`095d266` replaces a fixed `exec sleep 60` after `wait_ssh.sh` with
an active wait that SSHs to EVE and polls
`/persist/checkpoint/lastconfig` mtime — the same signal
`evetestkit.WaitForConfigApplied` uses. That file has existed in EVE
since the 5.x days.

`e81ba0b` replaces a fixed `exec sleep 10` after `eden eve reset` in
the ZFS layout test with (a) lowering
`timer.metric.diskscan.interval` to 15 s and (b) polling
`eden metric --tail=1 --format=json` until the reported /persist
total is strictly larger than a pre-perturbation baseline. All three
prerequisites — `eden disks set`, `eden metric --tail=N --format=json`,
and the EVE config knob `timer.metric.diskscan.interval` — are
already present on 13.4-stable.

## What is intentionally NOT backported

- `1a58d07` einfo,emetric: parse JSON from adam's redis stream — only
  matters when running against adam ≥ 0.0.70. 13.4-stable pins
  `DefaultAdamTag = 0.0.57`, which writes proto-binary and works with
  the existing `proto.Unmarshal` paths.
- `59843bb` defaults: bump DefaultAdamTag → 0.0.75 — couples to the
  above; no functional gap on 13.4 without it.
- `76d428f` DiscardUnknown on JSON decoders — on the stable branches,
  only `elog.go` / `eappslog.go` use protojson; einfo/emetric still
  use `proto.Unmarshal` which already tolerates unknown fields. No
  concrete log/applog drift observed on 13.4 today.

## Test plan

- [x] `make build build-tests` (done locally, green).
- [x] CI smoke + storage matrices pass.