### PR TITLE
controller: push loopback-stub EdgeNodeCluster by default

### DIFF
--- a/cmd/edenController.go
+++ b/cmd/edenController.go
@@ -35,6 +35,8 @@ func newControllerCmd(configName, verbosity *string) *cobra.Command {
 				newEdgeNodeUpdate(controllerMode),
 				newEdgeNodeGetConfig(controllerMode),
 				newEdgeNodeSetConfig(),
+				newEdgeNodeClusterSet(controllerMode),
+				newEdgeNodeClusterClear(controllerMode),
 				newEdgeNodeGetOptions(controllerMode),
 				newEdgeNodeSetOptions(controllerMode),
 			},
@@ -278,4 +280,49 @@ func newEdgeNodeSetConfig() *cobra.Command {
 	edgeNodeSetConfig.Flags().StringVar(&fileWithConfig, "file", "", "set config from file")
 
 	return edgeNodeSetConfig
+}
+
+func newEdgeNodeClusterSet(controllerMode string) *cobra.Command {
+	var clusterType string
+
+	var edgeNodeClusterSet = &cobra.Command{
+		Use:   "cluster-set",
+		Short: "set EdgeNodeCluster config on the device",
+		Long: `Set EdgeNodeCluster config on the device.
+
+This pushes a loopback-stub EdgeNodeCluster (clusterIpPrefix=127.0.0.1/32,
+joinServerIp=127.0.0.1, clusterInterface=lo, stable clusterId) with the
+selected --type. EVE-side, the publishing of an ENCC with Valid=true and
+a non-ReplicatedStorage clusterType makes volumemgr's startup wait
+short-circuit the longhorn-readiness sub-wait that otherwise costs ~10
+minutes on single-node EVE-k where longhorn is not installed.
+
+Workaround for lf-edge/eve#6018 — the cleaner long-term fix is on the
+EVE side (flip volumemgr's default waitForLhFlag to false).`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := openEVEC.EdgeNodeClusterSet(controllerMode, clusterType); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+
+	edgeNodeClusterSet.Flags().StringVar(&clusterType, "type", "k3sbase",
+		"cluster type: k3sbase | replicated-storage | ha | none")
+
+	return edgeNodeClusterSet
+}
+
+func newEdgeNodeClusterClear(controllerMode string) *cobra.Command {
+	var edgeNodeClusterClear = &cobra.Command{
+		Use:   "cluster-clear",
+		Short: "clear EdgeNodeCluster config on the device",
+		Long:  `Clear EdgeNodeCluster config on the device.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := openEVEC.EdgeNodeClusterClear(controllerMode); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+
+	return edgeNodeClusterClear
 }

--- a/pkg/controller/device.go
+++ b/pkg/controller/device.go
@@ -663,6 +663,7 @@ volumeLoop:
 		LocalProfileServer: dev.GetLocalProfileServer(),
 		ProfileServerToken: dev.GetProfileServerToken(),
 		Disks:              disksConfig,
+		Cluster:            dev.GetCluster(),
 	}
 	if jsonFormat {
 		return json.MarshalIndent(devConfig, "", "    ")

--- a/pkg/device/device.go
+++ b/pkg/device/device.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/lf-edge/eve-api/go/config"
 	"github.com/lf-edge/eve-api/go/evecommon"
 	uuid "github.com/satori/go.uuid"
 )
@@ -56,6 +57,7 @@ type Ctx struct {
 	localProfileServer         string
 	profileServerToken         string
 	diskLayout                 *DisksLayout
+	cluster                    *config.EdgeNodeCluster
 }
 
 // CreateEdgeNode generates EdgeNode
@@ -69,6 +71,35 @@ func CreateEdgeNode() *Ctx {
 		configItems:   map[string]string{},
 		state:         NotOnboarded,
 		epoch:         0,
+		cluster:       DefaultStubCluster(),
+	}
+}
+
+// DefaultStubCluster builds a loopback-stub EdgeNodeCluster config that
+// every eden-managed device gets by default. The stub's only purpose
+// is to cause pillar to publish an EdgeNodeClusterConfig with Valid=true
+// and ClusterType != ReplicatedStorage, which makes volumemgr's startup
+// wait skip the longhorn-readiness sub-wait (otherwise a 10-min stall
+// on single-node EVE-k where longhorn is not installed). Workaround for
+// lf-edge/eve#6018 — the cleaner long-term fix is on the EVE side; this
+// stub becomes redundant when that lands and should be deleted then.
+//
+// The stub uses loopback addresses + a stable UUID. It's consistent with
+// "this is the only node" (joinServerIp == clusterIpPrefix address →
+// BootstrapNode=true in pillar). No actual clustering happens; pillar
+// just doesn't block on longhorn-readiness when it sees Valid=true.
+//
+// Tests / users that want pillar's no-cluster behavior can override via
+// `eden controller edge-node cluster-clear`.
+func DefaultStubCluster() *config.EdgeNodeCluster {
+	return &config.EdgeNodeCluster{
+		ClusterName:      "eden-stub",
+		ClusterId:        "00000000-0000-0000-0000-000000000001",
+		ClusterInterface: "lo",
+		ClusterIpPrefix:  "127.0.0.1/32",
+		IsWorkerNode:     false,
+		JoinServerIp:     "127.0.0.1",
+		ClusterType:      config.ClusterType_CLUSTER_TYPE_K3S_BASE,
 	}
 }
 
@@ -404,4 +435,14 @@ func (cfg *Ctx) GetProfileServerToken() string {
 // SetProfileServerToken set profileServerToken
 func (cfg *Ctx) SetProfileServerToken(profileServerToken string) {
 	cfg.profileServerToken = profileServerToken
+}
+
+// GetCluster returns the EdgeNodeCluster config, or nil if not set.
+func (cfg *Ctx) GetCluster() *config.EdgeNodeCluster {
+	return cfg.cluster
+}
+
+// SetCluster sets the EdgeNodeCluster config. Pass nil to clear.
+func (cfg *Ctx) SetCluster(cluster *config.EdgeNodeCluster) {
+	cfg.cluster = cluster
 }

--- a/pkg/openevec/edgeNode.go
+++ b/pkg/openevec/edgeNode.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lf-edge/eden/pkg/controller"
 	"github.com/lf-edge/eden/pkg/controller/types"
 	"github.com/lf-edge/eden/pkg/defaults"
+	"github.com/lf-edge/eden/pkg/device"
 	"github.com/lf-edge/eden/pkg/expect"
 	"github.com/lf-edge/eden/pkg/utils"
 	"github.com/lf-edge/eve-api/go/config"
@@ -462,5 +463,71 @@ func (openEVEC *OpenEVEC) ControllerSetOptions(fileWithConfig string) error {
 	}
 	log.Info("Options loaded")
 
+	return nil
+}
+
+// EdgeNodeClusterSet pushes a stub EdgeNodeCluster config to the device
+// with the specified cluster type (k3sbase | replicated-storage | ha).
+// Workaround for lf-edge/eve#6018; see device.DefaultStubCluster for the
+// rationale.
+func (openEVEC *OpenEVEC) EdgeNodeClusterSet(controllerMode string, clusterType string) error {
+	var ct config.ClusterType
+	switch clusterType {
+	case "k3sbase":
+		ct = config.ClusterType_CLUSTER_TYPE_K3S_BASE
+	case "replicated-storage":
+		ct = config.ClusterType_CLUSTER_TYPE_REPLICATED_STORAGE
+	case "ha":
+		ct = config.ClusterType_CLUSTER_TYPE_HA
+	case "none":
+		ct = config.ClusterType_CLUSTER_TYPE_UNSPECIFIED
+	default:
+		return fmt.Errorf("unsupported cluster type %q (want one of: k3sbase, replicated-storage, ha, none)", clusterType)
+	}
+
+	changer, err := changerByControllerMode(controllerMode)
+	if err != nil {
+		return err
+	}
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
+	if err != nil {
+		return fmt.Errorf("getControllerAndDevFromConfig error: %w", err)
+	}
+
+	cluster := dev.GetCluster()
+	if cluster == nil {
+		// No prior cluster set — start from the loopback stub.
+		cluster = device.DefaultStubCluster()
+	}
+	cluster.ClusterType = ct
+	dev.SetCluster(cluster)
+
+	if err = changer.setControllerAndDev(ctrl, dev); err != nil {
+		return fmt.Errorf("setControllerAndDev error: %w", err)
+	}
+	log.Infof("Pushed EdgeNodeCluster (type=%s) to the device", clusterType)
+	return nil
+}
+
+// EdgeNodeClusterClear removes any EdgeNodeCluster config from the device.
+// After clearing, pillar's parseEdgeNodeClusterConfig will publish an
+// empty (Initialized=true, Valid=false) ENCC — which means volumemgr will
+// fall back to waiting for longhorn (the behavior workaround'd by the
+// default stub). Useful for tests that explicitly want pillar's "no
+// cluster config" branch.
+func (openEVEC *OpenEVEC) EdgeNodeClusterClear(controllerMode string) error {
+	changer, err := changerByControllerMode(controllerMode)
+	if err != nil {
+		return err
+	}
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
+	if err != nil {
+		return fmt.Errorf("getControllerAndDevFromConfig error: %w", err)
+	}
+	dev.SetCluster(nil)
+	if err = changer.setControllerAndDev(ctrl, dev); err != nil {
+		return fmt.Errorf("setControllerAndDev error: %w", err)
+	}
+	log.Info("Cleared EdgeNodeCluster on the device")
 	return nil
 }


### PR DESCRIPTION
Fixes #1193.

Eden-managed devices now publish an `EdgeNodeCluster` (loopback
addresses, `ClusterType=K3S_BASE`) by default. This causes pillar
to publish an `EdgeNodeClusterConfig` with `Valid=true`, which
makes EVE volumemgr skip its longhorn-readiness sub-wait — otherwise
a 10-min stall on every single-node EVE-k boot where longhorn isn't
installed.

Workaround for **lf-edge/eve#6018**. The cleaner long-term fix is
EVE-side (flip `waitForLhFlag`'s default); when that lands the
stub here becomes redundant and should be deleted.

## New CLI

- `eden controller edge-node cluster-set --type=k3sbase|replicated-storage|ha|none`
- `eden controller edge-node cluster-clear` (drops the stub; useful
  for tests that need pillar's no-cluster branch)

## Files

- `pkg/device/device.go`: add `cluster` field to `Ctx`,
  `GetCluster`/`SetCluster`, `DefaultStubCluster` helper, default
  in `CreateEdgeNode`.
- `pkg/controller/device.go`: wire `EdgeDevConfig.Cluster = dev.GetCluster()`.
- `pkg/openevec/edgeNode.go`: `EdgeNodeClusterSet` / `EdgeNodeClusterClear`.
- `cmd/edenController.go`: register new CLI subcommands.

Total: +156 lines, 4 files, no removals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)