### PR TITLE
tests/zfs: bump /persist metric wait budgets

### DIFF
--- a/tests/zfs/testdata/state_and_layout_check.txt
+++ b/tests/zfs/testdata/state_and_layout_check.txt
@@ -22,7 +22,10 @@ eden controller edge-node update --config timer.metric.diskscan.interval=15
 # post-resize reading by requiring a strictly larger total — that's the
 # direct property we care about ("metric now reflects the grown pool"),
 # not a stability proxy that would happily accept the stale cached value.
-exec -t 1m bash capture-persist-baseline.sh
+# Budget 5 min: volumemgr's diskMetricsTimerTask can land ~45 s after
+# onboarding on slow-boot CI runs, and zedagent ships metrics on a separate
+# 60 s ticker, so the first /persist entry can be ~100 s out from onboarding.
+exec -t 5m bash capture-persist-baseline.sh
 source .env
 
 # check for storage state
@@ -98,7 +101,7 @@ eden eve epoch &
 # disk-metric collector samples on its own ticker — verify the reported
 # total is strictly larger than the pre-perturbation baseline before
 # yielding to the next test.
-exec -t 5m bash wait-for-persist-grew.sh
+exec -t 6m bash wait-for-persist-grew.sh
 eden eve reset
 exec sleep 10
 
@@ -109,7 +112,7 @@ EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "ede
 # baseline: at least one `eden disks set` will run between this script and
 # the wait below (the skip points return earlier when the host has too few
 # disks), so the post-perturbation total will be strictly larger.
-DEADLINE=$(( $(date +%s) + 60 ))
+DEADLINE=$(( $(date +%s) + 300 ))
 while [ "$(date +%s)" -lt "$DEADLINE" ]; do
     TOTAL=$($EDEN metric --tail=1 --format=json | jq -r '.dm.disk[]? | select(.mountPath=="/persist") | .total // empty')
     if [ -n "$TOTAL" ] && [ "$TOTAL" -gt 0 ]; then
@@ -119,7 +122,7 @@ while [ "$(date +%s)" -lt "$DEADLINE" ]; do
     fi
     sleep 5
 done
-echo "capture-persist-baseline.sh: no /persist metric within 1 min" >&2
+echo "capture-persist-baseline.sh: no /persist metric within 5 min" >&2
 exit 1
 
 -- wait-for-persist-grew.sh --
@@ -132,7 +135,7 @@ if [ -z "$persist_total_baseline" ]; then
     echo "wait-for-persist-grew.sh: persist_total_baseline not set" >&2
     exit 1
 fi
-DEADLINE=$(( $(date +%s) + 240 ))
+DEADLINE=$(( $(date +%s) + 330 ))
 LAST=
 while [ "$(date +%s)" -lt "$DEADLINE" ]; do
     JSON=$($EDEN metric --tail=1 --format=json)
@@ -147,5 +150,5 @@ while [ "$(date +%s)" -lt "$DEADLINE" ]; do
     fi
     sleep 5
 done
-echo "wait-for-persist-grew.sh: /persist did not exceed baseline ${persist_total_baseline} MB within 4 min (last=${LAST} MB)" >&2
+echo "wait-for-persist-grew.sh: /persist did not exceed baseline ${persist_total_baseline} MB within 5.5 min (last=${LAST} MB)" >&2
 exit 1


### PR DESCRIPTION
state_and_layout_check.txt's 1-min budget on capture-persist-baseline.sh
is too tight against EVE's real time-to-first-metric. On slow-boot CI
runs volumemgr's diskMetricsTimerTask doesn't tick until ~45 s after
onboarding completes, and zedagent ships device metrics on a separate
60 s ticker that the test doesn't reconfigure — so the first /persist
entry can land ~100 s after onboarding even on a healthy run.

Two recent failures hit the deadline at exactly 60 s on lf-edge/eve:
[run 25730296544](https://github.com/lf-edge/eve/actions/runs/25730296544)
(2026-05-12, master) and
[run 26033232173](https://github.com/lf-edge/eve/actions/runs/26033232173)
(2026-05-18, 16.0-stable). In the latter, the saved metric.log carries
four reports in the test window all with empty `dm.disk` arrays; the
zedagent metric tick that would have included /persist landed ~30 s
after the test deadline.

Bump baseline capture 1 min → 5 min and post-resize wait 4 min → 5.5 min
(outer `exec -t` and the inner shell DEADLINEs together). Both scripts
exit on the first successful poll, so the happy path is unchanged; only
genuinely-slow boots burn the extra time.

Regression from #1161 (this file's introduction). Backports to 16.0-,
14.5-, 13.4-stable will follow once master CI passes.