### PR TITLE
Change default disk size to support new EVE partition layout

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -116,7 +116,7 @@ runs:
       if: inputs.file_system == 'zfs'
       run: |
         ./eden config set default --key=eve.disks --value=4
-        ./eden config set default --key=eve.disk --value=16384
+        ./eden config set default --key=eve.disk --value=28576
         ./eden setup -v debug --grub-options='set_global dom0_extra_args "$dom0_extra_args eve_install_zfs_with_raid_level "'
       shell: bash
       working-directory: "./eden"

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -158,7 +158,7 @@ const (
 
 	DefaultEVERemote = false
 
-	DefaultEVEImageSize = 16384
+	DefaultEVEImageSize = 28576
 
 	DefaultTPMEnabled       = false
 	DefaultCanEnabled       = false


### PR DESCRIPTION
## Description
    
EVE has bumped rootfs partition size from 4GB to 10GB. Adjust default disk size to support the new layout.

For reference: https://github.com/lf-edge/eve/pull/5973