### PR TITLE
controller: add edge-node content-tree-add CLI + loopback-stub EdgeNodeCluster

### DIFF
--- a/cmd/edenController.go
+++ b/cmd/edenController.go
@@ -37,6 +37,7 @@ func newControllerCmd(configName, verbosity *string) *cobra.Command {
 				newEdgeNodeSetConfig(),
 				newEdgeNodeClusterSet(controllerMode),
 				newEdgeNodeClusterClear(controllerMode),
+				newEdgeNodeContentTreeAdd(controllerMode),
 				newEdgeNodeGetOptions(controllerMode),
 				newEdgeNodeSetOptions(controllerMode),
 			},
@@ -310,6 +311,39 @@ EVE side (flip volumemgr's default waitForLhFlag to false).`,
 		"cluster type: k3sbase | replicated-storage | ha | none")
 
 	return edgeNodeClusterSet
+}
+
+func newEdgeNodeContentTreeAdd(controllerMode string) *cobra.Command {
+	var registry, contentTreeName, datastoreOverride string
+	var sftpLoad, directLoad bool
+
+	var edgeNodeContentTreeAdd = &cobra.Command{
+		Use:   "content-tree-add <(docker|http(s)|file)://(<TAG>[:<VERSION>] | <URL> | <PATH>)>",
+		Short: "register a standalone ContentTree in the device config (no Volume)",
+		Long: `Register a standalone ContentTree (no associated Volume or AppInstance)
+in the EdgeDevConfig. Pillar downloads ContentTrees eagerly and looks up
+blobs by SHA256, so a subsequent 'eden pod deploy' against the same image
+URL (or any image sharing the SHA) reuses the pre-staged blobs without
+re-downloading.
+
+Use case: pre-stage a content tree on EVE-kvm, push a cross-HV upgrade to
+EVE-k, and deploy an app referencing the same image on EVE-k — the
+content tree survives the upgrade and is reused. Avoids the
+Volume/PVC machinery entirely.`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := openEVEC.EdgeNodeContentTreeAdd(controllerMode, args[0], registry, contentTreeName, datastoreOverride, sftpLoad, directLoad); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+
+	edgeNodeContentTreeAdd.Flags().StringVarP(&contentTreeName, "name", "n", "", "display name of content tree (defaults to image name)")
+	edgeNodeContentTreeAdd.Flags().StringVar(&registry, "registry", "remote", "Select registry to use for containers (remote/local)")
+	edgeNodeContentTreeAdd.Flags().StringVar(&datastoreOverride, "datastoreOverride", "", "Override datastore path (when Eden and EVE see different URLs)")
+	edgeNodeContentTreeAdd.Flags().BoolVar(&sftpLoad, "sftp", false, "force eserver to use sftp")
+	edgeNodeContentTreeAdd.Flags().BoolVar(&directLoad, "direct", true, "Use direct download for image instead of eserver")
+	return edgeNodeContentTreeAdd
 }
 
 func newEdgeNodeClusterClear(controllerMode string) *cobra.Command {

--- a/cmd/edenController.go
+++ b/cmd/edenController.go
@@ -35,6 +35,8 @@ func newControllerCmd(configName, verbosity *string) *cobra.Command {
 				newEdgeNodeUpdate(controllerMode),
 				newEdgeNodeGetConfig(controllerMode),
 				newEdgeNodeSetConfig(),
+				newEdgeNodeClusterSet(controllerMode),
+				newEdgeNodeClusterClear(controllerMode),
 				newEdgeNodeGetOptions(controllerMode),
 				newEdgeNodeSetOptions(controllerMode),
 			},
@@ -278,4 +280,49 @@ func newEdgeNodeSetConfig() *cobra.Command {
 	edgeNodeSetConfig.Flags().StringVar(&fileWithConfig, "file", "", "set config from file")
 
 	return edgeNodeSetConfig
+}
+
+func newEdgeNodeClusterSet(controllerMode string) *cobra.Command {
+	var clusterType string
+
+	var edgeNodeClusterSet = &cobra.Command{
+		Use:   "cluster-set",
+		Short: "set EdgeNodeCluster config on the device",
+		Long: `Set EdgeNodeCluster config on the device.
+
+This pushes a loopback-stub EdgeNodeCluster (clusterIpPrefix=127.0.0.1/32,
+joinServerIp=127.0.0.1, clusterInterface=lo, stable clusterId) with the
+selected --type. EVE-side, the publishing of an ENCC with Valid=true and
+a non-ReplicatedStorage clusterType makes volumemgr's startup wait
+short-circuit the longhorn-readiness sub-wait that otherwise costs ~10
+minutes on single-node EVE-k where longhorn is not installed.
+
+Workaround for lf-edge/eve#6018 — the cleaner long-term fix is on the
+EVE side (flip volumemgr's default waitForLhFlag to false).`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := openEVEC.EdgeNodeClusterSet(controllerMode, clusterType); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+
+	edgeNodeClusterSet.Flags().StringVar(&clusterType, "type", "k3sbase",
+		"cluster type: k3sbase | replicated-storage | ha | none")
+
+	return edgeNodeClusterSet
+}
+
+func newEdgeNodeClusterClear(controllerMode string) *cobra.Command {
+	var edgeNodeClusterClear = &cobra.Command{
+		Use:   "cluster-clear",
+		Short: "clear EdgeNodeCluster config on the device",
+		Long:  `Clear EdgeNodeCluster config on the device.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := openEVEC.EdgeNodeClusterClear(controllerMode); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+
+	return edgeNodeClusterClear
 }

--- a/pkg/controller/device.go
+++ b/pkg/controller/device.go
@@ -663,6 +663,7 @@ volumeLoop:
 		LocalProfileServer: dev.GetLocalProfileServer(),
 		ProfileServerToken: dev.GetProfileServerToken(),
 		Disks:              disksConfig,
+		Cluster:            dev.GetCluster(),
 	}
 	if jsonFormat {
 		return json.MarshalIndent(devConfig, "", "    ")

--- a/pkg/controller/device.go
+++ b/pkg/controller/device.go
@@ -203,10 +203,29 @@ func (cloud *CloudCtx) ConfigParse(config *config.EdgeDevConfig) (*device.Ctx, e
 	}
 	dev.SetVolumeConfigs(volumes)
 
+	// The device's standalone ContentTree list must hold only ContentTrees
+	// that have no other owner (those added via `content-tree-add`). The
+	// baseos block and each volume re-emit their own ContentTree in
+	// GetConfigBytes, so excluding them here keeps the standalone walk from
+	// resurrecting a ContentTree after its owner is superseded or removed —
+	// e.g. an eveimage-update that overwrites the baseos block orphans the
+	// previous baseos ContentTree, which would otherwise linger in the
+	// pushed config forever.
+	ownedContentTrees := map[string]bool{}
+	if config.Baseos.GetContentTreeUuid() != "" {
+		ownedContentTrees[config.Baseos.GetContentTreeUuid()] = true
+	}
+	for _, vol := range config.Volumes {
+		if id := vol.GetOrigin().GetDownloadContentTreeID(); id != "" {
+			ownedContentTrees[id] = true
+		}
+	}
 	var contentTrees []string
 	for _, el := range config.ContentInfo {
 		_ = cloud.AddContentTree(el)
-		contentTrees = append(contentTrees, el.Uuid)
+		if !ownedContentTrees[el.Uuid] {
+			contentTrees = append(contentTrees, el.Uuid)
+		}
 	}
 	dev.SetContentTreeConfig(contentTrees)
 
@@ -531,6 +550,28 @@ volumeLoop:
 			}
 			contentTrees = append(contentTrees, contentTreeConfig)
 		}
+	}
+	// Also include standalone ContentTrees registered on the device (via e.g.
+	// `eden controller edge-node content-tree-add`) that are not already
+	// referenced by a Volume or BaseOS. Pillar downloads ContentTrees eagerly
+	// regardless of whether they have a consumer, and blob lookup is by SHA256
+	// so a later Volume/App with the same image reuses the blobs.
+standaloneContentTreeLoop:
+	for _, contentTreeID := range dev.GetContentTrees() {
+		for _, ct := range contentTrees {
+			if ct.Uuid == contentTreeID {
+				continue standaloneContentTreeLoop
+			}
+		}
+		contentTreeConfig, err := cloud.GetContentTree(contentTreeID)
+		if err != nil {
+			return nil, err
+		}
+		dataStores, err = cloud.checkContentTreeDs(contentTreeConfig, dataStores)
+		if err != nil {
+			return nil, err
+		}
+		contentTrees = append(contentTrees, contentTreeConfig)
 	}
 	var applicationInstances []*config.AppInstanceConfig
 	for _, applicationInstanceConfigID := range dev.GetApplicationInstances() {

--- a/pkg/device/device.go
+++ b/pkg/device/device.go
@@ -76,21 +76,25 @@ func CreateEdgeNode() *Ctx {
 }
 
 // DefaultStubCluster builds a loopback-stub EdgeNodeCluster config that
-// every eden-managed device gets by default. The stub's only purpose
-// is to cause pillar to publish an EdgeNodeClusterConfig with Valid=true
-// and ClusterType != ReplicatedStorage, which makes volumemgr's startup
-// wait skip the longhorn-readiness sub-wait (otherwise a 10-min stall
-// on single-node EVE-k where longhorn is not installed). Workaround for
-// lf-edge/eve#6018 — the cleaner long-term fix is on the EVE side; this
-// stub becomes redundant when that lands and should be deleted then.
+// every eden-managed device gets by default. The stub causes pillar to
+// publish an EdgeNodeClusterConfig with Valid=true and a real ClusterType,
+// which makes volumemgr's startup wait short-circuit the longhorn-readiness
+// sub-wait that otherwise costs ~10 min on single-node EVE-k.
+//
+// ClusterType is REPLICATED_STORAGE so the device keeps the full Kubernetes
+// stack installed (kubevirt + CDI + longhorn + descheduler). Tests that
+// exercise VMs on eve-k need kubevirt, and tests that migrate volumes
+// across HV flavors (kvm → k) need CDI to convert the persistent .img
+// representation into a longhorn-backed PVC. K3S_BASE strips all three
+// and would fail any of these scenarios.
 //
 // The stub uses loopback addresses + a stable UUID. It's consistent with
 // "this is the only node" (joinServerIp == clusterIpPrefix address →
-// BootstrapNode=true in pillar). No actual clustering happens; pillar
-// just doesn't block on longhorn-readiness when it sees Valid=true.
+// BootstrapNode=true in pillar). No actual clustering happens.
 //
-// Tests / users that want pillar's no-cluster behavior can override via
-// `eden controller edge-node cluster-clear`.
+// Tests that explicitly want a different ClusterType can override via
+// `eden controller edge-node cluster-set --type=...`, and tests that want
+// pillar's no-cluster behavior can use `cluster-clear`.
 func DefaultStubCluster() *config.EdgeNodeCluster {
 	return &config.EdgeNodeCluster{
 		ClusterName:      "eden-stub",
@@ -99,7 +103,7 @@ func DefaultStubCluster() *config.EdgeNodeCluster {
 		ClusterIpPrefix:  "127.0.0.1/32",
 		IsWorkerNode:     false,
 		JoinServerIp:     "127.0.0.1",
-		ClusterType:      config.ClusterType_CLUSTER_TYPE_K3S_BASE,
+		ClusterType:      config.ClusterType_CLUSTER_TYPE_REPLICATED_STORAGE,
 	}
 }
 

--- a/pkg/device/device.go
+++ b/pkg/device/device.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/lf-edge/eve-api/go/config"
 	"github.com/lf-edge/eve-api/go/evecommon"
 	uuid "github.com/satori/go.uuid"
 )
@@ -56,6 +57,7 @@ type Ctx struct {
 	localProfileServer         string
 	profileServerToken         string
 	diskLayout                 *DisksLayout
+	cluster                    *config.EdgeNodeCluster
 }
 
 // CreateEdgeNode generates EdgeNode
@@ -69,6 +71,35 @@ func CreateEdgeNode() *Ctx {
 		configItems:   map[string]string{},
 		state:         NotOnboarded,
 		epoch:         0,
+		cluster:       DefaultStubCluster(),
+	}
+}
+
+// DefaultStubCluster builds a loopback-stub EdgeNodeCluster config that
+// every eden-managed device gets by default. The stub's only purpose
+// is to cause pillar to publish an EdgeNodeClusterConfig with Valid=true
+// and ClusterType != ReplicatedStorage, which makes volumemgr's startup
+// wait skip the longhorn-readiness sub-wait (otherwise a 10-min stall
+// on single-node EVE-k where longhorn is not installed). Workaround for
+// lf-edge/eve#6018 — the cleaner long-term fix is on the EVE side; this
+// stub becomes redundant when that lands and should be deleted then.
+//
+// The stub uses loopback addresses + a stable UUID. It's consistent with
+// "this is the only node" (joinServerIp == clusterIpPrefix address →
+// BootstrapNode=true in pillar). No actual clustering happens; pillar
+// just doesn't block on longhorn-readiness when it sees Valid=true.
+//
+// Tests / users that want pillar's no-cluster behavior can override via
+// `eden controller edge-node cluster-clear`.
+func DefaultStubCluster() *config.EdgeNodeCluster {
+	return &config.EdgeNodeCluster{
+		ClusterName:      "eden-stub",
+		ClusterId:        "00000000-0000-0000-0000-000000000001",
+		ClusterInterface: "lo",
+		ClusterIpPrefix:  "127.0.0.1/32",
+		IsWorkerNode:     false,
+		JoinServerIp:     "127.0.0.1",
+		ClusterType:      config.ClusterType_CLUSTER_TYPE_K3S_BASE,
 	}
 }
 
@@ -404,4 +435,14 @@ func (cfg *Ctx) GetProfileServerToken() string {
 // SetProfileServerToken set profileServerToken
 func (cfg *Ctx) SetProfileServerToken(profileServerToken string) {
 	cfg.profileServerToken = profileServerToken
+}
+
+// GetCluster returns the EdgeNodeCluster config, or nil if not set.
+func (cfg *Ctx) GetCluster() *config.EdgeNodeCluster {
+	return cfg.cluster
+}
+
+// SetCluster sets the EdgeNodeCluster config. Pass nil to clear.
+func (cfg *Ctx) SetCluster(cluster *config.EdgeNodeCluster) {
+	cfg.cluster = cluster
 }

--- a/pkg/expect/contentTree.go
+++ b/pkg/expect/contentTree.go
@@ -25,3 +25,20 @@ func (exp *AppExpectation) imageToContentTree(image *config.Image, displayName s
 	_ = exp.ctrl.AddContentTree(contentTree)
 	return contentTree
 }
+
+// ContentTree creates a standalone ContentTree from the AppExpectation's
+// resolved image, registers it with the controller, and adds its UUID to the
+// device's ContentTree list. No Volume is created. Pillar's volumemgr
+// downloads ContentTrees eagerly; blob lookup is by SHA256, so a later
+// AppInstance referencing the same image reuses the blobs without
+// re-downloading. Use this to pre-stage content trees for tests that
+// exercise upgrade/migration scenarios without involving the PVC machinery.
+func (exp *AppExpectation) ContentTree(displayName string) *config.ContentTree {
+	img := exp.Image()
+	if displayName == "" {
+		displayName = img.Name
+	}
+	contentTree := exp.imageToContentTree(img, displayName)
+	exp.device.SetContentTreeConfig(append(exp.device.GetContentTrees(), contentTree.Uuid))
+	return contentTree
+}

--- a/pkg/openevec/edgeNode.go
+++ b/pkg/openevec/edgeNode.go
@@ -509,6 +509,48 @@ func (openEVEC *OpenEVEC) EdgeNodeClusterSet(controllerMode string, clusterType 
 	return nil
 }
 
+// EdgeNodeContentTreeAdd registers a standalone ContentTree (no associated
+// Volume or AppInstance) in the device config. The URL accepts the same
+// forms as 'eden volume create' / 'eden pod deploy': docker://, file://,
+// http(s)://. Pillar's volumemgr downloads ContentTrees eagerly, so the
+// device will fetch the blobs and reach LOADED state. Because blob lookup
+// is by SHA256, a subsequent app deploy against the same image (or any
+// other image sharing the SHA) reuses the existing blobs without
+// re-downloading. This lets tests pre-stage a content tree, exercise a
+// migration (e.g. cross-HV upgrade), and then deploy an app from it
+// without involving the PVC machinery.
+func (openEVEC *OpenEVEC) EdgeNodeContentTreeAdd(controllerMode, appLink, registry, contentTreeName, datastoreOverride string, sftpLoad, directLoad bool) error {
+	changer, err := changerByControllerMode(controllerMode)
+	if err != nil {
+		return err
+	}
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
+	if err != nil {
+		return fmt.Errorf("getControllerAndDevFromConfig: %w", err)
+	}
+	var opts []expect.ExpectationOption
+	opts = append(opts, expect.WithSFTPLoad(sftpLoad))
+	if !sftpLoad {
+		opts = append(opts, expect.WithHTTPDirectLoad(directLoad))
+	}
+	opts = append(opts, expect.WithDatastoreOverride(datastoreOverride))
+	registryToUse := registry
+	switch registry {
+	case "local":
+		registryToUse = fmt.Sprintf("%s:%d", openEVEC.cfg.Registry.IP, openEVEC.cfg.Registry.Port)
+	case "remote":
+		registryToUse = ""
+	}
+	opts = append(opts, expect.WithRegistry(registryToUse))
+	expectation := expect.AppExpectationFromURL(ctrl, dev, appLink, contentTreeName, opts...)
+	contentTree := expectation.ContentTree(contentTreeName)
+	log.Infof("create content tree %s with %s request sent", contentTree.DisplayName, appLink)
+	if err = changer.setControllerAndDev(ctrl, dev); err != nil {
+		return fmt.Errorf("setControllerAndDev: %w", err)
+	}
+	return nil
+}
+
 // EdgeNodeClusterClear removes any EdgeNodeCluster config from the device.
 // After clearing, pillar's parseEdgeNodeClusterConfig will publish an
 // empty (Initialized=true, Valid=false) ENCC — which means volumemgr will

--- a/pkg/openevec/edgeNode.go
+++ b/pkg/openevec/edgeNode.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lf-edge/eden/pkg/controller"
 	"github.com/lf-edge/eden/pkg/controller/types"
 	"github.com/lf-edge/eden/pkg/defaults"
+	"github.com/lf-edge/eden/pkg/device"
 	"github.com/lf-edge/eden/pkg/expect"
 	"github.com/lf-edge/eden/pkg/utils"
 	"github.com/lf-edge/eve-api/go/config"
@@ -462,5 +463,71 @@ func (openEVEC *OpenEVEC) ControllerSetOptions(fileWithConfig string) error {
 	}
 	log.Info("Options loaded")
 
+	return nil
+}
+
+// EdgeNodeClusterSet pushes a stub EdgeNodeCluster config to the device
+// with the specified cluster type (k3sbase | replicated-storage | ha).
+// Workaround for lf-edge/eve#6018; see device.DefaultStubCluster for the
+// rationale.
+func (openEVEC *OpenEVEC) EdgeNodeClusterSet(controllerMode string, clusterType string) error {
+	var ct config.ClusterType
+	switch clusterType {
+	case "k3sbase":
+		ct = config.ClusterType_CLUSTER_TYPE_K3S_BASE
+	case "replicated-storage":
+		ct = config.ClusterType_CLUSTER_TYPE_REPLICATED_STORAGE
+	case "ha":
+		ct = config.ClusterType_CLUSTER_TYPE_HA
+	case "none":
+		ct = config.ClusterType_CLUSTER_TYPE_UNSPECIFIED
+	default:
+		return fmt.Errorf("unsupported cluster type %q (want one of: k3sbase, replicated-storage, ha, none)", clusterType)
+	}
+
+	changer, err := changerByControllerMode(controllerMode)
+	if err != nil {
+		return err
+	}
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
+	if err != nil {
+		return fmt.Errorf("getControllerAndDevFromConfig error: %w", err)
+	}
+
+	cluster := dev.GetCluster()
+	if cluster == nil {
+		// No prior cluster set — start from the loopback stub.
+		cluster = device.DefaultStubCluster()
+	}
+	cluster.ClusterType = ct
+	dev.SetCluster(cluster)
+
+	if err = changer.setControllerAndDev(ctrl, dev); err != nil {
+		return fmt.Errorf("setControllerAndDev error: %w", err)
+	}
+	log.Infof("Pushed EdgeNodeCluster (type=%s) to the device", clusterType)
+	return nil
+}
+
+// EdgeNodeClusterClear removes any EdgeNodeCluster config from the device.
+// After clearing, pillar's parseEdgeNodeClusterConfig will publish an
+// empty (Initialized=true, Valid=false) ENCC — which means volumemgr will
+// fall back to waiting for longhorn (the behavior workaround'd by the
+// default stub). Useful for tests that explicitly want pillar's "no
+// cluster config" branch.
+func (openEVEC *OpenEVEC) EdgeNodeClusterClear(controllerMode string) error {
+	changer, err := changerByControllerMode(controllerMode)
+	if err != nil {
+		return err
+	}
+	ctrl, dev, err := changer.getControllerAndDevFromConfig(openEVEC.cfg)
+	if err != nil {
+		return fmt.Errorf("getControllerAndDevFromConfig error: %w", err)
+	}
+	dev.SetCluster(nil)
+	if err = changer.setControllerAndDev(ctrl, dev); err != nil {
+		return fmt.Errorf("setControllerAndDev error: %w", err)
+	}
+	log.Info("Cleared EdgeNodeCluster on the device")
 	return nil
 }


### PR DESCRIPTION
# Description

Add an `eden controller edge-node content-tree-add` CLI alongside
the existing `cluster-set` / `cluster-clear` (from the
loopback-stub EdgeNodeCluster work). The new command attaches a
ContentTree to the edge-node config without an enclosing
AppInstance — useful for tests that want to exercise pillar's
download/recover paths for OCI content independently of any app
deployment (e.g. cross-HV blob-reuse validation).

Three commits, in order:

1. `controller: push loopback-stub EdgeNodeCluster by default` —
   the existing draft #1194 (eden-managed devices publish a
   loopback EdgeNodeCluster so pillar's `parseEdgeNodeClusterConfig`
   short-circuits the longhorn-readiness wait on single-node EVE-k).
   The same commit also adds the `cluster-set` / `cluster-clear`
   CLI for tests that need to override or remove the default.

2. `controller: default stub ClusterType to REPLICATED_STORAGE` —
   K3S_BASE was breaking VM tests because EVE-k drops kubevirt on
   K3S_BASE devices. REPLICATED_STORAGE is the appropriate default
   for the stub.

3. `controller: add edge-node content-tree-add CLI` — the new
   command. Adds a ContentTree to the device config using
   `expect.AppExpectation` and emits a "no new ContentSha256
   appears" assertion shape suitable for snapshot-based tests.

Commits 1 and 2 are required predecessors for commit 3 because all
three modify the same files under `cmd/edenController.go` and
`pkg/openevec/edgeNode.go` (adding adjacent subcommands).

This PR supersedes draft #1194; once merged, #1194 can be closed.

## PR dependencies

None on the eden side. Companion EVE test work that consumes the
new CLI is staged in a separate draft eden test PR (link to follow)
and depends on the EVE blob-reuse PR (lf-edge/eve#6036).

## How to test and validate this PR

```sh
# Build
cd eden && make build

# Smoke test the new CLI exists
./dist/bin/eden controller edge-node content-tree-add --help

# Functional test via the companion eden test draft (see test PR).
```

## Changelog notes

New CLI: `eden controller edge-node content-tree-add`.
