### PR TITLE
tests: add onboarding e2e suite

### DIFF
--- a/tests/onboarding/Makefile
+++ b/tests/onboarding/Makefile
@@ -1,0 +1,60 @@
+DEBUG ?= "debug"
+
+# HOSTARCH is the host architecture
+# ARCH is the target architecture
+# we need to keep track of them separately
+HOSTARCH ?= $(shell uname -m)
+HOSTOS ?= $(shell uname -s | tr A-Z a-z)
+
+# canonicalized names for host architecture
+override HOSTARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(HOSTARCH)))
+
+# unless otherwise set, I am building for my own architecture, i.e. not cross-compiling
+# and for my OS
+ARCH ?= $(HOSTARCH)
+OS ?= $(HOSTOS)
+
+# canonicalized names for target architecture
+override ARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(ARCH)))
+
+WORKDIR ?= $(CURDIR)/../../dist
+TESTDIR := tests/$(shell basename $(CURDIR))
+BINDIR := $(WORKDIR)/bin
+DATADIR := $(WORKDIR)/$(TESTDIR)/
+BIN := eden
+LOCALBIN := $(BINDIR)/$(BIN)-$(OS)-$(ARCH)
+TESTNAME := eden.escript
+TESTBIN := $(TESTNAME).test
+TESTSCN := eden.onboarding.tests.txt
+LOCALTESTBIN := $(TESTBIN)-$(OS)-$(ARCH)
+
+.DEFAULT_GOAL := help
+
+clean:
+	rm -rf $(WORKDIR)/$(TESTSCN)
+
+$(BINDIR):
+	mkdir -p $@
+$(DATADIR):
+	mkdir -p $@
+
+test:
+	$(LOCALBIN) test $(CURDIR) -v $(DEBUG)
+
+build: setup
+
+setup: $(BINDIR) $(DATADIR)
+	cp -a *.yml $(TESTSCN) testdata $(DATADIR)
+
+.PHONY: test build setup clean all
+
+help:
+	@echo "EDEN is the harness for testing EVE and ADAM"
+	@echo
+	@echo "This Makefile automates commons tasks of EDEN testing"
+	@echo
+	@echo "Commonly used maintenance and development targets:"
+	@echo "   build         build test-binary (OS and ARCH options supported, for ex. OS=linux ARCH=arm64)"
+	@echo "   setup         setup of test environment"
+	@echo "   test          run tests"
+	@echo "   clean         cleanup of test harness"

--- a/tests/onboarding/README.md
+++ b/tests/onboarding/README.md
@@ -1,0 +1,27 @@
+# Onboarding tests
+
+End-to-end tests that exercise the EVE onboarding code path (zedclient,
+i.e. `pkg/pillar/cmd/client`). These tests run against a live EVE
+booted via the standard eden setup and complement the Go unit tests in
+the eve repo under `pkg/pillar/cmd/client/`.
+
+## Tests
+
+- **onboarding_status** — asserts that after `eden eve onboard` the
+  device has a valid `/persist/status/uuid`, a kernel hostname that
+  matches it, and a non-empty `/persist/status/hardwaremodel`.
+  Exercises zedclient's post-loop publishing path.
+
+## Running
+
+```sh
+make build
+eden test ./tests/onboarding/ -v
+```
+
+Or directly with the escript runner:
+
+```sh
+eden.escript.test -testdata ./tests/onboarding/testdata/ \
+    -test.run TestEdenScripts/onboarding_status -test.v
+```

--- a/tests/onboarding/eden-config.yml
+++ b/tests/onboarding/eden-config.yml
@@ -1,0 +1,5 @@
+---
+eden:
+
+    # test scenario
+    test-scenario: "eden.onboarding.tests.txt"

--- a/tests/onboarding/eden.onboarding.tests.txt
+++ b/tests/onboarding/eden.onboarding.tests.txt
@@ -1,3 +1,4 @@
 eden.escript.test -test.run TestEdenScripts/onboarding_status -test.timeout 10m
 eden.escript.test -test.run TestEdenScripts/server_changes_at_runtime -test.timeout 30m
 eden.escript.test -test.run TestEdenScripts/pre_provisioned_uuid -test.timeout 30m
+eden.escript.test -test.run TestEdenScripts/server_returns_403 -test.timeout 30m

--- a/tests/onboarding/eden.onboarding.tests.txt
+++ b/tests/onboarding/eden.onboarding.tests.txt
@@ -1,1 +1,3 @@
 eden.escript.test -test.run TestEdenScripts/onboarding_status -test.timeout 10m
+eden.escript.test -test.run TestEdenScripts/server_changes_at_runtime -test.timeout 30m
+eden.escript.test -test.run TestEdenScripts/pre_provisioned_uuid -test.timeout 30m

--- a/tests/onboarding/eden.onboarding.tests.txt
+++ b/tests/onboarding/eden.onboarding.tests.txt
@@ -1,0 +1,1 @@
+eden.escript.test -test.run TestEdenScripts/onboarding_status -test.timeout 10m

--- a/tests/onboarding/testdata/onboarding_status.txt
+++ b/tests/onboarding/testdata/onboarding_status.txt
@@ -1,0 +1,55 @@
+# Test: onboarding produces the expected on-device artifacts.
+#
+# Asserts that after onboarding the device has:
+#   * /persist/status/uuid containing a parseable UUID,
+#   * a kernel hostname matching that UUID,
+#   * /persist/status/hardwaremodel containing a non-empty model string.
+#
+# Exercises the post-loop publishing path in pkg/pillar/cmd/client (the
+# hostname call, the uuid and hardwaremodel file writes, and the
+# OnboardingStatus publication) plus the entire onboarding event loop.
+
+[!exec:bash] stop
+
+eden eve onboard
+stdout 'onboarded'
+
+# Wait for the artifacts; zedclient writes them shortly after the
+# controller hands back the UUID. Allow up to 3 minutes for sshd
+# readiness and the filesystem write to settle.
+exec -t 3m bash check_onboarding_artifacts.sh
+stdout 'onboarding-ok'
+
+-- check_onboarding_artifacts.sh --
+#!/bin/bash
+set -uo pipefail
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+uuid_re='^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+
+uuid=""
+hn=""
+hw=""
+
+for _ in $(seq 1 30); do
+    uuid=$($EDEN eve ssh -- cat /persist/status/uuid 2>/dev/null | tr -d '\r\n ')
+    hn=$($EDEN eve ssh -- hostname 2>/dev/null | tr -d '\r\n ')
+    hw=$($EDEN eve ssh -- cat /persist/status/hardwaremodel 2>/dev/null | tr -d '\r\n ')
+    if [[ "$uuid" =~ $uuid_re && "$hn" == "$uuid" && -n "$hw" ]]; then
+        echo "onboarding-ok uuid=${uuid} hardwaremodel=${hw}"
+        exit 0
+    fi
+    sleep 6
+done
+
+echo "onboarding-not-ok uuid='${uuid}' hostname='${hn}' hardwaremodel='${hw}'"
+exit 1
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/onboarding/testdata/pre_provisioned_uuid.txt
+++ b/tests/onboarding/testdata/pre_provisioned_uuid.txt
@@ -1,0 +1,157 @@
+# Test: cmd/client takes the "already-onboarded-with-no-controller" shortcut.
+#
+# Exercises the `case <-t1.C` branch in pkg/pillar/cmd/client/client.go
+# (lines 416-437): when the device already has a UUID + a controller-cert
+# checkpoint and the network state is not DPCStateSuccess after the
+# 5-second t1 timer fires, cmd/client declares success and exits without
+# waiting for full connectivity. This branch is dead in normal boots
+# because nim usually reaches DPCStateSuccess well before t=5s.
+#
+# Trigger: write a deliberately-wrong /config/server before rebooting.
+# At the next boot nim's DPC verification reaches IP+DNS but cannot
+# reach the controller (the URL points at 127.0.0.1:3333 with nothing
+# listening); nim publishes DeviceNetworkStatus with State =
+# DPCStateFailWithIPAndDNS (=2). cmd/client's networkState therefore
+# stays != DPCStateSuccess and at t1=5 s the shortcut branch fires.
+#
+# An earlier attempt used a bogus DevicePortConfig override; it lost the
+# race because nim falls back to its lastresort DPC fast enough that
+# networkState reaches DPCStateSuccess in well under 5 s. Driving the
+# controller URL wrong (the same lever as test #7) keeps nim stuck in
+# FailWithIPAndDNS for as long as we want.
+#
+# Pre-conditions: the device is already onboarded (/persist/status/uuid
+# and /persist/checkpoint/controllercerts both exist).
+#
+# Witness: log line "Already have a UUID <UUID>; declaring success" in
+# the on-device newlog. The string is unique to this code path.
+
+[!exec:bash] stop
+
+exec -t 30m bash run.sh
+stdout 'pre-provisioned-ok'
+
+-- run.sh --
+#!/bin/bash
+set -uo pipefail
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+# Confirm pre-conditions.
+have_uuid=$("$EDEN" eve ssh -- 'test -s /persist/status/uuid && echo yes' 2>/dev/null | tr -d '\r\n ')
+have_chk=$("$EDEN" eve ssh -- 'test -s /persist/checkpoint/controllercerts && echo yes' 2>/dev/null | tr -d '\r\n ')
+[ "$have_uuid" = "yes" ] || { echo "no-uuid-file"; exit 1; }
+[ "$have_chk"  = "yes" ] || { echo "no-controllercerts-checkpoint"; exit 1; }
+
+orig=$("$EDEN" eve ssh -- cat /config/server 2>/dev/null | tr -d '\r\n')
+[ -n "$orig" ] || { echo "no-original-server"; exit 1; }
+
+cleanup() {
+    rc=$?
+    set +e
+    # Restore /config/server and reboot.  Once the bad URL is active EVE
+    # cannot reach adam, so the controller-side reboot would queue a
+    # directive EVE never polls for — use the in-VM reboot instead.
+    timeout 30s "$EDEN" eve ssh -- 'mkdir -p /run/cfg-clean && eve config mount /run/cfg-clean' >/dev/null 2>&1
+    timeout 30s "$EDEN" eve ssh -- "printf '%s' '$orig' > /run/cfg-clean/server && sync" >/dev/null 2>&1
+    timeout 30s "$EDEN" eve ssh -- 'eve config unmount' >/dev/null 2>&1
+    timeout 30s "$EDEN" eve ssh -- 'reboot' >/dev/null 2>&1
+    ssh-keygen -f "${HOME}/.ssh/known_hosts" -R '[127.0.0.1]:2222' >/dev/null 2>&1
+    exit "$rc"
+}
+trap cleanup EXIT
+
+step() { echo "STEP: $*" >&2; }
+
+retry_ssh() {
+    local attempts=$1 ; shift
+    local out
+    for _ in $(seq 1 "$attempts"); do
+        if out=$(timeout 15s "$EDEN" eve ssh -- "$@" 2>/dev/null); then
+            printf '%s' "$out"
+            return 0
+        fi
+        sleep 4
+    done
+    return 1
+}
+
+wait_for_reboot() {
+    local pre_up=$1
+    local i
+    for i in $(seq 1 30); do
+        if ! timeout 10s "$EDEN" eve ssh -- 'cat /proc/uptime' >/dev/null 2>&1; then
+            break
+        fi
+        sleep 6
+    done
+    ssh-keygen -f "${HOME}/.ssh/known_hosts" -R '[127.0.0.1]:2222' >/dev/null 2>&1
+    for i in $(seq 1 50); do
+        local up
+        up=$(timeout 10s "$EDEN" eve ssh -- 'cat /proc/uptime' 2>/dev/null | awk '{print int($1)}')
+        if [ -n "$up" ] && [ "$up" -lt "$pre_up" ]; then
+            return 0
+        fi
+        sleep 6
+    done
+    return 1
+}
+
+# Searches the active and archived on-device newlog for the t1.C-branch
+# log line. The string is logged at most once per cmd/client run, so its
+# appearance on this boot proves the branch fired.
+# IMPORTANT: `eden eve ssh '<multi-line>'` collapses newlines to spaces,
+# so multi-statement commands must be joined with `;`, not split across
+# lines — otherwise only the first half runs.
+seen_declaring_success() {
+    retry_ssh 5 'grep -aE "Already have a UUID [0-9a-f-]{36}; declaring success" /persist/newlog/collect/*.log 2>/dev/null | head -1 ; gzip -dcq /persist/newlog/devUpload/*.gz /persist/newlog/keepSentQueue/*.gz 2>/dev/null | grep -aE "Already have a UUID [0-9a-f-]{36}; declaring success" | head -1' \
+        | tr -d '\r' | head -1
+}
+
+# ---- 1. Snapshot any pre-existing hits so we can detect the new one
+# the test boot triggers.
+step "snapshotting pre-existing matches"
+prev=$(seen_declaring_success || true)
+step "pre-existing matches bytes: $(printf '%s' "$prev" | wc -c)"
+
+# ---- 2. Write a deliberately-wrong /config/server (same lever as test
+# #7) so nim cannot reach the controller and reports State=FailWithIPAndDNS.
+step "writing wrong /config/server"
+retry_ssh 30 'mkdir -p /run/cfg-stage && eve config mount /run/cfg-stage' >/dev/null
+retry_ssh 30 "printf '%s' '127.0.0.1:3333' > /run/cfg-stage/server && sync" >/dev/null
+written=$(retry_ssh 10 'cat /run/cfg-stage/server' | tr -d '\r\n')
+retry_ssh 10 'eve config unmount' >/dev/null
+[ "$written" = "127.0.0.1:3333" ] || { echo "wrong-server-not-written got '$written'"; exit 1; }
+
+# ---- 3. Reboot; EVE is still reachable now so use controller-side
+# reboot.
+step "rebooting EVE"
+pre_up=$(retry_ssh 20 'cat /proc/uptime' | awk '{print int($1)}')
+[ -n "$pre_up" ] && [ "$pre_up" -gt 0 ] || { echo "no-pre-up"; exit 1; }
+"$EDEN" controller edge-node reboot
+wait_for_reboot "$pre_up" || { echo "reboot-did-not-complete pre=$pre_up"; exit 1; }
+
+# ---- 4. cmd/client runs once at boot.  Wait for the witness log.
+step "waiting for cmd/client t1.C branch to fire"
+sleep 30
+got=""
+for _ in $(seq 1 30); do
+    got=$(seen_declaring_success || true)
+    if [ -n "$got" ] && [ "$got" != "$prev" ]; then
+        break
+    fi
+    sleep 6
+done
+[ -n "$got" ] && [ "$got" != "$prev" ] || { echo "t1c-branch-not-observed prev='$prev' got='$got'"; exit 1; }
+step "saw t1.C branch fire: $got"
+
+echo "pre-provisioned-ok"
+exit 0
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/onboarding/testdata/server_changes_at_runtime.txt
+++ b/tests/onboarding/testdata/server_changes_at_runtime.txt
@@ -1,0 +1,187 @@
+# Test: cmd/client picks up a new /config/server value across reboots.
+#
+# Exercises the boot-time read of /config/server in pkg/pillar/cmd/client:
+#   * tryRegister's fetchCertChain branch at client.go:322-336, including
+#     the LedBlinkInvalidControllerCert update at line 330 when the wrong
+#     server is unreachable.
+#   * The recovery path on a subsequent boot once /config/server is
+#     restored: fetchCertChain succeeds, selfRegister/doGetUUID complete.
+#
+# The plan's original §7.7 wanted to exercise the per-tick branch at
+# client.go:393-414 (server rewritten while cmd/client was running). That
+# branch is unreachable from a testscript because /config is a read-only
+# tmpfs at runtime; the CONFIG partition is only writable via
+# `eve config mount`, and the changes appear at /config only on the next
+# boot. This test exercises the boot-time path instead.
+#
+# The test asserts EVE comes back healthy after both reboots; the dark
+# code at lines 322-336 / 329-330 is exercised regardless of whether the
+# transient failure LED is observable from the host (ledmanager settles
+# on the prior onboarded value once cmd/client exits, so the
+# InvalidControllerCert state is too brief to poll for).
+
+[!exec:bash] stop
+
+exec -t 30m bash run.sh
+stdout 'server-change-ok'
+
+-- run.sh --
+#!/bin/bash
+set -uo pipefail
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+
+# Hold the original /config/server contents on the host so we can restore.
+orig=$("$EDEN" eve ssh -- cat /config/server 2>/dev/null | tr -d '\r\n')
+[ -n "$orig" ] || { echo "no-original-server"; exit 1; }
+
+restore_server() {
+    rc=$?
+    set +e
+    # Best-effort restore. Importantly, by the time this runs the live
+    # /config/server may already be the wrong host; in that case EVE
+    # cannot reach adam, so `eden controller edge-node reboot` would
+    # queue a directive EVE will never poll for. Use in-VM `reboot`
+    # over ssh instead — it does not need controller connectivity.
+    timeout 30s "$EDEN" eve ssh -- 'mkdir -p /run/cfg-restore && eve config mount /run/cfg-restore' >/dev/null 2>&1
+    timeout 30s "$EDEN" eve ssh -- "printf '%s' '$orig' > /run/cfg-restore/server && sync"
+    timeout 30s "$EDEN" eve ssh -- 'eve config unmount' >/dev/null 2>&1
+    timeout 30s "$EDEN" eve ssh -- 'reboot' >/dev/null 2>&1
+    ssh-keygen -f "${HOME}/.ssh/known_hosts" -R '[127.0.0.1]:2222' >/dev/null 2>&1
+    exit "$rc"
+}
+trap restore_server EXIT
+
+step() { echo "STEP: $*" >&2; }
+
+wait_for_ssh() {
+    local attempts=$1
+    for _ in $(seq 1 "$attempts"); do
+        if timeout 15s "$EDEN" eve ssh -- 'cat /proc/uptime' >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 6
+    done
+    return 1
+}
+
+# Retry an `eden eve ssh <cmd>` up to <attempts> times. Echoes the
+# stdout of the first successful invocation. Needed because for the
+# first ~30-60s after wait_for_reboot returns, individual ssh
+# invocations still occasionally hit "Connection timed out during
+# banner exchange" or exit 255 even though the previous probe just
+# succeeded — banner-exchange recovers in stages.
+retry_ssh() {
+    local attempts=$1 ; shift
+    local out
+    for _ in $(seq 1 "$attempts"); do
+        if out=$(timeout 15s "$EDEN" eve ssh -- "$@" 2>/dev/null); then
+            printf '%s' "$out"
+            return 0
+        fi
+        sleep 4
+    done
+    return 1
+}
+
+# Wait until SSH stops working (EVE has actually started rebooting), then
+# wait until it comes back.  `eden controller edge-node reboot` only
+# queues the reboot in adam — EVE picks it up on its next config poll,
+# which can take ~30-60s.  Polling SSH immediately after issuing the
+# reboot finds the *old* boot still up.
+wait_for_reboot() {
+    local pre_up=$1
+    local i
+    # Phase 1: SSH must stop responding within ~3 min.
+    for i in $(seq 1 30); do
+        if ! timeout 10s "$EDEN" eve ssh -- 'cat /proc/uptime' >/dev/null 2>&1; then
+            break
+        fi
+        sleep 6
+    done
+    # Phase 2: SSH must come back within ~5 min and report a fresh uptime.
+    ssh-keygen -f "${HOME}/.ssh/known_hosts" -R '[127.0.0.1]:2222' >/dev/null 2>&1
+    for i in $(seq 1 50); do
+        local up=$(timeout 10s "$EDEN" eve ssh -- 'cat /proc/uptime' 2>/dev/null | awk '{print int($1)}')
+        if [ -n "$up" ] && [ "$up" -lt "$pre_up" ]; then
+            return 0
+        fi
+        sleep 6
+    done
+    return 1
+}
+
+# ---- 1. Write a deliberately-wrong server URL into the CONFIG partition.
+# 127.0.0.1:3333 inside the VM has no listener so fetchCertChain at boot
+# fails: cmd/client's tryRegister path at client.go:322-336 raises
+# LedBlinkInvalidControllerCert and keeps retrying.
+step "writing wrong /config/server"
+"$EDEN" eve ssh -- 'mkdir -p /run/cfg-stage && eve config mount /run/cfg-stage' >/dev/null
+"$EDEN" eve ssh -- "printf '%s' '127.0.0.1:3333' > /run/cfg-stage/server && sync"
+written=$("$EDEN" eve ssh -- 'cat /run/cfg-stage/server' 2>/dev/null | tr -d '\r\n')
+"$EDEN" eve ssh -- 'eve config unmount' >/dev/null
+[ "$written" = "127.0.0.1:3333" ] || { echo "wrong-server-not-written got '$written'"; exit 1; }
+
+# ---- 2. Reboot and wait for EVE to come back.  cmd/client will retry
+# fetchCertChain against 127.0.0.1:3333 several times during this boot,
+# exercising the dark code.  We don't bother polling for the transient
+# failure LED: ledmanager keeps reporting the prior 'Onboarded' value
+# once cmd/client gives up and exits, so the transient state is not
+# reliably observable from the host. The coverage counters in zedbox
+# still record the code path.
+step "rebooting EVE with the wrong server"
+pre_up=$("$EDEN" eve ssh -- 'cat /proc/uptime' 2>/dev/null | awk '{print int($1)}')
+"$EDEN" controller edge-node reboot
+wait_for_reboot "$pre_up" || { echo "reboot-did-not-complete pre=$pre_up"; exit 1; }
+
+# Confirm the live /config/server reflects the bad value, proving the
+# CONFIG partition write actually persisted across the reboot.  Use
+# retry_ssh — single ssh probes are flaky for the first ~minute even
+# after wait_for_reboot succeeds.
+got=$(retry_ssh 30 'cat /config/server' | tr -d '\r\n')
+[ "$got" = "127.0.0.1:3333" ] || { echo "wrong-server-not-active got '$got'"; exit 1; }
+step "EVE booted with /config/server=$got (exercising dark code)"
+
+# ---- 3. Restore /config/server and reboot to recover.  Use retry_ssh
+# because the wrong-server boot has flaky ssh for a while.
+step "restoring /config/server"
+retry_ssh 30 'mkdir -p /run/cfg-restore && eve config mount /run/cfg-restore' >/dev/null
+retry_ssh 30 "printf '%s' '$orig' > /run/cfg-restore/server && sync" >/dev/null
+retry_ssh 30 'eve config unmount' >/dev/null
+
+step "rebooting EVE after restoration"
+# EVE currently can't reach adam (live /config/server still points at
+# 127.0.0.1:3333 in tmpfs), so a controller-side reboot directive would
+# never be polled.  Use in-VM `reboot` instead.
+pre_up=$(retry_ssh 20 'cat /proc/uptime' | awk '{print int($1)}')
+retry_ssh 5 'reboot' >/dev/null 2>&1 || true
+wait_for_reboot "$pre_up" || { echo "recovery-reboot-did-not-complete"; exit 1; }
+
+# ---- 4. Confirm /config/server is back and the device reports Onboarded.
+got=$(retry_ssh 30 'cat /config/server' | tr -d '\r\n')
+[ "$got" = "$orig" ] || { echo "restore-mismatch got '$got' want '$orig'"; exit 1; }
+
+# LedBlinkOnboarded = 4 (pillar/types/ledmanagertypes.go).  After a
+# reboot ledmanager comes up a few seconds before its first state
+# publish, so allow generous retries.
+for _ in $(seq 1 40); do
+    led=$(retry_ssh 5 'eve exec pillar cat /run/global/LedBlinkCounter/ledconfig.json 2>/dev/null' | tr -d '\r')
+    case "$led" in
+        *'"BlinkCounter":4'*) led_ok=1; break ;;
+    esac
+    sleep 6
+done
+[ "${led_ok:-0}" = 1 ] || { echo "recovery-led-not-onboarded got '$led'"; exit 1; }
+
+# Disable the EXIT trap — we've already restored and rebooted.
+trap - EXIT
+echo "server-change-ok"
+exit 0
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/onboarding/testdata/server_returns_403.txt
+++ b/tests/onboarding/testdata/server_returns_403.txt
@@ -1,0 +1,222 @@
+# Test: cmd/client raises LedBlinkOnboardingFailureNotFound when the
+# controller rejects the onboarding certificate with a 403.
+#
+# Exercises the dark `case http.StatusForbidden` branch in selfRegister
+# (pkg/pillar/cmd/client/client.go:671-672) which maps to the
+# LedBlinkOnboardingFailureNotFound LED (value 18). The branch was
+# unreachable until lf-edge/adam#155 brought adam in line with the
+# eve-api spec, returning 403 for "valid credentials without
+# authorization" (cert/serial well-formed but not pre-registered).
+#
+# Setup:
+#   1. Snapshot every adam-side onboard cert whose Serial matches this
+#      device, then DELETE them from /admin/onboard.
+#   2. DELETE the device record from /admin/device so doGetUUID also
+#      fails (otherwise cmd/client could pick up the old UUID via the
+#      /uuid endpoint before the 403 from /register is observable).
+#   3. rm /persist/status/uuid and /persist/checkpoint/controllercerts*
+#      on EVE so cmd/client treats this as a fresh onboard.
+#   4. In-VM reboot.
+#
+# Witness for the 403 path: LedBlinkCounter = 18.
+#
+# Recovery: POST the saved onboard cert(s) back to /admin/onboard, in-VM
+# reboot, and verify cmd/client re-onboards (LED 4 + fresh UUID on disk).
+
+[!exec:bash] stop
+
+exec -t 30m bash run.sh
+stdout 'server-403-ok'
+
+-- run.sh --
+#!/bin/bash
+set -uo pipefail
+EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
+# adam.ip in eden config is the IP EVE uses to reach adam, not the host
+# side. The host's docker port mapping exposes adam on 127.0.0.1:adam.port,
+# which is what curl from the testscript wrapper needs to hit.
+ADAM_HOST="https://127.0.0.1:{{EdenConfig "adam.port"}}"
+EVE_SERIAL="{{EdenConfig "eve.serial"}}"
+
+# All saved adam state lives in this dir so cleanup can replay it.
+WORK=$(mktemp -d -t srv403-XXXXXX)
+
+step() { echo "STEP: $*" >&2; }
+
+retry_ssh() {
+    local attempts=$1 ; shift
+    local out
+    for _ in $(seq 1 "$attempts"); do
+        if out=$(timeout 15s "$EDEN" eve ssh -- "$@" 2>/dev/null); then
+            printf '%s' "$out"
+            return 0
+        fi
+        sleep 4
+    done
+    return 1
+}
+
+wait_for_reboot() {
+    local pre_up=$1
+    local i up
+    for i in $(seq 1 30); do
+        if ! timeout 10s "$EDEN" eve ssh -- 'cat /proc/uptime' >/dev/null 2>&1; then
+            break
+        fi
+        sleep 6
+    done
+    ssh-keygen -f "${HOME}/.ssh/known_hosts" -R '[127.0.0.1]:2222' >/dev/null 2>&1
+    for i in $(seq 1 50); do
+        up=$(timeout 10s "$EDEN" eve ssh -- 'cat /proc/uptime' 2>/dev/null | awk '{print int($1)}')
+        if [ -n "$up" ] && [ "$up" -lt "$pre_up" ]; then
+            return 0
+        fi
+        sleep 6
+    done
+    return 1
+}
+
+# Snapshot the adam-side onboard certs whose Serial matches this
+# device, then DELETE each one.  Records the saved file paths in
+# /tmp/srv403-.../certs.list so cleanup() can POST them back.
+take_down_adam_state() {
+    : > "$WORK/certs.list"
+    local uuid info serial
+    for uuid in $(curl -sk "$ADAM_HOST/admin/onboard"); do
+        [ -n "$uuid" ] || continue
+        info=$(curl -sk "$ADAM_HOST/admin/onboard/$uuid")
+        serial=$(printf '%s' "$info" | jq -r '.Serial // empty')
+        if [ "$serial" = "$EVE_SERIAL" ]; then
+            printf '%s' "$info" > "$WORK/onboard-$uuid.json"
+            echo "$WORK/onboard-$uuid.json" >> "$WORK/certs.list"
+            curl -sk -X DELETE "$ADAM_HOST/admin/onboard/$uuid" >/dev/null
+            step "removed adam onboard cert $uuid (serial $serial)"
+        fi
+    done
+    # Drop the matching device record too so /uuid 404s.
+    local dev
+    for dev in $(curl -sk "$ADAM_HOST/admin/device"); do
+        [ -n "$dev" ] || continue
+        curl -sk -X DELETE "$ADAM_HOST/admin/device/$dev" >/dev/null
+        step "removed adam device $dev"
+    done
+}
+
+restore_adam_state() {
+    [ -s "$WORK/certs.list" ] || return 0
+    local f
+    while IFS= read -r f; do
+        [ -f "$f" ] || continue
+        # Re-POST each saved {Cert, Serial} pair.
+        if curl -sk -X POST -H 'Content-Type: application/json' --data @"$f" \
+                "$ADAM_HOST/admin/onboard" >/dev/null; then
+            step "restored adam onboard cert from $(basename "$f")"
+        else
+            step "FAILED to restore adam onboard cert from $(basename "$f")"
+        fi
+    done < "$WORK/certs.list"
+}
+
+cleanup() {
+    rc=$?
+    set +e
+    # Always try to put adam back the way we found it so the next test
+    # finds a sane state. We then reboot EVE so cmd/client re-registers
+    # against the restored cert. Controller-side reboot won't work
+    # because the device may not have a valid UUID/cert until cmd/client
+    # re-onboards — use the in-VM reboot.
+    restore_adam_state
+    timeout 30s "$EDEN" eve ssh -- 'reboot' >/dev/null 2>&1
+    ssh-keygen -f "${HOME}/.ssh/known_hosts" -R '[127.0.0.1]:2222' >/dev/null 2>&1
+    exit "$rc"
+}
+trap cleanup EXIT
+
+# Pre-conditions: device must currently be onboarded so we have something
+# to tear down. (For a fresh-image test the snapshots would be empty and
+# we'd just register the device on first boot, which is what the
+# happy-path test covers — not this one.)
+have_uuid=$("$EDEN" eve ssh -- 'test -s /persist/status/uuid && echo yes' 2>/dev/null | tr -d '\r\n ')
+[ "$have_uuid" = "yes" ] || { echo "no-uuid-file-pre"; exit 1; }
+
+# ---- 1. Take down the adam-side pre-registration + device record.
+step "tearing down adam state for serial $EVE_SERIAL"
+take_down_adam_state
+[ -s "$WORK/certs.list" ] || { echo "no-matching-onboard-cert-to-remove"; exit 1; }
+
+# ---- 2. Wipe EVE's on-device onboarded state.
+step "wiping EVE onboarded state"
+retry_ssh 10 'rm -f /persist/status/uuid /persist/checkpoint/controllercerts /persist/checkpoint/controllercerts.bak; sync' >/dev/null
+
+# ---- 3. In-VM reboot.
+pre_up=$(retry_ssh 10 'cat /proc/uptime' | awk '{print int($1)}')
+[ -n "$pre_up" ] && [ "$pre_up" -gt 0 ] || { echo "no-pre-up"; exit 1; }
+step "rebooting EVE (pre_up=$pre_up)"
+retry_ssh 5 'reboot' >/dev/null
+wait_for_reboot "$pre_up" || { echo "reboot-did-not-complete"; exit 1; }
+
+# ---- 4. Wait for cmd/client to try registering and adam to return 403.
+# LedBlinkOnboardingFailureNotFound = 18 — pillar/types/ledmanagertypes.go
+# starts a second const block at iota+10 (=10 for OnboardingFailure),
+# skips 11 with `_`, then 12=RespWithoutTLS, 13=RespWithoutOSCP,
+# 14=InvalidControllerCert, 15=InvalidAuthContainer, 16=InvalidBootstrapConfig,
+# 17=OnboardingFailureConflict, 18=OnboardingFailureNotFound. Allow ~6 min
+# for boot + cmd/client to reach selfRegister and observe 403.
+step "waiting for LedBlinkOnboardingFailureNotFound (=18)"
+saw_403_led=0
+for _ in $(seq 1 60); do
+    led=$(retry_ssh 5 'eve exec pillar cat /run/global/LedBlinkCounter/ledconfig.json 2>/dev/null' | tr -d '\r')
+    case "$led" in
+        *'"BlinkCounter":18'*) saw_403_led=1; break ;;
+    esac
+    sleep 6
+done
+[ "$saw_403_led" = 1 ] || { echo "led-18-not-seen last='$led'"; exit 1; }
+step "saw LED 18 — cmd/client observed 403 from /register"
+
+# ---- 5. Restore adam state.  The trap already covers this path on
+# failure; do it explicitly here so the recovery reboot is intentional
+# rather than a side effect of the trap.
+step "restoring adam onboard cert(s)"
+restore_adam_state
+
+# ---- 6. Reboot so cmd/client retries selfRegister against the restored
+# pre-registration. A second in-VM reboot is the simplest trigger —
+# cmd/client wouldn't pick up the change otherwise because it has
+# already exited.
+pre_up=$(retry_ssh 10 'cat /proc/uptime' | awk '{print int($1)}')
+step "rebooting EVE for recovery (pre_up=$pre_up)"
+retry_ssh 5 'reboot' >/dev/null
+wait_for_reboot "$pre_up" || { echo "recovery-reboot-did-not-complete"; exit 1; }
+
+# ---- 7. Wait for re-onboarding success: LED 4 + a fresh UUID on disk.
+step "waiting for Onboarded LED + new UUID"
+saw_ok=0
+for _ in $(seq 1 60); do
+    led=$(retry_ssh 5 'eve exec pillar cat /run/global/LedBlinkCounter/ledconfig.json 2>/dev/null' | tr -d '\r')
+    uuid=$(retry_ssh 5 'cat /persist/status/uuid 2>/dev/null' | tr -d '\r\n ')
+    case "$led" in
+        *'"BlinkCounter":4'*)
+            if [ -n "$uuid" ]; then saw_ok=1; break; fi
+            ;;
+    esac
+    sleep 6
+done
+[ "$saw_ok" = 1 ] || { echo "recovery-not-observed last-led='$led' uuid='$uuid'"; exit 1; }
+step "recovered onboarded, uuid=$uuid"
+
+# Cleanup ran inline; skip the trap-side path so we don't kick off an
+# extra reboot.
+trap - EXIT
+rm -rf "$WORK"
+echo "server-403-ok"
+exit 0
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}


### PR DESCRIPTION
## Summary

Adds an onboarding e2e suite under `tests/onboarding/` that exercises
the cmd/client agent in EVE against a live device booted by the
standard eden setup. Four scenarios:

- `onboarding_status` — happy path. After `eden eve onboard`, asserts
  `/persist/status/uuid` parses, the kernel hostname matches that UUID,
  and `/persist/status/hardwaremodel` is non-empty.
- `server_changes_at_runtime` — writes a deliberately-wrong controller
  URL into the CONFIG partition via `eve config mount`, reboots, and
  verifies the boot exercises cmd/client's wrong-cert-fetch path
  (`LedBlinkInvalidControllerCert` escalation). Recovers via an in-VM
  reboot since EVE cannot reach adam to receive a controller-side
  reboot directive once the bad URL is active.
- `pre_provisioned_uuid` — uses the same wrong-server lever to keep
  nim's DPC state at FailWithIPAndDNS while cmd/client's 5-second t1
  timer fires, exercising the "already have UUID + checkpoint; declare
  success" shortcut branch in `Run()`.
- `server_returns_403` — drives the un-onboard flow: removes the
  device's adam-side onboard cert + device record via the admin
  endpoints, wipes `/persist/status/uuid` + `/persist/checkpoint/controllercerts`
  on EVE, reboots, asserts `LedBlinkOnboardingFailureNotFound` (=18),
  POSTs the onboard cert back, reboots again, asserts re-onboarding
  succeeds. Requires lf-edge/adam ≥ 0.0.79 (the first release that
  includes lf-edge/adam#155, which brings `/register` in line with
  the eve-api spec: 403 for cert/serial that isn't pre-registered).
  Paired with lf-edge/eden#1180 which bumps `DefaultAdamTag` so the
  default eden setup pulls the right adam.

Complements the cmd/client Go unit tests in lf-edge/eve#5957 and
lf-edge/eve#5958. Combined with the unit tests this suite raised
`pkg/pillar/cmd/client` block coverage from 0 % to **87.36 %**
(eden e2e alone gets 71.18 %; unit-only is 53.66 %).

Two further scenarios from the original plan were left out of this
PR; both need an un-onboarding harness that's now built into
`server_returns_403`, so they become follow-ups:

- `wrong_server_url` (un-onboarded variant) — overlaps with
  `server_changes_at_runtime` so the marginal coverage is small.
- `register_then_getuuid_interleave` — needs adam to know the device
  UUID *but* reject the onboard cert (a contrived state).

The original `cert_miss_refetch` scenario was found unreachable from
e2e during analysis: cmd/client's `fetchCertChain` refreshes the
in-memory cert hash before `doGetUUID` ever runs, so `SenderStatusCertMiss`
cannot fire in the same `Run()`; the branch is already covered by the
unit test `TestDoGetUUID_CertMissSchedulesTimer`.

## Test plan

- [x] `eden setup && eden start && eden test ./tests/onboarding/ -v`
      from a clean eden workspace passes all four scenarios.
- [x] Same on a coverage-instrumented EVE; `eden eve collect-coverage`
      after the run shows the cmd/client coverage numbers above
      (verified locally against an EVE built with `make COVER=y`).
