### PR TITLE
defaults: include k and mini in DefaultRootFSVersionPattern

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -107,7 +107,7 @@ const (
 	NetSwitch                    = "6822e35f-c1b8-43ca-b344-0bbc0ece8cf4"
 	DefaultTestProg              = "eden.escript.test"
 	DefaultTestScenario          = ""
-	DefaultRootFSVersionPattern  = `^.*-(xen|kvm|acrn|rpi|rpi-xen|rpi-kvm)-(amd64|arm64)$`
+	DefaultRootFSVersionPattern  = `^.*-(xen|kvm|k|mini|acrn|rpi|rpi-xen|rpi-kvm)-(amd64|arm64)$`
 	DefaultControllerModePattern = `^(?P<Type>(file|proto|adam|zedcloud)):\/\/(?P<URL>.*)$`
 	DefaultPodLinkPattern        = `^(?P<TYPE>(oci|docker|http[s]{0,1}|file|directory)):\/\/(?P<TAG>[^:]+):*(?P<VERSION>.*)$`
 	DefaultRedisContainerName    = "eden_redis"


### PR DESCRIPTION
Fixes #1191.

`DefaultRootFSVersionPattern` was missing `k` and `mini` from
the HV alternation, so `eden controller edge-node eveimage-update`
/ `eveimage-remove` rejected any eve-k or eve-mini rootfs file.
Both HVs are listed as supported in EVE's Makefile
(`HV_SUPPORTED=kvm k mini xen`). Adding them to the regex.

See #1191 for the full failure mode and reproducer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)