### PR TITLE
qemu: pre-flight TCP port probe before exec

### DIFF
--- a/pkg/eden/qemu.go
+++ b/pkg/eden/qemu.go
@@ -42,6 +42,36 @@ func StopSWTPM(stateDir string) error {
 	return utils.StopCommandWithPid(pidFile)
 }
 
+// tcpPortReservation describes a TCP listen that QEMU will attempt at
+// spawn time. The host field matches the string passed to QEMU (e.g.
+// "localhost" for the chardev/monitor sockets, "0.0.0.0" for hostfwd
+// and serial-PCI backends) so a probe with net.Listen sees the same
+// conflict QEMU would.
+type tcpPortReservation struct {
+	host string
+	port int
+	role string
+}
+
+// checkPortFree probes whether the given TCP host:port can be bound
+// right now. Returns an actionable error if not. The probe is
+// best-effort pre-flight: the port could in principle race closed
+// between the probe and QEMU's bind, but in practice this catches
+// stuck-process leaks (a stranded QEMU from a prior run holding the
+// EVE console port, etc.) before we exec QEMU and wait out the
+// onboarding timeout on a VM that never started.
+func checkPortFree(host string, port int, role string) error {
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("%s port %s already in use: %v "+
+			"(find owner with: sudo ss -tlnp 'sport = :%d')",
+			role, addr, err, port)
+	}
+	_ = ln.Close()
+	return nil
+}
+
 func startQMPLogger(qmpSockFile string, qmpLogFile string) error {
 	shellcmd := fmt.Sprintf(
 		"echo '{\"execute\": \"qmp_capabilities\"}' | "+
@@ -243,6 +273,50 @@ func StartEVEQemu(qemuARCH, qemuOS, eveImageFile, imageFormat string, isInstalle
 
 	// QMP sock
 	qemuOptions += fmt.Sprintf("-qmp unix:%s,server,wait=off", qmpSockFile)
+
+	// Pre-flight: probe every TCP port QEMU is about to listen on. A
+	// stranded process holding any of them (most commonly the EVE
+	// console port from a leaked prior-run QEMU) makes the QEMU bind
+	// fail several seconds in, after which "eden eve onboard" waits
+	// out the full onboarding timeout on a VM that never started. The
+	// probe surfaces the real cause immediately, with the offending
+	// port and a hint for finding the owner.
+	portChecks := []tcpPortReservation{
+		{host: "localhost", port: eveTelnetPort, role: "EVE console (telnet)"},
+	}
+	if qemuMonitorPort != 0 {
+		portChecks = append(portChecks, tcpPortReservation{
+			host: "localhost", port: qemuMonitorPort, role: "QEMU monitor",
+		})
+	}
+	if !withSDN {
+		for i := range netModel.Ports {
+			for k, v := range qemuHostFwd {
+				origPort, err1 := strconv.Atoi(k)
+				newPort, err2 := strconv.Atoi(v)
+				if err1 != nil || err2 != nil {
+					continue
+				}
+				portChecks = append(portChecks, tcpPortReservation{
+					host: "0.0.0.0",
+					port: origPort + i*10,
+					role: fmt.Sprintf("hostfwd %d->guest:%d",
+						origPort+i*10, newPort+i*10),
+				})
+			}
+		}
+	}
+	if serialPCI {
+		portChecks = append(portChecks,
+			tcpPortReservation{host: "0.0.0.0", port: 4444, role: "serial PCI 1"},
+			tcpPortReservation{host: "0.0.0.0", port: 4445, role: "serial PCI 2"},
+		)
+	}
+	for _, c := range portChecks {
+		if err := checkPortFree(c.host, c.port, c.role); err != nil {
+			return fmt.Errorf("StartEVEQemu: %w", err)
+		}
+	}
 
 	log.Infof("Start EVE: %s %s", qemuCommand, qemuOptions)
 	if foreground {

--- a/pkg/eden/qemu_test.go
+++ b/pkg/eden/qemu_test.go
@@ -1,0 +1,67 @@
+package eden
+
+import (
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestCheckPortFree_Free(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("setup listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := ln.Close(); err != nil {
+		t.Fatalf("setup close: %v", err)
+	}
+	if err := checkPortFree("127.0.0.1", port, "test role"); err != nil {
+		t.Fatalf("checkPortFree on free port: %v", err)
+	}
+}
+
+func TestCheckPortFree_InUseAndReleased(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("setup listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	// Listener still open: checkPortFree should report it in use with
+	// the role, address, and actionable hint in the message.
+	err = checkPortFree("127.0.0.1", port, "EVE console (telnet)")
+	if err == nil {
+		ln.Close()
+		t.Fatalf("checkPortFree on bound port: want error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "EVE console (telnet)") {
+		t.Errorf("error missing role: %q", msg)
+	}
+	if !strings.Contains(msg, "127.0.0.1:"+strconv.Itoa(port)) {
+		t.Errorf("error missing address: %q", msg)
+	}
+	if !strings.Contains(msg, "sudo ss -tlnp") {
+		t.Errorf("error missing actionable hint: %q", msg)
+	}
+
+	// Close the listener — the port is now free.
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
+	// checkPortFree must now succeed: the conflict has cleared.
+	if err := checkPortFree("127.0.0.1", port, "EVE console (telnet)"); err != nil {
+		t.Fatalf("checkPortFree after release: %v", err)
+	}
+
+	// And checkPortFree's own probe listener must not have lingered:
+	// a fresh net.Listen on the same port has to succeed immediately.
+	// (If checkPortFree leaked its socket, this would fail with EADDRINUSE.)
+	ln2, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(port))
+	if err != nil {
+		t.Fatalf("net.Listen after successful checkPortFree: %v", err)
+	}
+	ln2.Close()
+}


### PR DESCRIPTION
## Why

\`StartEVEQemu\` binds several TCP listeners via QEMU: the EVE console chardev (\`eveTelnetPort\`, default 17777 on \`localhost\`), the QEMU monitor (\`qemuMonitorPort\` on \`localhost\`), each declared \`hostfwd\` port in non-SDN mode (bound on \`0.0.0.0\`), and the two serial-PCI backends when that mode is enabled. If any of those ports is already held by another process, QEMU exits with \`Failed to find an available port: Address already in use\` several seconds into startup, and \`eden eve onboard\` then waits out its full onboarding timeout on a VM that never started. The QEMU stderr that names the offending port is buried in the dist log and easy to miss in CI output.

This recurs in practice on self-hosted CI runners: a stranded QEMU from an earlier run keeps port 17777 bound across jobs (\`eden stop\` can't reap it because its pidfile points at a freshly-written PID, not the leaked process), and every subsequent eden job on that runner fails the same way until the host is cleaned. Two of the lf-edge/eve CI runners (\`kratos-runner-eden-02\`, \`kratos-runner-eden-09\`) spent ~3.5 days in that state recently, failing every Eden test job assigned to them with this exact signature.

## What

Probe each port with \`net.Listen\` just before exec'ing QEMU and return a clear error naming the role, the address, and the command to find the owner. Example:

\`\`\`
StartEVEQemu: EVE console (telnet) port localhost:17777 already in use:
  listen tcp 127.0.0.1:17777: bind: address already in use
  (find owner with: sudo ss -tlnp 'sport = :17777')
\`\`\`

Fail-fast on the first conflict; the operator needs the offending port and the hint, not an exhaustive list. The probe is best-effort pre-flight, so a port could in principle race closed between the listen-probe and QEMU's bind, but the previously-observed failure mode is sticky stuck processes, not flapping ports.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./pkg/eden/...\` — new \`TestCheckPortFree_Free\` and \`TestCheckPortFree_InUseAndReleased\` pass; the latter verifies the in-use case is detected with the proper error, the released case is detected as free, and that a follow-up \`net.Listen\` on the same port succeeds (proving the probe's own listener was closed)
- [ ] Local manual: bind 17777 with \`nc -lk 17777 &\`, run \`eden eve start\` — should fail fast with the new error instead of timing out onboarding