### PR TITLE
config: random per-context SMBIOS serial

### DIFF
--- a/pkg/openevec/defaults.go
+++ b/pkg/openevec/defaults.go
@@ -36,6 +36,11 @@ func GetDefaultConfig(projectRootPath string) (*EdenSetupArgs, error) {
 		return nil, err
 	}
 
+	eveSerial, err := utils.GenerateRandomSerial()
+	if err != nil {
+		return nil, err
+	}
+
 	imageDist := filepath.Join(projectRootPath, defaults.DefaultDist, fmt.Sprintf("%s-%s", defaults.DefaultContext, defaults.DefaultImageDist))
 	certsDist := filepath.Join(projectRootPath, defaults.DefaultDist, fmt.Sprintf("%s-%s", defaults.DefaultContext, defaults.DefaultCertsDist))
 
@@ -142,7 +147,7 @@ func GetDefaultConfig(projectRootPath string) (*EdenSetupArgs, error) {
 			QemuCpus:       defaults.DefaultCpus,
 			QemuMemory:     defaults.DefaultMemory,
 			ImageSizeMB:    defaults.DefaultEVEImageSize,
-			Serial:         defaults.DefaultEVESerial,
+			Serial:         eveSerial,
 			Pid:            filepath.Join(projectRootPath, defaults.DefaultDist, fmt.Sprintf("%s-eve.pid", strings.ToLower(defaults.DefaultContext))),
 			Log:            filepath.Join(projectRootPath, defaults.DefaultDist, fmt.Sprintf("%s-eve.log", strings.ToLower(defaults.DefaultContext))),
 			TelnetPort:     defaults.DefaultTelnetPort,

--- a/pkg/openevec/edenConfig.go
+++ b/pkg/openevec/edenConfig.go
@@ -101,6 +101,16 @@ func ConfigAdd(cfg *EdenSetupArgs, currentContext, contextFile string, force boo
 			log.Infof("Context file generated: %s", cfg.ConfigFile)
 		} else {
 			log.Infof("Config file already exists %s", cfg.ConfigFile)
+			// Preserve the existing yaml unchanged. Otherwise the
+			// WriteConfig at the end of this function overwrites
+			// fields like eve.serial with fresh defaults, which is
+			// surprising after a `config add NAME` re-run against
+			// an onboarded context. Use `--force` to opt into
+			// regeneration.
+			if !force {
+				context.SetContext(currentContextName)
+				return nil
+			}
 		}
 	}
 	context.SetContext(context.Current)

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -2,8 +2,10 @@ package utils
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"net"
 	"os"
 	"os/user"
@@ -19,6 +21,22 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
+
+// GenerateRandomSerial returns a 10-digit numeric SMBIOS serial. New eden
+// contexts get a unique serial per `eden config add` so two devices ever
+// onboarded against the same adam don't collide on the (onboard-cert,
+// serial) tuple.
+func GenerateRandomSerial() (string, error) {
+	var s strings.Builder
+	for i := 0; i < 10; i++ {
+		n, err := rand.Int(rand.Reader, big.NewInt(10))
+		if err != nil {
+			return "", fmt.Errorf("GenerateRandomSerial: %w", err)
+		}
+		s.WriteString(strconv.FormatInt(n.Int64(), 10))
+	}
+	return s.String(), nil
+}
 
 var viperAccessMutex sync.RWMutex
 
@@ -304,6 +322,11 @@ func generateConfigFileFromTemplate(filePath string, templateString string, cont
 		return err
 	}
 
+	eveSerial, err := GenerateRandomSerial()
+	if err != nil {
+		return err
+	}
+
 	imageDist := fmt.Sprintf("%s-%s", context.Current, defaults.DefaultImageDist)
 
 	certsDist := fmt.Sprintf("%s-%s", context.Current, defaults.DefaultCertsDist)
@@ -380,7 +403,7 @@ func generateConfigFileFromTemplate(filePath string, templateString string, cont
 		case "eve.hv":
 			return defaults.DefaultEVEHV
 		case "eve.serial":
-			return defaults.DefaultEVESerial
+			return eveSerial
 		case "eve.cert":
 			return filepath.Join(certsDist, "onboard.cert.pem")
 		case "eve.device-cert":

--- a/pkg/utils/config_test.go
+++ b/pkg/utils/config_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/lf-edge/eden/pkg/utils"
+)
+
+// TestGenerateRandomSerialFormat asserts the returned serial is 10 numeric
+// digits — the SMBIOS-friendly format eden writes into qemu and adam.
+func TestGenerateRandomSerialFormat(t *testing.T) {
+	s, err := utils.GenerateRandomSerial()
+	if err != nil {
+		t.Fatalf("GenerateRandomSerial: %v", err)
+	}
+	if len(s) != 10 {
+		t.Fatalf("GenerateRandomSerial length=%d, want 10: %q", len(s), s)
+	}
+	for i, c := range s {
+		if c < '0' || c > '9' {
+			t.Fatalf("GenerateRandomSerial[%d]=%q non-digit in %q", i, c, s)
+		}
+	}
+}
+
+// TestGenerateRandomSerialUniqueness checks that 1 000 draws don't collide.
+// The serial space is 10^10 so the expected collision probability across
+// 1 000 draws (birthday bound) is ~5e-5; a single collision here would
+// almost certainly indicate a broken RNG path, not bad luck.
+func TestGenerateRandomSerialUniqueness(t *testing.T) {
+	const draws = 1000
+	seen := make(map[string]struct{}, draws)
+	for i := 0; i < draws; i++ {
+		s, err := utils.GenerateRandomSerial()
+		if err != nil {
+			t.Fatalf("GenerateRandomSerial[%d]: %v", i, err)
+		}
+		if _, dup := seen[s]; dup {
+			t.Fatalf("collision after %d draws: %q", i, s)
+		}
+		seen[s] = struct{}{}
+	}
+}


### PR DESCRIPTION
## Summary

When using claude to drive eden test development and test running, I accidentally ended up with in one case two separate instances of the EVE qemu in series, and in another case of two in parallel. That cause confusion in adam's redis DB since there were two records with the same serial number. This PR reduces the blast radius and confusion when that happens (but it does not in itsellf allow multiple instances of eden to run concurrently.)

--------------

Replaces the hardcoded \`-smbios serial=31415926\` with a unique 10-digit
numeric serial generated per \`eden config add\`. Each new eden context
ends up with a distinct device serial so two devices ever registered
against the same adam don't collide on the \`(onboard-cert, serial)\`
tuple.

## Why

In the current upstream behavior, every device registered through eden
sends the same SMBIOS serial \`31415926\`. Adam keys onboard entries by
\`(onboard-cert, serial)\`, so two devices through the same adam — for
example the same workspace running tests across separate \`/persist\`
resets, or two coverage captures sharing one adam — collide. Adam then
returns \"Onboarding failure due to conflict with another device\" for
every subsequent registration attempt until one of the conflicting
entries is wiped from redis by hand.

Concretely, this surfaces as:

\`\`\`
# In adam logs:
2026/05/14 06:43:24 INFO: device: unspecified attest: None vault: UNKNOWN
ERROR: Summary: Onboarding failure due to conflict with another device

# In redis state:
HGETALL DEVICE_SERIALS
2ee8b1ff-c31a-4538-9791-49ab8db20631
31415926                # ← prior boot
76968138-9946-4cb6-b24a-953b020ce95e
31415926                # ← current boot, same serial
\`\`\`

The workaround today is \`docker volume rm eden_redis_volume eden_adam_volume\`
plus a full re-setup. That works but loses any in-flight test state.

## Approach

1. \`utils.GenerateRandomSerial\` — new helper, produces 10 random digits
   via \`crypto/rand\` for ~10¹⁰ possible values.
2. \`openevec.GetDefaultConfig\` — uses the generated serial in the
   in-memory cfg struct.
3. \`generateConfigFileFromTemplate\` — uses the generated serial when
   \`{{parse \"eve.serial\"}}\` is evaluated in the default yaml template.
4. \`openevec.ConfigAdd\` — preserves an existing context yaml when
   \`config add NAME\` is re-run, so the random serial stays stable
   across re-invocations. Previously the function unconditionally
   overwrote the file with current defaults; the constant default
   hid this. With a random default the overwrite would shift the
   serial on every re-run and orphan an onboarded device. \`--force\`
   still bypasses the early return and regenerates the yaml.

## Compat / migration

- Existing context yamls that have \`serial: '31415926'\` baked in keep
  their value — \`config add\` with no \`--force\` no longer rewrites
  them. To opt into a fresh random serial, use
  \`eden config add NAME --force\` or
  \`eden config set NAME --key=eve.serial --value=<new>\`.
- The \`--eve-serial X\` flag on \`eden start\` and \`eden eve start\`
  continues to work for explicit overrides.

## Test plan

- [x] \`make build\` (full eden build)
- [x] \`go test ./...\` — no new failures vs master (pre-existing
      integration tests in \`tests/vector\` and \`tests/volume\` need a
      running eden and fail on master too)
- [x] Two parallel \`EDEN_HOME\`s → \`eden config add NAME\` produces
      distinct serials (\`7492254288\` vs \`2642374555\`)
- [x] Re-running \`eden config add NAME\` against the same EDEN_HOME →
      serial preserved
- [x] \`eden config add NAME --force\` → regenerates with a new random
      serial
- [ ] End-to-end: spin up two parallel edens, verify both onboard
      without collision (planned)