### PR TITLE
defaults: bump DefaultAdamTag from 0.0.75 to 0.0.79

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -59,7 +59,7 @@ const (
 
 	//tags, versions, repos
 	DefaultEVETag               = "16.6.0" // DefaultEVETag tag for EVE image
-	DefaultAdamTag              = "0.0.75"
+	DefaultAdamTag              = "0.0.79"
 	DefaultRedisTag             = "7"
 	DefaultRegistryTag          = "2.7"
 	DefaultProcTag              = "83cfe07"


### PR DESCRIPTION
## Summary

Bumps `DefaultAdamTag` from `0.0.75` to `0.0.79`. The new release is
the first build that includes lf-edge/adam#155, which brings the
`/register` handler into compliance with the eve-api spec
(APIv2.md §/register): cert + serial combinations that verify
cryptographically but are not in the controller's pre-registration
set now return **403 Forbidden** instead of `401 Unauthorized`. EVE's
`pkg/pillar/cmd/client` already maps 403 to
`LedBlinkOnboardingFailureNotFound`, so the longstanding controller-
side eve-api gap is now closable end-to-end.

Pinning a specific release tag (rather than a rolling `snapshot` tag,
as the initial revision of this PR proposed) keeps the version
requirement expressible — if a future eden change requires
`adam ≥ x.y.z`, bumping this constant is the natural way to declare
it, and stale cached `snapshot` images on contributor machines cannot
silently regress. Per @milan-zededa's review point above. Override at
config time remains supported via `eden config set default
--key=adam.tag --value=<sha-or-tag>`.

## Test plan

- [x] `go build ./...` clean.
- [x] `gofmt -l pkg/defaults/defaults.go` clean.
- [ ] Fresh `make build && eden config add default && eden setup &&
      eden start` from a clean state pulls `lfedge/adam:0.0.79` from
      Docker Hub and brings up adam. CI should cover this.

## Notes

- The Docker Hub digest for `lfedge/adam:0.0.79` matches the `snapshot`
  tag and the per-SHA tag for adam master's HEAD commit
  (`b27f2aa6a214a9c2f954048531a89b6876be8d50`, the merge commit of
  lf-edge/adam#155) — verified via
  `hub.docker.com/v2/repositories/lfedge/adam/tags/0.0.79/`.
