### PR TITLE
[WIP] tests/update_eve_image: cross-HV (kvm↔k) BaseOs upgrade test suite

### DIFF
--- a/tests/update_eve_image/eden.update_eve_image.tests.txt
+++ b/tests/update_eve_image/eden.update_eve_image.tests.txt
@@ -1,2 +1,5 @@
 eden.escript.test -test.run TestEdenScripts/update_eve_image_http -test.timeout 60m
 eden.escript.test -test.run TestEdenScripts/update_eve_image_oci -test.timeout 60m
+eden.escript.test -test.run TestEdenScripts/update_eve_image_cross_hv -test.timeout 90m
+eden.escript.test -test.run TestEdenScripts/update_eve_image_cross_hv_with_contenttree -test.timeout 90m
+eden.escript.test -test.run TestEdenScripts/update_eve_image_cross_hv_with_app_recreate -test.timeout 180m

--- a/tests/update_eve_image/testdata/README_kvm_to_k_geom.md
+++ b/tests/update_eve_image/testdata/README_kvm_to_k_geom.md
@@ -1,0 +1,111 @@
+# kvm->k geometry matrix (`update_eve_image_kvm_to_k_geom`)
+
+A geometry-only sibling of `update_eve_image_kvm_to_k_resize`. It proves that,
+whatever the boot disk's **starting** GPT layout, driving an EVE-kvm -> EVE-k
+base-OS upgrade ends with the full EVE-k target of **2+2+10+10 GiB**:
+
+| partition | target |
+|-----------|--------|
+| ESP-A ("EFI System", PARTUUID `…30051`) | 2 GiB |
+| ESP-B, reserved ("EFI System", PARTUUID `…30056`) | 2 GiB |
+| IMGA | 10 GiB |
+| IMGB | 10 GiB |
+
+It deliberately skips apps, deferred content-tree deletes, blob-reuse, and the
+TPM-seal check — those live in the resize/volmig tests. One escript, parameterized
+by the starting release; the matrix runner runs it once per release.
+
+## The one escript, driven by parameters
+
+`update_eve_image_kvm_to_k_geom.txt` reads:
+
+| env | meaning |
+|-----|---------|
+| `RESIZE_EVE_VER` (req) | conversion-capable build base, e.g. `0.0.0-kvm-to-k-resize-<sha8>` |
+| `RESIZE_EVE_REG` | image namespace (default `lfedge/eve`) |
+| `BRINGUP_EVE_VER` (req) | the release EVE was brought up on (asserted at Step 1) |
+| `START_ESP_MIB` / `START_IMGA_MIB` / `START_IMGB_MIB` | expected start sizes (0 = skip that band check) |
+| `START_HAS_ESPB` | 1 if the start image already has the reserved ESP-B |
+
+Flow: assert START release + geometry → kvm→kvm hop onto `RESIZE_EVE_VER` (lands
+the conversion code, geometry unchanged) → kvm→k (arms the offline repartition) →
+`assert-final` = 2+2+10+10.
+
+The two ESPs share the GPT label `"EFI System"`; `capture-geom.sh` tells them
+apart by PARTUUID and by **count**, so `assert-final` requires **two** ~2 GiB
+"EFI System" partitions, one carrying the reserved ESP-B UUID (`…30056`).
+
+## Starting-release matrix
+
+Sizes verified against each tag's `pkg/mkimage-raw-efi/make-raw`:
+
+| release | ESP | ESP-B | IMGA | IMGB | what the convert must add |
+|---------|-----|-------|------|------|---------------------------|
+| **10.1.0**    | 36 MiB | — | 300 MiB | 300 MiB | grow ESP + both IMGx (+ shrink P3) + create ESP-B |
+| **16.13.0**   | 2 GiB  | — | 4 GiB   | 4 GiB   | grow both IMGx (+ shrink P3) + create ESP-B |
+| **17.0.0-rc1**| 2 GiB  | — | 10 GiB  | 10 GiB  | **only** create ESP-B |
+| **17.1.0** (TBD, unreleased) | 2 GiB | 2 GiB | 10 GiB | 10 GiB | nothing (no-op; must stay 2+2+10+10) |
+
+10.1.0 is the pre-512 MiB baseline (`ROOTFS_PART_SIZE=300 MiB`); 512 MiB first
+shipped in 10.2.0. 2 GiB ESP first shipped in 16.13.0; 10 GiB IMGx in the 17.0.0
+series; the reserved ESP-B is not in any release yet (build-time `make-raw` only).
+
+## Status: e2e check for the ESP-B retrofit (RED until the EVE wiring lands)
+
+This matrix is the end-to-end verification for the **ESP-B retrofit** (design:
+`~/notes/esp-b-retrofit-3-design.md` — retrofit the reserved ESP-B onto old
+pre-ESP-B disks during the kvm→k grow so a converted device is byte-identical to a
+fresh EVE-k install: partition **#7**, GUID `…30056`, `ef00`, 2 GiB).
+
+- **Library side (done + validated):** partitionresizer branch `esp-b-create` has
+  the declarative create path (empty FAT32 by offset, ESP-B folded into the final
+  GPT write, #7 reserved); diskfs PRs #21/#23/#414.
+- **EVE side (in progress):** `pkg/storage-resizer` gains the dynamic 22/24 GiB
+  budget (24 when ESP-B must be created) and wires `Apply` (select ESP-A by GUID
+  `…30051`, create ESP-B `…30056` when absent) — branch `esp-b-create-resize` at
+  `~/lf-edge/esp-b-create/eve`.
+
+So `assert-final` (which requires two ~2 GiB "EFI System" partitions, one carrying
+`…30056`) goes **green only when `RESIZE_EVE_VER` is a create-capable build**.
+Against a build whose resizer still targets `spaceNeededBytes = 2+10+10` with no
+ESP-B it is RED, correctly showing the not-yet-created state.
+
+**Validated 2026-07-09 (all four starts GREEN)** in a multipass sandbox against
+`0.0.0-esp-b-create-resize-nostress-6fb1e67c` (resizer `3eeaf245`): 10.1.0, 12.1.0,
+16.13.0, 17.0.0-rc1 each converted to 2+2+10+10 with the reserved ESP-B created.
+The sandbox suffices because this test boots no app guest (no depth-2 nested-KVM
+wall). 17.1.0 additionally covers the already-converted no-op once such an image
+exists.
+
+## Running
+
+Single-tenant eden — the runner takes over the host eden slot (destructive reset).
+
+```sh
+S=~/.claude/skills/kvm-to-k-conversion-testing/scripts
+RESIZE_EVE_VER=0.0.0-kvm-to-k-resize-<sha8> bash "$S/run-kvm-to-k-geom-matrix.sh"
+# add the unreleased ESP-B build once you have it built locally:
+RESIZE_EVE_VER=... RELEASES="10.1.0 16.13.0 17.0.0-rc1 17.1.0" bash "$S/run-kvm-to-k-geom-matrix.sh"
+```
+
+Results (per-release logs + `summary.txt`) land in `~/kvm-to-k-geom-matrix-<utc>/`.
+To run a single start by hand against an already-onboarded device, invoke the
+escript directly (see `resize-fullrun.sh` for the `eden test … -e …` form) with
+`BRINGUP_EVE_VER` + the `START_*` values from the table above.
+
+## Operational notes (from the 2026-07-09 validation)
+
+- **Watch budget scales with the IMGx-grow copy.** A start whose IMGA/IMGB must
+  GROW (16.13.0: 4→10 GiB, ~8 GiB online-grow copy) can take ~30 min before the
+  offline shrink + EVE-k boot even begin; on constrained I/O the whole run is
+  ~70 min. The watch step is `exec -t 90m` for this reason. Tiny-IMGx starts
+  (10.1.0/12.1.0) and no-grow starts (17.0.0-rc1) finish in ~32-40 min.
+- **`RESIZE_EVE_VER` must be genuinely create-capable.** storage-init runs the
+  storage-resizer *binary* pinned in `pkg/storage-init/Dockerfile`
+  (`FROM lfedge/eve-storage-resizer:<hash>`), not the eve tree's Go source, so a
+  build whose source has the create but pins a pre-feature binary produces
+  2+10+10 (RED). Confirm the pin is create-capable before a green run.
+- **10.1.0 boots + onboards fine** under current eden (was flagged as a risk; the
+  2021→2026 kvm→kvm hop applied cleanly). No need to substitute 12.1.0.
+- **17.1.0** needs a local build carrying both the ESP-B `make-raw` change and the
+  conversion wiring; it is unreleased, so the runner skips it unless present.

--- a/tests/update_eve_image/testdata/README_kvm_to_k_grow.md
+++ b/tests/update_eve_image/testdata/README_kvm_to_k_grow.md
@@ -1,0 +1,149 @@
+# Eden setup for the kvm-to-k boot-disk repartition test — GROW (no-shrink) variant
+
+`update_eve_image_kvm_to_k_grow.txt` drives the EVE-kvm → EVE-k in-field boot-disk
+repartition (small → large GPT geometry) for the case where the boot disk already
+has **≥ 22 GB of free space after the last partition**, so the resizer grows
+ESP/IMGA/IMGB into that free tail **without shrinking `/persist`**. It is the
+grow-only sibling of `update_eve_image_kvm_to_k_resize.txt` (the shrink variant,
+where P3 fills the disk and must be shrunk first); the two escripts diff only on
+those variant specifics.
+
+The repartition runs **offline in storage-init**: baseosmgr arms a grow-only flag
+and reboots; storage-init grows the partitions while `/persist` is unmounted (the
+boot disk's GPT can't be re-read live while its rootfs is mounted). The test
+asserts:
+
+1. the disk **started small** and had a **≥ 22 GB free tail** (the `grow`
+   precondition — `storage-resizer check`, fail-fast);
+2. ESP/IMGA/IMGB **grew to the large geometry** and **P3 did NOT shrink**;
+3. the repartition **preserved the TPM seal** — checked post-hoc from
+   `/persist/newlog` (the last boot on the conversion-capable kvm image unsealed
+   locally; no boot re-sealed due to PCR5). The EVE-k boot's controller-key unlock
+   is the expected new-rootfs behavior, not a failure;
+4. an app **redeploy reused cached blobs** (downloader `< 1 MiB`), thanks to
+   `timer.defer.content.delete=24h` holding the blobs across the delete + convert.
+
+## Image sequence (3 images — build these first)
+
+| Step | Image | HV | Layout | Source |
+|------|-------|----|--------|--------|
+| bringup | `12.1.0` (or any small-layout release) | kvm | **small** (36 MiB ESP, 300/512 MiB IMGA/IMGB) | published `lfedge/eve` |
+| 2 | `kvm-to-k-resize-<sha>` | kvm | small (unchanged) | local build |
+| 3 | `kvm-to-k-resize-<sha>` | k | large (after repartition) | local build |
+
+The kvm→kvm hop (step 2) lands the conversion code on the small layout without
+changing geometry; the kvm→k hop (step 3) triggers the repartition. Build the two
+local images from the kvm-to-k-resize eve workspace (must go through the build
+script — see CLAUDE.md):
+
+```sh
+~/bin/eve-build.sh ~/lf-edge/work/kvm-to-k-resize/eve kvm   # -> lfedge/eve:0.0.0-kvm-to-k-resize-<sha>-kvm-amd64
+~/bin/eve-build.sh ~/lf-edge/work/kvm-to-k-resize/eve k     # -> lfedge/eve:0.0.0-kvm-to-k-resize-<sha>-k-amd64
+```
+
+`RESIZE_EVE_VER` is the part **before** `-kvm-amd64` / `-k-amd64`, e.g.
+`0.0.0-kvm-to-k-resize-<sha>`.
+
+## eden bringup (TPM required) — small image THEN enlarge the disk
+
+The vault assertions need a TPM, so eden must run with `eve.tpm=true` + swtpm. The
+free tail must be created **after first boot**, not before: on its first boot
+12.1.0's `storage-init.sh` runs `sgdisk --largest-new` and P3 would otherwise
+swallow the enlarged disk. So boot small once, settle, stop, enlarge + relocate
+the backup GPT, then restart:
+
+```sh
+# 1) bring up on the SMALL 12.1.0-kvm image with a TPM
+eden config add default
+eden config set default --key=eve.tpm     --value=true
+eden config set default --key=eve.accel   --value=true
+eden config set default --key=eve.tag     --value=12.1.0       # small layout
+eden config set default --key=eve.hostfwd --value='{"2222":"22","2223":"2223"}'
+eden setup
+eden start
+eden eve onboard
+# let it settle: zedagent up, P3 created (fills the ORIGINAL ~28 GB disk)
+
+# 2) stop eden and enlarge + fix the disk (host-side). qcow2 must be exposed as
+#    a block device for sgdisk; needs sudo + the nbd module.
+eden eve stop
+IMG=dist/default-images/eve/live.img       # under EDEN_HOME: $EDEN_HOME/default-images/eve/live.img
+cp -f "$IMG" "$IMG.prespare.bak"
+qemu-img resize "$IMG" +24G                # >22 GB tail
+sudo modprobe nbd max_part=16
+sudo qemu-nbd --connect=/dev/nbd0 "$IMG"
+sgdisk -v /dev/nbd0                        # expect: corrupt (secondary header not at end)
+sudo sgdisk -e /dev/nbd0                   # relocate backup GPT + extend last-usable-LBA
+sgdisk -v /dev/nbd0                        # expect: No problems found
+sudo qemu-nbd --disconnect /dev/nbd0
+
+# 3) resume — eden start ONLY (do NOT re-run `eden setup`; it regenerates live.img)
+eden start
+```
+
+The free tail survives the later kvm→kvm hop and the settle reboots: once P3
+exists the first-boot gate is false, so P3 is never re-grown. (See the
+`kvm-to-k-conversion-testing` skill and `eden-bringup.sh` for the swtpm-socket
+gotcha and a scripted bringup.)
+
+> Single-tenant: only one eden runs per host. Do not start this against a host
+> that already has an eden instance you care about.
+
+This test does **not** bring eve up itself — it assumes a running, onboarded
+device on the small image **with the free tail already in place**. Step 1 fails
+fast (via `storage-resizer check`) if the tail is missing.
+
+## Run
+
+```sh
+cd <this-eden-workspace>
+RESIZE_EVE_VER=0.0.0-kvm-to-k-resize-<sha> \
+  ./eden test ./tests/update_eve_image -e update_eve_image_kvm_to_k_grow -v debug
+```
+
+### Parameters
+
+| Env var | Required | Default | Meaning |
+|---------|----------|---------|---------|
+| `RESIZE_EVE_VER` | **yes** | — | Version base of the local kvm-to-k-resize build, i.e. the part **before** `-kvm-amd64` / `-k-amd64`, e.g. `0.0.0-kvm-to-k-resize-<sha>`. Both the kvm hop and the k hop use this same base; the test appends `-kvm-<arch>` and `-k-<arch>`. |
+| `RESIZE_EVE_REG` | no | `lfedge/eve` | The image **registry/repo namespace** (not a version). The full docker tag is `<RESIZE_EVE_REG>:<RESIZE_EVE_VER>-<hv>-<arch>`. `eden utils download eve-rootfs --eve-registry=<this>` extracts the rootfs from that **local** docker image — no registry push. `eve-build.sh` tags under `lfedge/eve`, so override only if you keep EVE images elsewhere. |
+| `BRINGUP_EVE_VER` | no | `12.1.0` | Substring the running base release (`/run/eve-release`) must contain at Step 1, asserting the device is on the small bringup image and not already upgraded. Set it if you brought eve up on a small release other than 12.1.0. |
+
+The escript does **not** install the small bringup image — that is whatever
+`eve.tag` you set at eden setup. It only *asserts* the running base matches
+`BRINGUP_EVE_VER` at Step 1.
+
+## What each step watches
+
+- **Step 1 `assert-running-version.sh` + `capture-partitions.sh assert-small` +
+  `assert-free-tail.sh` + (post-kvm) `assert-check-grow.sh`** — fail fast unless
+  the device is on the expected small bringup release, the disk is genuinely small
+  (ESP `< 256 MiB`, IMGA/IMGB `< 1 GiB`), there is a **≥ 22 GB free tail**, and
+  `storage-resizer check` reports `decision == grow`. The grow decision is the
+  load-bearing precondition: if it is `shrink`, the bringup didn't create the tail
+  and the test would silently become the shrink test.
+- **Step 8 `watch-conversion.sh`** — drives the conversion to completion (booted
+  the `-k` version, active partition runs it) and logs device state/sub-state
+  TRANSITIONS (running version, active slot, controller-reported `ZDEVICE_STATE`/
+  sub-state, on-device `Converting`/`ConvertSubState`), tolerating the reboots the
+  offline resize needs. Slot-agnostic (the grow relocates the active partition).
+- **Step 9 `wait-for-volumemgr-ready.sh`** — the redeploy gate: volumemgr must
+  finish its EVE-k content-store init before the redeploy, or the image is
+  re-downloaded instead of reusing the retained ContentTree. Logs the readiness
+  timeline.
+- **Step 10 `capture-partitions.sh assert-grown-no-shrink` + `assert-seal-from-newlog.sh`** —
+  ESP/IMGA/IMGB grew past the large floors and **P3 did not shrink**; and the
+  repartition preserved the local TPM seal (post-hoc from `/persist/newlog`).
+- **Step 11 `wait-for-app-running.sh` + `capture-blob-diagnostics.sh` +
+  `snapshot-rcv-bytes.sh post-and-assert` + `wait-for-ssh-to-app.sh`** — the app
+  comes online on EVE-k, **< 1 MiB** downloaded (blob reuse), and it is functional
+  over the network (ssh to the eclient).
+
+## Caveats / not-yet-validated
+
+- The EVE-k first boot installs longhorn (kubevirt/CDI/longhorn/descheduler);
+  helper budgets are sized for a slow rig but may need bumping.
+- `assert-seal-from-newlog.sh` relies on the vaultmgr observability in the
+  kvm-to-k-resize image (`VaultStatus.UnlockMethod` / the `unlocked: method=` log
+  line). The bringup image (12.1.0) need not have it — the seal check keys on the
+  conversion-capable kvm version's boots.

--- a/tests/update_eve_image/testdata/README_kvm_to_k_resize.md
+++ b/tests/update_eve_image/testdata/README_kvm_to_k_resize.md
@@ -1,0 +1,123 @@
+# Eden setup for the kvm-to-k boot-disk repartition test — shrink variant
+
+`update_eve_image_kvm_to_k_resize.txt` drives the EVE-kvm → EVE-k in-field
+boot-disk repartition (small → large GPT geometry) for the default field layout,
+where **P3 fills the disk**, so the resizer must **shrink the ext4 `/persist`**
+first to free room, then grow ESP/IMGA/IMGB. It is the shrink sibling of
+`update_eve_image_kvm_to_k_grow.txt` (the grow-only variant, where the disk
+already has a free tail and P3 is left unchanged); the two escripts diff only on
+those variant specifics.
+
+The repartition runs **offline in storage-init**: baseosmgr backs up the
+device-identity files to the CONFIG partition, arms a shrink flag, and reboots;
+storage-init shrinks `/persist` then grows the partitions while `/persist` is
+unmounted (the boot disk's GPT can't be re-read live while its rootfs is mounted).
+The test asserts:
+
+1. the disk **started small** (P3 filling it — the `shrink` case);
+2. ESP/IMGA/IMGB **grew to the large geometry** and **P3 shrank** to make room;
+3. the repartition **preserved the TPM seal** — checked post-hoc from
+   `/persist/newlog` (the last boot on the conversion-capable kvm image unsealed
+   locally; no boot re-sealed due to PCR5). The EVE-k boot's controller-key unlock
+   is the expected new-rootfs behavior, not a failure;
+4. an app **redeploy reused cached blobs** (downloader `< 1 MiB`), thanks to
+   `timer.defer.content.delete=24h` holding the blobs across the delete + convert.
+
+## Image sequence (3 images — build these first)
+
+| Step | Image | HV | Layout | Source |
+|------|-------|----|--------|--------|
+| bringup | `12.1.0` (or any small-layout release) | kvm | **small** (36 MiB ESP, 300/512 MiB IMGA/IMGB) | published `lfedge/eve` |
+| 2 | `kvm-to-k-resize-<sha>` | kvm | small (unchanged) | local build |
+| 3 | `kvm-to-k-resize-<sha>` | k | large (after repartition) | local build |
+
+The kvm→kvm hop (step 2) lands the conversion code on the small layout without
+changing geometry; the kvm→k hop (step 3) triggers the repartition. Build the two
+local images from the kvm-to-k-resize eve workspace (must go through the build
+script — see CLAUDE.md):
+
+```sh
+~/bin/eve-build.sh ~/lf-edge/work/kvm-to-k-resize/eve kvm   # -> lfedge/eve:0.0.0-kvm-to-k-resize-<sha>-kvm-amd64
+~/bin/eve-build.sh ~/lf-edge/work/kvm-to-k-resize/eve k     # -> lfedge/eve:0.0.0-kvm-to-k-resize-<sha>-k-amd64
+```
+
+`RESIZE_EVE_VER` is the part **before** `-kvm-amd64` / `-k-amd64`, e.g.
+`0.0.0-kvm-to-k-resize-<sha>`.
+
+## eden bringup (TPM required)
+
+The vault assertions need a TPM, so eden must run with `eve.tpm=true` + swtpm.
+Bring eve up on the **small 12.1.0-kvm** image; P3 fills the disk on first boot,
+which is exactly the shrink precondition — no host-side disk surgery needed:
+
+```sh
+eden config add default
+eden config set default --key=eve.tpm     --value=true
+eden config set default --key=eve.accel   --value=true
+eden config set default --key=eve.tag     --value=12.1.0       # small layout
+eden config set default --key=eve.hostfwd --value='{"2222":"22","2223":"2223"}'
+eden setup
+eden start
+eden eve onboard
+```
+
+(See the `kvm-to-k-conversion-testing` skill and `eden-bringup.sh` for the
+swtpm-socket gotcha and a scripted bringup.)
+
+> Single-tenant: only one eden runs per host. Do not start this against a host
+> that already has an eden instance you care about.
+
+This test does **not** bring eve up itself — it assumes a running, onboarded
+device on the small image.
+
+## Run
+
+```sh
+cd <this-eden-workspace>
+RESIZE_EVE_VER=0.0.0-kvm-to-k-resize-<sha> \
+  ./eden test ./tests/update_eve_image -e update_eve_image_kvm_to_k_resize -v debug
+```
+
+### Parameters
+
+| Env var | Required | Default | Meaning |
+|---------|----------|---------|---------|
+| `RESIZE_EVE_VER` | **yes** | — | Version base of the local kvm-to-k-resize build, i.e. the part **before** `-kvm-amd64` / `-k-amd64`, e.g. `0.0.0-kvm-to-k-resize-<sha>`. Both the kvm hop and the k hop use this same base; the test appends `-kvm-<arch>` and `-k-<arch>`. |
+| `RESIZE_EVE_REG` | no | `lfedge/eve` | The image **registry/repo namespace** (not a version). The full docker tag is `<RESIZE_EVE_REG>:<RESIZE_EVE_VER>-<hv>-<arch>`. `eden utils download eve-rootfs --eve-registry=<this>` extracts the rootfs from that **local** docker image — no registry push. `eve-build.sh` tags under `lfedge/eve`, so override only if you keep EVE images elsewhere. |
+| `BRINGUP_EVE_VER` | no | `12.1.0` | Substring the running base release (`/run/eve-release`) must contain at Step 1, asserting the device is on the small bringup image and not already upgraded. Set it if you brought eve up on a small release other than 12.1.0. |
+
+The escript does **not** install the small bringup image — that is whatever
+`eve.tag` you set at eden setup. It only *asserts* the running base matches
+`BRINGUP_EVE_VER` at Step 1.
+
+## What each step watches
+
+- **Step 1 `assert-running-version.sh` + `capture-partitions.sh assert-small`** —
+  fail fast unless the device is on the expected small bringup release and the disk
+  is genuinely small (ESP `< 256 MiB`, IMGA/IMGB `< 1 GiB`). P3 fills the disk, so
+  the resizer's check returns `shrink`.
+- **Step 8 `watch-conversion.sh`** — drives the conversion to completion (booted
+  the `-k` version, active partition runs it) and logs device state/sub-state
+  TRANSITIONS (running version, active slot, controller-reported `ZDEVICE_STATE`/
+  sub-state, on-device `Converting`/`ConvertSubState`), tolerating the reboots the
+  offline resize needs. Slot-agnostic (the grow relocates the active partition).
+- **Step 9 `wait-for-volumemgr-ready.sh`** — the redeploy gate: volumemgr must
+  finish its EVE-k content-store init before the redeploy, or the image is
+  re-downloaded instead of reusing the retained ContentTree. Logs the readiness
+  timeline.
+- **Step 10 `capture-partitions.sh assert-grown` + `assert-seal-from-newlog.sh`** —
+  ESP/IMGA/IMGB grew past the large floors and **P3 shrank**; and the
+  repartition preserved the local TPM seal (post-hoc from `/persist/newlog`).
+- **Step 11 `wait-for-app-running.sh` + `capture-blob-diagnostics.sh` +
+  `snapshot-rcv-bytes.sh post-and-assert` + `wait-for-ssh-to-app.sh`** — the app
+  comes online on EVE-k, **< 1 MiB** downloaded (blob reuse), and it is functional
+  over the network (ssh to the eclient).
+
+## Caveats / not-yet-validated
+
+- The EVE-k first boot installs longhorn (kubevirt/CDI/longhorn/descheduler);
+  helper budgets are sized for a slow rig but may need bumping.
+- `assert-seal-from-newlog.sh` relies on the vaultmgr observability in the
+  kvm-to-k-resize image (`VaultStatus.UnlockMethod` / the `unlocked: method=` log
+  line). The bringup image (12.1.0) need not have it — the seal check keys on the
+  conversion-capable kvm version's boots.

--- a/tests/update_eve_image/testdata/prep-kvm-to-k-topology.sh
+++ b/tests/update_eve_image/testdata/prep-kvm-to-k-topology.sh
@@ -1,0 +1,368 @@
+#!/bin/bash
+# prep-kvm-to-k-topology.sh — bring eden up in one of the disk topologies the
+# kvm->k repartition tests need, BEFORE running the escript. Host-side helper,
+# NOT an escript (it is never enumerated by `eden test`).
+#
+# The conversion tests always start on a SMALL, old bringup image; what differs
+# between scenarios is the /persist filesystem (ext4 vs ZFS) and disk layout
+# (single vs two disks), which determine the storage-resizer `check` decision and
+# therefore which escript applies:
+#
+#   topology       persist        layout            check decision   escript / knobs                          status
+#   -------------  -------------  ----------------  ---------------  --------------------------------         ------
+#   ext4-shrink    ext4, full     1 disk            shrink           kvm_to_k.txt EXPECT_DECISION=shrink       ok
+#   ext4-grow      ext4, +tail    1 disk            grow             kvm_to_k.txt EXPECT_DECISION=grow         ok (README recipe)
+#   twodisk-zfs    zfs on sdb     2 disks           grow             kvm_to_k.txt ... DISK_TOPOLOGY=two-disk   VERIFIED 2026-06-22
+#   ext4-toofull   ext4, full     1 disk            insufficient     kvm_to_k_refused.txt REFUSE_REASON=too-full  VERIFIED 2026-07-01
+#   zfs-grow       zfs,  +tail    1 disk            grow             kvm_to_k.txt ... DISK_TOPOLOGY=zfs        VERIFIED 2026-06-25 (notail base)
+#   zfs-notail     zfs, full      1 disk            insufficient     kvm_to_k_refused.txt REFUSE_REASON=zfs    VERIFIED 2026-06-25
+#
+# Decision logic is from pkg/storage-resizer (decide()/evaluate()): shrink applies
+# ONLY to an ext4 /persist on the boot disk; a ZFS persist or a persist on another
+# disk can only get room from the boot disk's free tail, else `insufficient`.
+# (`grow` is documented as "also the multi-disk / ZFS-persist case".)
+#
+# HOW ZFS /persist IS BUILT (verified empirically in an eden Multipass sandbox):
+#   * SINGLE-disk ZFS-on-boot (VERIFIED 2026-06-25): the `--grub-options` route DOES
+#     work; the earlier "doesn't work" was a misdiagnosis. Two real reasons it had
+#     been failing:
+#       1. setupConfigDir (pkg/openevec/eden.go) only calls GenerateEveCerts — which
+#          is what WRITES grub.cfg — when CertsDir has NO root-certificate.pem. On a
+#          reused context the certs already exist, so `eden setup --grub-options ...`
+#          SILENTLY skips grub.cfg generation and the token never lands. `--force`
+#          does NOT override this. Fix: `rm -rf dist/default-certs` (+ adam/redis
+#          volumes) before setup so the grub.cfg is regenerated. (A fresh EDEN_HOME,
+#          as in the run-eden-test skill's ZFS recipe, has the same effect.)
+#       2. The live.img has NO pre-baked P3 (only EFI/IMGA/IMGB/CONFIG); storage-init
+#          CREATES P3 on first boot and honors P3_FS_TYPE_DEFAULT=zfs (set by the
+#          token at storage-init.sh:113) -> P3 formatted ZFS on the boot disk.
+#     Verified result: /proc/cmdline carries eve_install_zfs_with_raid_level,
+#     /run/eve.persist_type=zfs, zpool ONLINE on sda9 (boot disk P3), /persist mounted.
+#     The P3 takes the whole free tail (largest-new) -> no tail left -> this is the
+#     zfs-notail (insufficient) base; zfs-grow adds a tail AFTER it (see that case).
+#   * The canonical eden MULTI-disk ZFS recipe (run-eden-test skill) is
+#     `eve.disks=4 eve.disk=16384` + the same grub-option; that puts the pool on the
+#     extra blank disks rather than the boot P3.
+#   * `eden setup --installer` requires the `general` devmodel and is NOT
+#     qemu-managed (only ZedVirtual-4G gets a qemu config + `eden start`), so eden
+#     cannot run an installer-built node itself.
+#   * Working route (two-disk): boot the live node with a blank second disk, have
+#     EVE ITSELF create the `persist` zpool on sdb (feature-correct — EVE's own
+#     zfs), `zfs set -u mountpoint=/persist`, export it, then OFFLINE delete the
+#     boot disk's P3 so storage-init's no-P3 branch does `zpool import -f persist`
+#     and mounts /persist from sdb. Verified: persist_type=zfs, no P3 on boot, pool
+#     ONLINE on sdb, /persist mounted.
+#
+# The additional disks come from eve.disks (count), each sized at eve.disk MB
+# (pkg/openevec/eden.go:101 — extra disks inherit ImageSizeMB). NOTE: the live.img
+# boot disk is the DOWNLOADED size (~28 GiB), not eve.disk — eve.disk only sizes
+# the EXTRA disks. So `eve.disks=1` gives a ~28 GiB boot disk + a 28 GiB (or
+# eve.disk-MB) second disk.
+#
+# The ext4 grow tail is created the way README_kvm_to_k_grow.md describes: boot
+# small once (storage-init creates P3 at the original size), stop, enlarge the
+# qcow2 + `sgdisk -e` to add the free tail, restart.
+#
+# Usage:
+#   ./prep-kvm-to-k-topology.sh <topology> [--yes]
+# eden-touching stages are gated behind a check that no OTHER eden is already
+# running on this host (single-tenant — see CLAUDE.md).
+
+set -uo pipefail
+
+TOPOLOGY="${1:-}"
+ASSUME_YES=0
+[ "${2:-}" = "--yes" ] && ASSUME_YES=1
+
+BRINGUP_TAG="${BRINGUP_EVE_VER:-12.1.0}"   # small-layout released image
+GROW_TAIL_GB="${GROW_TAIL_GB:-24}"         # >22 GiB so check decides grow
+EVE_DISK_MB="${EVE_DISK_MB:-32768}"        # size of the EXTRA disk(s) (not the boot disk)
+SSH_TRIES="${SSH_TRIES:-40}"               # ssh-up poll attempts (x12s)
+TOOFULL_BOOT_GB="${TOOFULL_BOOT_GB:-64}"   # ext4-toofull boot-disk size: big enough that an
+                                           # EMPTY P3 would shrink fine, so the refusal is
+                                           # genuinely fill-driven, not "disk too small".
+FILL_PCT="${FILL_PCT:-70}"                 # ext4-toofull: fill /persist to this used% so
+                                           # used > maxFull(90%) x (P3-22G) => check insufficient.
+
+die() { echo "FATAL: $*" >&2; exit 1; }
+note() { echo "=== $* ==="; }
+
+usage() { sed -n '2,60p' "$0" | sed 's/^# \{0,1\}//'; exit 2; }
+[ -n "$TOPOLOGY" ] || usage
+
+# --- single-tenant guard: refuse if another eden is already up -----------------
+guard_no_other_eden() {
+    local busy=0
+    docker ps --format '{{.Names}}' 2>/dev/null | grep -qE '^eden_(adam|redis|eserver|registry)$' && busy=1
+    pgrep -f 'qemu-system.*-drive' >/dev/null 2>&1 && busy=1
+    if [ "$busy" = 1 ]; then
+        echo "An eden instance appears to be running on this host (eden_* containers or qemu)." >&2
+        echo "eden is single-tenant; this script would disturb it. Stop it first or use a" >&2
+        echo "dedicated host / the eden-vm-sandbox skill. Refusing." >&2
+        exit 1
+    fi
+}
+
+confirm() {
+    [ "$ASSUME_YES" = 1 ] && return 0
+    read -r -p "$1 [y/N] " a
+    case "$a" in y|Y|yes) return 0 ;; *) echo "aborted."; exit 1 ;; esac
+}
+
+image_dir() {
+    if [ -n "${EDEN_HOME:-}" ] && [ -d "$EDEN_HOME/default-images/eve" ]; then
+        echo "$EDEN_HOME/default-images/eve"; return
+    fi
+    [ -d dist/default-images/eve ] && { echo dist/default-images/eve; return; }
+    die "could not locate the eve image dir (set EDEN_HOME or run from the eden workspace root)"
+}
+
+base_config() {
+    note "base eden config (TPM + accel + small bringup tag $BRINGUP_TAG)"
+    eden config add default
+    eden config set default --key=eve.tpm     --value=true
+    eden config set default --key=eve.accel   --value=true
+    eden config set default --key=eve.tag     --value="$BRINGUP_TAG"
+    eden config set default --key=eve.hostfwd --value='{"2222":"22","2223":"2223"}'
+}
+
+eve_ssh() { eden eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+wait_ssh() {
+    note "waiting for EVE ssh"
+    local i
+    for i in $(seq 1 "$SSH_TRIES"); do
+        timeout 8 eden eve ssh -- "true" 2>/dev/null && { echo "ssh up"; return 0; }
+        sleep 12
+    done
+    die "EVE ssh did not come up after $((SSH_TRIES*12))s"
+}
+
+# Enlarge a qcow2 boot disk by GROW_TAIL_GB and relocate the backup GPT so the
+# free tail is usable (README_kvm_to_k_grow.md recipe). eden must be stopped.
+add_free_tail() {
+    local img="$1"
+    [ -f "$img" ] || die "boot image not found: $img"
+    note "enlarging $img by +${GROW_TAIL_GB}G and relocating backup GPT"
+    cp -f "$img" "$img.prespare.bak"
+    qemu-img resize "$img" "+${GROW_TAIL_GB}G"
+    sudo modprobe nbd max_part=16
+    sudo qemu-nbd --connect=/dev/nbd0 "$img"; sleep 1
+    sgdisk -v /dev/nbd0 || true       # expect: corrupt (secondary header not at end)
+    sudo sgdisk -e /dev/nbd0          # relocate backup GPT + extend last-usable-LBA
+    sgdisk -v /dev/nbd0               # expect: No problems found
+    sudo qemu-nbd --disconnect /dev/nbd0
+}
+
+# Grow the boot disk to an ABSOLUTE size BEFORE first boot and relocate the backup
+# GPT so storage-init's first-boot P3 carve fills the whole disk (NO tail — the
+# ext4-toofull topology). Unlike add_free_tail this is sudo-free: sgdisk on a raw
+# *file* is plain file I/O, and a qcow2 is round-tripped through a sparse raw
+# intermediate (qemu-img convert is sparse-aware, so cheap). Call while eden is
+# stopped, between `eden setup` and the first `eden start`.
+grow_boot_no_tail() {
+    local img="$1" size_gb="$2" fmt
+    [ -f "$img" ] || die "boot image not found: $img"
+    fmt=$(qemu-img info "$img" | sed -ne 's/^file format: //p')
+    note "growing $img to ${size_gb}G (no tail; fmt=$fmt) + relocating backup GPT"
+    qemu-img resize "$img" "${size_gb}G" || die "boot resize failed"
+    if [ "$fmt" = raw ]; then
+        sgdisk -e "$img" || die "sgdisk -e failed"
+        sgdisk -v "$img" || die "sgdisk -v failed"
+    else
+        local raw="$img.raw.tmp"
+        qemu-img convert -f qcow2 -O raw "$img" "$raw" || die "qcow2->raw failed"
+        sgdisk -e "$raw" || die "sgdisk -e on raw failed"
+        sgdisk -v "$raw" || die "sgdisk -v on raw failed"
+        qemu-img convert -f raw -O qcow2 "$raw" "$img" || die "raw->qcow2 failed"
+        rm -f "$raw"
+    fi
+}
+
+# Fill the ext4 /persist to FILL_PCT% used with random-content files so the
+# storage-resizer shrink check (which reads the ext4 filesystem's used blocks
+# directly — NOT volumemgr's RemainingSpace, so no declared volume is needed)
+# can't free 22G within --max-full => decision `insufficient` (reason=too-full).
+# Gauges on `df` used% (what the resizer reads), leaving ~(100-FILL_PCT)% free so
+# the later kvm->kvm hop's rootfs blob still fits.
+fill_persist() {
+    local dir=/persist/resize-fill i usedpct
+    note "filling /persist to ${FILL_PCT}% used (random content)"
+    eve_ssh "eve exec pillar mkdir -p $dir"
+    for i in $(seq 1 400); do
+        usedpct=$(eve_ssh "eve exec pillar sh -c 'df --output=pcent /persist | tail -1 | tr -dc 0-9'" | tr -d '\r' | tail -1)
+        usedpct=${usedpct:-0}
+        echo "  /persist used=${usedpct}% (target ${FILL_PCT}%)"
+        [ "$usedpct" -ge "$FILL_PCT" ] 2>/dev/null && { echo "  reached ${usedpct}%"; break; }
+        eve_ssh "eve exec pillar sh -c 'dd if=/dev/urandom of=$dir/f$i bs=1M count=1024 conv=fsync 2>/dev/null; sync'"
+    done
+    eve_ssh "eve exec pillar sh -c 'df -h /persist'"
+}
+
+# Create the EVE persist zpool on a block device FROM INSIDE the running EVE, so
+# the pool's feature flags match EVE's own zfs and storage-init can import it.
+# Mirrors storage-init.sh's create; `zfs set -u` sets the mountpoint WITHOUT
+# mounting now (avoids clobbering the live ext4 /persist), so the next boot's
+# `zpool import` mounts it at /persist. $1 = device (e.g. /dev/sdb).
+eve_make_persist_pool() {
+    local dev="$1"
+    # Build the pool to MATCH a real EVE-ZFS install — a faithful mirror of
+    # pkg/installer/install prepare_mounts_and_zfs_pool (the installer, not storage-init,
+    # is what lays down a multi-disk ZFS persist): same pool flags, PLUS persist/reserved
+    # (refreservation = available/5), primarycache=metadata, and the non-clustered
+    # persist/snapshots dataset. The bringup base is kvm => non-clustered shape. Child
+    # datasets are created with `-u` (do not mount now) because the live ext4 /persist is
+    # still mounted during this build; they mount on the later storage-init import.
+    note "EVE creating persist zpool on $dev (installer-faithful: +reserved +primarycache +snapshots)"
+    eve_ssh "eve exec pillar sh -c \"zpool labelclear -f $dev 2>/dev/null; \
+        zpool create -f -m none -o feature@encryption=enabled -O atime=off -O overlay=on persist $dev && echo CREATED\"" \
+        | grep -q CREATED || die "zpool create failed on $dev"
+    # refreservation = available/5, computed exactly as the installer does (bytes -> MiB, /5)
+    local avail_bytes resv_mib
+    avail_bytes=$(eve_ssh "eve exec pillar zfs get -o value -Hp available persist" | grep -oE '^[0-9]+$' | head -1)
+    [ -n "$avail_bytes" ] || die "could not read pool available bytes"
+    resv_mib=$(( avail_bytes / 1024 / 1024 / 5 ))
+    note "persist/reserved refreservation = ${resv_mib}m (= available/5)"
+    eve_ssh "eve exec pillar sh -c \"\
+        zfs create -u -o refreservation=${resv_mib}m persist/reserved && \
+        zfs set -u mountpoint=/persist persist && \
+        zfs set primarycache=metadata persist && \
+        zfs create -u -o mountpoint=/persist/containerd/io.containerd.snapshotter.v1.zfs persist/snapshots && \
+        zpool export persist && echo POOL_READY\"" | grep -q POOL_READY \
+        || die "failed to set up/export persist pool on $dev"
+}
+
+# Offline-delete the boot disk's P3 (partition 9) so storage-init takes the no-P3
+# -> `zpool import persist` path. eden must be stopped. $1 = boot qcow2.
+delete_boot_p3() {
+    local img="$1"
+    note "offline-deleting boot P3 (partition 9) from $img"
+    sudo modprobe nbd max_part=16
+    sudo qemu-nbd --connect=/dev/nbd0 "$img"; sleep 1
+    sudo sgdisk -d 9 /dev/nbd0 || die "sgdisk -d 9 failed"
+    sudo sgdisk -p /dev/nbd0 | grep -qE 'P3|persist' && { sudo qemu-nbd --disconnect /dev/nbd0; die "P3 still present after delete"; }
+    sudo qemu-nbd --disconnect /dev/nbd0
+    echo "boot P3 deleted"
+}
+
+wait_settled() {
+    note "onboard + settle (P3/persist created)"
+    eden eve onboard || true
+    eden status || true
+    confirm "Has the device onboarded and settled (P3/persist created)?"
+}
+
+case "$TOPOLOGY" in
+
+    ext4-shrink)
+        # Single ext4 disk, P3 fills the disk (no tail) — the default install.
+        guard_no_other_eden
+        base_config
+        note "eden setup (live.img, single ext4 disk, no tail)"
+        eden setup; eden start; eden eve onboard
+        echo "READY: ext4-shrink. Run: EXPECT_DECISION=shrink ... kvm_to_k"
+        ;;
+
+    ext4-grow)
+        # Single ext4 disk + >=22G free tail. live.img bringup, then enlarge.
+        guard_no_other_eden
+        base_config
+        note "eden setup (live.img, single ext4 disk)"
+        eden setup; eden start
+        wait_settled
+        note "stopping eden to enlarge the boot disk"
+        eden eve stop; sleep 5
+        add_free_tail "$(image_dir)/live.img"
+        note "resuming (eden start only — do NOT re-run eden setup; --force regenerates live.img)"
+        eden start
+        echo "READY: ext4-grow. Run: EXPECT_DECISION=grow ... kvm_to_k"
+        ;;
+
+    twodisk-zfs)
+        # VERIFIED 2026-06-22 (eden sandbox). Two disks: sda boot (P3 deleted =>
+        # free tail), sdb ZFS /persist. EVE builds the pool; we delete boot P3.
+        guard_no_other_eden
+        base_config
+        eden config set default --key=eve.disks --value=1   # adds sdb
+        eden config set default --key=eve.disk  --value="$EVE_DISK_MB"  # sizes sdb
+        note "eden setup + start + onboard (sda boot ext4 P3, sdb blank)"
+        eden setup; eden start; eden eve onboard
+        wait_ssh
+        eve_make_persist_pool /dev/sdb
+        note "stopping eden to delete the boot P3"
+        eden eve stop; sleep 6
+        delete_boot_p3 "$(image_dir)/live.img"
+        note "restart — storage-init no-P3 branch imports persist from sdb"
+        eden start
+        wait_ssh
+        note "verify"
+        eve_ssh "echo persist_type=\$(cat /run/eve.persist_type); eve exec pillar sh -c \"zpool status persist; df -h /persist\""
+        echo "READY: twodisk-zfs. Run: EXPECT_DECISION=grow DISK_TOPOLOGY=two-disk ... kvm_to_k"
+        ;;
+
+    ext4-toofull)
+        # Single ext4 disk grown to TOOFULL_BOOT_GB so an EMPTY P3 could shrink to
+        # free 22G; then /persist is filled to FILL_PCT% so the shrink CAN'T free
+        # 22G within --max-full => check `insufficient` (reason=too-full). Refused
+        # case. VERIFIED end-to-end on host eden 2026-07-01 (e2e testplan row C):
+        # check `decision=insufficient persistType=ext4 shrinkApplicable=true
+        # shrink.ok=false`, kvm->k declined with BaseOsStatus.Error
+        # "conversion not possible: persist is too full to free the needed space".
+        guard_no_other_eden
+        base_config
+        eden config set default --key=eve.disks --value=0   # single boot disk
+        note "eden setup (live.img, single ext4 disk)"
+        eden setup
+        grow_boot_no_tail "$(image_dir)/live.img" "$TOOFULL_BOOT_GB"
+        eden start; eden eve onboard
+        wait_ssh
+        # A ZFS persist here would be the wrong topology (that is zfs-notail).
+        ptype=$(eve_ssh 'cat /run/eve.persist_type' | tr -d '\r' | tail -1)
+        [ "$ptype" = ext4 ] || die "persist_type='$ptype' (expected ext4 for ext4-toofull)"
+        fill_persist
+        echo "READY: ext4-toofull. Run: REFUSE_REASON=too-full ... kvm_to_k_refused"
+        ;;
+
+    zfs-grow|zfs-notail)
+        # SINGLE-disk ZFS /persist (persist == the boot disk's P3 as ZFS).
+        # VERIFIED 2026-06-25. The token is delivered via grub.cfg, which eden only
+        # (re)writes when CertsDir has no root-certificate.pem (setupConfigDir gate) —
+        # so we MUST wipe dist/default-certs (and adam/redis volumes) before setup,
+        # else `eden setup --grub-options ...` silently skips grub.cfg and the token
+        # never lands. live.img has no pre-baked P3, so storage-init creates it on
+        # first boot and formats it ZFS because the token sets P3_FS_TYPE_DEFAULT=zfs
+        # (storage-init.sh:113). Result: persist_type=zfs, zpool ONLINE on sda9.
+        guard_no_other_eden
+        base_config
+        eden config set default --key=eve.disks --value=0   # single boot disk
+        note "wipe certs + adam/redis volumes so eden setup regenerates grub.cfg"
+        eden stop || true
+        rm -rf "$(image_dir)/live.img" "$(image_dir)/live.raw.qcow2" dist/default-certs
+        docker volume rm eden_adam_volume eden_redis_volume 2>/dev/null || true
+        note "eden setup with the grub-option (canonical bare token, set_global form)"
+        # $dom0_extra_args is a grub variable expanded at boot; it must reach grub
+        # literally, so keep the single quotes and do not let the shell expand it.
+        # shellcheck disable=SC2016
+        eden setup --grub-options 'set_global dom0_extra_args "$dom0_extra_args eve_install_zfs_with_raid_level "'
+        [ -f dist/default-certs/grub.cfg ] || die "grub.cfg not written — certs were not wiped?"
+        eden start; eden eve onboard
+        wait_ssh
+        note "confirm the cmdline took effect"
+        eve_ssh "echo cmdline=\$(cat /proc/cmdline); echo persist_type=\$(cat /run/eve.persist_type)"
+        # Expect: cmdline contains eve_install_zfs_with_raid_level AND persist_type=zfs.
+        if [ "$TOPOLOGY" = zfs-grow ]; then
+            note "zfs-grow: add a >=22G free tail after the ZFS P3"
+            eden eve stop; sleep 5
+            add_free_tail "$(image_dir)/live.img"   # ZFS partition is not auto-grown -> leaves a tail
+            eden start
+            echo "READY(if persist_type=zfs above): zfs-grow. Run: EXPECT_DECISION=grow DISK_TOPOLOGY=zfs ... kvm_to_k"
+        else
+            echo "READY(if persist_type=zfs above): zfs-notail. Run: REFUSE_REASON=zfs ... kvm_to_k_refused"
+        fi
+        ;;
+
+    *)
+        echo "unknown topology: $TOPOLOGY" >&2
+        usage
+        ;;
+esac

--- a/tests/update_eve_image/testdata/update_eve_image_cross_hv.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_cross_hv.txt
@@ -1,0 +1,212 @@
+# Test: cross-HV-flavor EVE upgrade succeeds when no volumes exist
+#
+# Verifies that EVE accepts a baseos config whose HV flavor differs from
+# the currently running one (e.g. kvm -> k or k -> kvm) when the device
+# has no VolumeConfig / VolumeStatus instances — the happy path enabled
+# by EVE PR #5993 (baseosmgr volume-gate relaxation).
+#
+# Pair: update_eve_image_cross_hv_blocked.txt covers the negative case
+# (volumes present -> upgrade is rejected with "is not supported while
+# volumes exist").
+#
+# Diagnostic enhancement (post-2026-06-07):
+# On kvm -> k, after EVE reboots into IMGB the upgrade may stall at
+# PartitionState:inprogress because baseosmgr (+ volumemgr + domainmgr)
+# block in WaitForUserContainerd waiting for /run/containerd-user/
+# containerd.sock — which k3s creates only once cluster-init.sh succeeds.
+# A kvm /persist may lack state k3s expects, so k3s never comes up and
+# the wait blocks forever. We poll k3s/kube diagnostics during the wait
+# so the failure surfaces with actionable detail instead of a bare timeout.
+#
+# Parameters (env vars; defaults assume both flavors are pullable from
+# lfedge/eve at release tag 12.1.0):
+#  - ALT_HV:        the *other* HV flavor to upgrade to (default: 'k' if
+#                   running kvm, 'kvm' if running k). Auto-derived.
+#  - ALT_EVE_VER:   the EVE release tag for the alternate flavor
+#                   (default: '12.1.0').
+#  - ALT_EVE_REG:   docker registry for the alternate-flavor image
+#                   (default: 'lfedge/eve').
+
+{{$current_hv := EdenConfig "eve.hv"}}
+{{$arch       := EdenConfig "eve.arch"}}
+
+{{$alt_hv_env := EdenGetEnv "ALT_HV"}}
+{{$alt_hv := "k"}}
+{{if eq $current_hv "k"}}{{$alt_hv = "kvm"}}{{end}}
+{{if $alt_hv_env}}{{$alt_hv = $alt_hv_env}}{{end}}
+
+{{$alt_ver_env := EdenGetEnv "ALT_EVE_VER"}}
+{{$alt_ver := "12.1.0"}}
+{{if $alt_ver_env}}{{$alt_ver = $alt_ver_env}}{{end}}
+
+{{$alt_reg_env := EdenGetEnv "ALT_EVE_REG"}}
+{{$alt_reg := "lfedge/eve"}}
+{{if $alt_reg_env}}{{$alt_reg = $alt_reg_env}}{{end}}
+
+{{$alt_short_version := printf "%s-%s-%s" $alt_ver $alt_hv $arch}}
+
+# Step 1: pre-flight — no live volumes on the device.
+message 'pre-flight: assert no live volumes on the device'
+exec -t 1m bash assert-no-volumes.sh
+
+# Shorten baseimage test cooldown so partition flip is quick.
+eden controller edge-node update --config timer.test.baseimage.update=30
+
+# Step 2: download the alternate-flavor EVE rootfs.
+message 'downloading alternate-flavor EVE rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$alt_ver}} --eve-hv={{$alt_hv}} --eve-registry={{$alt_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs'
+
+# Step 3: push the cross-flavor eveimage-update.
+# --os-version explicit so adam's BaseOsConfig.BaseOsVersion carries the
+# cross-flavor tag regardless of any stale eve_version metadata in the
+# squashfs (a known kvm<->k Makefile quirk; see ~/CLAUDE.md memories).
+message 'pushing cross-flavor eveimage-update'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs --os-version={{ $alt_short_version }} -m adam://
+
+! stderr .
+
+# Step 4: wait for the upgrade — and poll k3s / kube diagnostics
+# while we wait. If eve-k boots but k3s never comes up, this is where
+# we'll surface the failure.
+message 'waiting for cross-flavor upgrade to complete (with k3s diagnostics)'
+exec -t 35m bash wait-for-cross-hv-upgrade.sh
+
+# Step 5: roll back via the existing revert_eve_image_update scenario.
+# Skipped if step 4 failed (escript halts on first failure).
+test eden.escript.test -test.run TestEdenScripts/revert_eve_image_update -test.v -testdata {{EdenConfig "eden.tests"}}/update_eve_image/testdata/
+
+# Step 6: clear adam's leftover BaseOsConfig for the alternate version.
+eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs -m adam://
+eden controller edge-node get-config
+! stdout '{{ $alt_short_version }}'
+
+exec sleep 10
+eden eve reset
+
+-- assert-no-volumes.sh --
+#!/bin/bash
+# Pre-flight: assert no live volumes (IN_CONFIG / DELIVERED) on EVE.
+# Transient delete states (NOT_IN_CONFIG / RESOLVING_TAG) are tolerated.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for i in $(seq 1 12); do
+    out=$("$EDEN" volume ls 2>/dev/null)
+    live=$(echo "$out" | awk 'NR>1 && ($(NF-1) == "IN_CONFIG" || $NF == "DELIVERED")')
+    if [ -z "$live" ]; then
+        echo "OK: no live volumes on the device"
+        echo "$out"
+        exit 0
+    fi
+    echo "Waiting for transient volumes to settle (attempt $i/12):"
+    echo "$live"
+    sleep 5
+done
+echo "FAIL: live volume(s) still present after polling" >&2
+echo "$out" >&2
+exit 1
+
+-- wait-for-cross-hv-upgrade.sh --
+#!/bin/bash
+# Wait for the upgraded EVE to reach PartitionState:active AND running
+# the expected $EXPECT_VERSION, while periodically dumping k3s/kube
+# diagnostics once we've booted into eve-k. Timeout is enforced by the
+# wrapping `exec -t 35m`.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT_VERSION='{{ $alt_short_version }}'
+DEADLINE=$(( $(date +%s) + 1800 ))   # 30 min
+
+# Resilient SSH probe — returns empty (not fatal log line) if SSH fails.
+probe() {
+    local out
+    out=$(timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null)
+    echo "$out" | grep -v 'level=fatal'
+}
+
+dump_k3s_diags() {
+    echo "  --- k3s diagnostics ---"
+    sock=$(probe 'test -S /run/containerd-user/containerd.sock && echo present || echo absent')
+    echo "  /run/containerd-user/containerd.sock: $sock"
+
+    # Container-side runtime view of kube
+    kube_pid=$(probe 'ctr -n services c info kube 2>/dev/null | sed -n "s/.*\"Pid\": *\\([0-9]*\\).*/\\1/p"')
+    echo "  kube container pid: ${kube_pid:-not running}"
+
+    # Cluster-init log — common candidate paths on EVE-k
+    for log in /persist/kubelog/cluster-init.log /persist/k3s/cluster-init.log /persist/log/cluster-init.log /persist/kube/cluster-init.log; do
+        present=$(probe "test -f $log && echo y")
+        if [ "$present" = "y" ]; then
+            echo "  --- tail of $log ---"
+            probe "tail -30 $log" | sed 's/^/    /'
+            break
+        fi
+    done
+
+    # Recent k3s / cluster-init errors anywhere on the device
+    errs=$(probe 'logread 2>/dev/null | grep -iE "k3s|cluster-init|kubelet" | grep -iE "level=error|level=fatal|fail" | tail -10')
+    if [ -n "$errs" ]; then
+        echo "  --- recent k3s/cluster-init errors ---"
+        echo "$errs" | sed 's/^/    /'
+    fi
+
+    # baseosmgr's progress (or stuck spin)
+    baseosmgr_tail=$(probe 'logread 2>/dev/null | grep baseosmgr | tail -3')
+    if [ -n "$baseosmgr_tail" ]; then
+        echo "  --- baseosmgr last 3 log lines ---"
+        echo "$baseosmgr_tail" | sed 's/^/    /'
+    fi
+}
+
+prev_running=""
+diags_dumped_this_state=""
+
+while [ $(date +%s) -lt $DEADLINE ]; do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then
+        echo "$(date +%H:%M:%S): EVE not reachable via SSH (possibly rebooting)"
+        sleep 20
+        continue
+    fi
+
+    imgb_state=$(probe 'eve exec pillar cat /run/baseosmgr/ZbootStatus/IMGB.json' \
+        | grep -oP '"PartitionState":"\K[^"]+' | head -1)
+    [ -z "$imgb_state" ] && imgb_state='unknown'
+
+    echo "$(date +%H:%M:%S): running='$running' IMGB.PartitionState='$imgb_state'"
+
+    # Success: IMGB is now active running the new version.
+    if [ "$running" = "$EXPECT_VERSION" ] && [ "$imgb_state" = "active" ]; then
+        echo "OK: cross-HV upgrade complete (IMGB active, version=$running)"
+        exit 0
+    fi
+
+    # If we've reached the target version but are stuck inprogress,
+    # dump k3s diagnostics every iteration to capture why.
+    if [ "$running" = "$EXPECT_VERSION" ] && [ "$imgb_state" = "inprogress" ]; then
+        dump_k3s_diags
+    fi
+
+    # First time we see the new running version, also dump diags.
+    if [ "$running" = "$EXPECT_VERSION" ] && [ "$prev_running" != "$running" ]; then
+        echo "  (transitioned to $running — booting eve-k)"
+        dump_k3s_diags
+    fi
+
+    prev_running="$running"
+    sleep 30
+done
+
+echo "FAIL: 30m timeout. Last seen: running='$running' IMGB.PartitionState='$imgb_state'"
+dump_k3s_diags
+exit 1
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/update_eve_image/testdata/update_eve_image_cross_hv_with_app_recreate.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_cross_hv_with_app_recreate.txt
@@ -1,0 +1,597 @@
+# Test: end-to-end app-survives-upgrade via delete+recreate around a
+# kvm→k cross-flavor baseos update, with timer.defer.content.delete set
+# to keep the cached blobs alive across the gap.
+#
+# Variant 3 of the app-survives-upgrade family. Variants 1 & 2 attempt
+# to migrate the live AppInstance / Volume through the
+# `RolloutDiskToPVC` path, which currently fails on single-node EVE-k
+# (see lf-edge/eve#6032 — longhorn scratch PVC can't schedule with
+# upstream 3-replica + strict-anti-affinity defaults).
+#
+# This variant is the *operator-facing recipe* that works today AND
+# exercises the blob-reuse code path end-to-end:
+#
+#   1. Deploy xhv-app (eclient) on EVE-kvm; wait RUNNING + functional.
+#   2. Bump timer.defer.content.delete to 24h so deleting the app
+#      below doesn't immediately purge its ContentTree blobs.
+#   3. Delete the app + its network. Volumes/ContentTrees stay in the
+#      CAS (pillar's per-blob GC defers).
+#   4. Push the kvm→k baseos update.
+#   5. After EVE-k boots and volumemgr unblocks from longhorn-wait,
+#      RE-DEPLOY xhv-app with the SAME image.
+#   6. Assert pillar's downloader did NOT pull image bytes for the
+#      redeploy — the cached blobs from step 1 are reused via the
+#      namespace-port (b14391bad) + transitive-label-walk (5fc09f631)
+#      paths. A new longhorn PVC is provisioned natively on EVE-k;
+#      `RolloutDiskToPVC` is NOT exercised (the .img file doesn't
+#      exist for a fresh deploy).
+#   7. Verify the app is RUNNING + functional on EVE-k.
+#   8. Reset timer.defer.content.delete back to 0 so the device's
+#      GC behavior returns to default.
+#
+# Parameters: ALT_HV, ALT_EVE_VER, ALT_EVE_REG — see
+# update_eve_image_cross_hv.txt header for defaults.
+
+{{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+
+{{$current_hv := EdenConfig "eve.hv"}}
+{{$arch       := EdenConfig "eve.arch"}}
+
+{{$alt_hv_env := EdenGetEnv "ALT_HV"}}
+{{$alt_hv := "k"}}
+{{if eq $current_hv "k"}}{{$alt_hv = "kvm"}}{{end}}
+{{if $alt_hv_env}}{{$alt_hv = $alt_hv_env}}{{end}}
+
+{{$alt_ver_env := EdenGetEnv "ALT_EVE_VER"}}
+{{$alt_ver := "12.1.0"}}
+{{if $alt_ver_env}}{{$alt_ver = $alt_ver_env}}{{end}}
+
+{{$alt_reg_env := EdenGetEnv "ALT_EVE_REG"}}
+{{$alt_reg := "lfedge/eve"}}
+{{if $alt_reg_env}}{{$alt_reg = $alt_reg_env}}{{end}}
+
+{{$alt_short_version := printf "%s-%s-%s" $alt_ver $alt_hv $arch}}
+
+# Step 1: pre-flight — clean state.
+message 'pre-flight: clean state'
+exec -t 1m bash assert-no-volumes.sh
+eden -t 1m pod ps
+! stdout 'IN_CONFIG'
+eden controller edge-node update --config timer.test.baseimage.update=30
+
+# Step 2: deploy xhv-app PRE-upgrade on the current EVE (kvm).
+message 'deploying eclient app on EVE-kvm'
+eden -t 1m network create 10.11.12.0/24 -n xhv-app-net
+eden -t 5m pod deploy -n xhv-app {{template "eclient_image"}} -p 2223:22 --networks=xhv-app-net --memory=512MB
+exec -t 10m bash wait-for-app-running.sh
+# Functional check: SSH directly into the app via the host hostfwd
+# (eve.hostfwd: 2223:2223 → zedrouter NAT to app:22 → eclient sshd).
+# eden-bringup.sh extends hostfwd to include 2223:2223 specifically
+# so that ssh root@127.0.0.1 -p 2223 works without `eden sdn fwd`.
+message 'pre-upgrade functional check'
+exec -t 5m bash wait-for-ssh-to-app.sh
+stdout 'OK: app SSH reachable'
+
+# Step 3: set timer.defer.content.delete to 24h. This is the key knob —
+# it tells pillar's volumemgr to retain ContentTree blobs for 24h
+# after the last reference goes away, instead of GC'ing immediately
+# when the app is deleted in Step 4.
+message 'setting timer.defer.content.delete=86400 (24h)'
+eden controller edge-node update --config timer.defer.content.delete=86400
+
+# Wait out one controller config-fetch interval (timer.config.interval=60s)
+# plus margin so volumemgr applies the new deferContentDelete BEFORE the app
+# delete below. Otherwise the device can fetch the timer set and the app delete
+# in one config cycle and volumemgr's select loop may process the delete first,
+# deleting the app's ContentTree with deferContentDelete still 0 and GC-ing its
+# blobs -> the redeploy re-downloads (the FAIL[blob-reuse] mode).
+message 'waiting ~90s for the device to apply deferContentDelete=86400'
+exec sleep 90
+
+# Step 4: delete just the app. The network stays — it has no
+# content-tree association, and keeping it across the upgrade matches
+# what an operator would do in production (a network instance
+# typically outlives many app lifecycles). Volume / ContentTree
+# blobs stay on /persist thanks to the deferred-delete timer.
+message 'deleting app on EVE-kvm (network kept, blobs retained for 24h)'
+eden -t 1m pod delete xhv-app
+# Poll until xhv-app fully disappears from `pod ps` AND volumemgr's
+# VolumeStatus tree empties out. The delete returns as soon as
+# controller config is updated, but EVE-side teardown can take 10+
+# minutes — domainmgr shuts down the VM, volumemgr unrolls the PVC,
+# and (on EVE-k) longhorn detaches and releases the replica. Anything
+# less than a hard wait-for-removal here will start the upgrade on a
+# device with live Volume / DomainStatus and trip the cross-HV gate.
+exec -t 15m bash wait-for-app-gone.sh
+exec -t 1m bash assert-no-volumes.sh
+
+# Step 5: push the cross-flavor eveimage-update.
+message 'downloading alternate-flavor EVE rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$alt_ver}} --eve-hv={{$alt_hv}} --eve-registry={{$alt_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs'
+
+message 'pushing cross-flavor eveimage-update'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs --os-version={{ $alt_short_version }} -m adam://
+! stderr .
+
+# Step 6: wait for the upgrade to complete.
+message 'waiting for cross-flavor upgrade to complete'
+exec -t 35m bash wait-for-cross-hv-upgrade.sh
+
+# Step 7: snapshot eve-k's downloader RecvByteCount baseline NOW, on boot,
+# BEFORE we deploy. /run/downloader/MetricsMap is tmpfs so the counter restarted
+# at the EVE-k reboot; taking the baseline here means the post-assert below
+# measures ALL re-download since boot (volumemgr's blob reconstruction plus the
+# deploy). Blob reuse (commits b14391bad + 5fc09f631) should keep it ~0.
+message 'snapshot eve-k downloader RecvByteCount (baseline, pre-deploy)'
+exec -t 1m bash snapshot-rcv-bytes.sh pre
+
+# Step 8: deploy xhv-app on EVE-k IMMEDIATELY on boot — do NOT wait for volumemgr
+# / cluster readiness first. The network (xhv-app-net) is still present from
+# Step 2. With the defer-delete timer holding the ContentTree blobs on /persist,
+# pillar's CAS finds the manifest by SHA and reuses the existing BlobStatus — no
+# DownloaderConfig for the eden-eclient image. A fresh longhorn PVC is provisioned
+# natively once cluster storage is up.
+message 'deploying eclient app on EVE-k immediately on boot (independent of commit/cluster state)'
+eden -t 5m pod deploy -n xhv-app {{template "eclient_image"}} -p 2223:22 --networks=xhv-app-net --memory=512MB
+
+# Step 9: split the readiness waits for diagnosability, in order:
+#   (a) volumemgr ready (incl kubeapi.WaitForKubernetes),
+#   (b) longhorn StorageClass ready,
+#   (c) app RUNNING,
+#   (d) app SSH-reachable.
+message '(a) waiting for volumemgr ready (incl kubeapi.WaitForKubernetes)'
+exec -t 45m bash wait-for-volumemgr-ready.sh
+message '(b) waiting for EVE-k longhorn StorageClass ready (cluster storage up)'
+exec -t 50m bash wait-for-longhorn-sc.sh
+stdout 'OK: longhorn StorageClass ready'
+message '(c) waiting for the app to reach RUNNING on EVE-k'
+exec -t 45m bash wait-for-app-running.sh
+message '(d) post-upgrade functional check (SSH into the app guest)'
+exec -t 5m bash wait-for-ssh-to-app.sh 2223 30 fresh
+stdout 'OK: app SSH reachable'
+
+# Step 10: assert eve-k's downloader did NOT pull more than ~1 MiB since boot
+# (eden-eclient is ~44 MiB; a real re-download would be unmistakable).
+message 'asserting blob reuse: no image re-download across the conversion'
+exec -t 1m bash snapshot-rcv-bytes.sh post-and-assert
+
+# Step 10a: reboot recovery. Earlier observations on this path showed
+# the longhorn Volume CR could get stuck STATE=detached/ROBUSTNESS=
+# unknown after a routine reboot, with virt-launcher Pending and a
+# misleading "untolerated taint" event. Driving one reboot through
+# this test catches a regression of that mode end-to-end.
+message 'requesting controller-initiated reboot'
+eden -t 1m controller edge-node -m adam:// reboot -v debug
+message 'waiting for EVE down + back (uptime < 120s)'
+exec -t 15m bash wait-for-reboot-and-back.sh
+message 'post-reboot: waiting for volumemgr Initialized:true'
+exec -t 45m bash wait-for-volumemgr-ready.sh
+message 'post-reboot: waiting for xhv-app to return to RUNNING'
+message 'waiting for EVE-k longhorn StorageClass ready (cluster storage up)'
+exec -t 50m bash wait-for-longhorn-sc.sh
+stdout 'OK: longhorn StorageClass ready'
+exec -t 45m bash wait-for-app-running.sh
+message 'post-reboot functional check'
+exec -t 5m bash wait-for-ssh-to-app.sh 2223 30 fresh
+stdout 'OK: app SSH reachable'
+
+# Step 11: reset the defer-delete timer to default (0 → immediate
+# delete on refcount=0). Always runs, even if a later assertion fails
+# in a future revision — make this explicit and unconditional.
+message 'reset timer.defer.content.delete=0 (back to default)'
+eden controller edge-node update --config timer.defer.content.delete=0
+
+# Step 12: cleanup. We skip `eden controller edge-node eveimage-remove`
+# here even though other tests in this family use it — eden's CLI
+# rejects rootfs filenames containing `-k-amd64` (its regex allows
+# only kvm|xen|acrn|rpi|rpi-xen|rpi-kvm; see
+# pkg/openevec/eveImageUpdate.go). adam's record of the staged image
+# is harmless to leave in place and gets wiped on the next bringup.
+eden -t 1m pod delete xhv-app
+eden -t 1m network delete xhv-app-net  # final teardown — release the network too
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs.ver
+exec sleep 10
+eden eve reset
+
+-- assert-no-volumes.sh --
+#!/bin/bash
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for i in $(seq 1 12); do
+    out=$("$EDEN" volume ls 2>/dev/null)
+    live=$(echo "$out" | awk 'NR>1 && ($(NF-1) == "IN_CONFIG" || $NF == "DELIVERED")')
+    if [ -z "$live" ]; then echo "OK: no live volumes"; exit 0; fi
+    sleep 5
+done
+echo "FAIL: live volume(s) present" >&2; "$EDEN" volume ls >&2; exit 1
+
+-- wait-for-app-running.sh --
+#!/bin/bash
+# Poll `eden pod ps` until xhv-app reaches LAST_STATE(EVE)=RUNNING.
+# 25m budget covers both the pre-upgrade kvm case (fast, ~2m) and the
+# post-upgrade eve-k redeploy (slow first boot — longhorn install +
+# VMI start can take 15-20m on a slow rig).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for i in $(seq 1 240); do   # 40m at 10s intervals (deploy-on-boot: app RUNNING is gated on the full post-longhorn volume create + CDI upload + guest boot, ~27m observed)
+    line=$("$EDEN" pod ps 2>/dev/null | grep -E '^xhv-app\s')
+    if echo "$line" | grep -q 'RUNNING'; then
+        echo "OK: xhv-app RUNNING"
+        echo "$line"
+        exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: xhv-app did not reach RUNNING in 40m" >&2
+"$EDEN" pod ps >&2
+exit 1
+
+-- wait-for-app-gone.sh --
+#!/bin/bash
+# Poll until xhv-app fully disappears AND no VolumeStatus files remain
+# under /run/volumemgr/VolumeStatus/. Pillar tears down in this order:
+#   1. controller config drops the app (immediate after `eden pod delete`)
+#   2. domainmgr halts the VM domain (~30-60s)
+#   3. volumemgr unrolls the PVC; on EVE-k longhorn detaches+releases
+#      the replica, which can take 5-10 minutes
+#   4. AppInstanceStatus and VolumeStatus pubsub records get removed
+# We watch (3) + (4) — those are the on-device-state signals.
+# 15m budget covers the slow longhorn case observed in v17.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+last_pod=""
+last_vol=""
+for i in $(seq 1 90); do   # 15m at 10s intervals
+    pod_present=$("$EDEN" pod ps 2>/dev/null | grep -cE '^xhv-app\s')
+    # Count only the per-instance .json files; pillar/pubsub writes a
+    # `restarted` sentinel into this directory at startup and never
+    # removes it, so `ls | wc -l` returns 1 even when no volumes exist.
+    vol_count=$(timeout 12 "$EDEN" eve ssh \
+        'eve exec pillar ls /run/volumemgr/VolumeStatus/*.json 2>/dev/null | wc -l' \
+        2>/dev/null | tr -d '\r' | tail -1)
+    [ -z "$vol_count" ] && vol_count="?"
+    if [ "$pod_present" = "0" ] && [ "$vol_count" = "0" ]; then
+        echo "OK: xhv-app removed and no VolumeStatus files remain"
+        exit 0
+    fi
+    # Progress line — print only when state changes
+    state="pod_rows=$pod_present vol_files=$vol_count"
+    if [ "$last_pod $last_vol" != "$pod_present $vol_count" ]; then
+        echo "$(date +%H:%M:%S) waiting for teardown: $state"
+        last_pod=$pod_present
+        last_vol=$vol_count
+    fi
+    sleep 10
+done
+echo "FAIL: app+volumes did not fully clear in 15m" >&2
+echo "--- final pod ps ---" >&2
+"$EDEN" pod ps >&2
+echo "--- final VolumeStatus listing ---" >&2
+"$EDEN" eve ssh 'eve exec pillar ls -la /run/volumemgr/VolumeStatus/ 2>&1' >&2
+exit 1
+
+-- wait-for-ssh-to-app.sh --
+#!/bin/bash
+# wait-for-ssh-to-app.sh — the REAL guest-readiness / functional gate for the
+# eclient app instance, shared verbatim across the cross-HV / kvm->k tests.
+#
+# `eden pod ps` RUNNING (wait-for-app-running.sh) only reflects
+# AppInstState.EVEState — the ZSwState EVE reports. On EVE-k that is the
+# kubevirt VMI Running phase (qemu launched), NOT the guest kernel booted with
+# sshd accepting connections; on EVE-kvm the gap is smaller but still not
+# guest-ready. So pod-ps RUNNING is a cheap pre-filter only — success is
+# declared HERE, once an AUTHENTICATED ssh command has actually run inside the
+# guest and returned the expected output.
+#
+# Transport: host hostfwd 127.0.0.1:2223 -> EVE-eth0:2223 (eve.hostfwd
+# extension set by eden-bringup.sh) -> zedrouter NAT -> app:22 (eclient sshd).
+# The `eden sdn fwd` wrapper collapses to the same 127.0.0.1:hostport under the
+# non-SDN QEMU user-net these tests run in, so the direct path is used.
+#
+# FRESHNESS: host port 2223 is a static QEMU forward for the whole VM lifetime,
+# so after a delete+redeploy (or a reboot) a *stale* previous eclient could keep
+# answering on it and falsely satisfy a post-conversion check. To guard that,
+# each successful check records the guest's boot_id
+# (/proc/sys/kernel/random/boot_id — a fresh UUID per VM boot) to
+# /tmp/xhv-app-bootid. In "fresh" mode the check requires the connected guest's
+# boot_id to DIFFER from that recorded value; a matching (stale) instance is
+# treated as not-ready-yet and retried until the fresh deploy takes over the
+# port or the budget runs out.
+#
+# Fail-closed: a refused / closed / timed-out ssh, a non-eclient guest, or (in
+# fresh mode) only the stale instance answering, never prints the success
+# marker. On success it prints "OK: app SSH reachable" so the escript pins the
+# framework verdict to a real session:
+#     exec -t 5m bash wait-for-ssh-to-app.sh
+#     stdout 'OK: app SSH reachable'
+#
+# Args (optional): $1 host port (default 2223); $2 attempts, 10s apart
+# (default 30 => 5m); $3 = "fresh" to require a NEW guest instance vs the
+# boot_id the previous successful check recorded (use after a redeploy/reboot).
+#
+# Cert: ssh refuses group-readable keys, so the eclient id_rsa is copied to a
+# 0600 temp file. testscript sets HOME=/no-home, so the real home is resolved
+# from the running UID; dist/tests is only populated by a full `make eden`, so
+# fall back to the master/main reference clones.
+set -uo pipefail
+PORT="${1:-2223}"
+ATTEMPTS="${2:-30}"
+FRESH="${3:-}"
+BOOTID_FILE=/tmp/xhv-app-bootid
+EDEN_TESTS="{{EdenConfig "eden.tests"}}"
+USER_HOME=$(getent passwd "$(id -u)" | cut -d: -f6)
+SRC=""
+for c in "$EDEN_TESTS/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/master/eden/tests/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/main/eden/tests/eclient/image/cert/id_rsa"; do
+    if [ -f "$c" ]; then SRC="$c"; break; fi
+done
+if [ -z "$SRC" ]; then
+    echo "FAIL: could not locate eclient id_rsa cert (EDEN_TESTS=$EDEN_TESTS, USER_HOME=$USER_HOME)" >&2
+    exit 1
+fi
+KEY=$(mktemp); install -m 600 "$SRC" "$KEY"; trap 'rm -f "$KEY"' EXIT
+SSH_OPTS=(-o ConnectTimeout=10 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -i "$KEY")
+prev=""
+[ -f "$BOOTID_FILE" ] && prev=$(cat "$BOOTID_FILE" 2>/dev/null)
+connected=0
+saw_stale=0
+for _ in $(seq 1 "$ATTEMPTS"); do
+    # One round-trip proves auth, the eclient identity, and the guest boot_id.
+    # "AUTHED" is echoed before the identity check, so a connect+auth that fails
+    # only the /etc/issue match is distinguishable from a never-connected ssh.
+    out=$(ssh "${SSH_OPTS[@]}" root@127.0.0.1 -p "$PORT" \
+        'echo AUTHED; grep -q Ubuntu /etc/issue && cat /proc/sys/kernel/random/boot_id' \
+        2>/dev/null)
+    case "$out" in *AUTHED*) connected=1 ;; esac
+    bootid=$(printf '%s\n' "$out" | tr -d '\r' | grep -Ex '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | tail -1)
+    if [ -n "$bootid" ]; then
+        if [ "$FRESH" = "fresh" ] && [ -n "$prev" ] && [ "$bootid" = "$prev" ]; then
+            # Still the previous instance on the static port — wait for the fresh
+            # deploy/boot to take over the NAT before declaring success.
+            saw_stale=1; sleep 10; continue
+        fi
+        echo "$bootid" > "$BOOTID_FILE"
+        echo "OK: app SSH reachable (port=$PORT, boot_id=$bootid, fresh=${FRESH:-no}, cert=$SRC)"
+        exit 0
+    fi
+    sleep 10
+done
+budget=$(( ATTEMPTS * 10 ))
+if [ "$saw_stale" = 1 ]; then
+    echo "FAIL: only the previous app instance (boot_id=$prev) answered within ${budget}s — the fresh deploy never took over the port (stale instance)" >&2
+elif [ "$connected" = 1 ]; then
+    echo "FAIL: ssh connected+authed but the guest never matched the eclient (grep Ubuntu /etc/issue) within ${budget}s (port=$PORT)" >&2
+else
+    echo "FAIL: app never answered an authenticated ssh within ${budget}s (port=$PORT, cert=$SRC)" >&2
+fi
+echo "--- host TCP probe ---" >&2
+( exec 3<>/dev/tcp/127.0.0.1/"$PORT" ) 2>&1 || true
+exit 1
+
+-- wait-for-volumemgr-ready.sh --
+#!/bin/bash
+# After a cross-HV upgrade we need volumemgr on eve-k to have
+# unblocked from its `wait for kubernetes` / longhorn-ready sub-wait
+# and run populateInitBlobStatus(). The signal we watch for is the
+# state file /run/volumemgr/VolumeMgrStatus/volumemgr.json with
+# "Initialized":true — set after kubeapi.WaitForKubernetes returns.
+#
+# Earlier revisions of this helper grepped the volumemgr log for
+# "kubernetes node ready, longhorn ready". That's unreliable: EVE's
+# memlog is a ring buffer; under the load of a fresh longhorn install
+# the buffer rotates within ~20 min, and the marker line scrolls out
+# before we observe it. The state-file approach reads the *persistent
+# fact* on tmpfs, independent of log retention.
+#
+# Print progress every iteration so a stall is visible in the test
+# output (matters because the helper sits silent for up to 20m on
+# first boot, while longhorn pulls + starts its DaemonSets).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+last=""
+for i in $(seq 1 240); do   # 40m at 10s intervals (deploy-on-boot: this wait now starts at EVE-k boot, and Initialized lands ~24m later after kubeapi.WaitForKubernetes)
+    state=$(timeout 8 "$EDEN" eve ssh 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>/dev/null' 2>/dev/null \
+            | tr -d '\r' | grep -oE '"Initialized":[a-z]+')
+    if [ "$state" = '"Initialized":true' ]; then
+        echo "OK: volumemgr Initialized:true — populateInitBlobStatus has run"
+        exit 0
+    fi
+    if [ "$last" != "$state" ]; then
+        echo "$(date +%H:%M:%S) volumemgr state: ${state:-<not-yet-published>}"
+        last="$state"
+    fi
+    sleep 10
+done
+echo "FAIL: volumemgr did not reach Initialized:true within 40m" >&2
+echo "--- final state file ---" >&2
+"$EDEN" eve ssh 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>&1' >&2
+exit 1
+
+-- snapshot-rcv-bytes.sh --
+#!/bin/bash
+# Snapshot the cumulative RecvByteCount from /run/downloader/MetricsMap
+# on EVE. The downloader publishes per-interface, per-URL byte
+# counters there; we sum across all URLs and interfaces.
+#
+# With "pre", capture the baseline to /tmp/xhv-rcv-pre.txt. With
+# "post-and-assert", recapture, compute the delta vs the pre-snapshot,
+# and assert the delta is below MAX_DELTA_BYTES (default 1 MiB).
+#
+# Note: /run/ is tmpfs, so the counter is reset on reboot. This
+# script is meant to bracket a single phase (e.g. the post-upgrade
+# redeploy) where pre and post are taken without an intervening
+# reboot.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+MODE=${1:-pre}
+MAX_DELTA_BYTES=${2:-1048576}  # 1 MiB default
+
+capture_recv_bytes() {
+    timeout 15 "$EDEN" eve ssh -- 'eve exec pillar cat /run/downloader/MetricsMap/global.json 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' \
+        | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print(0); sys.exit(0)
+total = 0
+for iface, conn in d.items():
+    for url, m in (conn.get('URLCounters') or {}).items():
+        total += m.get('RecvByteCount', 0)
+print(total)
+"
+}
+
+case "$MODE" in
+    pre)
+        bytes=$(capture_recv_bytes)
+        echo "$bytes" > /tmp/xhv-rcv-pre.txt
+        echo "Pre-snapshot: RecvByteCount total = $bytes bytes"
+        ;;
+    post-and-assert)
+        post=$(capture_recv_bytes)
+        pre=$(cat /tmp/xhv-rcv-pre.txt 2>/dev/null || echo 0)
+        delta=$(( post - pre ))
+        echo "Post-snapshot: RecvByteCount total = $post bytes (pre was $pre, delta = $delta)"
+        if [ "$delta" -lt 0 ]; then
+            echo "FAIL: post < pre — counter went backwards (reboot? not expected on eve-k)" >&2
+            exit 1
+        fi
+        if [ "$delta" -lt "$MAX_DELTA_BYTES" ]; then
+            echo "OK: only $delta bytes received (< ${MAX_DELTA_BYTES} threshold) — no image re-download"
+            exit 0
+        fi
+        echo "FAIL: $delta bytes received exceeds ${MAX_DELTA_BYTES} threshold — image likely re-downloaded" >&2
+        exit 1
+        ;;
+    *)
+        echo "Usage: $0 pre | post-and-assert [max-delta-bytes]" >&2
+        exit 1
+        ;;
+esac
+
+-- wait-for-cross-hv-upgrade.sh --
+#!/bin/bash
+# Wait for the upgraded EVE to reach PartitionState:active running
+# $EXPECT_VERSION, dumping k3s diagnostics if it stalls.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT_VERSION='{{ $alt_short_version }}'
+DEADLINE=$(( $(date +%s) + 1800 ))
+
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+dump_k3s_diags() {
+    sock=$(probe 'test -S /run/containerd-user/containerd.sock && echo present || echo absent')
+    echo "  /run/containerd-user/containerd.sock: $sock"
+    kube_pid=$(probe 'ctr -n services.linuxkit t ls 2>/dev/null | awk "/^kube/{print \$2}"')
+    echo "  kube container pid: ${kube_pid:-not running}"
+}
+
+prev_running=""
+while [ $(date +%s) -lt $DEADLINE ]; do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then
+        echo "$(date +%H:%M:%S): EVE unreachable (rebooting?)"; sleep 20; continue
+    fi
+    imgb_state=$(probe 'eve exec pillar cat /run/baseosmgr/ZbootStatus/IMGB.json' | grep -oP '"PartitionState":"\K[^"]+' | head -1)
+    [ -z "$imgb_state" ] && imgb_state='unknown'
+    echo "$(date +%H:%M:%S): running='$running' IMGB.PartitionState='$imgb_state'"
+    # Proceed as soon as EVE-k is the running rootfs — do NOT also wait for
+    # IMGB to commit 'active' (that's gated on cluster/node readiness ~16m,
+    # which would delay the app deploy and mask the device-side
+    # clusterStorageReady defer + park-and-retry we want to exercise).
+    if [ "$running" = "$EXPECT_VERSION" ]; then
+        echo "OK: booted EVE-k (version=$running, IMGB.PartitionState=$imgb_state) — proceeding now, independent of commit/cluster state"
+        dump_k3s_diags
+        exit 0
+    fi
+    prev_running="$running"
+    sleep 30
+done
+echo "FAIL: 30m timeout. running='$running' IMGB='$imgb_state'" >&2
+dump_k3s_diags >&2
+exit 1
+
+-- wait-for-reboot-and-back.sh --
+#!/bin/bash
+# Wait for EVE to actually reboot. Three phases:
+#   1. Wait up to 2m for SSH to start failing (kernel going down).
+#   2. Wait up to 10m for SSH to succeed AGAIN (kernel up + sshd up).
+#   3. Verify /proc/uptime < 120s (proves an actual reboot happened,
+#      not a transient SSH glitch).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+
+echo "phase 1: waiting for SSH to start failing (reboot underway)"
+went_down=0
+for i in $(seq 1 24); do   # 24 * 5s = 2m
+    if ! timeout 5 "$EDEN" eve ssh 'true' 2>/dev/null; then
+        echo "$(date +%H:%M:%S) SSH unreachable -- reboot in progress"
+        went_down=1
+        break
+    fi
+    sleep 5
+done
+if [ "$went_down" = "0" ]; then
+    echo "FAIL: SSH stayed reachable for 2m -- reboot did not start?" >&2
+    exit 1
+fi
+
+echo "phase 2: waiting for SSH to come back (post-reboot kernel + sshd up)"
+came_up=0
+for i in $(seq 1 60); do   # 60 * 10s = 10m
+    if timeout 8 "$EDEN" eve ssh 'true' 2>/dev/null; then
+        echo "$(date +%H:%M:%S) SSH back online"
+        came_up=1
+        break
+    fi
+    sleep 10
+done
+if [ "$came_up" = "0" ]; then
+    echo "FAIL: SSH did not come back within 10m" >&2
+    exit 1
+fi
+
+echo "phase 3: verifying uptime reset (< 120s)"
+uptime_secs=$(timeout 10 "$EDEN" eve ssh 'cat /proc/uptime' 2>/dev/null | tr -d '\r' | awk '{print int($1)}' | head -1)
+if [ -z "$uptime_secs" ]; then
+    echo "FAIL: could not read /proc/uptime after reboot" >&2
+    exit 1
+fi
+if [ "$uptime_secs" -gt 120 ]; then
+    echo "FAIL: uptime $uptime_secs > 120s -- SSH glitch, not a real reboot" >&2
+    exit 1
+fi
+echo "OK: EVE rebooted, uptime now ${uptime_secs}s"
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- wait-for-longhorn-sc.sh --
+#!/bin/bash
+# Wait until the EVE-k `longhorn` StorageClass exists (longhorn deployed + its CSI
+# provisioner up). On a freshly-converted EVE-k node longhorn can take tens of
+# minutes to deploy -- well after the device reports ONLINE -- so wait for it
+# EXPLICITLY here, before deploying/waiting for an app whose volume needs longhorn.
+# This separates cluster-bringup time from app-bringup time: the wait-for-app-running
+# that follows can be short, and a failure here clearly says "longhorn", not "app".
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 90); do   # ~45m at 30s
+    if "$EDEN" eve ssh -- 'eve exec kube kubectl get sc 2>/dev/null' 2>/dev/null | grep -qE '^longhorn'; then
+        echo "OK: longhorn StorageClass ready"; exit 0
+    fi
+    sleep 30
+done
+echo "FAIL: longhorn StorageClass not ready within budget" >&2; exit 1

--- a/tests/update_eve_image/testdata/update_eve_image_cross_hv_with_contenttree.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_cross_hv_with_contenttree.txt
@@ -1,0 +1,417 @@
+# Test: pre-staged ContentTree (no Volume) survives a cross-HV-flavor EVE
+# upgrade, and an app instance deployed post-upgrade reuses the existing
+# blobs instead of re-downloading.
+#
+# Variant of update_eve_image_cross_hv_with_volume.txt that side-steps
+# the Volume/PVC/CDI machinery entirely:
+#   - Pre-stage a standalone ContentTree on the running EVE (e.g. kvm)
+#     via `eden controller edge-node content-tree-add`. Pillar's
+#     volumemgr downloads ContentTrees eagerly, so the image bits land
+#     on /persist without any Volume being created. No .img file, no
+#     PVC, no CDI involvement on the post-upgrade side.
+#   - Push a cross-flavor baseos update (kvm <-> k).
+#   - After EVE reboots into the other flavor: verify the ContentTree
+#     is still present and LOADED (pubsub-persisted, blobs on /persist).
+#   - Deploy an app instance from the same image. Blob lookup is by
+#     SHA256, so volumemgr finds the pre-staged blobs and reuses them.
+#   - Assert no new ContentSha256 appeared in /run/volumemgr/
+#     ContentTreeStatus — confirms reuse, not re-download.
+#
+# Why this variant exists: the with_volume variant trips on a longhorn
+# scratch-PVC scheduling bug post-upgrade (REPLICATED_STORAGE single-node
+# clusters can't allocate the CDI scratch volume), which is unrelated to
+# the content-tree-survival question. This variant tests the same
+# user-visible property (image bits survive upgrade) without involving
+# the longhorn-backed PVC path at all.
+#
+# Parameters: ALT_HV, ALT_EVE_VER, ALT_EVE_REG — same as the volume variant.
+
+{{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+
+{{$current_hv := EdenConfig "eve.hv"}}
+{{$arch       := EdenConfig "eve.arch"}}
+
+{{$alt_hv_env := EdenGetEnv "ALT_HV"}}
+{{$alt_hv := "k"}}
+{{if eq $current_hv "k"}}{{$alt_hv = "kvm"}}{{end}}
+{{if $alt_hv_env}}{{$alt_hv = $alt_hv_env}}{{end}}
+
+{{$alt_ver_env := EdenGetEnv "ALT_EVE_VER"}}
+{{$alt_ver := "12.1.0"}}
+{{if $alt_ver_env}}{{$alt_ver = $alt_ver_env}}{{end}}
+
+{{$alt_reg_env := EdenGetEnv "ALT_EVE_REG"}}
+{{$alt_reg := "lfedge/eve"}}
+{{if $alt_reg_env}}{{$alt_reg = $alt_reg_env}}{{end}}
+
+{{$alt_short_version := printf "%s-%s-%s" $alt_ver $alt_hv $arch}}
+
+# Step 1: pre-flight — clean state.
+message 'pre-flight: clean state'
+eden -t 1m pod ps
+! stdout 'IN_CONFIG'
+eden controller edge-node update --config timer.test.baseimage.update=30
+
+# Step 2: pre-stage a ContentTree from the eclient image.
+# This kicks off an eager download in pillar's volumemgr; the blobs
+# land on /persist content-addressed storage. No Volume is created.
+message 'pre-staging ContentTree (no Volume)'
+eden -t 1m controller edge-node content-tree-add {{template "eclient_image"}} -n xhv-pre-ct
+
+# Wait for ContentTreeStatus to reach LOADED (state 108) on EVE.
+exec -t 10m bash wait-for-content-tree-loaded.sh
+
+# Step 3: push the cross-flavor eveimage-update.
+# This exercises the ZFS-only gate in baseosmgr that ALLOWS this upgrade
+# on ext3/ext4 /persist (the gate refuses ZFS, see PR baseos-hv-check-volume-gate).
+message 'downloading alternate-flavor EVE rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$alt_ver}} --eve-hv={{$alt_hv}} --eve-registry={{$alt_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs'
+
+message 'pushing cross-flavor eveimage-update with content tree present'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs --os-version={{ $alt_short_version }} -m adam://
+! stderr .
+
+# Step 4: wait for the upgrade to complete.
+message 'waiting for cross-flavor upgrade to complete'
+exec -t 35m bash wait-for-cross-hv-upgrade.sh
+
+# No post-upgrade "wait for ContentTree LOADED on eve-k" gate here, by
+# design. Such a gate would implicitly wait out the ~16m
+# longhorn/kubevirt/CDI install, because volumemgr only republishes
+# ContentTreeStatus after its internal WaitForKubernetes. Deploying the
+# app while the cluster is still coming up is the point: it exercises the
+# device-side volumemgr retry of cluster-storage volume creation
+# (retryFailedClusterVolumeCreate + idempotent CreatePVC) rather than
+# masking the longhorn/CDI-readiness race.
+
+# Step 5b: capture eve-k's RecvByteCount baseline NOW, right after the
+# upgrade completes and before any app deploy. /run/downloader/MetricsMap
+# is tmpfs so the counter restarted at the reboot — what we want is the
+# delta between "just before app deploy" and "after app deploy" on eve-k,
+# which isolates exactly the bytes pulled (if any) to satisfy the new
+# app's image reference.
+message 'snapshot eve-k downloader RecvByteCount (baseline pre-app-deploy)'
+exec -t 1m bash snapshot-rcv-bytes.sh pre
+
+# Step 6: deploy an app instance from the SAME image post-upgrade.
+# Blob lookup is by SHA256, so volumemgr finds the pre-staged blobs
+# and reuses them — no network download.
+message 'deploying app on new flavor using the pre-existing ContentTree'
+eden -t 1m network create 10.11.12.0/24 -n xhv-pre-net
+eden -t 5m pod deploy -n xhv-pre-app {{template "eclient_image"}} -p 2223:22 --networks=xhv-pre-net --memory=512MB
+# The app is deployed as soon as EVE-k's rootfs is running (the cross-hv
+# upgrade wait no longer blocks on IMGB PartitionState=active), so longhorn/CDI
+# are still coming up. Wait for the longhorn StorageClass explicitly with a
+# long timer BEFORE the (short) app-running wait: this separates cluster-bringup
+# time from app-bringup time, so a failure here clearly says "longhorn" rather
+# than an opaque app timeout.
+message 'waiting for EVE-k longhorn StorageClass ready (cluster storage up)'
+exec -t 50m bash wait-for-longhorn-sc.sh
+stdout 'OK: longhorn StorageClass ready'
+exec -t 45m bash wait-for-app-running.sh
+
+# Step 7: assert pillar's downloader on eve-k didn't fetch more than 1 MB
+# of bytes since the baseline taken in Step 5b. The eden-eclient image is
+# ~44 MB, so a re-download would be unmistakable; auth/control traffic
+# rounds to a few KB. The byte-count check is taken straight from
+# /run/downloader/MetricsMap/global.json (pillar's per-URL counter) so it
+# directly measures what we care about: did any image bytes flow.
+message 'asserting pre-staged ContentTree was reused (no re-download): byte-count check'
+exec -t 1m bash snapshot-rcv-bytes.sh post-and-assert
+
+# Step 8: functional check on the post-upgrade app.
+message 'post-upgrade functional check'
+exec -t 5m bash wait-for-ssh-to-app.sh
+stdout 'OK: app SSH reachable'
+
+# Step 9: cleanup. The pod and content-tree are configured at the
+# controller; deleting them is best-effort — `eden eve reset` at the
+# end wipes any residue.
+eden -t 1m pod delete xhv-pre-app
+eden -t 1m network delete xhv-pre-net
+eden controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs -m adam://
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs.ver
+
+exec sleep 10
+eden eve reset
+
+-- wait-for-content-tree-loaded.sh --
+#!/bin/bash
+# Poll EVE-side ContentTreeStatus until xhv-pre-ct reaches State=108
+# (LOADED). On kvm pre-upgrade, blob download from Docker Hub can
+# take a few minutes for the eclient image (~44MB).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for i in $(seq 1 120); do   # 10m at 5s intervals
+    out=$(timeout 10 "$EDEN" eve ssh -- \
+        'eve exec pillar sh -c "cat /run/volumemgr/ContentTreeStatus/*.json 2>/dev/null"' \
+        2>/dev/null | grep -v 'level=fatal')
+    if echo "$out" | python3 -c "
+import json, sys, re
+data = sys.stdin.read()
+for m in re.finditer(r'\{[^{}]*?\"DisplayName\":\"[^\"]*xhv-pre-ct[^\"]*\"[^{}]*\}', data):
+    try:
+        obj = json.loads(m.group(0))
+        if obj.get('State') == 108:
+            print('found LOADED ContentTreeStatus for xhv-pre-ct')
+            sys.exit(0)
+    except Exception:
+        pass
+sys.exit(1)
+" 2>/dev/null; then
+        echo "OK: ContentTreeStatus for xhv-pre-ct on EVE is LOADED"
+        exit 0
+    fi
+    sleep 5
+done
+echo "FAIL: ContentTreeStatus for xhv-pre-ct never reached LOADED within 10m" >&2
+timeout 10 "$EDEN" eve ssh -- 'eve exec pillar cat /run/volumemgr/ContentTreeStatus/*.json' 2>/dev/null >&2
+exit 1
+
+-- snapshot-rcv-bytes.sh --
+#!/bin/bash
+# Snapshot the cumulative RecvByteCount from /run/downloader/MetricsMap
+# on EVE. The downloader publishes per-interface, per-URL byte counters
+# there; we sum across all URLs and interfaces.
+#
+# With "pre", capture the baseline to /tmp/xhv-rcv-pre.txt. With
+# "post-and-assert", recapture, compute the delta vs the pre-snapshot,
+# and assert the delta is below MAX_DELTA_BYTES (default 1 MiB). A
+# successful reuse should see only a few KB of control/auth traffic;
+# a re-download would add tens of MB (the eden-eclient image is ~44 MB
+# uncompressed).
+#
+# Note: /run/ is tmpfs, so the counter is reset on reboot. This script
+# is meant to bracket a single phase (e.g. post-upgrade app deploy on
+# eve-k) where pre and post are taken without an intervening reboot.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+MODE=${1:-pre}
+MAX_DELTA_BYTES=${2:-1048576}  # 1 MiB default
+
+capture_recv_bytes() {
+    timeout 15 "$EDEN" eve ssh -- 'eve exec pillar cat /run/downloader/MetricsMap/global.json 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' \
+        | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print(0); sys.exit(0)
+total = 0
+for iface, conn in d.items():
+    for url, m in (conn.get('URLCounters') or {}).items():
+        total += m.get('RecvByteCount', 0)
+print(total)
+"
+}
+
+case "$MODE" in
+    pre)
+        bytes=$(capture_recv_bytes)
+        echo "$bytes" > /tmp/xhv-rcv-pre.txt
+        echo "Pre-snapshot: RecvByteCount total = $bytes bytes"
+        ;;
+    post-and-assert)
+        post=$(capture_recv_bytes)
+        pre=$(cat /tmp/xhv-rcv-pre.txt 2>/dev/null || echo 0)
+        delta=$(( post - pre ))
+        echo "Post-snapshot: RecvByteCount total = $post bytes (pre was $pre, delta = $delta)"
+        if [ "$delta" -lt 0 ]; then
+            echo "FAIL: post < pre — counter went backwards (reboot? not expected on eve-k)" >&2
+            exit 1
+        fi
+        if [ "$delta" -lt "$MAX_DELTA_BYTES" ]; then
+            echo "OK: only $delta bytes received (< ${MAX_DELTA_BYTES} threshold) — no image re-download"
+            exit 0
+        fi
+        echo "FAIL: $delta bytes received exceeds ${MAX_DELTA_BYTES} threshold — image likely re-downloaded" >&2
+        exit 1
+        ;;
+    *)
+        echo "Usage: $0 pre | post-and-assert [max-delta-bytes]" >&2
+        exit 1
+        ;;
+esac
+
+-- wait-for-app-running.sh --
+#!/bin/bash
+# 15m budget (180 x 5s), matching the escript's `exec -t 15m` wrapper.
+# The longhorn StorageClass wait runs first (separate helper), so by the
+# time we get here the cluster storage is up and the app should reach
+# RUNNING quickly; this is just the app-only gate.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for i in $(seq 1 480); do   # 40m at 5s (deploy-on-boot: app RUNNING gated on the full cluster bring-up + volume create + guest boot)
+    line=$("$EDEN" pod ps 2>/dev/null | grep -E '^xhv-pre-app\s')
+    if echo "$line" | grep -q 'RUNNING'; then
+        echo "OK: xhv-pre-app RUNNING"
+        echo "$line"
+        exit 0
+    fi
+    sleep 5
+done
+echo "FAIL: xhv-pre-app did not reach RUNNING in 40m" >&2
+"$EDEN" pod ps >&2
+exit 1
+
+-- wait-for-ssh-to-app.sh --
+#!/bin/bash
+# wait-for-ssh-to-app.sh — the REAL guest-readiness / functional gate for the
+# eclient app instance, shared verbatim across the cross-HV / kvm->k tests.
+#
+# `eden pod ps` RUNNING (wait-for-app-running.sh) only reflects
+# AppInstState.EVEState — the ZSwState EVE reports. On EVE-k that is the
+# kubevirt VMI Running phase (qemu launched), NOT the guest kernel booted with
+# sshd accepting connections; on EVE-kvm the gap is smaller but still not
+# guest-ready. So pod-ps RUNNING is a cheap pre-filter only — success is
+# declared HERE, once an AUTHENTICATED ssh command has actually run inside the
+# guest and returned the expected output.
+#
+# Transport: host hostfwd 127.0.0.1:2223 -> EVE-eth0:2223 (eve.hostfwd
+# extension set by eden-bringup.sh) -> zedrouter NAT -> app:22 (eclient sshd).
+# The `eden sdn fwd` wrapper collapses to the same 127.0.0.1:hostport under the
+# non-SDN QEMU user-net these tests run in, so the direct path is used.
+#
+# FRESHNESS: host port 2223 is a static QEMU forward for the whole VM lifetime,
+# so after a delete+redeploy (or a reboot) a *stale* previous eclient could keep
+# answering on it and falsely satisfy a post-conversion check. To guard that,
+# each successful check records the guest's boot_id
+# (/proc/sys/kernel/random/boot_id — a fresh UUID per VM boot) to
+# /tmp/xhv-app-bootid. In "fresh" mode the check requires the connected guest's
+# boot_id to DIFFER from that recorded value; a matching (stale) instance is
+# treated as not-ready-yet and retried until the fresh deploy takes over the
+# port or the budget runs out.
+#
+# Fail-closed: a refused / closed / timed-out ssh, a non-eclient guest, or (in
+# fresh mode) only the stale instance answering, never prints the success
+# marker. On success it prints "OK: app SSH reachable" so the escript pins the
+# framework verdict to a real session:
+#     exec -t 5m bash wait-for-ssh-to-app.sh
+#     stdout 'OK: app SSH reachable'
+#
+# Args (optional): $1 host port (default 2223); $2 attempts, 10s apart
+# (default 30 => 5m); $3 = "fresh" to require a NEW guest instance vs the
+# boot_id the previous successful check recorded (use after a redeploy/reboot).
+#
+# Cert: ssh refuses group-readable keys, so the eclient id_rsa is copied to a
+# 0600 temp file. testscript sets HOME=/no-home, so the real home is resolved
+# from the running UID; dist/tests is only populated by a full `make eden`, so
+# fall back to the master/main reference clones.
+set -uo pipefail
+PORT="${1:-2223}"
+ATTEMPTS="${2:-30}"
+FRESH="${3:-}"
+BOOTID_FILE=/tmp/xhv-app-bootid
+EDEN_TESTS="{{EdenConfig "eden.tests"}}"
+USER_HOME=$(getent passwd "$(id -u)" | cut -d: -f6)
+SRC=""
+for c in "$EDEN_TESTS/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/master/eden/tests/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/main/eden/tests/eclient/image/cert/id_rsa"; do
+    if [ -f "$c" ]; then SRC="$c"; break; fi
+done
+if [ -z "$SRC" ]; then
+    echo "FAIL: could not locate eclient id_rsa cert (EDEN_TESTS=$EDEN_TESTS, USER_HOME=$USER_HOME)" >&2
+    exit 1
+fi
+KEY=$(mktemp); install -m 600 "$SRC" "$KEY"; trap 'rm -f "$KEY"' EXIT
+SSH_OPTS=(-o ConnectTimeout=10 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -i "$KEY")
+prev=""
+[ -f "$BOOTID_FILE" ] && prev=$(cat "$BOOTID_FILE" 2>/dev/null)
+connected=0
+saw_stale=0
+for _ in $(seq 1 "$ATTEMPTS"); do
+    # One round-trip proves auth, the eclient identity, and the guest boot_id.
+    # "AUTHED" is echoed before the identity check, so a connect+auth that fails
+    # only the /etc/issue match is distinguishable from a never-connected ssh.
+    out=$(ssh "${SSH_OPTS[@]}" root@127.0.0.1 -p "$PORT" \
+        'echo AUTHED; grep -q Ubuntu /etc/issue && cat /proc/sys/kernel/random/boot_id' \
+        2>/dev/null)
+    case "$out" in *AUTHED*) connected=1 ;; esac
+    bootid=$(printf '%s\n' "$out" | tr -d '\r' | grep -Ex '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | tail -1)
+    if [ -n "$bootid" ]; then
+        if [ "$FRESH" = "fresh" ] && [ -n "$prev" ] && [ "$bootid" = "$prev" ]; then
+            # Still the previous instance on the static port — wait for the fresh
+            # deploy/boot to take over the NAT before declaring success.
+            saw_stale=1; sleep 10; continue
+        fi
+        echo "$bootid" > "$BOOTID_FILE"
+        echo "OK: app SSH reachable (port=$PORT, boot_id=$bootid, fresh=${FRESH:-no}, cert=$SRC)"
+        exit 0
+    fi
+    sleep 10
+done
+budget=$(( ATTEMPTS * 10 ))
+if [ "$saw_stale" = 1 ]; then
+    echo "FAIL: only the previous app instance (boot_id=$prev) answered within ${budget}s — the fresh deploy never took over the port (stale instance)" >&2
+elif [ "$connected" = 1 ]; then
+    echo "FAIL: ssh connected+authed but the guest never matched the eclient (grep Ubuntu /etc/issue) within ${budget}s (port=$PORT)" >&2
+else
+    echo "FAIL: app never answered an authenticated ssh within ${budget}s (port=$PORT, cert=$SRC)" >&2
+fi
+echo "--- host TCP probe ---" >&2
+( exec 3<>/dev/tcp/127.0.0.1/"$PORT" ) 2>&1 || true
+exit 1
+
+-- wait-for-cross-hv-upgrade.sh --
+#!/bin/bash
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT_VERSION='{{ $alt_short_version }}'
+DEADLINE=$(( $(date +%s) + 1800 ))
+
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+prev_running=""
+while [ $(date +%s) -lt $DEADLINE ]; do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then
+        echo "$(date +%H:%M:%S): EVE unreachable (rebooting?)"; sleep 20; continue
+    fi
+    imgb_state=$(probe 'eve exec pillar cat /run/baseosmgr/ZbootStatus/IMGB.json' | grep -oP '"PartitionState":"\K[^"]+' | head -1)
+    [ -z "$imgb_state" ] && imgb_state='unknown'
+    echo "$(date +%H:%M:%S): running='$running' IMGB.PartitionState='$imgb_state'"
+    # Proceed as soon as EVE-k is the running rootfs — do NOT also wait for
+    # IMGB to commit 'active'. On EVE-k the commit is gated on cluster/node
+    # readiness (~16m), so requiring 'active' here would delay the app deploy
+    # until longhorn/CDI are up, defeating the device-side clusterStorageReady
+    # defer + park-and-retry we want to exercise.
+    if [ "$running" = "$EXPECT_VERSION" ]; then
+        echo "OK: booted EVE-k (version=$running, IMGB.PartitionState=$imgb_state) — deploying app now, independent of commit/cluster state"
+        exit 0
+    fi
+    prev_running="$running"
+    sleep 30
+done
+echo "FAIL: 30m timeout. running='$running' IMGB='$imgb_state'" >&2
+exit 1
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- wait-for-longhorn-sc.sh --
+#!/bin/bash
+# Wait until the EVE-k `longhorn` StorageClass exists (longhorn deployed + its CSI
+# provisioner up). On a freshly-converted EVE-k node longhorn can take tens of
+# minutes to deploy -- well after the device reports ONLINE -- so wait for it
+# EXPLICITLY here, before deploying/waiting for an app whose volume needs longhorn.
+# This separates cluster-bringup time from app-bringup time: the wait-for-app-running
+# that follows can be short, and a failure here clearly says "longhorn", not "app".
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 90); do   # ~45m at 30s
+    if "$EDEN" eve ssh -- 'eve exec kube kubectl get sc 2>/dev/null' 2>/dev/null | grep -qE '^longhorn'; then
+        echo "OK: longhorn StorageClass ready"; exit 0
+    fi
+    sleep 30
+done
+echo "FAIL: longhorn StorageClass not ready within budget" >&2; exit 1

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k.txt
@@ -1,0 +1,1238 @@
+# Test: EVE-kvm -> EVE-k in-field boot-disk repartition (small -> large GPT
+# geometry conversion), driven end-to-end through the controller, with a
+# deferred-content-delete app so a post-conversion redeploy needs no download.
+#
+# One parameterized escript for the REPARTITIONING successful-conversion cases of
+# the kvm-to-k e2e test plan. It replaces the former grow/resize sibling pair:
+# the shrink and grow variants differ only in a Step-1 precondition and the final
+# geometry assertion, so they are selected by env knobs rather than duplicated.
+#
+# These cases ALWAYS start on a SMALL (old, released) image that lacks the
+# conversion code; a kvm->kvm hop to the conversion-capable build lands the code
+# without changing geometry, and the kvm->k hop is the cross-flavor seam that
+# triggers the repartition.
+#
+# Image sequence (exact — see the kvm-to-k README for how to build/bring up):
+#   1. SMALL start: EVE up on a stock 12.1.0-kvm install (small: 36 MiB ESP,
+#                   512 MiB IMGA/IMGB). For EXPECT_DECISION=grow the disk is also
+#                   enlarged host-side so >= 22 GB is unallocated after P3.
+#   2. kvm conversion-capable: BaseOs-update kvm->kvm to the local kvm-to-k build.
+#                   Same geometry; lands the conversion code. Then settle the
+#                   vault to a local TPM unlock.
+#   3. k image    : BaseOs-update kvm->k. The cross-flavor seam arms the offline
+#                   repartition; storage-init resizes ESP/IMGA/IMGB (shrinking P3
+#                   first if there is no free tail), then boots EVE-k on the
+#                   now-large geometry. The grow/shrink runs offline because the
+#                   boot disk's GPT can't be re-read live while its rootfs is mounted.
+#
+# Knobs (env):
+#   EXPECT_DECISION  shrink|grow  (default shrink)
+#       shrink: the boot disk is full; ext4 P3 is shrunk to make room, then
+#               ESP/IMGA/IMGB grow. (the field layout)
+#       grow:   the boot disk has a >= 22 GB free tail; ESP/IMGA/IMGB grow into
+#               it and P3 is untouched.
+#       Drives the Step-1 precondition and the post-conversion geometry assert.
+#       ('proceed' is not a repartition; 'insufficient' is the declined sibling —
+#        both are separate escripts, out of scope here.)
+#   DISK_TOPOLOGY  single|two-disk|zfs  (default single)
+#       Drives the data-preservation invariant. two-disk/zfs setup is NOT done by
+#       this escript (installer / host-side; see the test plan's Format D/G); the
+#       escript only asserts the result, and the persist-disk assertion for those
+#       layouts is still a TODO.
+#   POST_REBOOT_CHECK  non-empty => after the conversion, reboot EVE-k once and
+#       re-verify the app recovers (longhorn re-attach regression).
+#   RESIZE_EVE_VER  (required) version base of the local kvm-to-k images, without
+#       the -<hv>-<arch> suffix, e.g. "0.0.0-kvm-to-k-resize-<sha>". No default
+#       for a local build; the test fails fast if unset.
+#   RESIZE_EVE_REG  (default lfedge/eve) image registry/repo namespace; the full
+#       docker tag is <RESIZE_EVE_REG>:<RESIZE_EVE_VER>-<hv>-<arch>.
+#   BRINGUP_EVE_VER (default 12.1.0) substring the running base release must
+#       contain at Step 1; this escript does NOT install the base image (bringup
+#       is manual — see the kvm-to-k README).
+#
+# What it asserts:
+#   - the boot disk started SMALL and ended LARGE (per-partition sizes; for grow
+#     P3 is unchanged, for shrink P3 shrank);
+#   - the conversion was observed (device state/sub-state transitions logged);
+#   - the repartition preserved the TPM seal (post-hoc from /persist/newlog: the
+#     last boot on the conversion-capable kvm image unsealed locally, no PCR5
+#     re-seal; the EVE-k boot's controller-key is the expected new-rootfs behavior);
+#   - the redeploy reused cached blobs (downloader received < 1 MiB).
+
+{{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+
+{{$arch := EdenConfig "eve.arch"}}
+
+{{$resize_ver_env := EdenGetEnv "RESIZE_EVE_VER"}}
+{{$resize_ver := "REPLACE-WITH-RESIZE-VERSION"}}
+{{if $resize_ver_env}}{{$resize_ver = $resize_ver_env}}{{end}}
+
+{{$resize_reg_env := EdenGetEnv "RESIZE_EVE_REG"}}
+{{$resize_reg := "lfedge/eve"}}
+{{if $resize_reg_env}}{{$resize_reg = $resize_reg_env}}{{end}}
+
+{{$bringup_ver_env := EdenGetEnv "BRINGUP_EVE_VER"}}
+{{$bringup_ver := "12.1.0"}}
+{{if $bringup_ver_env}}{{$bringup_ver = $bringup_ver_env}}{{end}}
+
+# --- knob: expected resizer decision ---
+{{$decision_env := EdenGetEnv "EXPECT_DECISION"}}
+{{$decision := "shrink"}}
+{{if $decision_env}}{{$decision = $decision_env}}{{end}}
+
+# --- knob: disk topology ---
+{{$topology_env := EdenGetEnv "DISK_TOPOLOGY"}}
+{{$topology := "single"}}
+{{if $topology_env}}{{$topology = $topology_env}}{{end}}
+
+{{$post_reboot := EdenGetEnv "POST_REBOOT_CHECK"}}
+
+# Derive the post-conversion geometry assert mode from (decision, topology).
+#   shrink/single         -> assert-grown            (ESP/IMGA/IMGB grew, P3 shrank)
+#   grow/single, grow/zfs -> assert-grown-no-shrink  (grew, P3 untouched)
+#   grow/two-disk         -> assert-grown-no-p3       (grew, no P3 on boot disk)  [TODO: format D]
+{{$geomMode := "assert-grown"}}
+{{if eq $decision "grow"}}{{$geomMode = "assert-grown-no-shrink"}}{{end}}
+{{if and (eq $decision "grow") (eq $topology "two-disk")}}{{$geomMode = "assert-grown-no-p3"}}{{end}}
+
+{{$kvm_short := printf "%s-kvm-%s" $resize_ver $arch}}
+{{$k_short   := printf "%s-k-%s" $resize_ver $arch}}
+
+# Step 0: pre-flight. Fail fast if the version param wasn't supplied, confirm a
+# clean device, and shorten the baseimage commit timer so updates apply fast.
+message 'pre-flight: parameters + clean state'
+exec -t 1m bash require-resize-ver.sh
+exec -t 1m bash assert-no-volumes.sh
+eden -t 1m pod ps
+! stdout 'IN_CONFIG'
+eden controller edge-node update --config timer.test.baseimage.update=30
+
+# Step 1: baseline — always SMALL/old start. The conversion code isn't on a
+# released small image; the kvm hop below lands it. The disk must be SMALL
+# (load-bearing: if it is already large the conversion is a no-op and the test
+# proves nothing). For EXPECT_DECISION=grow, also require the >= 22 GB free tail
+# so the resizer's check returns `grow`; without it the test would silently
+# degrade into the shrink path, so the precondition is fail-fast.
+message 'baseline: confirm we are on the expected SMALL bringup release'
+exec -t 3m bash assert-running-version.sh {{ $bringup_ver }}
+message 'baseline: confirm SMALL boot-disk geometry'
+exec -t 2m bash capture-partitions.sh save small
+exec -t 1m bash capture-partitions.sh assert-small
+{{if eq $decision "grow"}}
+message 'precondition: boot disk has a >= 22G free tail (lsblk; resizer not on bringup image yet)'
+exec -t 2m bash assert-free-tail.sh
+{{end}}
+
+# Step 2: kvm->kvm hop — lands the conversion code, geometry unchanged.
+message 'downloading conversion-capable kvm rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$resize_ver}} --eve-hv=kvm --eve-registry={{$resize_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs'
+message 'pushing kvm->kvm BaseOs update (lands conversion code)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs --os-version={{ $kvm_short }} -m adam://
+! stderr .
+message 'waiting for kvm->kvm upgrade to complete'
+exec -t 25m bash wait-for-upgrade.sh {{ $kvm_short }}
+
+# A same-flavor upgrade must not repartition: re-confirm geometry is still SMALL,
+# then confirm the resizer's check returns the decision THIS scenario requires. A
+# regression that repartitions on a same-flavor upgrade, or that consumes the
+# free tail (grow) / frees space (shrink), is caught here.
+message 'post-kvm-upgrade: geometry must still be SMALL'
+exec -t 1m bash capture-partitions.sh assert-small
+message 'post-kvm-upgrade: assert storage-resizer check decision == {{ $decision }}'
+exec -t 2m bash assert-check-decision.sh {{ $decision }}
+
+# Step 3: settle the vault to a LOCAL TPM unlock. A new rootfs moves PCRs 8,13,
+# so the first post-upgrade boot unlocks via the controller key; one or more
+# controller-driven reboots return it to a local seal. UnlockMethod==0 means
+# "not decided yet this boot" — wait, don't treat it as a value.
+message 'settling vault to local TPM unlock (reboot loop)'
+exec -t 40m bash settle-vault-local.sh
+
+# Step 4: deploy the eclient app on EVE-kvm; wait RUNNING + functional.
+message 'deploying eclient app on EVE-kvm'
+eden -t 1m network create 10.11.12.0/24 -n xhv-app-net
+eden -t 5m pod deploy -n xhv-app {{template "eclient_image"}} -p 2223:22 --networks=xhv-app-net --memory=512MB
+exec -t 10m bash wait-for-app-running.sh
+message 'pre-conversion functional check'
+exec -t 5m bash wait-for-ssh-to-app.sh
+stdout 'OK: app SSH reachable'
+
+# Step 5: set timer.defer.content.delete=24h so deleting the app below does NOT
+# immediately GC its ContentTree blobs — they must survive the conversion so the
+# post-conversion redeploy reuses them (asserted at Step 11).
+message 'setting timer.defer.content.delete=86400 (24h)'
+eden controller edge-node update --config timer.defer.content.delete=86400
+
+# Wait out one controller config-fetch interval (timer.config.interval=60s)
+# plus margin so volumemgr applies the new deferContentDelete BEFORE the app
+# delete below. Otherwise the device can fetch the timer set and the app delete
+# in one config cycle and volumemgr's select loop may process the delete first,
+# deleting the app's ContentTree with deferContentDelete still 0 and GC-ing its
+# blobs -> the redeploy re-downloads (the FAIL[blob-reuse] mode).
+message 'waiting ~90s for the device to apply deferContentDelete=86400'
+exec sleep 90
+
+# Step 6: delete the app (keep the network), then wait for full EVE-side teardown.
+# The cross-HV gate refuses kvm<->k while any Volume exists, so we must reach zero
+# volumes before pushing the -k update.
+message 'deleting app on EVE-kvm (network kept, blobs retained for 24h)'
+eden -t 1m pod delete xhv-app
+exec -t 15m bash wait-for-app-gone.sh
+exec -t 1m bash assert-no-volumes.sh
+
+# Step 7: BaseOs-update kvm->k. This is the cross-flavor seam that triggers the
+# boot-disk repartition.
+message 'downloading k rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$resize_ver}} --eve-hv=k --eve-registry={{$resize_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs'
+message 'pushing kvm->k BaseOs update (triggers boot-disk repartition)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs --os-version={{ $k_short }} -m adam://
+! stderr .
+
+# Step 8: drive AND watch the conversion. The repartition runs OFFLINE in
+# storage-init, so this logs device state/sub-state TRANSITIONS as it polls to
+# completion and tolerates the reboots the offline resize needs. It returns once
+# EVE-k is running; the seal is checked post-hoc (Step 10).
+message 'waiting for + watching the kvm->k conversion (logging state transitions)'
+exec -t 45m bash watch-conversion.sh {{ $k_short }}
+
+# Step 9: deploy the app on EVE-k IMMEDIATELY after boot — do NOT wait for
+# volumemgr / cluster readiness first. Blob reuse (no image re-download) is still
+# required, but it is asserted at the END of Step 11 (downloader byte count
+# unchanged): with the app deployed early, volumemgr re-establishes the retained
+# ContentTree store while the app volume is deferred until cluster storage is up.
+# Snapshot the downloader baseline (RecvByteCount resets on the EVE-k reboot) just
+# before deploying so the post-assert measures only re-download after the deploy.
+message 'snapshot eve-k downloader RecvByteCount (baseline, pre-deploy)'
+exec -t 1m bash snapshot-rcv-bytes.sh pre
+message 'deploying eclient app on EVE-k immediately on boot (independent of commit/cluster state)'
+eden -t 5m pod deploy -n xhv-app {{template "eclient_image"}} -p 2223:22 --networks=xhv-app-net --memory=512MB
+
+# Step 10: while the app installs, run the static post-conversion checks: the boot
+# disk grew to LARGE (P3 unchanged on grow, shrank on shrink), and the repartition
+# preserved the local TPM seal (post-hoc from /persist/newlog: the LAST boot on
+# the conversion-capable kvm image unsealed locally — keyed on the specific
+# version so a future baseline that logs a local unlock can't satisfy it — plus no
+# PCR5-driven re-seal; the EVE-k boot's controller-key is expected and not asserted).
+message 'asserting boot-disk repartition outcome ({{ $decision }} / {{ $topology }})'
+exec -t 2m bash capture-partitions.sh save large
+exec -t 1m bash capture-partitions.sh {{ $geomMode }}
+{{if or (eq $topology "two-disk") (eq $topology "zfs")}}
+# TODO(two-disk/zfs — formats D/G): assert the persist partition/disk is
+# byte-unchanged after the grow. Needs the format-D/G setup (installer or
+# host-side hand-construction) the e2e test plan describes; the persist device
+# is NOT /dev/sda P3 in those layouts. Wire a capture-partitions mode that
+# reads the persist disk (or P3 fs-type for zfs) once that setup exists.
+{{end}}
+message 'asserting repartition preserved the TPM seal (post-hoc from /persist/newlog)'
+exec -t 3m bash assert-seal-from-newlog.sh {{ $k_short }} {{ $kvm_short }}
+
+# Step 11: split the readiness waits into SEPARATE steps for diagnosability, in
+# order, so a failure localizes to one stage:
+#   (a) volumemgr ready (incl kubeapi.WaitForKubernetes),
+#   (b) longhorn StorageClass ready (cluster storage up),
+#   (c) app RUNNING,
+#   (d) app SSH-reachable,
+# and only THEN assert blob reuse (downloader byte count did not increase since
+# the deploy — proving the early deploy reused the retained ContentTree).
+message '(a) waiting for volumemgr ready (incl kubeapi.WaitForKubernetes)'
+exec -t 45m bash wait-for-volumemgr-ready.sh
+message '(b) waiting for EVE-k longhorn StorageClass ready (cluster storage up)'
+exec -t 50m bash wait-for-longhorn-sc.sh
+stdout 'OK: longhorn StorageClass ready'
+message '(c) waiting for the app to reach RUNNING on EVE-k'
+exec -t 45m bash wait-for-app-running.sh
+message '(d) post-conversion functional check (SSH into the app guest)'
+exec -t 5m bash wait-for-ssh-to-app.sh 2223 30 fresh
+stdout 'OK: app SSH reachable'
+message 'capturing blob-reuse diagnostics (downloader / contenttree / verifier)'
+exec -t 3m bash capture-blob-diagnostics.sh
+message 'asserting blob reuse across the conversion: no image re-download after deploy'
+exec -t 1m bash snapshot-rcv-bytes.sh post-and-assert
+
+# Step 11b (optional): EVE-k app survives a plain reboot (longhorn re-attach
+# regression — see update_eve_image_cross_hv_with_app_recreate.txt Step 10a).
+{{if $post_reboot}}
+message 'post-conversion reboot-recovery: requesting controller-initiated reboot'
+eden -t 1m controller edge-node -m adam:// reboot -v debug
+message 'waiting for EVE down + back (uptime < 120s)'
+exec -t 15m bash wait-for-reboot-and-back.sh
+message 'post-reboot: volumemgr Initialized:true'
+exec -t 45m bash wait-for-volumemgr-ready.sh
+message 'post-reboot: app back to RUNNING + functional'
+message 'waiting for EVE-k longhorn StorageClass ready (cluster storage up)'
+exec -t 50m bash wait-for-longhorn-sc.sh
+stdout 'OK: longhorn StorageClass ready'
+exec -t 45m bash wait-for-app-running.sh
+exec -t 5m bash wait-for-ssh-to-app.sh 2223 30 fresh
+stdout 'OK: app SSH reachable'
+{{end}}
+
+# Step 12: reset the defer-delete timer to default and clean up.
+message 'reset timer.defer.content.delete=0 (back to default)'
+eden controller edge-node update --config timer.defer.content.delete=0
+eden -t 1m pod delete xhv-app
+eden -t 1m network delete xhv-app-net
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs.ver
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs.ver
+exec sleep 10
+eden eve reset
+
+-- require-resize-ver.sh --
+#!/bin/bash
+# Fail fast if RESIZE_EVE_VER wasn't supplied (the escript default is a
+# placeholder). Without it, the eveimage-update steps would silently try to
+# download a bogus version.
+set -uo pipefail
+VER='{{ $resize_ver }}'
+if [ -z "$VER" ] || [ "$VER" = "REPLACE-WITH-RESIZE-VERSION" ]; then
+    echo "FAIL: RESIZE_EVE_VER not set." >&2
+    echo "      Export it to the version base of your local kvm-to-k" >&2
+    echo "      build, e.g. RESIZE_EVE_VER=0.0.0-kvm-to-k-resize-1a2b3c4d" >&2
+    echo "      (the part before -kvm-amd64 / -k-amd64 in the docker tag)." >&2
+    exit 1
+fi
+echo "OK: RESIZE_EVE_VER=$VER"
+
+-- assert-running-version.sh --
+#!/bin/bash
+# Sanity-check that EVE is running the expected SMALL bringup release before the
+# conversion starts. This escript does not install the base image — bringup
+# happens manually before the test (see the kvm-to-k README). This guards against
+# running the test against the wrong base image or an already-upgraded device.
+#
+# Matches the expected version as a substring of /run/eve-release (which is the
+# full "<ver>-<hv>-<arch>" form, e.g. "12.1.0-kvm-amd64"), so passing "12.1.0"
+# accepts the kvm bringup image without pinning the hv/arch suffix.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT="${1:?expected bringup version substring}"
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+for _ in $(seq 1 18); do   # ~3m at 10s; tolerate ssh not up yet
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -n "$running" ]; then
+        case "$running" in
+            *"$EXPECT"*)
+                echo "OK: running the expected bringup release ('$running' contains '$EXPECT')"
+                exit 0 ;;
+            *)
+                echo "FAIL: running version '$running' does not match expected bringup '$EXPECT'." >&2
+                echo "      Bring eve up on the small '$EXPECT' image before this test, or set" >&2
+                echo "      BRINGUP_EVE_VER to the release you brought up on." >&2
+                echo "      See the kvm-to-k README." >&2
+                exit 1 ;;
+        esac
+    fi
+    sleep 10
+done
+echo "FAIL: could not read /run/eve-release (ssh down / device not up?)" >&2
+exit 1
+
+-- capture-partitions.sh --
+#!/bin/bash
+# Read the boot-disk GPT geometry from EVE via lsblk and either save it, assert it
+# is the SMALL layout, or assert it grew to the LARGE layout. Three grow asserts:
+#   assert-grown            requires P3 to have SHRUNK     (shrink/single)
+#   assert-grown-no-shrink  requires P3 UNCHANGED          (grow/single, grow/zfs)
+#   assert-grown-no-p3      requires NO P3 on the boot disk (grow/two-disk) [TODO]
+# The escript derives which one to use from (EXPECT_DECISION, DISK_TOPOLOGY).
+#
+# Usage:
+#   capture-partitions.sh save  <tag>             # snapshot sizes to /tmp/xhv-parts-<tag>.env
+#   capture-partitions.sh assert-small            # ESP/IMGA/IMGB small (pre-convert)
+#   capture-partitions.sh assert-grown            # grew; P3 SHRANK
+#   capture-partitions.sh assert-grown-no-shrink  # grew; P3 UNCHANGED
+#   capture-partitions.sh assert-grown-no-p3      # grew; NO P3 on boot disk [TODO format D]
+#
+# Sizes come straight from `lsblk -b -P -o NAME,PARTLABEL,SIZE /dev/sda` — the
+# same lsblk pillar's diskmetrics uses, so it is present in the pillar ns. The
+# disk is /dev/sda under eden (qemu SATA/IDE).
+#
+# SMALL layout (12.1.0 make-raw): ESP 36 MiB, IMGA/IMGB 512 MiB, big P3.
+# LARGE layout (EVE-k target):    ESP 2 GiB,  IMGA/IMGB 10 GiB; P3 shrinks
+# (shrink variant), is unchanged (grow-only), or absent (two-disk persist).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+MODE=${1:-}
+TAG=${2:-}
+GiB=$(( 1024 * 1024 * 1024 ))
+MiB=$(( 1024 * 1024 ))
+
+# Read sizes into env-file form: ESP=<bytes> IMGA=<bytes> IMGB=<bytes> P3=<bytes>
+read_sizes() {
+    timeout 20 "$EDEN" eve ssh -- \
+        'eve exec pillar lsblk -b -P -o NAME,PARTLABEL,SIZE /dev/sda 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c '
+import sys, re
+keys = {"EFI System": "ESP", "IMGA": "IMGA", "IMGB": "IMGB", "P3": "P3"}
+out = {}
+for line in sys.stdin:
+    m = dict(re.findall(r"(\w+)=\"([^\"]*)\"", line))
+    label = m.get("PARTLABEL", "")
+    if label in keys and m.get("SIZE"):
+        out[keys[label]] = m["SIZE"]
+for k in ("ESP", "IMGA", "IMGB", "P3"):
+    print("%s=%s" % (k, out.get(k, "0")))
+'
+}
+
+# Loads ESP/IMGA/IMGB/P3 into the env. P3 may legitimately be 0 (two-disk: no P3
+# on the boot disk), so only ESP/IMGA/IMGB are required to be non-zero.
+load_current() {
+    local env
+    env=$(read_sizes)
+    eval "$env"
+    if [ "${ESP:-0}" = "0" ] || [ "${IMGA:-0}" = "0" ] || [ "${IMGB:-0}" = "0" ]; then
+        echo "FAIL: could not read ESP/IMGA/IMGB sizes from /dev/sda" >&2
+        echo "      raw lsblk:" >&2
+        timeout 20 "$EDEN" eve ssh -- 'eve exec pillar lsblk -b -o NAME,PARTLABEL,SIZE /dev/sda' >&2 2>/dev/null
+        exit 1
+    fi
+}
+
+print_table() {
+    printf '  %-10s %12s  (%s)\n' EFI  "$ESP"  "$(( ESP  / MiB )) MiB"
+    printf '  %-10s %12s  (%s)\n' IMGA "$IMGA" "$(( IMGA / MiB )) MiB"
+    printf '  %-10s %12s  (%s)\n' IMGB "$IMGB" "$(( IMGB / MiB )) MiB"
+    printf '  %-10s %12s  (%s)\n' P3   "$P3"   "$(( P3   / MiB )) MiB"
+}
+
+base_get() { grep "^$2=" "/tmp/xhv-parts-$1.env" | cut -d= -f2; }
+
+case "$MODE" in
+    save)
+        [ -n "$TAG" ] || { echo "Usage: $0 save <tag>" >&2; exit 1; }
+        load_current
+        printf 'ESP=%s\nIMGA=%s\nIMGB=%s\nP3=%s\n' "$ESP" "$IMGA" "$IMGB" "$P3" > "/tmp/xhv-parts-$TAG.env"
+        echo "Saved $TAG partition sizes:"
+        print_table
+        ;;
+    assert-small)
+        load_current
+        echo "Current partition sizes:"
+        print_table
+        # Small ESP is 36 MiB, IMGA/IMGB 512 MiB; allow generous headroom but
+        # stay far below the large floors so this is unambiguous.
+        if [ "$ESP"  -ge $(( 256 * MiB )) ] || \
+           [ "$IMGA" -ge "$GiB" ] || \
+           [ "$IMGB" -ge "$GiB" ]; then
+            echo "FAIL: geometry is not SMALL (ESP/IMGA/IMGB too big)" >&2
+            exit 1
+        fi
+        echo "OK: boot disk is on the SMALL geometry"
+        ;;
+    assert-grown|assert-grown-no-shrink|assert-grown-no-p3)
+        load_current
+        if [ ! -f /tmp/xhv-parts-small.env ]; then
+            echo "FAIL: no small baseline (/tmp/xhv-parts-small.env) to compare against" >&2
+            exit 1
+        fi
+        S_ESP=$(base_get small ESP);   S_IMGA=$(base_get small IMGA)
+        S_IMGB=$(base_get small IMGB); S_P3=$(base_get small P3)
+        echo "Partition sizes before -> after conversion (bytes):"
+        printf '  %-10s %14s -> %14s\n' EFI  "$S_ESP"  "$ESP"
+        printf '  %-10s %14s -> %14s\n' IMGA "$S_IMGA" "$IMGA"
+        printf '  %-10s %14s -> %14s\n' IMGB "$S_IMGB" "$IMGB"
+        printf '  %-10s %14s -> %14s\n' P3   "$S_P3"   "$P3"
+        rc=0
+        # ESP/IMGA/IMGB must have grown vs baseline AND reached the large floor.
+        # Large targets are ESP 2 GiB, IMGA/IMGB 10 GiB; floors are set below the
+        # target to tolerate GPT alignment while still being unambiguously large.
+        [ "$ESP"  -gt "$S_ESP"  ] || { echo "FAIL: ESP did not grow"  >&2; rc=1; }
+        [ "$IMGA" -gt "$S_IMGA" ] || { echo "FAIL: IMGA did not grow" >&2; rc=1; }
+        [ "$IMGB" -gt "$S_IMGB" ] || { echo "FAIL: IMGB did not grow" >&2; rc=1; }
+        [ "$ESP"  -ge $(( 1 * GiB )) ] || { echo "FAIL: ESP < 1 GiB floor (target 2 GiB)"  >&2; rc=1; }
+        [ "$IMGA" -ge $(( 8 * GiB )) ] || { echo "FAIL: IMGA < 8 GiB floor (target 10 GiB)" >&2; rc=1; }
+        [ "$IMGB" -ge $(( 8 * GiB )) ] || { echo "FAIL: IMGB < 8 GiB floor (target 10 GiB)" >&2; rc=1; }
+        case "$MODE" in
+            assert-grown)            # shrink variant: P3 must have shrunk to make room
+                [ "$P3" -lt "$S_P3" ] || { echo "FAIL: P3 did not shrink" >&2; rc=1; }
+                ok="OK: boot disk repartitioned SMALL -> LARGE (ESP/IMGA/IMGB grew, P3 shrank)" ;;
+            assert-grown-no-shrink)  # grow-only variant: P3 unchanged (1 MiB jitter)
+                [ "$P3" -ge $(( S_P3 - MiB )) ] || { echo "FAIL: P3 shrank ($S_P3 -> $P3) — expected unchanged on the grow-only path" >&2; rc=1; }
+                ok="OK: ESP/IMGA/IMGB grew to LARGE and P3 was not shrunk (grow-only path)" ;;
+            assert-grown-no-p3)      # two-disk: no P3 on the boot disk
+                # TODO(format D): also assert the persist disk is byte-unchanged.
+                [ "$P3" = "0" ] || { echo "FAIL: boot disk has a P3 ($P3) — expected none (two-disk persist)" >&2; rc=1; }
+                ok="OK: ESP/IMGA/IMGB grew to LARGE, no P3 on boot disk (two-disk path)" ;;
+        esac
+        [ "$rc" = "0" ] && echo "$ok"
+        exit "$rc"
+        ;;
+    *)
+        echo "Usage: $0 save <tag> | assert-small | assert-grown | assert-grown-no-shrink | assert-grown-no-p3" >&2
+        exit 1
+        ;;
+esac
+
+-- assert-free-tail.sh --
+#!/bin/bash
+# Step-1 fail-fast (grow variant only) that the boot disk has >= ~22 GB free after
+# its partitions, using only lsblk. The small bringup image (e.g. 12.1.0) does NOT
+# ship the storage-resizer binary, so the authoritative `storage-resizer check`
+# cannot run yet — that runs after the kvm->kvm hop (assert-check-decision.sh).
+# This geometric check just confirms the host-side enlarge created the tail before
+# we proceed.
+#
+# free tail ~= disk total - sum(partition sizes). Alignment gaps and the GPT
+# reservation make this a slight over-estimate (< 1 MiB), negligible against the
+# 22 GB threshold and the ~24 GB tail the recipe adds.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+GiB=$(( 1024 * 1024 * 1024 ))
+NEED=$(( 22 * GiB ))
+
+read_disk_and_parts() {
+    timeout 20 "$EDEN" eve ssh -- \
+        'eve exec pillar lsblk -b -P -o NAME,TYPE,SIZE /dev/sda 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c '
+import sys, re
+disk = 0; parts = 0
+for line in sys.stdin:
+    m = dict(re.findall(r"(\w+)=\"([^\"]*)\"", line))
+    t = m.get("TYPE", ""); s = int(m.get("SIZE", "0") or 0)
+    if t == "disk":
+        disk = max(disk, s)
+    elif t == "part":
+        parts += s
+print("%d %d" % (disk, parts))
+'
+}
+
+pair=$(read_disk_and_parts)
+disk=${pair%% *}; parts=${pair##* }
+if [ "${disk:-0}" = "0" ] || [ "${parts:-0}" = "0" ]; then
+    echo "FAIL: could not read disk/partition sizes from /dev/sda" >&2
+    exit 1
+fi
+free=$(( disk - parts ))
+echo "disk=$disk parts=$parts free_tail~=$free ($(( free / GiB )) GiB); need $(( NEED / GiB )) GiB"
+if [ "$free" -ge "$NEED" ]; then
+    echo "OK: free tail ~$(( free / GiB )) GiB present (>= 22 GiB) — grow precondition met"
+    exit 0
+fi
+echo "FAIL: free tail ~$(( free / GiB )) GiB < 22 GiB. Enlarge the disk before this test" >&2
+echo "      (qemu-img resize + sgdisk -e); see the kvm-to-k README." >&2
+exit 1
+
+-- assert-check-decision.sh --
+#!/bin/bash
+# Assert storage-resizer's pre-flight `check` returns the EXPECTED decision on the
+# live boot disk. Generalizes the former assert-check-grow.sh: the expected
+# decision is arg 1, so one helper serves every format in the matrix. This is the
+# load-bearing precondition guard — if the bringup/topology was not set up for the
+# requested EXPECT_DECISION, the test would silently exercise a different path.
+#
+# decision meanings (pkg/storage-resizer/README.md check table):
+#   grow         free tail >= --need; ESP/IMGA/IMGB grow into it, P3 untouched
+#   shrink       no free tail; ext4 P3 shrunk to make room, then grow
+#   proceed      already EVE-k geometry; no-op
+#   insufficient can't free --need within --max-full (or zfs P3 with no free tail)
+#
+# Usage: assert-check-decision.sh <grow|shrink|proceed|insufficient> [disk=/dev/sda]
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT="${1:?expected decision: grow|shrink|proceed|insufficient}"
+DISK="${2:-/dev/sda}"
+
+run_check() {
+    timeout 30 "$EDEN" eve ssh -- \
+        "eve exec pillar /usr/bin/storage-resizer check --disk $DISK --json 2>/dev/null" \
+        2>/dev/null | grep -v 'level=fatal'
+}
+
+for _ in $(seq 1 12); do   # ~2m at 10s — tolerate ssh/pillar not up yet
+    js=$(run_check)
+    dec=$(echo "$js" | python3 -c '
+import sys, json
+try:
+    o = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+sp = o.get("spaceForLargePartitions", {}) or {}
+print("%s|%s|%s" % (o.get("decision",""), sp.get("ok"), sp.get("freeTailBytes",0)))
+' 2>/dev/null)
+    if [ -n "$dec" ] && [ "${dec%%|*}" != "" ]; then
+        decision=${dec%%|*}; rest=${dec#*|}; ok=${rest%%|*}; tail=${rest##*|}
+        echo "storage-resizer check: decision=$decision freeTailOK=$ok freeTailBytes=$tail (expected=$EXPECT)"
+        if [ "$decision" = "$EXPECT" ]; then
+            echo "OK: check decided '$EXPECT' as this scenario requires"
+            exit 0
+        fi
+        echo "FAIL: check decided '$decision' but EXPECT_DECISION='$EXPECT'." >&2
+        echo "      The disk was not set up for the '$EXPECT' path — check the bringup/topology." >&2
+        echo "$js" >&2
+        exit 1
+    fi
+    sleep 10
+done
+echo "FAIL: no decision from storage-resizer check (binary missing or ssh down?)" >&2
+echo "      tried: eve exec pillar /usr/bin/storage-resizer check --disk $DISK --json" >&2
+exit 1
+
+-- settle-vault-local.sh --
+#!/bin/bash
+# Settle the TPM-sealed vault to a LOCAL unlock by rebooting through the
+# controller until VaultStatus.UnlockMethod is 1 (tpm-local-sealed).
+#
+# UnlockMethod values (pkg/pillar/types/vaultmgrtypes.go):
+#   0 none (not decided yet this boot)   1 tpm-local-sealed
+#   2 controller-key                     3 no-tpm
+# Per the conversion test design, 0 means "wait until it is set" — never treat
+# an unpublished/0 value as a result. The expected path after a new rootfs is
+# one controller-key boot (PCRs 8,13 moved) then a local seal.
+#
+# Reboots go through the controller (eden ... reboot), never `eve ssh reboot`:
+# the controller path is update-aware and recorded in reboot-reason.log. By the
+# time this runs the kvm->kvm update is already active, so the reboot is safe.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+
+# Read the highest UnlockMethod seen across all VaultStatus files (there is
+# normally one). Prints 0 if not yet published / ssh down.
+read_unlock() {
+    _u=$(timeout 15 "$EDEN" eve ssh -- \
+        'eve exec pillar sh -c "cat /run/vaultmgr/VaultStatus/*.json 2>/dev/null"' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c '
+import sys, json, re
+best = 0
+data = sys.stdin.read()
+for m in re.finditer(r"\{.*?\}", data, re.S):
+    try:
+        o = json.loads(m.group(0))
+    except Exception:
+        continue
+    v = o.get("UnlockMethod", 0)
+    if isinstance(v, int) and v > best:
+        best = v
+print(best)
+' 2>/dev/null)
+    # Emit only a validated 0-3. A transient/garbled read (e.g. pillar still
+    # starting right after a reboot, when eve ssh answers but eve exec pillar
+    # does not yet) becomes 0 so the caller keeps polling rather than treating
+    # the stray value as a settled decision and aborting.
+    case "$_u" in 0|1|2|3) echo "$_u" ;; *) echo 0 ;; esac
+}
+
+# Wait (up to ~12m) for UnlockMethod to become non-zero this boot, then echo it.
+wait_decided() {
+    local m
+    for _ in $(seq 1 72); do   # 12m at 10s
+        m=$(read_unlock)
+        if [ "${m:-0}" != "0" ]; then echo "$m"; return 0; fi
+        sleep 10
+    done
+    echo 0
+}
+
+reboot_and_wait_back() {
+    echo "$(date +%H:%M:%S) rebooting via controller to re-seal..."
+    timeout 60 "$EDEN" controller edge-node -m adam:// reboot -v debug || true
+    # Wait for SSH to drop then return.
+    for _ in $(seq 1 24); do timeout 5 "$EDEN" eve ssh 'true' 2>/dev/null || break; sleep 5; done
+    for _ in $(seq 1 90); do timeout 8 "$EDEN" eve ssh 'true' 2>/dev/null && return 0; sleep 10; done
+    echo "WARN: SSH did not return within 15m after reboot" >&2
+    return 0
+}
+
+for attempt in $(seq 1 4); do
+    echo "$(date +%H:%M:%S) settle attempt $attempt: waiting for vault unlock decision"
+    m=$(wait_decided)
+    case "$m" in
+        1) echo "OK: vault unlocked locally (tpm-local-sealed) — settled"; exit 0 ;;
+        2) echo "  unlock=controller-key (2): rebooting to re-seal to the settled state" ;;
+        3) echo "FAIL: unlock=no-tpm (3) — this test requires eve.tpm=true" >&2; exit 1 ;;
+        *) echo "FAIL: vault never reported an unlock method (stuck at 0/none)" >&2; exit 1 ;;
+    esac
+    reboot_and_wait_back
+done
+echo "FAIL: vault did not settle to a local unlock after 4 reboots" >&2
+exit 1
+
+-- watch-conversion.sh --
+#!/bin/bash
+# Drive AND watch the kvm->k conversion (shrink+grow, or grow) to completion,
+# state/sub-state TRANSITION. The post-grow vault seal check is done POST-HOC
+# from /persist/newlog (assert-seal-from-newlog.sh): the live post-grow EVE-kvm
+# window is only ~1-2 min and an ssh poll loop misses it.
+#
+# The repartition runs OFFLINE in storage-init (the boot disk's GPT can't be re-read
+# live while its rootfs is mounted): baseosmgr arms the shrink/grow flag and
+# reboots, storage-init grows ESP/IMGA/IMGB (possibly with a busy-disk
+# reboot-to-apply), the device re-checks (proceed) and does the cross-flavor A/B
+# install, then reboots into EVE-k.
+#
+# Logs, only when it changes, the tuple of: running version, IMGA/IMGB active
+# partition+version, controller-reported device state + sub-state (from adam),
+# and on-device Converting + ConvertSubState. Completion is slot-agnostic (the
+# grow can relocate the active slot).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+K_VERSION="${1:?expected -k version}"
+SERIAL_LOG='{{EdenConfig "eve.log"}}'
+DEADLINE=$(( $(date +%s) + 2700 ))   # 45m
+
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+substate_name() {
+    case "$1" in
+        1) echo preflight ;;
+        2) echo rebooting-to-resize ;;
+        3) echo making-space ;;
+        4) echo creating-partitions ;;
+        5) echo renaming-partitions ;;
+        6) echo installing ;;
+        7) echo rebooting-to-target ;;
+        *) echo "sub_$1" ;;
+    esac
+}
+
+# Controller's view from adam: the latest ZiDevice report's state + sub_state.
+# (eden info -o/--format json panics on this build, so grep the text-proto.)
+ctrl_state() {
+    local c st sub
+    c=$(timeout 20 "$EDEN" info --tail 8 2>/dev/null | grep -a '^content: ztype:ZiDevice' | tail -1)
+    st=$(echo "$c" | grep -oE 'state:ZDEVICE_STATE_[A-Z_]+' | head -1 | cut -d: -f2)
+    sub=$(echo "$c" | grep -oE 'sub_state:ZDEVICE_SUBSTATE_[A-Z_]+' | head -1 | cut -d: -f2)
+    echo "${st:-?}/${sub:-NONE}"
+}
+
+# Which partition (IMGA/IMGB) is active, and the version on it.
+active_part() {
+    probe 'eve exec pillar sh -c "cat /run/baseosmgr/ZbootStatus/IMGA.json /run/baseosmgr/ZbootStatus/IMGB.json 2>/dev/null"' | python3 -c '
+import sys, json, re
+act = "?"; ver = "?"
+for m in re.finditer(r"\{.*?\}", sys.stdin.read(), re.S):
+    try:
+        o = json.loads(m.group(0))
+    except Exception:
+        continue
+    if o.get("PartitionState") == "active":
+        act = o.get("PartitionLabel", "?"); ver = o.get("ShortVersion", "?")
+print("%s:%s" % (act, ver))' 2>/dev/null || echo "?:?"
+}
+
+serial_off=0
+report_serial() {
+    [ -f "$SERIAL_LOG" ] || return 0
+    local size new
+    size=$(stat -c%s "$SERIAL_LOG" 2>/dev/null || echo 0)
+    if [ "$size" -gt "$serial_off" ]; then
+        new=$(tail -c +$(( serial_off + 1 )) "$SERIAL_LOG" 2>/dev/null)
+        serial_off=$size
+        echo "$new" | grep -aE 'storage-resizer:|repartition|grow|reboot to apply|convert' | while IFS= read -r l; do
+            echo "  serial> $l"
+        done
+    fi
+}
+
+last_sig=""
+reboots=0
+unreachable_run=0
+seen_converting=0
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    report_serial
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then
+        unreachable_run=$(( unreachable_run + 1 ))
+        if [ "$last_sig" != "UNREACHABLE" ]; then
+            echo "$(date +%H:%M:%S) [transition] EVE unreachable (rebooting?)"
+            last_sig="UNREACHABLE"
+        fi
+        sleep 15
+        continue
+    fi
+    if [ "$unreachable_run" -ge 2 ]; then
+        reboots=$(( reboots + 1 ))
+        echo "$(date +%H:%M:%S) observed a reboot (count=$reboots)"
+    fi
+    unreachable_run=0
+
+    actver=$(active_part)
+    bos=$(probe 'eve exec pillar sh -c "cat /run/baseosmgr/BaseOsStatus/*.json 2>/dev/null"')
+    conv=$(echo "$bos" | grep -o '"Converting":[a-z]*' | head -1 | cut -d: -f2); [ -z "$conv" ] && conv=false
+    csub=$(echo "$bos" | grep -o '"ConvertSubState":[0-9]*' | head -1 | cut -d: -f2); [ -z "$csub" ] && csub=0
+    [ "$conv" = "true" ] && seen_converting=1
+    dev=$(ctrl_state)
+
+    sig="run=$running active=$actver dev=$dev converting=$conv csub=$csub($(substate_name "$csub"))"
+    if [ "$sig" != "$last_sig" ]; then
+        echo "$(date +%H:%M:%S) [transition] $sig"
+        last_sig="$sig"
+    fi
+
+    # Done: the device has BOOTED the -k version. We deliberately do NOT wait for
+    # the A/B commit to 'active' or for the cluster to be online here — the app is
+    # deployed immediately after this, and readiness is verified in the split steps
+    # of Step 11. PartitionState is typically still 'updating'/'inprogress' now.
+    if [ "$running" = "$K_VERSION" ]; then
+        report_serial
+        echo "OK: EVE-k booted (running=$running, active=$actver, converting=$conv)"
+        echo "    observed: CONVERTING=$seen_converting reboots=$reboots"
+        exit 0
+    fi
+    sleep 15
+done
+echo "FAIL: 45m timeout. running='${running:-?}' active='${actver:-?}' dev='${dev:-?}'" >&2
+echo "      observed: CONVERTING=$seen_converting reboots=$reboots" >&2
+exit 1
+
+-- assert-seal-from-newlog.sh --
+#!/bin/bash
+# Post-hoc, VERSION-MAPPED TPM-seal check from /persist/newlog (durable across the
+# conversion's reboots; survives the repartition since /persist is on P3). Robust
+# and future-proof vs racing the ~1-2 min live post-grow window.
+#
+# Args: <k-version> <kvm-version>  (the -k target, and the conversion-capable kvm
+# image whose post-grow boot must unseal locally).
+#
+# Each unlock line is mapped to the EXACT eve version of its boot using the
+# per-boot "EVE version: <ver>" marker that device-steps.sh logs on pillar.out
+# (NOT baseosmgr's embedded "to EVE version X", which is source pillar). Then:
+#   (1) the LAST boot on the conversion-capable kvm version must have unsealed
+#       LOCALLY (tpm-local-sealed) — that is the post-grow / pre-EVE-k boot, on
+#       which only PCR5 (the repartition, excluded from the seal) changed. Keying
+#       on the specific kvm version (not "any kvm boot") keeps the test correct
+#       even if a future baseline OS also logs a local unlock; and
+#   (2) no controller-key / unseal-FAILED boot lists PCR5 in its mismatch set
+#       (an independent gate: a PCR5-driven re-seal means the repartition broke
+#       the seal). The -k boot is legitimately controller-key (PCRs 8/9/13).
+#
+# Retrieval per the eve-device-logs skill: /persist/newlog has no top-level
+# dev.log; logs are in collect/ (plaintext) + keepSentQueue/ (gz); busybox find
+# has no -exec {} +, so use -exec ... \; per-file (zcat -f handles both).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+K_VERSION="${1:?expected -k version}"
+KVM_VERSION="${2:?expected kvm (conversion-capable) version}"
+
+raw=$(timeout 120 "$EDEN" eve ssh 'eve exec pillar sh -c "find /persist/newlog -name \"dev.log.*\" -exec zcat -f {} \; 2>/dev/null | grep -aE \"EVE version: |unlocked: method=|local TPM unseal FAILED\""' 2>/dev/null | grep -v 'level=fatal')
+
+echo "$raw" | KVM="$KVM_VERSION" K="$K_VERSION" python3 -c '
+import sys, os, re
+kvm = os.environ["KVM"]
+ev = []
+for line in sys.stdin:
+    sm = re.search(r"\"seconds\":(\d+)", line); nm = re.search(r"\"nanos\":(\d+)", line)
+    sec = int(sm.group(1)) if sm else 0; ns = int(nm.group(1)) if nm else 0
+    # per-boot version marker: device-steps echo on pillar.out, "<date> EVE version: <ver>".
+    # Exclude baseosmgr "to EVE version X" (source pillar, embedded) by requiring pillar.out.
+    if "pillar.out" in line and "EVE version:" in line:
+        mv = re.search(r"EVE version: ([0-9][A-Za-z0-9._+-]*)", line)
+        if mv:
+            ev.append((sec, ns, "VER", mv.group(1), []))
+        continue
+    if "unlocked: method=tpm-local-sealed" in line:
+        ev.append((sec, ns, "UNLOCK", "local", []))
+    elif "method=controller-key" in line:
+        pc = re.search(r"mismatching ?PCRs=\[([0-9 ]*)\]", line)
+        ev.append((sec, ns, "UNLOCK", "controller", pc.group(1).split() if pc else []))
+    elif "unseal FAILED" in line:
+        pc = re.search(r"mismatching ?PCRs=\[([0-9 ]*)\]", line)
+        ev.append((sec, ns, "FAILED", "failed", pc.group(1).split() if pc else []))
+ev.sort(key=lambda x: (x[0], x[1]))
+cur = None; unlocks = []; pcr5 = []
+for e in ev:
+    if e[2] == "VER":
+        cur = e[3]
+    else:
+        unlocks.append((cur, e[3], e[4]))
+        if "5" in e[4]:
+            pcr5.append((cur, e[3], e[4]))
+for u in unlocks:
+    print("  unlock> version=%s method=%s pcrs=%s" % (u[0], u[1], u[2] or "-"))
+kvmu = [u for u in unlocks if u[0] == kvm]
+print("SUMMARY: kvm_version=%s kvm_unlocks=%d pcr5_reseals=%d" % (kvm, len(kvmu), len(pcr5)))
+rc = 0
+if pcr5:
+    print("FAIL: PCR5 in a re-seal/unseal-FAILED set %s -> the repartition broke the TPM seal" % pcr5); rc = 1
+if not kvmu:
+    print("FAIL: no unlock recorded on the conversion-capable kvm version %s (post-grow boot not observed)" % kvm); rc = 1
+elif kvmu[-1][1] != "local":
+    print("FAIL: the LAST %s boot (post-grow) unlocked %s, not local -> repartition broke the seal" % (kvm, kvmu[-1][1])); rc = 1
+else:
+    print("OK: post-grow %s boot unlocked LOCALLY (%d kvm local unseal(s); no PCR5 re-seal)" % (kvm, sum(1 for u in kvmu if u[1] == "local")))
+sys.exit(rc)
+'
+
+-- wait-for-volumemgr-ready.sh --
+#!/bin/bash
+# Gate before the post-conversion redeploy. On EVE-k, volumemgr must finish its
+# "wait for kubernetes" / longhorn-ready init and RE-ESTABLISH the retained
+# ContentTree blobs in the EVE-k content store before a redeploy can REUSE them.
+# Deploying earlier causes the image to be re-downloaded (verified: ~44 MiB vs 0
+# with this gate). Wait for /run/volumemgr/VolumeMgrStatus/volumemgr.json
+# "Initialized":true (set after kubeapi.WaitForKubernetes returns).
+#
+# Instrumented: logs a timeline of (volumemgr Initialized, number of
+# ContentTreeStatus objects volumemgr currently tracks) so we can see WHEN the
+# store becomes ready and whether the retained ContentTree is recognized before
+# full Initialized — i.e. whether a narrower "blobs recognized" signal would let
+# the deploy fire sooner than waiting for the whole longhorn bring-up.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+probe() { timeout 8 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+ct_count() {
+    probe 'eve exec pillar sh -c "ls /run/volumemgr/ContentTreeStatus/*.json 2>/dev/null | wc -l"' \
+        | tr -d '\r' | grep -E '^[0-9]+$' | tail -1
+}
+last=""
+for _ in $(seq 1 240); do   # 40m at 10s (deploy-on-boot: this wait now starts at EVE-k boot, and Initialized lands ~24m later after kubeapi.WaitForKubernetes)
+    init=$(probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>/dev/null' \
+            | tr -d '\r' | grep -oE '"Initialized":[a-z]+')
+    ct=$(ct_count); [ -z "$ct" ] && ct='?'
+    sig="init=${init:-<none>} contenttrees=$ct"
+    if [ "$sig" != "$last" ]; then
+        echo "$(date +%H:%M:%S) [readiness] $sig"; last="$sig"
+    fi
+    if [ "$init" = '"Initialized":true' ]; then
+        echo "OK: volumemgr Initialized:true (contenttrees=$ct)"; exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: volumemgr did not reach Initialized:true within 40m" >&2
+probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>&1' >&2
+exit 1
+
+-- capture-blob-diagnostics.sh --
+#!/bin/bash
+# Observational diagnostics for the post-conversion blob-reuse question (does the
+# redeploy reuse the retained ContentTree, or re-download?). Runs after the app
+# reaches RUNNING, before the byte-count assertion, so it captures regardless of
+# pass/fail. Pulls the downloader / ContentTree / verifier lines from the EVE-k
+# boot out of /persist/newlog (see the eve-device-logs skill for the retrieval
+# form: logs live in collect/+keepSentQueue/, busybox find has no -exec {} +).
+# Never fails the test — purely informational.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+echo "--- live downloader RecvByteCount (per-URL) ---"
+timeout 15 "$EDEN" eve ssh -- 'eve exec pillar cat /run/downloader/MetricsMap/global.json 2>/dev/null' 2>/dev/null \
+    | grep -v 'level=fatal' | python3 -c '
+import sys, json
+try: d=json.load(sys.stdin)
+except Exception: sys.exit(0)
+for iface,conn in d.items():
+    for url,m in (conn.get("URLCounters") or {}).items():
+        rb=m.get("RecvByteCount",0)
+        if rb: print("  %d bytes  %s" % (rb, url))
+' 2>/dev/null || true
+echo "--- newlog: downloader/contenttree/verifier on the EVE-k boot (cache hit vs fetch) ---"
+timeout 90 "$EDEN" eve ssh 'eve exec pillar sh -c "find /persist/newlog -name \"dev.log.*\" -exec zcat -f {} \; 2>/dev/null | grep -aE \"already (in cache|verified|downloaded)|reusing|RecvByteCount|starting download|download done|ContentTree.*(DOWNLOAD|DELIVERED|LOADED)\""' 2>/dev/null \
+    | grep -v 'level=fatal' | grep -aoE 'msg\\":\\"[^"]*' | sed 's/^msg.":."/  newlog> /' | tail -30 || true
+echo "OK: blob diagnostics captured (informational)"
+
+-- wait-for-upgrade.sh --
+#!/bin/bash
+# Generic "wait for a same- or cross-flavor BaseOs upgrade to land": poll until
+# /run/eve-release equals the expected version AND IMGB is the active partition.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT_VERSION="${1:?expected version}"
+DEADLINE=$(( $(date +%s) + 1500 ))   # 25m
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then echo "$(date +%H:%M:%S): EVE unreachable (rebooting?)"; sleep 20; continue; fi
+    imgb_state=$(probe 'eve exec pillar cat /run/baseosmgr/ZbootStatus/IMGB.json' | grep -oP '"PartitionState":"\K[^"]+' | head -1)
+    [ -z "$imgb_state" ] && imgb_state='unknown'
+    echo "$(date +%H:%M:%S): running='$running' IMGB.PartitionState='$imgb_state'"
+    if [ "$running" = "$EXPECT_VERSION" ] && [ "$imgb_state" = "active" ]; then
+        echo "OK: upgrade to $running complete (IMGB active)"; exit 0
+    fi
+    sleep 20
+done
+echo "FAIL: upgrade to $EXPECT_VERSION did not complete in 25m (running='$running')" >&2
+exit 1
+
+-- assert-no-volumes.sh --
+#!/bin/bash
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 12); do
+    out=$("$EDEN" volume ls 2>/dev/null)
+    live=$(echo "$out" | awk 'NR>1 && ($(NF-1) == "IN_CONFIG" || $NF == "DELIVERED")')
+    if [ -z "$live" ]; then echo "OK: no live volumes"; exit 0; fi
+    sleep 5
+done
+echo "FAIL: live volume(s) present" >&2; "$EDEN" volume ls >&2; exit 1
+
+-- wait-for-app-running.sh --
+#!/bin/bash
+# Poll `eden pod ps` until xhv-app reaches LAST_STATE(EVE)=RUNNING. 25m budget
+# covers both the fast pre-conversion kvm case and the slow post-conversion
+# eve-k redeploy (longhorn install + VMI start).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 240); do   # 40m at 10s (deploy-on-boot: app RUNNING is gated on the full post-longhorn volume create + CDI upload + guest boot, ~27m observed)
+    line=$("$EDEN" pod ps 2>/dev/null | grep -E '^xhv-app\s')
+    if echo "$line" | grep -q 'RUNNING'; then
+        echo "OK: xhv-app RUNNING"; echo "$line"; exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: xhv-app did not reach RUNNING in 40m" >&2
+"$EDEN" pod ps >&2
+exit 1
+
+-- wait-for-app-gone.sh --
+#!/bin/bash
+# Poll until xhv-app fully disappears AND no per-instance VolumeStatus files
+# remain under /run/volumemgr/VolumeStatus/. Pillar tears down VM -> PVC ->
+# pubsub records; the cross-HV gate refuses kvm<->k while any Volume exists, so
+# we must reach zero before pushing the -k update.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+last_pod=""; last_vol=""
+for _ in $(seq 1 90); do   # 15m at 10s
+    pod_present=$("$EDEN" pod ps 2>/dev/null | grep -cE '^xhv-app\s')
+    # Count only per-instance .json; pubsub writes a never-removed `restarted`
+    # sentinel into this dir, so `ls | wc -l` is 1 even with no volumes.
+    vol_count=$(timeout 12 "$EDEN" eve ssh \
+        'eve exec pillar ls /run/volumemgr/VolumeStatus/*.json 2>/dev/null | wc -l' \
+        2>/dev/null | tr -d '\r' | tail -1)
+    [ -z "$vol_count" ] && vol_count="?"
+    if [ "$pod_present" = "0" ] && [ "$vol_count" = "0" ]; then
+        echo "OK: xhv-app removed and no VolumeStatus files remain"; exit 0
+    fi
+    if [ "$last_pod $last_vol" != "$pod_present $vol_count" ]; then
+        echo "$(date +%H:%M:%S) waiting for teardown: pod_rows=$pod_present vol_files=$vol_count"
+        last_pod=$pod_present; last_vol=$vol_count
+    fi
+    sleep 10
+done
+echo "FAIL: app+volumes did not fully clear in 15m" >&2
+"$EDEN" pod ps >&2
+"$EDEN" eve ssh 'eve exec pillar ls -la /run/volumemgr/VolumeStatus/ 2>&1' >&2
+exit 1
+
+-- snapshot-rcv-bytes.sh --
+#!/bin/bash
+# Snapshot cumulative RecvByteCount from /run/downloader/MetricsMap on EVE.
+# "pre" saves the baseline; "post-and-assert" recomputes the delta and asserts
+# it is below MAX_DELTA_BYTES (default 1 MiB). /run is tmpfs (reset on reboot),
+# so pre/post must bracket a single phase with no intervening reboot.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+MODE=${1:-pre}
+MAX_DELTA_BYTES=${2:-1048576}
+
+capture_recv_bytes() {
+    timeout 15 "$EDEN" eve ssh -- 'eve exec pillar cat /run/downloader/MetricsMap/global.json 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print(0); sys.exit(0)
+total = 0
+for iface, conn in d.items():
+    for url, m in (conn.get('URLCounters') or {}).items():
+        total += m.get('RecvByteCount', 0)
+print(total)
+"
+}
+
+case "$MODE" in
+    pre)
+        bytes=$(capture_recv_bytes)
+        echo "$bytes" > /tmp/xhv-rcv-pre.txt
+        echo "Pre-snapshot: RecvByteCount total = $bytes bytes"
+        ;;
+    post-and-assert)
+        post=$(capture_recv_bytes)
+        pre=$(cat /tmp/xhv-rcv-pre.txt 2>/dev/null || echo 0)
+        delta=$(( post - pre ))
+        echo "Post-snapshot: RecvByteCount total = $post bytes (pre was $pre, delta = $delta)"
+        if [ "$delta" -lt 0 ]; then
+            echo "FAIL: post < pre — counter went backwards (unexpected reboot?)" >&2; exit 1
+        fi
+        if [ "$delta" -lt "$MAX_DELTA_BYTES" ]; then
+            echo "OK: only $delta bytes received (< ${MAX_DELTA_BYTES}) — no image re-download"; exit 0
+        fi
+        echo "FAIL: $delta bytes received exceeds ${MAX_DELTA_BYTES} — image likely re-downloaded" >&2
+        exit 1
+        ;;
+    *) echo "Usage: $0 pre | post-and-assert [max-delta-bytes]" >&2; exit 1 ;;
+esac
+
+-- wait-for-ssh-to-app.sh --
+#!/bin/bash
+# wait-for-ssh-to-app.sh — the REAL guest-readiness / functional gate for the
+# eclient app instance, shared verbatim across the cross-HV / kvm->k tests.
+#
+# `eden pod ps` RUNNING (wait-for-app-running.sh) only reflects
+# AppInstState.EVEState — the ZSwState EVE reports. On EVE-k that is the
+# kubevirt VMI Running phase (qemu launched), NOT the guest kernel booted with
+# sshd accepting connections; on EVE-kvm the gap is smaller but still not
+# guest-ready. So pod-ps RUNNING is a cheap pre-filter only — success is
+# declared HERE, once an AUTHENTICATED ssh command has actually run inside the
+# guest and returned the expected output.
+#
+# Transport: host hostfwd 127.0.0.1:2223 -> EVE-eth0:2223 (eve.hostfwd
+# extension set by eden-bringup.sh) -> zedrouter NAT -> app:22 (eclient sshd).
+# The `eden sdn fwd` wrapper collapses to the same 127.0.0.1:hostport under the
+# non-SDN QEMU user-net these tests run in, so the direct path is used.
+#
+# FRESHNESS: host port 2223 is a static QEMU forward for the whole VM lifetime,
+# so after a delete+redeploy (or a reboot) a *stale* previous eclient could keep
+# answering on it and falsely satisfy a post-conversion check. To guard that,
+# each successful check records the guest's boot_id
+# (/proc/sys/kernel/random/boot_id — a fresh UUID per VM boot) to
+# /tmp/xhv-app-bootid. In "fresh" mode the check requires the connected guest's
+# boot_id to DIFFER from that recorded value; a matching (stale) instance is
+# treated as not-ready-yet and retried until the fresh deploy takes over the
+# port or the budget runs out.
+#
+# Fail-closed: a refused / closed / timed-out ssh, a non-eclient guest, or (in
+# fresh mode) only the stale instance answering, never prints the success
+# marker. On success it prints "OK: app SSH reachable" so the escript pins the
+# framework verdict to a real session:
+#     exec -t 5m bash wait-for-ssh-to-app.sh
+#     stdout 'OK: app SSH reachable'
+#
+# Args (optional): $1 host port (default 2223); $2 attempts, 10s apart
+# (default 30 => 5m); $3 = "fresh" to require a NEW guest instance vs the
+# boot_id the previous successful check recorded (use after a redeploy/reboot).
+#
+# Cert: ssh refuses group-readable keys, so the eclient id_rsa is copied to a
+# 0600 temp file. testscript sets HOME=/no-home, so the real home is resolved
+# from the running UID; dist/tests is only populated by a full `make eden`, so
+# fall back to the master/main reference clones.
+set -uo pipefail
+PORT="${1:-2223}"
+ATTEMPTS="${2:-30}"
+FRESH="${3:-}"
+BOOTID_FILE=/tmp/xhv-app-bootid
+EDEN_TESTS="{{EdenConfig "eden.tests"}}"
+USER_HOME=$(getent passwd "$(id -u)" | cut -d: -f6)
+SRC=""
+for c in "$EDEN_TESTS/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/master/eden/tests/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/main/eden/tests/eclient/image/cert/id_rsa"; do
+    if [ -f "$c" ]; then SRC="$c"; break; fi
+done
+if [ -z "$SRC" ]; then
+    echo "FAIL: could not locate eclient id_rsa cert (EDEN_TESTS=$EDEN_TESTS, USER_HOME=$USER_HOME)" >&2
+    exit 1
+fi
+KEY=$(mktemp); install -m 600 "$SRC" "$KEY"; trap 'rm -f "$KEY"' EXIT
+SSH_OPTS=(-o ConnectTimeout=10 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -i "$KEY")
+prev=""
+[ -f "$BOOTID_FILE" ] && prev=$(cat "$BOOTID_FILE" 2>/dev/null)
+connected=0
+saw_stale=0
+for _ in $(seq 1 "$ATTEMPTS"); do
+    # One round-trip proves auth, the eclient identity, and the guest boot_id.
+    # "AUTHED" is echoed before the identity check, so a connect+auth that fails
+    # only the /etc/issue match is distinguishable from a never-connected ssh.
+    out=$(ssh "${SSH_OPTS[@]}" root@127.0.0.1 -p "$PORT" \
+        'echo AUTHED; grep -q Ubuntu /etc/issue && cat /proc/sys/kernel/random/boot_id' \
+        2>/dev/null)
+    case "$out" in *AUTHED*) connected=1 ;; esac
+    bootid=$(printf '%s\n' "$out" | tr -d '\r' | grep -Ex '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | tail -1)
+    if [ -n "$bootid" ]; then
+        if [ "$FRESH" = "fresh" ] && [ -n "$prev" ] && [ "$bootid" = "$prev" ]; then
+            # Still the previous instance on the static port — wait for the fresh
+            # deploy/boot to take over the NAT before declaring success.
+            saw_stale=1; sleep 10; continue
+        fi
+        echo "$bootid" > "$BOOTID_FILE"
+        echo "OK: app SSH reachable (port=$PORT, boot_id=$bootid, fresh=${FRESH:-no}, cert=$SRC)"
+        exit 0
+    fi
+    sleep 10
+done
+budget=$(( ATTEMPTS * 10 ))
+if [ "$saw_stale" = 1 ]; then
+    echo "FAIL: only the previous app instance (boot_id=$prev) answered within ${budget}s — the fresh deploy never took over the port (stale instance)" >&2
+elif [ "$connected" = 1 ]; then
+    echo "FAIL: ssh connected+authed but the guest never matched the eclient (grep Ubuntu /etc/issue) within ${budget}s (port=$PORT)" >&2
+else
+    echo "FAIL: app never answered an authenticated ssh within ${budget}s (port=$PORT, cert=$SRC)" >&2
+fi
+echo "--- host TCP probe ---" >&2
+( exec 3<>/dev/tcp/127.0.0.1/"$PORT" ) 2>&1 || true
+exit 1
+
+-- wait-for-reboot-and-back.sh --
+#!/bin/bash
+# Wait for EVE to actually reboot. Three phases:
+#   1. Wait up to 2m for SSH to start failing (kernel going down).
+#   2. Wait up to 10m for SSH to succeed AGAIN (kernel up + sshd up).
+#   3. Verify /proc/uptime < 120s (proves an actual reboot happened,
+#      not a transient SSH glitch).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+
+echo "phase 1: waiting for SSH to start failing (reboot underway)"
+went_down=0
+for i in $(seq 1 24); do   # 24 * 5s = 2m
+    if ! timeout 5 "$EDEN" eve ssh 'true' 2>/dev/null; then
+        echo "$(date +%H:%M:%S) SSH unreachable -- reboot in progress"
+        went_down=1
+        break
+    fi
+    sleep 5
+done
+if [ "$went_down" = "0" ]; then
+    echo "FAIL: SSH stayed reachable for 2m -- reboot did not start?" >&2
+    exit 1
+fi
+
+echo "phase 2: waiting for SSH to come back (post-reboot kernel + sshd up)"
+came_up=0
+for i in $(seq 1 60); do   # 60 * 10s = 10m
+    if timeout 8 "$EDEN" eve ssh 'true' 2>/dev/null; then
+        echo "$(date +%H:%M:%S) SSH back online"
+        came_up=1
+        break
+    fi
+    sleep 10
+done
+if [ "$came_up" = "0" ]; then
+    echo "FAIL: SSH did not come back within 10m" >&2
+    exit 1
+fi
+
+echo "phase 3: verifying uptime reset (< 120s)"
+uptime_secs=$(timeout 10 "$EDEN" eve ssh 'cat /proc/uptime' 2>/dev/null | tr -d '\r' | awk '{print int($1)}' | head -1)
+if [ -z "$uptime_secs" ]; then
+    echo "FAIL: could not read /proc/uptime after reboot" >&2
+    exit 1
+fi
+if [ "$uptime_secs" -gt 120 ]; then
+    echo "FAIL: uptime $uptime_secs > 120s -- SSH glitch, not a real reboot" >&2
+    exit 1
+fi
+echo "OK: EVE rebooted, uptime now ${uptime_secs}s"
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- wait-for-longhorn-sc.sh --
+#!/bin/bash
+# Wait until the EVE-k `longhorn` StorageClass exists (longhorn deployed + its CSI
+# provisioner up). On a freshly-converted EVE-k node longhorn can take tens of
+# minutes to deploy -- well after the device reports ONLINE -- so wait for it
+# EXPLICITLY here, before deploying/waiting for an app whose volume needs longhorn.
+# This separates cluster-bringup time from app-bringup time: the wait-for-app-running
+# that follows can be short, and a failure here clearly says "longhorn", not "app".
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 90); do   # ~45m at 30s
+    if "$EDEN" eve ssh -- 'eve exec kube kubectl get sc 2>/dev/null' 2>/dev/null | grep -qE '^longhorn'; then
+        echo "OK: longhorn StorageClass ready"; exit 0
+    fi
+    sleep 30
+done
+echo "FAIL: longhorn StorageClass not ready within budget" >&2; exit 1

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_geom.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_geom.txt
@@ -1,0 +1,453 @@
+# Test: EVE-kvm -> EVE-k boot-disk repartition, GEOMETRY ONLY, parameterized by
+# the STARTING release. One escript, many starts: the matrix runner
+# (run-kvm-to-k-geom-matrix.sh) brings EVE up on each release in turn and runs
+# this with BRINGUP_EVE_VER + the expected start sizes.
+#
+# Unlike update_eve_image_kvm_to_k_resize.txt this deliberately does NOT deploy an
+# app, defer content-tree deletes, or check blob reuse or the TPM seal. It proves
+# exactly one thing: whatever the starting geometry, driving kvm->k ends with the
+# full EVE-k target layout of 2+2+10+10 GiB, i.e. ESP-A 2G, the reserved ESP-B 2G,
+# IMGA 10G, IMGB 10G.
+#
+# Image sequence (same three-hop shape as the resize test):
+#   1. START     : EVE up on the parameterized BRINGUP_EVE_VER (a stock release
+#                  whose geometry is asserted against START_* below). Does NOT carry
+#                  the conversion code.
+#   2. kvm hop   : BaseOs-update kvm->kvm to the conversion-capable RESIZE_EVE_VER
+#                  build. Same geometry; lands the conversion code.
+#   3. k image   : BaseOs-update kvm->k. The cross-flavor seam arms the offline
+#                  repartition; storage-init grows the disk to the EVE-k target.
+#
+# NOTE (TDD): as of this writing the in-field resizer (pkg/storage-resizer,
+# sizecheck.go: espTargetBytes=2G, imgTargetBytes=10G, spaceNeededBytes=2+10+10)
+# grows only ESP/IMGA/IMGB and does NOT create the reserved ESP-B. So the final
+# assertion FAILS until the conversion is taught to carve ESP-B. This escript is
+# the spec for that work.
+#
+# Parameters (env):
+#   RESIZE_EVE_VER  (required) version base of the local conversion-capable images,
+#                   without the -<hv>-<arch> suffix, e.g. "0.0.0-kvm-to-k-resize-<sha>".
+#   RESIZE_EVE_REG  (default lfedge/eve) image registry/repo namespace.
+#   BRINGUP_EVE_VER (required) the starting release EVE was brought up on; asserted
+#                   as a substring of /run/eve-release. No default — the runner
+#                   sets it per release.
+#   START_ESP_MIB   (default 0) expected starting ESP-A size in MiB; 0 skips the
+#   START_IMGA_MIB  (default 0)  size band check for that partition (presence and
+#   START_IMGB_MIB  (default 0)  the ESP-B flag are always checked).
+#   START_HAS_ESPB  (default 0) 1 if the starting image already has the reserved
+#                   ESP-B (only the TBD post-ESP-B releases do).
+
+{{$arch := EdenConfig "eve.arch"}}
+
+{{$resize_ver_env := EdenGetEnv "RESIZE_EVE_VER"}}
+{{$resize_ver := "REPLACE-WITH-RESIZE-VERSION"}}
+{{if $resize_ver_env}}{{$resize_ver = $resize_ver_env}}{{end}}
+
+{{$resize_reg_env := EdenGetEnv "RESIZE_EVE_REG"}}
+{{$resize_reg := "lfedge/eve"}}
+{{if $resize_reg_env}}{{$resize_reg = $resize_reg_env}}{{end}}
+
+{{$bringup_ver_env := EdenGetEnv "BRINGUP_EVE_VER"}}
+{{$bringup_ver := ""}}
+{{if $bringup_ver_env}}{{$bringup_ver = $bringup_ver_env}}{{end}}
+
+{{$start_esp := EdenGetEnv "START_ESP_MIB"}}{{if not $start_esp}}{{$start_esp = "0"}}{{end}}
+{{$start_imga := EdenGetEnv "START_IMGA_MIB"}}{{if not $start_imga}}{{$start_imga = "0"}}{{end}}
+{{$start_imgb := EdenGetEnv "START_IMGB_MIB"}}{{if not $start_imgb}}{{$start_imgb = "0"}}{{end}}
+{{$start_espb := EdenGetEnv "START_HAS_ESPB"}}{{if not $start_espb}}{{$start_espb = "0"}}{{end}}
+
+{{$kvm_short := printf "%s-kvm-%s" $resize_ver $arch}}
+{{$k_short   := printf "%s-k-%s" $resize_ver $arch}}
+
+# Step 0: pre-flight. Fail fast on missing params and a dirty device; shorten the
+# baseimage commit timer so updates apply fast.
+message 'pre-flight: parameters + clean state'
+exec -t 1m bash require-resize-ver.sh
+exec -t 1m bash require-bringup-ver.sh
+exec -t 1m bash assert-no-volumes.sh
+eden -t 1m pod ps
+! stdout 'IN_CONFIG'
+eden controller edge-node update --config timer.test.baseimage.update=30
+
+# Step 1: confirm the starting release and its geometry (parameterized per release).
+message 'baseline: confirm we are on the expected START release'
+exec -t 3m bash assert-running-version.sh {{ $bringup_ver }}
+message 'baseline: confirm the expected START boot-disk geometry'
+exec -t 2m bash capture-geom.sh assert-start {{ $start_esp }} {{ $start_imga }} {{ $start_imgb }} {{ $start_espb }}
+
+# Step 2: BaseOs-update kvm->kvm to the conversion-capable build. Same geometry;
+# this only lands the conversion code.
+message 'downloading conversion-capable kvm rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$resize_ver}} --eve-hv=kvm --eve-registry={{$resize_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs'
+
+message 'pushing kvm->kvm BaseOs update (lands conversion code, geometry unchanged)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs --os-version={{ $kvm_short }} -m adam://
+! stderr .
+
+message 'waiting for kvm->kvm upgrade to complete'
+exec -t 25m bash wait-for-upgrade.sh {{ $kvm_short }}
+
+# A same-flavor upgrade must NOT repartition — re-assert the START geometry so a
+# regression that resizes on a kvm->kvm hop is caught here.
+message 'post-kvm-upgrade: geometry must be UNCHANGED'
+exec -t 2m bash capture-geom.sh assert-start {{ $start_esp }} {{ $start_imga }} {{ $start_imgb }} {{ $start_espb }}
+
+# Step 3: BaseOs-update kvm->k. The cross-flavor seam triggers the offline
+# repartition; watch it to completion (state/sub-state transitions), tolerating the
+# reboots the offline resize needs.
+message 'downloading conversion-capable k rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$resize_ver}} --eve-hv=k --eve-registry={{$resize_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs'
+
+message 'pushing kvm->k BaseOs update (triggers boot-disk repartition)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs --os-version={{ $k_short }} -m adam://
+! stderr .
+
+message 'waiting for + watching the kvm->k repartition (logging state transitions)'
+# 90m budget: a start whose IMGA/IMGB must GROW (e.g. 16.13.0's 4->10 GiB) copies
+# several GiB during the online grow, which on constrained I/O can take ~30m before
+# the offline shrink + EVE-k boot even begin. Starts that only create ESP-B (17.0.0)
+# or copy tiny partitions (10.1.0/12.1.0) finish far sooner.
+exec -t 90m bash watch-conversion-geom.sh {{ $k_short }}
+
+# Step 4: the one assertion — the boot disk ended on the full EVE-k target of
+# 2+2+10+10 (ESP-A 2G, reserved ESP-B 2G, IMGA 10G, IMGB 10G).
+message 'asserting final boot-disk geometry: 2+2+10+10 (ESP-A, ESP-B, IMGA, IMGB)'
+exec -t 2m bash capture-geom.sh assert-final
+
+# Cleanup.
+message 'cleanup'
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs.ver
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs.ver
+exec sleep 10
+eden eve reset
+
+-- require-resize-ver.sh --
+#!/bin/bash
+# Fail fast if RESIZE_EVE_VER wasn't supplied (the escript default is a
+# placeholder). Without it the eveimage-update steps would try a bogus version.
+set -uo pipefail
+VER='{{ $resize_ver }}'
+if [ -z "$VER" ] || [ "$VER" = "REPLACE-WITH-RESIZE-VERSION" ]; then
+    echo "FAIL: RESIZE_EVE_VER not set." >&2
+    echo "      Export the version base of your conversion-capable build, e.g." >&2
+    echo "      RESIZE_EVE_VER=0.0.0-kvm-to-k-resize-1a2b3c4d (the part before" >&2
+    echo "      -kvm-amd64 / -k-amd64 in the docker tag)." >&2
+    exit 1
+fi
+echo "OK: RESIZE_EVE_VER=$VER"
+
+-- require-bringup-ver.sh --
+#!/bin/bash
+# Fail fast if BRINGUP_EVE_VER wasn't supplied. This escript does not install the
+# base image — the runner brings EVE up on the release under test and passes its
+# version here so Step 1 can confirm we are on the intended start.
+set -uo pipefail
+VER='{{ $bringup_ver }}'
+if [ -z "$VER" ]; then
+    echo "FAIL: BRINGUP_EVE_VER not set." >&2
+    echo "      Set it to the release EVE was brought up on (e.g. 10.1.0, 16.13.0," >&2
+    echo "      17.0.0-rc1). The matrix runner sets it per release." >&2
+    exit 1
+fi
+echo "OK: BRINGUP_EVE_VER=$VER"
+
+-- assert-no-volumes.sh --
+#!/bin/bash
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 12); do
+    out=$("$EDEN" volume ls 2>/dev/null)
+    live=$(echo "$out" | awk 'NR>1 && ($(NF-1) == "IN_CONFIG" || $NF == "DELIVERED")')
+    if [ -z "$live" ]; then echo "OK: no live volumes"; exit 0; fi
+    sleep 5
+done
+echo "FAIL: live volume(s) present" >&2; "$EDEN" volume ls >&2; exit 1
+
+-- assert-running-version.sh --
+#!/bin/bash
+# Sanity-check that EVE is running the expected START release before the conversion
+# starts. Matches the expected version as a substring of /run/eve-release (the full
+# "<ver>-<hv>-<arch>" form), so "10.1.0" accepts the kvm bringup image without
+# pinning the hv/arch suffix.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT="${1:?expected bringup version substring}"
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+for _ in $(seq 1 18); do   # ~3m at 10s; tolerate ssh not up yet
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -n "$running" ]; then
+        case "$running" in
+            *"$EXPECT"*)
+                echo "OK: running the expected START release ('$running' contains '$EXPECT')"
+                exit 0 ;;
+            *)
+                echo "FAIL: running version '$running' does not match expected START '$EXPECT'." >&2
+                echo "      Bring eve up on '$EXPECT' before this test, or set BRINGUP_EVE_VER" >&2
+                echo "      to the release you brought up on." >&2
+                exit 1 ;;
+        esac
+    fi
+    sleep 10
+done
+echo "FAIL: could not read /run/eve-release (ssh down / device not up?)" >&2
+exit 1
+
+-- capture-geom.sh --
+#!/bin/bash
+# Read the boot-disk GPT geometry from EVE (lsblk over ssh) and either assert the
+# expected STARTING geometry for this release, or assert the FINAL EVE-k target.
+#
+# The two ESPs (ESP-A and the reserved ESP-B) share the GPT PARTLABEL "EFI System"
+# and type ef00; they are distinguished ONLY by PARTUUID (pkg/mkimage-raw-efi/
+# make-raw: ESP-A = ...30051, ESP-B = ...30056). So this reads PARTUUID too and
+# COUNTS the "EFI System" partitions rather than matching on the (shared) label.
+#
+# Usage:
+#   capture-geom.sh report
+#   capture-geom.sh assert-start <esp_mib> <imga_mib> <imgb_mib> <has_espb 0|1>
+#   capture-geom.sh assert-final
+#
+# assert-final target (EVE-k, WITH the reserved ESP-B):
+#   ESP-A 2 GiB, ESP-B 2 GiB, IMGA 10 GiB, IMGB 10 GiB  ==  "2+2+10+10".
+# The in-field resizer does not yet create ESP-B (see the escript header), so
+# assert-final is expected to FAIL until that lands — this is the spec for it.
+#
+# Sizes/uuids come from `lsblk -b -P -o NAME,PARTLABEL,PARTUUID,SIZE /dev/sda` — the
+# same lsblk pillar's diskmetrics uses. Disk is /dev/sda under eden (qemu SATA/IDE).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+MODE=${1:-report}
+GiB=$(( 1024 * 1024 * 1024 ))
+MiB=$(( 1024 * 1024 ))
+
+read_geom() {
+    timeout 20 "$EDEN" eve ssh -- \
+        'eve exec pillar lsblk -b -P -o NAME,PARTLABEL,PARTUUID,SIZE /dev/sda 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c '
+import sys, re
+esp = []; img = {}
+for line in sys.stdin:
+    m = dict(re.findall(r"(\w+)=\"([^\"]*)\"", line))
+    lbl = m.get("PARTLABEL", ""); sz = m.get("SIZE", ""); uu = m.get("PARTUUID", "")
+    if not sz:
+        continue
+    if lbl == "EFI System":
+        esp.append((int(sz), uu))
+    elif lbl in ("IMGA", "IMGB"):
+        img[lbl] = int(sz)
+esp.sort()
+hasb = 1 if any(u.endswith("30056") for _, u in esp) else 0
+print("ESP_COUNT=%d" % len(esp))
+print("ESP_MIN=%d" % (esp[0][0] if esp else 0))
+print("ESP_MAX=%d" % (esp[-1][0] if esp else 0))
+print("ESP_HAS_B=%d" % hasb)
+print("ESP_UUIDS=%s" % ",".join(u for _, u in esp))
+print("IMGA=%d" % img.get("IMGA", 0))
+print("IMGB=%d" % img.get("IMGB", 0))
+'
+}
+
+load() {
+    eval "$(read_geom)"
+    if [ "${ESP_COUNT:-0}" = "0" ] || [ "${IMGA:-0}" = "0" ] || [ "${IMGB:-0}" = "0" ]; then
+        echo "FAIL: could not read partition geometry from /dev/sda" >&2
+        timeout 20 "$EDEN" eve ssh -- 'eve exec pillar lsblk -o NAME,PARTLABEL,PARTUUID,SIZE /dev/sda' >&2 2>/dev/null
+        exit 1
+    fi
+}
+
+report() {
+    printf '  ESPs : count=%s  sizes=[%s..%s] MiB  reserved_ESP_B=%s  uuids=[%s]\n' \
+        "$ESP_COUNT" "$(( ESP_MIN / MiB ))" "$(( ESP_MAX / MiB ))" "$ESP_HAS_B" "$ESP_UUIDS"
+    printf '  IMGA : %s MiB\n' "$(( IMGA / MiB ))"
+    printf '  IMGB : %s MiB\n' "$(( IMGB / MiB ))"
+}
+
+# in_band <actual_bytes> <expected_mib> <name>: expected 0 => skip. Otherwise accept
+# actual within [0.5x, 2x] of expected — loose enough for GPT alignment jitter, tight
+# enough to tell each release's start size apart from the 2G/10G targets.
+in_band() {
+    local actual=$1 exp_mib=$2 name=$3 lo hi
+    [ "$exp_mib" = "0" ] && return 0
+    lo=$(( exp_mib * MiB / 2 )); hi=$(( exp_mib * MiB * 2 ))
+    if [ "$actual" -lt "$lo" ] || [ "$actual" -gt "$hi" ]; then
+        echo "FAIL: $name = $(( actual / MiB )) MiB, expected ~${exp_mib} MiB (band $(( lo / MiB ))..$(( hi / MiB )) MiB)" >&2
+        return 1
+    fi
+    return 0
+}
+
+case "$MODE" in
+    report)
+        load; echo "Current boot-disk geometry:"; report
+        ;;
+    assert-start)
+        E_ESP=${2:?esp_mib}; E_IMGA=${3:?imga_mib}; E_IMGB=${4:?imgb_mib}; E_ESPB=${5:?has_espb}
+        load
+        echo "START geometry:"; report
+        rc=0
+        in_band "$ESP_MIN" "$E_ESP"  "ESP"  || rc=1
+        in_band "$IMGA"    "$E_IMGA" "IMGA" || rc=1
+        in_band "$IMGB"    "$E_IMGB" "IMGB" || rc=1
+        if [ "$ESP_HAS_B" != "$E_ESPB" ]; then
+            if [ "$E_ESPB" = "1" ]; then
+                echo "FAIL: expected the reserved ESP-B on this START release, none found (ESP_COUNT=$ESP_COUNT)" >&2
+            else
+                echo "FAIL: START release already has the reserved ESP-B (already converted?) ESP_COUNT=$ESP_COUNT" >&2
+            fi
+            rc=1
+        fi
+        [ "$rc" = "0" ] && echo "OK: START geometry matches the expected layout for this release"
+        exit "$rc"
+        ;;
+    assert-final)
+        load
+        echo "FINAL geometry:"; report
+        rc=0
+        # Target: two ESPs each ~2 GiB (ESP-A + reserved ESP-B), IMGA/IMGB ~10 GiB.
+        # Floors sit below target to tolerate alignment while staying unambiguous.
+        [ "$ESP_COUNT" -ge 2 ] || { echo "FAIL: expected 2 ESPs (ESP-A + reserved ESP-B); found $ESP_COUNT — the conversion did not create ESP-B" >&2; rc=1; }
+        [ "$ESP_HAS_B" = "1" ] || { echo "FAIL: no partition carries the reserved ESP-B PARTUUID (...30056)" >&2; rc=1; }
+        [ "$ESP_MIN" -ge $(( 3 * GiB / 2 )) ] || { echo "FAIL: an ESP is < 1.5 GiB (target 2 GiB): min=$(( ESP_MIN / MiB )) MiB" >&2; rc=1; }
+        [ "$IMGA" -ge $(( 9 * GiB )) ] || { echo "FAIL: IMGA < 9 GiB floor (target 10 GiB): $(( IMGA / MiB )) MiB" >&2; rc=1; }
+        [ "$IMGB" -ge $(( 9 * GiB )) ] || { echo "FAIL: IMGB < 9 GiB floor (target 10 GiB): $(( IMGB / MiB )) MiB" >&2; rc=1; }
+        [ "$rc" = "0" ] && echo "OK: final boot-disk geometry is 2+2+10+10 (ESP-A + reserved ESP-B 2G each, IMGA/IMGB 10G)"
+        exit "$rc"
+        ;;
+    *)
+        echo "Usage: $0 report | assert-start <esp_mib> <imga_mib> <imgb_mib> <has_espb> | assert-final" >&2
+        exit 1
+        ;;
+esac
+
+-- wait-for-upgrade.sh --
+#!/bin/bash
+# Wait for a same- or cross-flavor BaseOs upgrade to land: poll until
+# /run/eve-release equals the expected version AND IMGB is the active partition.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT_VERSION="${1:?expected version}"
+DEADLINE=$(( $(date +%s) + 1500 ))   # 25m
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then echo "$(date +%H:%M:%S): EVE unreachable (rebooting?)"; sleep 20; continue; fi
+    imgb_state=$(probe 'eve exec pillar cat /run/baseosmgr/ZbootStatus/IMGB.json' | grep -oP '"PartitionState":"\K[^"]+' | head -1)
+    [ -z "$imgb_state" ] && imgb_state='unknown'
+    echo "$(date +%H:%M:%S): running='$running' IMGB.PartitionState='$imgb_state'"
+    if [ "$running" = "$EXPECT_VERSION" ] && [ "$imgb_state" = "active" ]; then
+        echo "OK: upgrade to $running complete (IMGB active)"; exit 0
+    fi
+    sleep 20
+done
+echo "FAIL: upgrade to $EXPECT_VERSION did not complete in 25m (running='$running')" >&2
+exit 1
+
+-- watch-conversion-geom.sh --
+#!/bin/bash
+# Drive AND watch the kvm->k conversion to completion, logging state/sub-state
+# TRANSITIONS. The repartition runs OFFLINE in storage-init (the boot disk's GPT
+# can't be re-read live while its rootfs is mounted): baseosmgr arms the resize flag
+# and reboots, storage-init grows the partitions (possibly with a busy-disk
+# reboot-to-apply), the device re-checks and does the cross-flavor A/B install, then
+# boots EVE-k. Completion is slot-agnostic (the grow can relocate the active slot).
+#
+# Unlike the resize test's watch-conversion.sh this does NO /persist stress-fill
+# cleanup — this escript deploys no app and pre-fills nothing, so /persist stays
+# near-empty and there is nothing to free before the EVE-k cluster installs.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+K_VERSION="${1:?expected -k version}"
+DEADLINE=$(( $(date +%s) + 5400 ))   # 90m (matches the escript exec -t; see the budget note there)
+
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+substate_name() {
+    case "$1" in
+        1) echo preflight ;;
+        2) echo rebooting-to-resize ;;
+        3) echo making-space ;;
+        4) echo creating-partitions ;;
+        5) echo renaming-partitions ;;
+        6) echo installing ;;
+        7) echo rebooting-to-target ;;
+        *) echo "sub_$1" ;;
+    esac
+}
+
+# Controller's view from adam: the latest ZiDevice report's state + sub_state.
+ctrl_state() {
+    local c st sub
+    c=$(timeout 20 "$EDEN" info --tail 8 2>/dev/null | grep -a '^content: ztype:ZiDevice' | tail -1)
+    st=$(echo "$c" | grep -oE 'state:ZDEVICE_STATE_[A-Z_]+' | head -1 | cut -d: -f2)
+    sub=$(echo "$c" | grep -oE 'sub_state:ZDEVICE_SUBSTATE_[A-Z_]+' | head -1 | cut -d: -f2)
+    echo "${st:-?}/${sub:-NONE}"
+}
+
+# Which partition (IMGA/IMGB) is active, and the version on it.
+active_part() {
+    probe 'eve exec pillar sh -c "cat /run/baseosmgr/ZbootStatus/IMGA.json /run/baseosmgr/ZbootStatus/IMGB.json 2>/dev/null"' | python3 -c '
+import sys, json, re
+act = "?"; ver = "?"
+for m in re.finditer(r"\{.*?\}", sys.stdin.read(), re.S):
+    try:
+        o = json.loads(m.group(0))
+    except Exception:
+        continue
+    if o.get("PartitionState") == "active":
+        act = o.get("PartitionLabel", "?"); ver = o.get("ShortVersion", "?")
+print("%s:%s" % (act, ver))' 2>/dev/null || echo "?:?"
+}
+
+last_sig=""
+reboots=0
+unreachable_run=0
+seen_converting=0
+
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then
+        unreachable_run=$(( unreachable_run + 1 ))
+        if [ "$last_sig" != "UNREACHABLE" ]; then
+            echo "$(date +%H:%M:%S) [transition] EVE unreachable (rebooting?)"
+            last_sig="UNREACHABLE"
+        fi
+        sleep 15
+        continue
+    fi
+    if [ "$unreachable_run" -ge 2 ]; then
+        reboots=$(( reboots + 1 ))
+        echo "$(date +%H:%M:%S) observed a reboot (count=$reboots)"
+    fi
+    unreachable_run=0
+
+    actver=$(active_part)
+    bos=$(probe 'eve exec pillar sh -c "cat /run/baseosmgr/BaseOsStatus/*.json 2>/dev/null"')
+    conv=$(echo "$bos" | grep -o '"Converting":[a-z]*' | head -1 | cut -d: -f2); [ -z "$conv" ] && conv=false
+    csub=$(echo "$bos" | grep -o '"ConvertSubState":[0-9]*' | head -1 | cut -d: -f2); [ -z "$csub" ] && csub=0
+    [ "$conv" = "true" ] && seen_converting=1
+    dev=$(ctrl_state)
+
+    sig="run=$running active=$actver dev=$dev converting=$conv csub=$csub($(substate_name "$csub"))"
+    if [ "$sig" != "$last_sig" ]; then
+        echo "$(date +%H:%M:%S) [transition] $sig"
+        last_sig="$sig"
+    fi
+
+    # Done: booted the -k version and the conversion cleared. Slot-agnostic.
+    if [ "$running" = "$K_VERSION" ] && [ "$conv" = "false" ] && \
+       printf '%s' "$actver" | grep -q ":$K_VERSION$"; then
+        echo "OK: conversion+upgrade complete (active=$actver, running=$running)"
+        echo "    observed: CONVERTING=$seen_converting reboots=$reboots"
+        exit 0
+    fi
+    sleep 15
+done
+echo "FAIL: watch timeout (90m). running='${running:-?}' active='${actver:-?}' dev='${dev:-?}'" >&2
+echo "      observed: CONVERTING=$seen_converting reboots=$reboots" >&2
+exit 1

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_grow.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_grow.txt
@@ -1,0 +1,1169 @@
+# Test: EVE-kvm -> EVE-k in-field boot-disk repartition (small -> large GPT
+# geometry conversion), driven end-to-end through the controller, with a
+# deferred-content-delete app so a post-conversion redeploy needs no download.
+#
+# VARIANT: grow-only (no shrink). The boot disk already has >= 22 GB free after
+# the last partition, so storage-resizer's check returns `grow`: baseosmgr arms a
+# grow-only repartition (no /persist backup) and reboots, and storage-init grows
+# ESP/IMGA/IMGB into the free tail OFFLINE, leaving P3 UNCHANGED. (The sibling
+# update_eve_image_kvm_to_k_resize.txt covers the shrink variant, where P3 fills
+# the disk and must be shrunk first.) The grow runs offline because the boot
+# disk's GPT can't be re-read live while its rootfs is mounted.
+#
+# Image sequence (exact — see README_kvm_to_k_grow.md for how to build them):
+#   1. SMALL start + FREE TAIL: EVE up on a stock 12.1.0-kvm install (small:
+#                     36 MiB ESP, 512 MiB IMGA/IMGB), with the disk enlarged
+#                     host-side so >= 22 GB is unallocated after P3.
+#   2. kvm conversion-capable: BaseOs-update kvm->kvm to the kvm-to-k-resize
+#                     build. Same geometry; lands the conversion code. Then settle
+#                     the vault to a local TPM unlock.
+#   3. k image      : BaseOs-update kvm->k. The cross-flavor seam arms the offline
+#                     repartition; storage-init grows ESP/IMGA/IMGB, then boots
+#                     EVE-k on the now-large geometry.
+#
+# What it asserts:
+#   - the boot disk started SMALL and ended LARGE (per-partition sizes; P3
+#     unchanged on this grow-only path);
+#   - the conversion was observed (device state/sub-state transitions logged);
+#   - the repartition preserved the TPM seal (post-hoc from /persist/newlog: the
+#     last boot on the conversion-capable kvm image unsealed locally, no PCR5
+#     re-seal; the EVE-k boot's controller-key is the expected new-rootfs behavior);
+#   - the redeploy reused cached blobs (downloader received < 1 MiB).
+#
+# Parameters (env):
+#   RESIZE_EVE_VER  (required) version base of the local kvm-to-k-resize images,
+#                   without the -<hv>-<arch> suffix, e.g. "0.0.0-kvm-to-k-resize-<sha>".
+#                   No default for a local build; the test fails fast if unset.
+#   RESIZE_EVE_REG  (default lfedge/eve) image registry/repo namespace; the full
+#                   docker tag is <RESIZE_EVE_REG>:<RESIZE_EVE_VER>-<hv>-<arch>.
+#                   eve-build.sh tags under lfedge/eve, so override only if you
+#                   keep EVE images under a different namespace.
+#   BRINGUP_EVE_VER (default 12.1.0) substring the running base release must
+#                   contain at Step 1 — this escript does NOT install the base
+#                   image; bringup is manual (see the README).
+
+{{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+
+{{$arch := EdenConfig "eve.arch"}}
+
+{{$resize_ver_env := EdenGetEnv "RESIZE_EVE_VER"}}
+{{$resize_ver := "REPLACE-WITH-RESIZE-VERSION"}}
+{{if $resize_ver_env}}{{$resize_ver = $resize_ver_env}}{{end}}
+
+{{$resize_reg_env := EdenGetEnv "RESIZE_EVE_REG"}}
+{{$resize_reg := "lfedge/eve"}}
+{{if $resize_reg_env}}{{$resize_reg = $resize_reg_env}}{{end}}
+
+{{$bringup_ver_env := EdenGetEnv "BRINGUP_EVE_VER"}}
+{{$bringup_ver := "12.1.0"}}
+{{if $bringup_ver_env}}{{$bringup_ver = $bringup_ver_env}}{{end}}
+
+{{$kvm_short := printf "%s-kvm-%s" $resize_ver $arch}}
+{{$k_short   := printf "%s-k-%s" $resize_ver $arch}}
+
+# Step 0: pre-flight. Fail fast if the version param wasn't supplied, confirm
+# a clean device, and shorten the baseimage commit timer so updates apply fast.
+message 'pre-flight: parameters + clean state'
+exec -t 1m bash require-resize-ver.sh
+exec -t 1m bash assert-no-volumes.sh
+eden -t 1m pod ps
+! stdout 'IN_CONFIG'
+eden controller edge-node update --config timer.test.baseimage.update=30
+
+# Step 1: confirm the starting geometry. The disk must be SMALL (load-bearing: if
+# it is already large the conversion is a no-op and the test proves nothing), and
+# carry a >= 22 GB free tail so storage-resizer's check returns `grow`. If the
+# decision is `shrink` the bringup didn't create the tail and the test would
+# silently degrade into the shrink test — so the grow precondition is fail-fast.
+message 'baseline: confirm we are on the expected SMALL bringup release'
+exec -t 3m bash assert-running-version.sh {{ $bringup_ver }}
+message 'baseline: confirm SMALL boot-disk geometry'
+exec -t 2m bash capture-partitions.sh save small
+exec -t 1m bash capture-partitions.sh assert-small
+message 'precondition: boot disk has a >= 22G free tail (lsblk; resizer not on bringup image yet)'
+exec -t 2m bash assert-free-tail.sh
+
+# Step 2: BaseOs-update kvm->kvm to the conversion-capable kvm-to-k-resize
+# build. Same geometry (no repartition); this only lands the conversion code.
+message 'downloading kvm-to-k-resize kvm rootfs (conversion-capable)'
+eden -t 10m utils download eve-rootfs --eve-tag={{$resize_ver}} --eve-hv=kvm --eve-registry={{$resize_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs'
+
+message 'pushing kvm->kvm BaseOs update (lands conversion code on small layout)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs --os-version={{ $kvm_short }} -m adam://
+! stderr .
+
+message 'waiting for kvm->kvm upgrade to complete'
+exec -t 25m bash wait-for-upgrade.sh {{ $kvm_short }}
+
+# A kvm->kvm upgrade must change neither the geometry NOR the free tail: re-
+# confirm SMALL and re-confirm the grow decision. A regression that repartitions
+# on a same-flavor upgrade, or that consumes the tail, is caught here.
+message 'post-kvm-upgrade: geometry still SMALL and free tail intact (still GROW)'
+exec -t 1m bash capture-partitions.sh assert-small
+exec -t 2m bash assert-check-grow.sh
+
+# Step 3: settle the vault to a LOCAL TPM unlock. A new rootfs moves PCRs 8,13,
+# so the first post-upgrade boot unlocks via the controller key; one or more
+# controller-driven reboots return it to a local seal. UnlockMethod==0 means
+# "not decided yet this boot" — wait, don't treat it as a value.
+message 'settling vault to local TPM unlock (reboot loop)'
+exec -t 40m bash settle-vault-local.sh
+
+# Step 4: deploy the eclient app on EVE-kvm; wait RUNNING + functional.
+message 'deploying eclient app on EVE-kvm'
+eden -t 1m network create 10.11.12.0/24 -n xhv-app-net
+eden -t 5m pod deploy -n xhv-app {{template "eclient_image"}} -p 2223:22 --networks=xhv-app-net --memory=512MB
+exec -t 10m bash wait-for-app-running.sh
+message 'pre-conversion functional check'
+exec -t 5m bash wait-for-ssh-to-app.sh
+stdout 'OK: app SSH reachable'
+
+# Step 5: set timer.defer.content.delete=24h so deleting the app below does NOT
+# immediately GC its ContentTree blobs — they must survive the conversion so the
+# post-conversion redeploy reuses them (asserted at Step 11).
+message 'setting timer.defer.content.delete=86400 (24h)'
+eden controller edge-node update --config timer.defer.content.delete=86400
+
+# Wait out one controller config-fetch interval (timer.config.interval=60s)
+# plus margin so volumemgr applies the new deferContentDelete BEFORE the app
+# delete below. Otherwise the device can fetch the timer set and the app delete
+# in one config cycle and volumemgr's select loop may process the delete first,
+# deleting the app's ContentTree with deferContentDelete still 0 and GC-ing its
+# blobs -> the redeploy re-downloads (the FAIL[blob-reuse] mode).
+message 'waiting ~90s for the device to apply deferContentDelete=86400'
+exec sleep 90
+
+# Step 6: delete the app (keep the network), then wait for full EVE-side
+# teardown. The cross-HV gate refuses kvm<->k while any Volume exists, so we must
+# reach zero volumes before pushing the -k update.
+message 'deleting app on EVE-kvm (network kept, blobs retained for 24h)'
+eden -t 1m pod delete xhv-app
+exec -t 15m bash wait-for-app-gone.sh
+exec -t 1m bash assert-no-volumes.sh
+
+# Step 7: BaseOs-update kvm->k. This is the cross-flavor seam that triggers the
+# boot-disk repartition.
+message 'downloading kvm-to-k-resize k rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$resize_ver}} --eve-hv=k --eve-registry={{$resize_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs'
+
+message 'pushing kvm->k BaseOs update (triggers boot-disk repartition)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs --os-version={{ $k_short }} -m adam://
+! stderr .
+
+# Step 8: drive AND watch the conversion. The repartition runs OFFLINE in
+# storage-init, so this logs device state/sub-state TRANSITIONS as it polls to
+# completion and tolerates the reboots the offline resize needs. It returns once
+# EVE-k is running; the seal is checked post-hoc (Step 10).
+message 'waiting for + watching the kvm->k repartition (logging state transitions)'
+exec -t 45m bash watch-conversion.sh {{ $k_short }}
+
+# Step 9: deploy the app on EVE-k IMMEDIATELY after boot — do NOT wait for
+# volumemgr / cluster readiness first. Blob reuse (no image re-download) is still
+# required, but it is asserted at the END of Step 11 (downloader byte count
+# unchanged): with the app deployed early, volumemgr re-establishes the retained
+# ContentTree store while the app volume is deferred until cluster storage is up.
+# Snapshot the downloader baseline (RecvByteCount resets on the EVE-k reboot) just
+# before deploying so the post-assert measures only re-download after the deploy.
+message 'snapshot eve-k downloader RecvByteCount (baseline, pre-deploy)'
+exec -t 1m bash snapshot-rcv-bytes.sh pre
+message 'deploying eclient app on EVE-k immediately on boot (independent of commit/cluster state)'
+eden -t 5m pod deploy -n xhv-app {{template "eclient_image"}} -p 2223:22 --networks=xhv-app-net --memory=512MB
+
+# Step 10: while the app installs, run the static post-conversion checks. The
+# boot disk grew to LARGE (P3 unchanged on this grow-only path); and the
+# repartition preserved the local TPM seal (post-hoc from /persist/newlog: each
+# unseal mapped to its exact eve version; the LAST boot on the conversion-capable
+# kvm image unsealed locally — keyed on the specific version so a future baseline
+# that logs a local unlock can't satisfy it — plus no PCR5-driven re-seal; the
+# EVE-k boot's controller-key is expected and not asserted local).
+message 'asserting boot-disk repartition: SMALL -> LARGE (P3 unchanged)'
+exec -t 2m bash capture-partitions.sh save large
+exec -t 1m bash capture-partitions.sh assert-grown-no-shrink
+message 'asserting repartition preserved the TPM seal (post-hoc from /persist/newlog)'
+exec -t 3m bash assert-seal-from-newlog.sh {{ $k_short }} {{ $kvm_short }}
+message 'detecting whether the offline resize recreated /persist (for the blob-reuse verdict)'
+exec -t 2m bash assert-persist-not-recreated.sh
+
+# Step 11: split the readiness waits into SEPARATE steps for diagnosability, in
+# order, so a failure localizes to one stage:
+#   (a) volumemgr ready (incl kubeapi.WaitForKubernetes),
+#   (b) longhorn StorageClass ready (cluster storage up),
+#   (c) app RUNNING,
+#   (d) app SSH-reachable,
+# and only THEN assert blob reuse (downloader byte count did not increase since
+# the deploy — proving the early deploy reused the retained ContentTree).
+message '(a) waiting for volumemgr ready (incl kubeapi.WaitForKubernetes)'
+exec -t 45m bash wait-for-volumemgr-ready.sh
+message '(b) waiting for EVE-k longhorn StorageClass ready (cluster storage up)'
+exec -t 50m bash wait-for-longhorn-sc.sh
+stdout 'OK: longhorn StorageClass ready'
+message '(c) waiting for the app to reach RUNNING on EVE-k'
+exec -t 45m bash wait-for-app-running.sh
+message '(d) post-conversion functional check (SSH into the app guest)'
+exec -t 5m bash wait-for-ssh-to-app.sh 2223 30 fresh
+stdout 'OK: app SSH reachable'
+message 'capturing blob-reuse diagnostics (downloader / contenttree / verifier)'
+exec -t 3m bash capture-blob-diagnostics.sh
+message 'asserting blob reuse across the conversion: no image re-download after deploy'
+exec -t 1m bash snapshot-rcv-bytes.sh post-and-assert
+
+# Step 13: reset the defer-delete timer to default and clean up.
+message 'reset timer.defer.content.delete=0 (back to default)'
+eden controller edge-node update --config timer.defer.content.delete=0
+
+eden -t 1m pod delete xhv-app
+eden -t 1m network delete xhv-app-net
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs.ver
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs.ver
+exec sleep 10
+eden eve reset
+
+-- require-resize-ver.sh --
+#!/bin/bash
+# Fail fast if RESIZE_EVE_VER wasn't supplied (the escript default is a
+# placeholder). Without it, the eveimage-update steps would silently try to
+# download a bogus version.
+set -uo pipefail
+VER='{{ $resize_ver }}'
+if [ -z "$VER" ] || [ "$VER" = "REPLACE-WITH-RESIZE-VERSION" ]; then
+    echo "FAIL: RESIZE_EVE_VER not set." >&2
+    echo "      Export it to the version base of your local kvm-to-k-resize" >&2
+    echo "      build, e.g. RESIZE_EVE_VER=0.0.0-kvm-to-k-resize-1a2b3c4d" >&2
+    echo "      (the part before -kvm-amd64 / -k-amd64 in the docker tag)." >&2
+    exit 1
+fi
+echo "OK: RESIZE_EVE_VER=$VER"
+
+-- assert-running-version.sh --
+#!/bin/bash
+# Sanity-check that EVE is running the expected SMALL bringup release before the
+# conversion starts. This escript does not install the base image — bringup
+# happens manually before the test (see README_kvm_to_k_grow.md). This guards
+# against running the test against the wrong base image or an already-upgraded
+# device.
+#
+# Matches the expected version as a substring of /run/eve-release (which is the
+# full "<ver>-<hv>-<arch>" form, e.g. "12.1.0-kvm-amd64"), so passing "12.1.0"
+# accepts the kvm bringup image without pinning the hv/arch suffix.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT="${1:?expected bringup version substring}"
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+for _ in $(seq 1 18); do   # ~3m at 10s; tolerate ssh not up yet
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -n "$running" ]; then
+        case "$running" in
+            *"$EXPECT"*)
+                echo "OK: running the expected bringup release ('$running' contains '$EXPECT')"
+                exit 0 ;;
+            *)
+                echo "FAIL: running version '$running' does not match expected bringup '$EXPECT'." >&2
+                echo "      Bring eve up on the small '$EXPECT' image before this test, or set" >&2
+                echo "      BRINGUP_EVE_VER to the release you brought up on." >&2
+                echo "      See README_kvm_to_k_grow.md." >&2
+                exit 1 ;;
+        esac
+    fi
+    sleep 10
+done
+echo "FAIL: could not read /run/eve-release (ssh down / device not up?)" >&2
+exit 1
+
+-- capture-partitions.sh --
+#!/bin/bash
+# Read the boot-disk GPT geometry from EVE via lsblk and either save it, assert
+# it is the SMALL layout, or assert it grew to the LARGE layout. Two grow asserts:
+# assert-grown requires P3 to have SHRUNK (the shrink variant); assert-grown-no-
+# shrink requires P3 UNCHANGED (the grow-only variant). The escript picks one.
+#
+# Usage:
+#   capture-partitions.sh save  <tag>          # snapshot sizes to /tmp/xhv-parts-<tag>.env
+#   capture-partitions.sh assert-small         # assert ESP/IMGA/IMGB are small
+#   capture-partitions.sh assert-grown         # ESP/IMGA/IMGB grew; P3 shrank
+#   capture-partitions.sh assert-grown-no-shrink  # ESP/IMGA/IMGB grew; P3 unchanged
+#
+# Sizes come straight from `lsblk -b -P -o NAME,PARTLABEL,SIZE /dev/sda` — the
+# same lsblk pillar's diskmetrics uses, so it is present in the pillar ns. The
+# disk is /dev/sda under eden (qemu SATA/IDE).
+#
+# SMALL layout (12.1.0 make-raw): ESP 36 MiB, IMGA/IMGB 512 MiB, big P3.
+# LARGE layout (EVE-k target):    ESP 2 GiB,  IMGA/IMGB 10 GiB; P3 shrinks
+# (shrink variant) or is unchanged with the grow taken from a free tail.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+MODE=${1:-}
+TAG=${2:-}
+
+GiB=$(( 1024 * 1024 * 1024 ))
+MiB=$(( 1024 * 1024 ))
+
+# Read sizes into env-file form: ESP=<bytes> IMGA=<bytes> IMGB=<bytes> P3=<bytes>
+read_sizes() {
+    timeout 20 "$EDEN" eve ssh -- \
+        'eve exec pillar lsblk -b -P -o NAME,PARTLABEL,SIZE /dev/sda 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c '
+import sys, re
+keys = {"EFI System": "ESP", "IMGA": "IMGA", "IMGB": "IMGB", "P3": "P3"}
+out = {}
+for line in sys.stdin:
+    m = dict(re.findall(r"(\w+)=\"([^\"]*)\"", line))
+    label = m.get("PARTLABEL", "")
+    if label in keys and m.get("SIZE"):
+        out[keys[label]] = m["SIZE"]
+for k in ("ESP", "IMGA", "IMGB", "P3"):
+    print("%s=%s" % (k, out.get(k, "0")))
+'
+}
+
+load_current() {
+    local env
+    env=$(read_sizes)
+    eval "$env"
+    if [ "${ESP:-0}" = "0" ] || [ "${IMGA:-0}" = "0" ] || [ "${IMGB:-0}" = "0" ]; then
+        echo "FAIL: could not read partition sizes from /dev/sda" >&2
+        echo "      raw lsblk:" >&2
+        timeout 20 "$EDEN" eve ssh -- 'eve exec pillar lsblk -b -o NAME,PARTLABEL,SIZE /dev/sda' >&2 2>/dev/null
+        exit 1
+    fi
+}
+
+print_table() {
+    printf '  %-10s %12s  (%s)\n' EFI "$ESP"  "$(( ESP  / MiB )) MiB"
+    printf '  %-10s %12s  (%s)\n' IMGA "$IMGA" "$(( IMGA / MiB )) MiB"
+    printf '  %-10s %12s  (%s)\n' IMGB "$IMGB" "$(( IMGB / MiB )) MiB"
+    printf '  %-10s %12s  (%s)\n' P3   "$P3"   "$(( P3   / MiB )) MiB"
+}
+
+case "$MODE" in
+    save)
+        [ -n "$TAG" ] || { echo "Usage: $0 save <tag>" >&2; exit 1; }
+        load_current
+        printf 'ESP=%s\nIMGA=%s\nIMGB=%s\nP3=%s\n' "$ESP" "$IMGA" "$IMGB" "$P3" > "/tmp/xhv-parts-$TAG.env"
+        echo "Saved $TAG partition sizes:"
+        print_table
+        ;;
+    assert-small)
+        load_current
+        echo "Current partition sizes:"
+        print_table
+        # Small ESP is 36 MiB, IMGA/IMGB 512 MiB; allow generous headroom but
+        # stay far below the large floors so this is unambiguous.
+        if [ "$ESP"  -ge $(( 256 * MiB )) ] || \
+           [ "$IMGA" -ge "$GiB" ] || \
+           [ "$IMGB" -ge "$GiB" ]; then
+            echo "FAIL: geometry is not SMALL (ESP/IMGA/IMGB too big)" >&2
+            exit 1
+        fi
+        echo "OK: boot disk is on the SMALL geometry"
+        ;;
+    assert-grown|assert-grown-no-shrink)
+        load_current
+        # shellcheck disable=SC1091
+        if [ ! -f /tmp/xhv-parts-small.env ]; then
+            echo "FAIL: no small baseline (/tmp/xhv-parts-small.env) to compare against" >&2
+            exit 1
+        fi
+        S_ESP=$(grep '^ESP='  /tmp/xhv-parts-small.env | cut -d= -f2)
+        S_IMGA=$(grep '^IMGA=' /tmp/xhv-parts-small.env | cut -d= -f2)
+        S_IMGB=$(grep '^IMGB=' /tmp/xhv-parts-small.env | cut -d= -f2)
+        S_P3=$(grep '^P3='   /tmp/xhv-parts-small.env | cut -d= -f2)
+        echo "Partition sizes before -> after conversion (bytes):"
+        printf '  %-10s %14s -> %14s\n' EFI  "$S_ESP"  "$ESP"
+        printf '  %-10s %14s -> %14s\n' IMGA "$S_IMGA" "$IMGA"
+        printf '  %-10s %14s -> %14s\n' IMGB "$S_IMGB" "$IMGB"
+        printf '  %-10s %14s -> %14s\n' P3   "$S_P3"   "$P3"
+        rc=0
+        # ESP/IMGA/IMGB must have grown vs baseline AND reached the large floor.
+        # Large targets are ESP 2 GiB, IMGA/IMGB 10 GiB; floors are set below the
+        # target to tolerate GPT alignment while still being unambiguously large.
+        [ "$ESP"  -gt "$S_ESP"  ] || { echo "FAIL: ESP did not grow"  >&2; rc=1; }
+        [ "$IMGA" -gt "$S_IMGA" ] || { echo "FAIL: IMGA did not grow" >&2; rc=1; }
+        [ "$IMGB" -gt "$S_IMGB" ] || { echo "FAIL: IMGB did not grow" >&2; rc=1; }
+        [ "$ESP"  -ge $(( 1 * GiB )) ] || { echo "FAIL: ESP < 1 GiB floor (target 2 GiB)"  >&2; rc=1; }
+        [ "$IMGA" -ge $(( 8 * GiB )) ] || { echo "FAIL: IMGA < 8 GiB floor (target 10 GiB)" >&2; rc=1; }
+        [ "$IMGB" -ge $(( 8 * GiB )) ] || { echo "FAIL: IMGB < 8 GiB floor (target 10 GiB)" >&2; rc=1; }
+        if [ "$MODE" = assert-grown ]; then
+            # Shrink variant: P3 must have shrunk to make room.
+            [ "$P3" -lt "$S_P3" ] || { echo "FAIL: P3 did not shrink" >&2; rc=1; }
+            ok="OK: boot disk repartitioned SMALL -> LARGE (ESP/IMGA/IMGB grew, P3 shrank)"
+        else
+            # Grow-only variant: P3 must NOT have shrunk (the grow took the free
+            # tail). Allow 1 MiB tolerance for GPT alignment jitter.
+            [ "$P3" -ge $(( S_P3 - MiB )) ] || { echo "FAIL: P3 shrank ($S_P3 -> $P3) — expected unchanged on the grow-only path" >&2; rc=1; }
+            ok="OK: ESP/IMGA/IMGB grew to LARGE and P3 was not shrunk (grow-only path)"
+        fi
+        [ "$rc" = "0" ] && echo "$ok"
+        exit "$rc"
+        ;;
+    *)
+        echo "Usage: $0 save <tag> | assert-small | assert-grown | assert-grown-no-shrink" >&2
+        exit 1
+        ;;
+esac
+
+-- assert-free-tail.sh --
+#!/bin/bash
+# Step-1 fail-fast that the boot disk has >= ~22 GB free after its partitions,
+# using only lsblk. The small bringup image (e.g. 12.1.0) does NOT ship the
+# storage-resizer binary, so the authoritative `storage-resizer check` cannot run
+# yet — that runs after the kvm->kvm hop (assert-check-grow.sh). This geometric
+# check just confirms the host-side enlarge created the tail before we proceed.
+#
+# free tail ~= disk total - sum(partition sizes). Alignment gaps and the GPT
+# reservation make this a slight over-estimate (< 1 MiB), negligible against the
+# 22 GB threshold and the ~24 GB tail the recipe adds.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+GiB=$(( 1024 * 1024 * 1024 ))
+NEED=$(( 22 * GiB ))
+
+read_disk_and_parts() {
+    timeout 20 "$EDEN" eve ssh -- \
+        'eve exec pillar lsblk -b -P -o NAME,TYPE,SIZE /dev/sda 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c '
+import sys, re
+disk = 0; parts = 0
+for line in sys.stdin:
+    m = dict(re.findall(r"(\w+)=\"([^\"]*)\"", line))
+    t = m.get("TYPE", ""); s = int(m.get("SIZE", "0") or 0)
+    if t == "disk":
+        disk = max(disk, s)
+    elif t == "part":
+        parts += s
+print("%d %d" % (disk, parts))
+'
+}
+
+pair=$(read_disk_and_parts)
+disk=${pair%% *}; parts=${pair##* }
+if [ "${disk:-0}" = "0" ] || [ "${parts:-0}" = "0" ]; then
+    echo "FAIL: could not read disk/partition sizes from /dev/sda" >&2
+    exit 1
+fi
+free=$(( disk - parts ))
+echo "disk=$disk parts=$parts free_tail~=$free ($(( free / GiB )) GiB); need $(( NEED / GiB )) GiB"
+if [ "$free" -ge "$NEED" ]; then
+    echo "OK: free tail ~$(( free / GiB )) GiB present (>= 22 GiB) — grow precondition met"
+    exit 0
+fi
+echo "FAIL: free tail ~$(( free / GiB )) GiB < 22 GiB. Enlarge the disk before this test" >&2
+echo "      (qemu-img resize + sgdisk -e); see README_kvm_to_k_grow.md." >&2
+exit 1
+
+-- assert-check-grow.sh --
+#!/bin/bash
+# Assert the resizer's pre-flight check decides GROW on the live boot disk —
+# i.e. there is a >= 22 GB free tail after the last partition so ESP/IMGA/IMGB
+# can be grown without shrinking /persist. This is the load-bearing precondition
+# of the grow test: if the decision is `shrink`, the bringup never created the
+# free tail and the test would silently exercise the shrink path instead.
+#
+# Runs the resizer's own `check` subcommand inside the pillar namespace (the
+# binary is installed at /usr/bin/storage-resizer in the pillar image) and reads
+# the JSON `decision` + free-tail fields.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+
+run_check() {
+    timeout 30 "$EDEN" eve ssh -- \
+        'eve exec pillar /usr/bin/storage-resizer check --disk /dev/sda --json 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal'
+}
+
+for _ in $(seq 1 12); do   # ~2m at 10s — tolerate ssh/pillar not up yet
+    js=$(run_check)
+    dec=$(echo "$js" | python3 -c '
+import sys, json
+try:
+    o = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+sp = o.get("spaceForLargePartitions", {}) or {}
+print("%s|%s|%s" % (o.get("decision",""), sp.get("ok"), sp.get("freeTailBytes",0)))
+' 2>/dev/null)
+    if [ -n "$dec" ] && [ "$dec" != "||0" ]; then
+        decision=${dec%%|*}; rest=${dec#*|}; ok=${rest%%|*}; tail=${rest##*|}
+        echo "storage-resizer check: decision=$decision freeTailOK=$ok freeTailBytes=$tail"
+        case "$decision" in
+            grow)
+                echo "OK: check decides GROW (free tail present) — grow precondition met"
+                exit 0 ;;
+            shrink)
+                echo "FAIL: check decides SHRINK — the bringup did not create a >= 22 GB free tail." >&2
+                echo "      Enlarge the disk + sgdisk -e before this test (see README_kvm_to_k_grow.md)." >&2
+                echo "$js" >&2
+                exit 1 ;;
+            proceed)
+                echo "FAIL: check decides PROCEED — disk is already large; bring up on the SMALL image." >&2
+                exit 1 ;;
+            *)
+                echo "FAIL: unexpected check decision '$decision'" >&2
+                echo "$js" >&2
+                exit 1 ;;
+        esac
+    fi
+    sleep 10
+done
+echo "FAIL: could not get a decision from storage-resizer check (binary missing or ssh down?)" >&2
+echo "      tried: eve exec pillar /usr/bin/storage-resizer check --disk /dev/sda --json" >&2
+exit 1
+
+-- settle-vault-local.sh --
+#!/bin/bash
+# Settle the TPM-sealed vault to a LOCAL unlock by rebooting through the
+# controller until VaultStatus.UnlockMethod is 1 (tpm-local-sealed).
+#
+# UnlockMethod values (pkg/pillar/types/vaultmgrtypes.go):
+#   0 none (not decided yet this boot)   1 tpm-local-sealed
+#   2 controller-key                     3 no-tpm
+# Per the conversion test design, 0 means "wait until it is set" — never treat
+# an unpublished/0 value as a result. The expected path after a new rootfs is
+# one controller-key boot (PCRs 8,13 moved) then a local seal.
+#
+# Reboots go through the controller (eden ... reboot), never `eve ssh reboot`:
+# the controller path is update-aware and recorded in reboot-reason.log. By the
+# time this runs the kvm->kvm update is already active, so the reboot is safe.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+
+# Read the highest UnlockMethod seen across all VaultStatus files (there is
+# normally one). Prints 0 if not yet published / ssh down.
+read_unlock() {
+    _u=$(timeout 15 "$EDEN" eve ssh -- \
+        'eve exec pillar sh -c "cat /run/vaultmgr/VaultStatus/*.json 2>/dev/null"' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c '
+import sys, json, re
+best = 0
+data = sys.stdin.read()
+for m in re.finditer(r"\{.*?\}", data, re.S):
+    try:
+        o = json.loads(m.group(0))
+    except Exception:
+        continue
+    v = o.get("UnlockMethod", 0)
+    if isinstance(v, int) and v > best:
+        best = v
+print(best)
+' 2>/dev/null)
+    # Emit only a validated 0-3. A transient/garbled read (e.g. pillar still
+    # starting right after a reboot, when eve ssh answers but eve exec pillar
+    # does not yet) becomes 0 so the caller keeps polling rather than treating
+    # the stray value as a settled decision and aborting.
+    case "$_u" in 0|1|2|3) echo "$_u" ;; *) echo 0 ;; esac
+}
+
+# Wait (up to ~12m) for UnlockMethod to become non-zero this boot, then echo it.
+wait_decided() {
+    local m
+    for _ in $(seq 1 72); do   # 12m at 10s
+        m=$(read_unlock)
+        if [ "${m:-0}" != "0" ]; then echo "$m"; return 0; fi
+        sleep 10
+    done
+    echo 0
+}
+
+reboot_and_wait_back() {
+    echo "$(date +%H:%M:%S) rebooting via controller to re-seal..."
+    timeout 60 "$EDEN" controller edge-node -m adam:// reboot -v debug || true
+    # Wait for SSH to drop then return.
+    for _ in $(seq 1 24); do timeout 5 "$EDEN" eve ssh 'true' 2>/dev/null || break; sleep 5; done
+    for _ in $(seq 1 90); do timeout 8 "$EDEN" eve ssh 'true' 2>/dev/null && return 0; sleep 10; done
+    echo "WARN: SSH did not return within 15m after reboot" >&2
+    return 0
+}
+
+for attempt in $(seq 1 4); do
+    echo "$(date +%H:%M:%S) settle attempt $attempt: waiting for vault unlock decision"
+    m=$(wait_decided)
+    case "$m" in
+        1) echo "OK: vault unlocked locally (tpm-local-sealed) — settled"; exit 0 ;;
+        2) echo "  unlock=controller-key (2): rebooting to re-seal to the settled state" ;;
+        3) echo "FAIL: unlock=no-tpm (3) — this test requires eve.tpm=true" >&2; exit 1 ;;
+        *) echo "FAIL: vault never reported an unlock method (stuck at 0/none)" >&2; exit 1 ;;
+    esac
+    reboot_and_wait_back
+done
+echo "FAIL: vault did not settle to a local unlock after 4 reboots" >&2
+exit 1
+
+-- watch-conversion.sh --
+#!/bin/bash
+# Drive AND watch the kvm->k conversion (shrink+grow, or grow) to completion,
+# state/sub-state TRANSITION. The post-grow vault seal check is done POST-HOC
+# from /persist/newlog (assert-seal-from-newlog.sh): the live post-grow EVE-kvm
+# window is only ~1-2 min and an ssh poll loop misses it.
+#
+# The repartition runs OFFLINE in storage-init (the boot disk's GPT can't be re-read
+# live while its rootfs is mounted): baseosmgr arms the shrink/grow flag and
+# reboots, storage-init grows ESP/IMGA/IMGB (possibly with a busy-disk
+# reboot-to-apply), the device re-checks (proceed) and does the cross-flavor A/B
+# install, then reboots into EVE-k.
+#
+# Logs, only when it changes, the tuple of: running version, IMGA/IMGB active
+# partition+version, controller-reported device state + sub-state (from adam),
+# and on-device Converting + ConvertSubState. Completion is slot-agnostic (the
+# grow can relocate the active slot).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+K_VERSION="${1:?expected -k version}"
+SERIAL_LOG='{{EdenConfig "eve.log"}}'
+DEADLINE=$(( $(date +%s) + 2700 ))   # 45m
+
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+substate_name() {
+    case "$1" in
+        1) echo preflight ;;
+        2) echo rebooting-to-resize ;;
+        3) echo making-space ;;
+        4) echo creating-partitions ;;
+        5) echo renaming-partitions ;;
+        6) echo installing ;;
+        7) echo rebooting-to-target ;;
+        *) echo "sub_$1" ;;
+    esac
+}
+
+# Controller's view from adam: the latest ZiDevice report's state + sub_state.
+# (eden info -o/--format json panics on this build, so grep the text-proto.)
+ctrl_state() {
+    local c st sub
+    c=$(timeout 20 "$EDEN" info --tail 8 2>/dev/null | grep -a '^content: ztype:ZiDevice' | tail -1)
+    st=$(echo "$c" | grep -oE 'state:ZDEVICE_STATE_[A-Z_]+' | head -1 | cut -d: -f2)
+    sub=$(echo "$c" | grep -oE 'sub_state:ZDEVICE_SUBSTATE_[A-Z_]+' | head -1 | cut -d: -f2)
+    echo "${st:-?}/${sub:-NONE}"
+}
+
+# Which partition (IMGA/IMGB) is active, and the version on it.
+active_part() {
+    probe 'eve exec pillar sh -c "cat /run/baseosmgr/ZbootStatus/IMGA.json /run/baseosmgr/ZbootStatus/IMGB.json 2>/dev/null"' | python3 -c '
+import sys, json, re
+act = "?"; ver = "?"
+for m in re.finditer(r"\{.*?\}", sys.stdin.read(), re.S):
+    try:
+        o = json.loads(m.group(0))
+    except Exception:
+        continue
+    if o.get("PartitionState") == "active":
+        act = o.get("PartitionLabel", "?"); ver = o.get("ShortVersion", "?")
+print("%s:%s" % (act, ver))' 2>/dev/null || echo "?:?"
+}
+
+serial_off=0
+report_serial() {
+    [ -f "$SERIAL_LOG" ] || return 0
+    local size new
+    size=$(stat -c%s "$SERIAL_LOG" 2>/dev/null || echo 0)
+    if [ "$size" -gt "$serial_off" ]; then
+        new=$(tail -c +$(( serial_off + 1 )) "$SERIAL_LOG" 2>/dev/null)
+        serial_off=$size
+        echo "$new" | grep -aE 'storage-resizer:|repartition|grow|reboot to apply|convert' | while IFS= read -r l; do
+            echo "  serial> $l"
+        done
+    fi
+}
+
+last_sig=""
+reboots=0
+unreachable_run=0
+seen_converting=0
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    report_serial
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then
+        unreachable_run=$(( unreachable_run + 1 ))
+        if [ "$last_sig" != "UNREACHABLE" ]; then
+            echo "$(date +%H:%M:%S) [transition] EVE unreachable (rebooting?)"
+            last_sig="UNREACHABLE"
+        fi
+        sleep 15
+        continue
+    fi
+    if [ "$unreachable_run" -ge 2 ]; then
+        reboots=$(( reboots + 1 ))
+        echo "$(date +%H:%M:%S) observed a reboot (count=$reboots)"
+    fi
+    unreachable_run=0
+
+    actver=$(active_part)
+    bos=$(probe 'eve exec pillar sh -c "cat /run/baseosmgr/BaseOsStatus/*.json 2>/dev/null"')
+    conv=$(echo "$bos" | grep -o '"Converting":[a-z]*' | head -1 | cut -d: -f2); [ -z "$conv" ] && conv=false
+    csub=$(echo "$bos" | grep -o '"ConvertSubState":[0-9]*' | head -1 | cut -d: -f2); [ -z "$csub" ] && csub=0
+    [ "$conv" = "true" ] && seen_converting=1
+    dev=$(ctrl_state)
+
+    sig="run=$running active=$actver dev=$dev converting=$conv csub=$csub($(substate_name "$csub"))"
+    if [ "$sig" != "$last_sig" ]; then
+        echo "$(date +%H:%M:%S) [transition] $sig"
+        last_sig="$sig"
+    fi
+
+    # Done: the device has BOOTED the -k version. We deliberately do NOT wait for
+    # the A/B commit to 'active' or for the cluster to be online here — the app is
+    # deployed immediately after this, and readiness is verified in the split steps
+    # of Step 11. PartitionState is typically still 'updating'/'inprogress' now.
+    if [ "$running" = "$K_VERSION" ]; then
+        report_serial
+        echo "OK: EVE-k booted (running=$running, active=$actver, converting=$conv)"
+        echo "    observed: CONVERTING=$seen_converting reboots=$reboots"
+        exit 0
+    fi
+    sleep 15
+done
+echo "FAIL: 45m timeout. running='${running:-?}' active='${actver:-?}' dev='${dev:-?}'" >&2
+echo "      observed: CONVERTING=$seen_converting reboots=$reboots" >&2
+exit 1
+
+-- assert-seal-from-newlog.sh --
+#!/bin/bash
+# Post-hoc, VERSION-MAPPED TPM-seal check from /persist/newlog (durable across the
+# conversion's reboots; survives the repartition since /persist is on P3). Robust
+# and future-proof vs racing the ~1-2 min live post-grow window.
+#
+# Args: <k-version> <kvm-version>  (the -k target, and the conversion-capable kvm
+# image whose post-grow boot must unseal locally).
+#
+# Each unlock line is mapped to the EXACT eve version of its boot using the
+# per-boot "EVE version: <ver>" marker that device-steps.sh logs on pillar.out
+# (NOT baseosmgr's embedded "to EVE version X", which is source pillar). Then:
+#   (1) the LAST boot on the conversion-capable kvm version must have unsealed
+#       LOCALLY (tpm-local-sealed) — that is the post-grow / pre-EVE-k boot, on
+#       which only PCR5 (the repartition, excluded from the seal) changed. Keying
+#       on the specific kvm version (not "any kvm boot") keeps the test correct
+#       even if a future baseline OS also logs a local unlock; and
+#   (2) no controller-key / unseal-FAILED boot lists PCR5 in its mismatch set
+#       (an independent gate: a PCR5-driven re-seal means the repartition broke
+#       the seal). The -k boot is legitimately controller-key (PCRs 8/9/13).
+#
+# Retrieval per the eve-device-logs skill: /persist/newlog has no top-level
+# dev.log; logs are in collect/ (plaintext) + keepSentQueue/ (gz); busybox find
+# has no -exec {} +, so use -exec ... \; per-file (zcat -f handles both).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+K_VERSION="${1:?expected -k version}"
+KVM_VERSION="${2:?expected kvm (conversion-capable) version}"
+
+raw=$(timeout 120 "$EDEN" eve ssh 'eve exec pillar sh -c "find /persist/newlog -name \"dev.log.*\" -exec zcat -f {} \; 2>/dev/null | grep -aE \"EVE version: |unlocked: method=|local TPM unseal FAILED\""' 2>/dev/null | grep -v 'level=fatal')
+
+echo "$raw" | KVM="$KVM_VERSION" K="$K_VERSION" python3 -c '
+import sys, os, re
+kvm = os.environ["KVM"]
+ev = []
+for line in sys.stdin:
+    sm = re.search(r"\"seconds\":(\d+)", line); nm = re.search(r"\"nanos\":(\d+)", line)
+    sec = int(sm.group(1)) if sm else 0; ns = int(nm.group(1)) if nm else 0
+    # per-boot version marker: device-steps echo on pillar.out, "<date> EVE version: <ver>".
+    # Exclude baseosmgr "to EVE version X" (source pillar, embedded) by requiring pillar.out.
+    if "pillar.out" in line and "EVE version:" in line:
+        mv = re.search(r"EVE version: ([0-9][A-Za-z0-9._+-]*)", line)
+        if mv:
+            ev.append((sec, ns, "VER", mv.group(1), []))
+        continue
+    if "unlocked: method=tpm-local-sealed" in line:
+        ev.append((sec, ns, "UNLOCK", "local", []))
+    elif "method=controller-key" in line:
+        pc = re.search(r"mismatching ?PCRs=\[([0-9 ]*)\]", line)
+        ev.append((sec, ns, "UNLOCK", "controller", pc.group(1).split() if pc else []))
+    elif "unseal FAILED" in line:
+        pc = re.search(r"mismatching ?PCRs=\[([0-9 ]*)\]", line)
+        ev.append((sec, ns, "FAILED", "failed", pc.group(1).split() if pc else []))
+ev.sort(key=lambda x: (x[0], x[1]))
+cur = None; unlocks = []; pcr5 = []
+for e in ev:
+    if e[2] == "VER":
+        cur = e[3]
+    else:
+        unlocks.append((cur, e[3], e[4]))
+        if "5" in e[4]:
+            pcr5.append((cur, e[3], e[4]))
+for u in unlocks:
+    print("  unlock> version=%s method=%s pcrs=%s" % (u[0], u[1], u[2] or "-"))
+kvmu = [u for u in unlocks if u[0] == kvm]
+print("SUMMARY: kvm_version=%s kvm_unlocks=%d pcr5_reseals=%d" % (kvm, len(kvmu), len(pcr5)))
+rc = 0
+if pcr5:
+    print("FAIL: PCR5 in a re-seal/unseal-FAILED set %s -> the repartition broke the TPM seal" % pcr5); rc = 1
+if not kvmu:
+    print("FAIL: no unlock recorded on the conversion-capable kvm version %s (post-grow boot not observed)" % kvm); rc = 1
+elif kvmu[-1][1] != "local":
+    print("FAIL: the LAST %s boot (post-grow) unlocked %s, not local -> repartition broke the seal" % (kvm, kvmu[-1][1])); rc = 1
+else:
+    print("OK: post-grow %s boot unlocked LOCALLY (%d kvm local unseal(s); no PCR5 re-seal)" % (kvm, sum(1 for u in kvmu if u[1] == "local")))
+sys.exit(rc)
+'
+
+-- assert-persist-not-recreated.sh --
+#!/bin/bash
+# Detect whether the offline resize recreated (wiped) /persist, and RECORD it for
+# the final blob-reuse verdict (this step does not itself fail). storage-init
+# mkfs's P3 when its filesystem fails identification/fsck -- a watchdog-interrupted
+# shrink can corrupt it -- which destroys /persist (newlog, the retained
+# ContentTree, restored identity), so the post-conversion app redeploy must then
+# re-download. A recreate during INITIAL bringup (a blank, freshly-partitioned P3)
+# is expected and excluded; we flag only a recreate at/after the resize began
+# (storage-init's "shrink+grow requested"/"grow-only requested" marker), and note
+# WHICH resize step the watchdog interrupted (the last step logged before the
+# recreate) so the blob-reuse check can report FAIL[recreate-induced]. Markers in
+# storage-init.sh; retrieval per the eve-device-logs skill; ISO8601 sorts lexically.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+INFO=/tmp/xhv-persist-recreate.info
+echo "clean" > "$INFO"
+
+logs=$(timeout 90 "$EDEN" eve ssh 'eve exec pillar sh -c "find /persist/newlog -name \"dev.log.*\" -exec zcat -f {} \; 2>/dev/null | grep -aoE \"2026[^\\\"]*(recreating it as|shrink\+grow requested|grow-only requested|shrink P3 to|shrink complete|Resizing the filesystem|grow EFI|grow complete)[^\\\"]*\""' 2>/dev/null | grep -v 'level=fatal' | sort -u)
+
+tsof() { grep -aoE '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}'; }
+resize_ts=$(printf '%s\n' "$logs" | grep -aE 'shrink\+grow requested|grow-only requested' | tsof | sort | head -1)
+if [ -z "$resize_ts" ]; then
+    echo "WARNING: no resize marker in newlog; persist-recreate detection inconclusive"
+    echo "OK: /persist preserved (recorded clean)"; exit 0
+fi
+recreate_ts=$(printf '%s\n' "$logs" | grep -a 'recreating it as' | tsof | sort -u | awk -v r="$resize_ts" '$0>=r' | head -1)
+if [ -z "$recreate_ts" ]; then
+    echo "OK: /persist preserved across the resize (no P3 recreate at/after $resize_ts; bringup format excluded)"; exit 0
+fi
+# A recreate happened at/after the resize. The last resize step logged before it is
+# (best effort) what the watchdog interrupted.
+step=$(printf '%s\n' "$logs" | grep -aE 'shrink P3 to|shrink complete|Resizing the filesystem|grow EFI|grow complete' | tail -1)
+[ -n "$step" ] || step="(no resize step logged before the recreate)"
+printf 'recreated|%s|%s\n' "$recreate_ts" "$step" > "$INFO"
+echo "NOTE: /persist was recreated at $recreate_ts (at/after the resize); last step before it: $step"
+echo "(recorded -- the blob-reuse check reports FAIL[recreate-induced] if the app re-downloads)"
+
+-- wait-for-volumemgr-ready.sh --
+#!/bin/bash
+# Gate before the post-conversion redeploy. On EVE-k, volumemgr must finish its
+# "wait for kubernetes" / longhorn-ready init and RE-ESTABLISH the retained
+# ContentTree blobs in the EVE-k content store before a redeploy can REUSE them.
+# Deploying earlier causes the image to be re-downloaded (verified: ~44 MiB vs 0
+# with this gate). Wait for /run/volumemgr/VolumeMgrStatus/volumemgr.json
+# "Initialized":true (set after kubeapi.WaitForKubernetes returns).
+#
+# Instrumented: logs a timeline of (volumemgr Initialized, number of
+# ContentTreeStatus objects volumemgr currently tracks) so we can see WHEN the
+# store becomes ready and whether the retained ContentTree is recognized before
+# full Initialized — i.e. whether a narrower "blobs recognized" signal would let
+# the deploy fire sooner than waiting for the whole longhorn bring-up.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+probe() { timeout 8 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+ct_count() {
+    probe 'eve exec pillar sh -c "ls /run/volumemgr/ContentTreeStatus/*.json 2>/dev/null | wc -l"' \
+        | tr -d '\r' | grep -E '^[0-9]+$' | tail -1
+}
+last=""
+for _ in $(seq 1 240); do   # 40m at 10s (deploy-on-boot: this wait now starts at EVE-k boot, and Initialized lands ~24m later after kubeapi.WaitForKubernetes)
+    init=$(probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>/dev/null' \
+            | tr -d '\r' | grep -oE '"Initialized":[a-z]+')
+    ct=$(ct_count); [ -z "$ct" ] && ct='?'
+    sig="init=${init:-<none>} contenttrees=$ct"
+    if [ "$sig" != "$last" ]; then
+        echo "$(date +%H:%M:%S) [readiness] $sig"; last="$sig"
+    fi
+    if [ "$init" = '"Initialized":true' ]; then
+        echo "OK: volumemgr Initialized:true (contenttrees=$ct)"; exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: volumemgr did not reach Initialized:true within 40m" >&2
+probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>&1' >&2
+exit 1
+
+-- capture-blob-diagnostics.sh --
+#!/bin/bash
+# Observational diagnostics for the post-conversion blob-reuse question (does the
+# redeploy reuse the retained ContentTree, or re-download?). Runs after the app
+# reaches RUNNING, before the byte-count assertion, so it captures regardless of
+# pass/fail. Pulls the downloader / ContentTree / verifier lines from the EVE-k
+# boot out of /persist/newlog (see the eve-device-logs skill for the retrieval
+# form: logs live in collect/+keepSentQueue/, busybox find has no -exec {} +).
+# Never fails the test — purely informational.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+echo "--- live downloader RecvByteCount (per-URL) ---"
+timeout 15 "$EDEN" eve ssh -- 'eve exec pillar cat /run/downloader/MetricsMap/global.json 2>/dev/null' 2>/dev/null \
+    | grep -v 'level=fatal' | python3 -c '
+import sys, json
+try: d=json.load(sys.stdin)
+except Exception: sys.exit(0)
+for iface,conn in d.items():
+    for url,m in (conn.get("URLCounters") or {}).items():
+        rb=m.get("RecvByteCount",0)
+        if rb: print("  %d bytes  %s" % (rb, url))
+' 2>/dev/null || true
+echo "--- newlog: downloader/contenttree/verifier on the EVE-k boot (cache hit vs fetch) ---"
+timeout 90 "$EDEN" eve ssh 'eve exec pillar sh -c "find /persist/newlog -name \"dev.log.*\" -exec zcat -f {} \; 2>/dev/null | grep -aE \"already (in cache|verified|downloaded)|reusing|RecvByteCount|starting download|download done|ContentTree.*(DOWNLOAD|DELIVERED|LOADED)\""' 2>/dev/null \
+    | grep -v 'level=fatal' | grep -aoE 'msg\\":\\"[^"]*' | sed 's/^msg.":."/  newlog> /' | tail -30 || true
+echo "OK: blob diagnostics captured (informational)"
+
+-- wait-for-upgrade.sh --
+#!/bin/bash
+# Generic "wait for a same- or cross-flavor BaseOs upgrade to land": poll until
+# /run/eve-release equals the expected version AND IMGB is the active partition.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT_VERSION="${1:?expected version}"
+DEADLINE=$(( $(date +%s) + 1500 ))   # 25m
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then echo "$(date +%H:%M:%S): EVE unreachable (rebooting?)"; sleep 20; continue; fi
+    imgb_state=$(probe 'eve exec pillar cat /run/baseosmgr/ZbootStatus/IMGB.json' | grep -oP '"PartitionState":"\K[^"]+' | head -1)
+    [ -z "$imgb_state" ] && imgb_state='unknown'
+    echo "$(date +%H:%M:%S): running='$running' IMGB.PartitionState='$imgb_state'"
+    if [ "$running" = "$EXPECT_VERSION" ] && [ "$imgb_state" = "active" ]; then
+        echo "OK: upgrade to $running complete (IMGB active)"; exit 0
+    fi
+    sleep 20
+done
+echo "FAIL: upgrade to $EXPECT_VERSION did not complete in 25m (running='$running')" >&2
+exit 1
+
+-- assert-no-volumes.sh --
+#!/bin/bash
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 12); do
+    out=$("$EDEN" volume ls 2>/dev/null)
+    live=$(echo "$out" | awk 'NR>1 && ($(NF-1) == "IN_CONFIG" || $NF == "DELIVERED")')
+    if [ -z "$live" ]; then echo "OK: no live volumes"; exit 0; fi
+    sleep 5
+done
+echo "FAIL: live volume(s) present" >&2; "$EDEN" volume ls >&2; exit 1
+
+-- wait-for-app-running.sh --
+#!/bin/bash
+# Poll `eden pod ps` until xhv-app reaches LAST_STATE(EVE)=RUNNING. 25m budget
+# covers both the fast pre-conversion kvm case and the slow post-conversion
+# eve-k redeploy (longhorn install + VMI start).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 240); do   # 40m at 10s (deploy-on-boot: app RUNNING is gated on the full post-longhorn volume create + CDI upload + guest boot, ~27m observed)
+    line=$("$EDEN" pod ps 2>/dev/null | grep -E '^xhv-app\s')
+    if echo "$line" | grep -q 'RUNNING'; then
+        echo "OK: xhv-app RUNNING"; echo "$line"; exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: xhv-app did not reach RUNNING in 40m" >&2
+"$EDEN" pod ps >&2
+exit 1
+
+-- wait-for-app-gone.sh --
+#!/bin/bash
+# Poll until xhv-app fully disappears AND no per-instance VolumeStatus files
+# remain under /run/volumemgr/VolumeStatus/. Pillar tears down VM -> PVC ->
+# pubsub records; the cross-HV gate refuses kvm<->k while any Volume exists, so
+# we must reach zero before pushing the -k update.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+last_pod=""; last_vol=""
+for _ in $(seq 1 90); do   # 15m at 10s
+    pod_present=$("$EDEN" pod ps 2>/dev/null | grep -cE '^xhv-app\s')
+    # Count only per-instance .json; pubsub writes a never-removed `restarted`
+    # sentinel into this dir, so `ls | wc -l` is 1 even with no volumes.
+    vol_count=$(timeout 12 "$EDEN" eve ssh \
+        'eve exec pillar ls /run/volumemgr/VolumeStatus/*.json 2>/dev/null | wc -l' \
+        2>/dev/null | tr -d '\r' | tail -1)
+    [ -z "$vol_count" ] && vol_count="?"
+    if [ "$pod_present" = "0" ] && [ "$vol_count" = "0" ]; then
+        echo "OK: xhv-app removed and no VolumeStatus files remain"; exit 0
+    fi
+    if [ "$last_pod $last_vol" != "$pod_present $vol_count" ]; then
+        echo "$(date +%H:%M:%S) waiting for teardown: pod_rows=$pod_present vol_files=$vol_count"
+        last_pod=$pod_present; last_vol=$vol_count
+    fi
+    sleep 10
+done
+echo "FAIL: app+volumes did not fully clear in 15m" >&2
+"$EDEN" pod ps >&2
+"$EDEN" eve ssh 'eve exec pillar ls -la /run/volumemgr/VolumeStatus/ 2>&1' >&2
+exit 1
+
+-- snapshot-rcv-bytes.sh --
+#!/bin/bash
+# Snapshot cumulative RecvByteCount from /run/downloader/MetricsMap on EVE.
+# "pre" saves the baseline; "post-and-assert" recomputes the delta and asserts
+# it is below MAX_DELTA_BYTES (default 1 MiB). /run is tmpfs (reset on reboot),
+# so pre/post must bracket a single phase with no intervening reboot.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+MODE=${1:-pre}
+MAX_DELTA_BYTES=${2:-1048576}
+
+capture_recv_bytes() {
+    timeout 15 "$EDEN" eve ssh -- 'eve exec pillar cat /run/downloader/MetricsMap/global.json 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print(0); sys.exit(0)
+total = 0
+for iface, conn in d.items():
+    for url, m in (conn.get('URLCounters') or {}).items():
+        total += m.get('RecvByteCount', 0)
+print(total)
+"
+}
+
+case "$MODE" in
+    pre)
+        bytes=$(capture_recv_bytes)
+        echo "$bytes" > /tmp/xhv-rcv-pre.txt
+        echo "Pre-snapshot: RecvByteCount total = $bytes bytes"
+        ;;
+    post-and-assert)
+        post=$(capture_recv_bytes)
+        pre=$(cat /tmp/xhv-rcv-pre.txt 2>/dev/null || echo 0)
+        delta=$(( post - pre ))
+        echo "Post-snapshot: RecvByteCount total = $post bytes (pre was $pre, delta = $delta)"
+        if [ "$delta" -lt 0 ]; then
+            echo "FAIL: post < pre — counter went backwards (unexpected reboot?)" >&2; exit 1
+        fi
+        if [ "$delta" -lt "$MAX_DELTA_BYTES" ]; then
+            echo "OK: only $delta bytes received (< ${MAX_DELTA_BYTES}) — no image re-download"; exit 0
+        fi
+        info=$(cat /tmp/xhv-persist-recreate.info 2>/dev/null || echo clean)
+        if [ "${info%%|*}" = "recreated" ]; then
+            rts=$(printf '%s' "$info" | cut -d'|' -f2); rstep=$(printf '%s' "$info" | cut -d'|' -f3)
+            echo "FAIL[recreate-induced]: $delta bytes re-downloaded, BUT /persist was recreated during the resize -- storage-init mount-fsck found P3 corrupt at $rts, after the watchdog interrupted: $rstep. The re-download is the expected consequence; the conversion otherwise completed (this is the ONLY failure)." >&2
+            exit 1
+        fi
+        echo "FAIL[blob-reuse]: $delta bytes re-downloaded with NO /persist recreate -- real blob-reuse regression (image not reused across the conversion)." >&2
+        exit 1
+        ;;
+    *) echo "Usage: $0 pre | post-and-assert [max-delta-bytes]" >&2; exit 1 ;;
+esac
+
+-- wait-for-ssh-to-app.sh --
+#!/bin/bash
+# wait-for-ssh-to-app.sh — the REAL guest-readiness / functional gate for the
+# eclient app instance, shared verbatim across the cross-HV / kvm->k tests.
+#
+# `eden pod ps` RUNNING (wait-for-app-running.sh) only reflects
+# AppInstState.EVEState — the ZSwState EVE reports. On EVE-k that is the
+# kubevirt VMI Running phase (qemu launched), NOT the guest kernel booted with
+# sshd accepting connections; on EVE-kvm the gap is smaller but still not
+# guest-ready. So pod-ps RUNNING is a cheap pre-filter only — success is
+# declared HERE, once an AUTHENTICATED ssh command has actually run inside the
+# guest and returned the expected output.
+#
+# Transport: host hostfwd 127.0.0.1:2223 -> EVE-eth0:2223 (eve.hostfwd
+# extension set by eden-bringup.sh) -> zedrouter NAT -> app:22 (eclient sshd).
+# The `eden sdn fwd` wrapper collapses to the same 127.0.0.1:hostport under the
+# non-SDN QEMU user-net these tests run in, so the direct path is used.
+#
+# FRESHNESS: host port 2223 is a static QEMU forward for the whole VM lifetime,
+# so after a delete+redeploy (or a reboot) a *stale* previous eclient could keep
+# answering on it and falsely satisfy a post-conversion check. To guard that,
+# each successful check records the guest's boot_id
+# (/proc/sys/kernel/random/boot_id — a fresh UUID per VM boot) to
+# /tmp/xhv-app-bootid. In "fresh" mode the check requires the connected guest's
+# boot_id to DIFFER from that recorded value; a matching (stale) instance is
+# treated as not-ready-yet and retried until the fresh deploy takes over the
+# port or the budget runs out.
+#
+# Fail-closed: a refused / closed / timed-out ssh, a non-eclient guest, or (in
+# fresh mode) only the stale instance answering, never prints the success
+# marker. On success it prints "OK: app SSH reachable" so the escript pins the
+# framework verdict to a real session:
+#     exec -t 5m bash wait-for-ssh-to-app.sh
+#     stdout 'OK: app SSH reachable'
+#
+# Args (optional): $1 host port (default 2223); $2 attempts, 10s apart
+# (default 30 => 5m); $3 = "fresh" to require a NEW guest instance vs the
+# boot_id the previous successful check recorded (use after a redeploy/reboot).
+#
+# Cert: ssh refuses group-readable keys, so the eclient id_rsa is copied to a
+# 0600 temp file. testscript sets HOME=/no-home, so the real home is resolved
+# from the running UID; dist/tests is only populated by a full `make eden`, so
+# fall back to the master/main reference clones.
+set -uo pipefail
+PORT="${1:-2223}"
+ATTEMPTS="${2:-30}"
+FRESH="${3:-}"
+BOOTID_FILE=/tmp/xhv-app-bootid
+EDEN_TESTS="{{EdenConfig "eden.tests"}}"
+USER_HOME=$(getent passwd "$(id -u)" | cut -d: -f6)
+SRC=""
+for c in "$EDEN_TESTS/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/master/eden/tests/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/main/eden/tests/eclient/image/cert/id_rsa"; do
+    if [ -f "$c" ]; then SRC="$c"; break; fi
+done
+if [ -z "$SRC" ]; then
+    echo "FAIL: could not locate eclient id_rsa cert (EDEN_TESTS=$EDEN_TESTS, USER_HOME=$USER_HOME)" >&2
+    exit 1
+fi
+KEY=$(mktemp); install -m 600 "$SRC" "$KEY"; trap 'rm -f "$KEY"' EXIT
+SSH_OPTS=(-o ConnectTimeout=10 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -i "$KEY")
+prev=""
+[ -f "$BOOTID_FILE" ] && prev=$(cat "$BOOTID_FILE" 2>/dev/null)
+connected=0
+saw_stale=0
+for _ in $(seq 1 "$ATTEMPTS"); do
+    # One round-trip proves auth, the eclient identity, and the guest boot_id.
+    # "AUTHED" is echoed before the identity check, so a connect+auth that fails
+    # only the /etc/issue match is distinguishable from a never-connected ssh.
+    out=$(ssh "${SSH_OPTS[@]}" root@127.0.0.1 -p "$PORT" \
+        'echo AUTHED; grep -q Ubuntu /etc/issue && cat /proc/sys/kernel/random/boot_id' \
+        2>/dev/null)
+    case "$out" in *AUTHED*) connected=1 ;; esac
+    bootid=$(printf '%s\n' "$out" | tr -d '\r' | grep -Ex '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | tail -1)
+    if [ -n "$bootid" ]; then
+        if [ "$FRESH" = "fresh" ] && [ -n "$prev" ] && [ "$bootid" = "$prev" ]; then
+            # Still the previous instance on the static port — wait for the fresh
+            # deploy/boot to take over the NAT before declaring success.
+            saw_stale=1; sleep 10; continue
+        fi
+        echo "$bootid" > "$BOOTID_FILE"
+        echo "OK: app SSH reachable (port=$PORT, boot_id=$bootid, fresh=${FRESH:-no}, cert=$SRC)"
+        exit 0
+    fi
+    sleep 10
+done
+budget=$(( ATTEMPTS * 10 ))
+if [ "$saw_stale" = 1 ]; then
+    echo "FAIL: only the previous app instance (boot_id=$prev) answered within ${budget}s — the fresh deploy never took over the port (stale instance)" >&2
+elif [ "$connected" = 1 ]; then
+    echo "FAIL: ssh connected+authed but the guest never matched the eclient (grep Ubuntu /etc/issue) within ${budget}s (port=$PORT)" >&2
+else
+    echo "FAIL: app never answered an authenticated ssh within ${budget}s (port=$PORT, cert=$SRC)" >&2
+fi
+echo "--- host TCP probe ---" >&2
+( exec 3<>/dev/tcp/127.0.0.1/"$PORT" ) 2>&1 || true
+exit 1
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- wait-for-longhorn-sc.sh --
+#!/bin/bash
+# Wait until the EVE-k `longhorn` StorageClass exists (longhorn deployed + its CSI
+# provisioner up). On a freshly-converted EVE-k node longhorn can take tens of
+# minutes to deploy -- well after the device reports ONLINE -- so wait for it
+# EXPLICITLY here, before deploying/waiting for an app whose volume needs longhorn.
+# This separates cluster-bringup time from app-bringup time: the wait-for-app-running
+# that follows can be short, and a failure here clearly says "longhorn", not "app".
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 90); do   # ~45m at 30s
+    if "$EDEN" eve ssh -- 'eve exec kube kubectl get sc 2>/dev/null' 2>/dev/null | grep -qE '^longhorn'; then
+        echo "OK: longhorn StorageClass ready"; exit 0
+    fi
+    sleep 30
+done
+echo "FAIL: longhorn StorageClass not ready within budget" >&2; exit 1

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_refused.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_refused.txt
@@ -1,0 +1,404 @@
+# Test: EVE-kvm -> EVE-k conversion is DECLINED when the boot disk cannot be
+# repartitioned, and the device stays on the kvm image, reports the reason, and
+# remains controller-manageable. This is the "refused" sibling of the successful
+# update_eve_image_kvm_to_k.txt; it covers the e2e test plan's `insufficient`
+# cases, parameterized over the REASON for refusal.
+#
+# Per pkg/storage-resizer decide()/evaluate() (and baseosmgr/diskconvert, which
+# always calls `check --disk <boot> --json` with NO --persist flags), the
+# conversion is refused (decision=insufficient) when no room can be freed:
+#   REFUSE_REASON=zfs       /persist is ZFS (shrinking ZFS is unsupported) and the
+#                           boot disk has no >=22G free tail.   (persistType=zfs)
+#   REFUSE_REASON=too-full  /persist is ext4 on the boot disk but too full to free
+#                           22G within --max-full.   (shrinkApplicable, !shrink.ok)
+# (A ZFS or other-disk persist WITH a boot free tail is a `grow` success and lives
+# in update_eve_image_kvm_to_k.txt, not here.)
+#
+# Set up the matching topology first (see prep-kvm-to-k-topology.sh):
+#   REFUSE_REASON=zfs       -> prep zfs-notail     (1-disk ZFS persist, no tail)
+#   REFUSE_REASON=too-full  -> prep ext4-toofull   (1-disk ext4 persist, filled)
+#
+# What it asserts:
+#   - after the kvm->kvm hop, `storage-resizer check` decides `insufficient` for
+#     the expected reason (the topology was set up correctly);
+#   - the kvm->k BaseOs update is DECLINED: the device stays on the kvm image,
+#     baseosmgr publishes a BaseOsStatus.Error (the decline is reported, not a
+#     silent stall), and EVE->adam stays reachable (device still manageable);
+#   - the boot-disk geometry is UNCHANGED (no repartition happened).
+#
+# Knobs (env):
+#   REFUSE_REASON   zfs|too-full   (default zfs). Drives the check-reason assert.
+#   RESIZE_EVE_VER  (required) version base of the local kvm-to-k build, e.g.
+#                   "0.0.0-kvm-to-k-resize-<sha>". Fails fast if unset.
+#   RESIZE_EVE_REG  (default lfedge/eve) image registry/repo namespace.
+#   BRINGUP_EVE_VER (default 12.1.0) substring the running base release must
+#                   contain at Step 1 (bringup is manual — see the README).
+
+{{$arch := EdenConfig "eve.arch"}}
+
+{{$resize_ver_env := EdenGetEnv "RESIZE_EVE_VER"}}
+{{$resize_ver := "REPLACE-WITH-RESIZE-VERSION"}}
+{{if $resize_ver_env}}{{$resize_ver = $resize_ver_env}}{{end}}
+
+{{$resize_reg_env := EdenGetEnv "RESIZE_EVE_REG"}}
+{{$resize_reg := "lfedge/eve"}}
+{{if $resize_reg_env}}{{$resize_reg = $resize_reg_env}}{{end}}
+
+{{$bringup_ver_env := EdenGetEnv "BRINGUP_EVE_VER"}}
+{{$bringup_ver := "12.1.0"}}
+{{if $bringup_ver_env}}{{$bringup_ver = $bringup_ver_env}}{{end}}
+
+# --- knob: expected refusal reason ---
+{{$reason_env := EdenGetEnv "REFUSE_REASON"}}
+{{$reason := "zfs"}}
+{{if $reason_env}}{{$reason = $reason_env}}{{end}}
+
+{{$kvm_short := printf "%s-kvm-%s" $resize_ver $arch}}
+{{$k_short   := printf "%s-k-%s" $resize_ver $arch}}
+
+# Step 0: pre-flight. Fail fast if the version param wasn't supplied, confirm a
+# clean device, and shorten the baseimage commit timer so the update applies fast.
+message 'pre-flight: parameters + clean state'
+exec -t 1m bash require-resize-ver.sh
+exec -t 1m bash assert-no-volumes.sh
+eden -t 1m pod ps
+! stdout 'IN_CONFIG'
+eden controller edge-node update --config timer.test.baseimage.update=30
+
+# Step 1: baseline — SMALL/old start, and (by construction) a disk that cannot be
+# repartitioned: a full ZFS persist, or a too-full ext4 persist. There is NO free
+# tail; the refusal is the point of the test.
+message 'baseline: confirm we are on the expected SMALL bringup release'
+exec -t 3m bash assert-running-version.sh {{ $bringup_ver }}
+message 'baseline: confirm SMALL boot-disk geometry'
+exec -t 2m bash capture-partitions.sh save small
+exec -t 1m bash capture-partitions.sh assert-small
+
+# Step 2: kvm->kvm hop — lands the conversion code + the storage-resizer binary,
+# geometry unchanged. (No vault settle / no app: the refusal is independent of
+# both, and nothing repartitions, so there is no seal to preserve.)
+message 'downloading conversion-capable kvm rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$resize_ver}} --eve-hv=kvm --eve-registry={{$resize_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs'
+message 'pushing kvm->kvm BaseOs update (lands conversion code)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs --os-version={{ $kvm_short }} -m adam://
+! stderr .
+message 'waiting for kvm->kvm upgrade to complete'
+exec -t 25m bash wait-for-upgrade.sh {{ $kvm_short }}
+
+# Step 3: assert the resizer's pre-flight check REFUSES for the expected reason.
+# This is the load-bearing precondition: if the disk was not set up for the
+# requested REFUSE_REASON, the conversion might actually succeed (or refuse for a
+# different reason) and the test would prove nothing.
+message 'post-kvm-upgrade: geometry must still be SMALL'
+exec -t 1m bash capture-partitions.sh assert-small
+message 'post-kvm-upgrade: assert storage-resizer check refuses ({{ $reason }})'
+exec -t 2m bash assert-refused-check.sh {{ $reason }}
+
+# Step 4: push the kvm->k BaseOs update. baseosmgr runs the cross-flavor check,
+# gets `insufficient`, and must decline rather than repartition.
+message 'downloading k rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$resize_ver}} --eve-hv=k --eve-registry={{$resize_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs'
+message 'pushing kvm->k BaseOs update (must be DECLINED)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs --os-version={{ $k_short }} -m adam://
+! stderr .
+
+# Step 5: assert the convert was declined cleanly — still on the kvm image,
+# BaseOsStatus carries the decline Error (baseosmgr SetErrorNow on
+# OutcomeInsufficient), and EVE->adam is still reachable. Polls for the decline
+# to be published (baseosmgr processes the -k config first).
+message 'asserting the conversion was DECLINED (still kvm, error reported, manageable)'
+exec -t 10m bash assert-declined.sh {{ $kvm_short }}
+
+# Step 6: the boot disk must NOT have been repartitioned — geometry still SMALL.
+message 'asserting the boot disk was NOT repartitioned (geometry still SMALL)'
+exec -t 1m bash capture-partitions.sh assert-small
+
+# Step 7: clean up.
+message 'reset timer.test.baseimage.update + clean up'
+eden controller edge-node update --config timer.defer.content.delete=0
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs.ver
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs.ver
+exec sleep 10
+eden eve reset
+
+-- require-resize-ver.sh --
+#!/bin/bash
+# Fail fast if RESIZE_EVE_VER wasn't supplied (the escript default is a
+# placeholder). Without it, the eveimage-update steps would silently try to
+# download a bogus version.
+set -uo pipefail
+VER='{{ $resize_ver }}'
+if [ -z "$VER" ] || [ "$VER" = "REPLACE-WITH-RESIZE-VERSION" ]; then
+    echo "FAIL: RESIZE_EVE_VER not set." >&2
+    echo "      Export it to the version base of your local kvm-to-k" >&2
+    echo "      build, e.g. RESIZE_EVE_VER=0.0.0-kvm-to-k-resize-1a2b3c4d" >&2
+    echo "      (the part before -kvm-amd64 / -k-amd64 in the docker tag)." >&2
+    exit 1
+fi
+echo "OK: RESIZE_EVE_VER=$VER"
+
+-- assert-running-version.sh --
+#!/bin/bash
+# Sanity-check that EVE is running the expected SMALL bringup release before the
+# test. This escript does not install the base image — bringup happens manually
+# (see the kvm-to-k README + prep-kvm-to-k-topology.sh). Matches as a substring of
+# /run/eve-release (the full "<ver>-<hv>-<arch>" form).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT="${1:?expected bringup version substring}"
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+for _ in $(seq 1 18); do   # ~3m at 10s; tolerate ssh not up yet
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -n "$running" ]; then
+        case "$running" in
+            *"$EXPECT"*)
+                echo "OK: running the expected bringup release ('$running' contains '$EXPECT')"
+                exit 0 ;;
+            *)
+                echo "FAIL: running version '$running' does not match expected bringup '$EXPECT'." >&2
+                echo "      Bring eve up on the small '$EXPECT' image before this test, or set" >&2
+                echo "      BRINGUP_EVE_VER to the release you brought up on." >&2
+                exit 1 ;;
+        esac
+    fi
+    sleep 10
+done
+echo "FAIL: could not read /run/eve-release (ssh down / device not up?)" >&2
+exit 1
+
+-- capture-partitions.sh --
+#!/bin/bash
+# Trimmed boot-disk geometry helper for the refused test: only `save` and
+# `assert-small` are needed (the refused case never grows). Sizes from
+# `lsblk -b -P -o NAME,PARTLABEL,SIZE /dev/sda`. P3 may be 0 (ZFS-on-another-disk),
+# so only ESP/IMGA/IMGB are required non-zero.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+MODE=${1:-}
+TAG=${2:-}
+GiB=$(( 1024 * 1024 * 1024 ))
+MiB=$(( 1024 * 1024 ))
+
+read_sizes() {
+    timeout 20 "$EDEN" eve ssh -- \
+        'eve exec pillar lsblk -b -P -o NAME,PARTLABEL,SIZE /dev/sda 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c '
+import sys, re
+keys = {"EFI System": "ESP", "IMGA": "IMGA", "IMGB": "IMGB", "P3": "P3"}
+out = {}
+for line in sys.stdin:
+    m = dict(re.findall(r"(\w+)=\"([^\"]*)\"", line))
+    label = m.get("PARTLABEL", "")
+    if label in keys and m.get("SIZE"):
+        out[keys[label]] = m["SIZE"]
+for k in ("ESP", "IMGA", "IMGB", "P3"):
+    print("%s=%s" % (k, out.get(k, "0")))
+'
+}
+
+load_current() {
+    eval "$(read_sizes)"
+    if [ "${ESP:-0}" = "0" ] || [ "${IMGA:-0}" = "0" ] || [ "${IMGB:-0}" = "0" ]; then
+        echo "FAIL: could not read ESP/IMGA/IMGB sizes from /dev/sda" >&2
+        timeout 20 "$EDEN" eve ssh -- 'eve exec pillar lsblk -b -o NAME,PARTLABEL,SIZE /dev/sda' >&2 2>/dev/null
+        exit 1
+    fi
+}
+
+print_table() {
+    for p in ESP IMGA IMGB P3; do
+        v=$(eval echo "\$$p")
+        printf '  %-10s %12s  (%s MiB)\n' "$p" "$v" "$(( v / MiB ))"
+    done
+}
+
+case "$MODE" in
+    save)
+        [ -n "$TAG" ] || { echo "Usage: $0 save <tag>" >&2; exit 1; }
+        load_current
+        printf 'ESP=%s\nIMGA=%s\nIMGB=%s\nP3=%s\n' "$ESP" "$IMGA" "$IMGB" "$P3" > "/tmp/xhv-parts-$TAG.env"
+        echo "Saved $TAG partition sizes:"; print_table
+        ;;
+    assert-small)
+        load_current; echo "Current partition sizes:"; print_table
+        if [ "$ESP" -ge $(( 256 * MiB )) ] || [ "$IMGA" -ge "$GiB" ] || [ "$IMGB" -ge "$GiB" ]; then
+            echo "FAIL: geometry is not SMALL (ESP/IMGA/IMGB too big)" >&2; exit 1
+        fi
+        echo "OK: boot disk is on the SMALL geometry"
+        ;;
+    *)
+        echo "Usage: $0 save <tag> | assert-small" >&2
+        exit 1
+        ;;
+esac
+
+-- assert-refused-check.sh --
+#!/bin/bash
+# Assert storage-resizer's pre-flight `check` REFUSES the conversion for the
+# expected reason. Mirrors how baseosmgr/diskconvert invokes it — `check --disk
+# <boot> --json` with NO --persist flags, so persistType comes from
+# /run/eve.persist_type and persist is assumed on the boot disk.
+#
+# Verifies decision==insufficient AND the reason-specific fields of the report
+# (pkg/storage-resizer evaluate()/decide(), JSON tags from sizecheck.go):
+#   zfs:      persistType=="zfs"  (shrink not applicable; ZFS can't be shrunk)
+#   too-full: shrinkApplicable==true AND spaceToShrinkExt.ok==false (ext4 too full)
+#
+# Usage: assert-refused-check.sh <zfs|too-full> [disk=/dev/sda]
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT="${1:?expected reason: zfs|too-full}"
+DISK="${2:-/dev/sda}"
+
+run_check() {
+    timeout 30 "$EDEN" eve ssh -- \
+        "eve exec pillar /usr/bin/storage-resizer check --disk $DISK --json 2>/dev/null" \
+        2>/dev/null | grep -v 'level=fatal'
+}
+
+for _ in $(seq 1 12); do   # ~2m at 10s — tolerate ssh/pillar not up yet
+    js=$(run_check)
+    parsed=$(echo "$js" | EXPECT="$EXPECT" python3 -c '
+import sys, os, json
+try:
+    o = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+expect = os.environ["EXPECT"]
+dec = o.get("decision", "")
+ptype = o.get("persistType", "")
+sapp = o.get("shrinkApplicable", False)
+sh = o.get("spaceToShrinkExt", {}) or {}
+shok = sh.get("ok", None)
+reason = o.get("decisionReason", "")
+print("decision=%s persistType=%s shrinkApplicable=%s shrink.ok=%s reason=%r"
+      % (dec, ptype, sapp, shok, reason))
+ok = (dec == "insufficient")
+if expect == "zfs":
+    ok = ok and (ptype == "zfs")
+elif expect == "too-full":
+    ok = ok and bool(sapp) and (shok is False)
+else:
+    print("UNKNOWN_EXPECT"); sys.exit(3)
+sys.exit(0 if ok else 1)
+' 2>/dev/null)
+    rc=$?
+    if [ -n "$parsed" ] && echo "$parsed" | grep -q '^decision='; then
+        echo "storage-resizer check: $parsed (expected refusal=$EXPECT)"
+        if [ "$rc" = "0" ]; then
+            echo "OK: check refuses ('insufficient') for the '$EXPECT' reason as required"
+            exit 0
+        fi
+        echo "FAIL: check did not refuse for '$EXPECT'." >&2
+        echo "      The disk was not set up for the '$EXPECT' refusal — check the topology" >&2
+        echo "      (prep-kvm-to-k-topology.sh zfs-notail / ext4-toofull)." >&2
+        echo "$js" >&2
+        exit 1
+    fi
+    sleep 10
+done
+echo "FAIL: no decision from storage-resizer check (binary missing or ssh down?)" >&2
+echo "      tried: eve exec pillar /usr/bin/storage-resizer check --disk $DISK --json" >&2
+exit 1
+
+-- assert-declined.sh --
+#!/bin/bash
+# Assert a cross-flavor update was DECLINED (insufficient): the device did NOT
+# repartition, is still running the kvm image, reports the decline via a non-empty
+# BaseOsStatus.Error (baseosmgr SetErrorNow on OutcomeInsufficient), and remains
+# controller-reachable. Polls for the decline Error to be published.
+# Arg: <kvm-version> (the conversion-capable kvm image the device must stay on).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+KVM_VERSION="${1:?expected kvm (conversion-capable) version}"
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+bos_error() {
+    probe 'eve exec pillar sh -c "cat /run/baseosmgr/BaseOsStatus/*.json 2>/dev/null"' \
+        | python3 -c 'import sys,re,json
+errs=[]
+for m in re.finditer(r"\{.*?\}", sys.stdin.read(), re.S):
+    try: o=json.loads(m.group(0))
+    except Exception: continue
+    e=o.get("Error","")
+    if e: errs.append(e)
+print(" | ".join(errs))' 2>/dev/null
+}
+
+# 1. Wait (up to ~8m) for baseosmgr to publish the decline Error, while the device
+#    stays on the kvm image (a transition to -k would mean it was NOT declined).
+err=""
+for _ in $(seq 1 48); do   # 8m at 10s
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -n "$running" ] && [ "$running" != "$KVM_VERSION" ]; then
+        echo "FAIL: device left the kvm image ('$running' != '$KVM_VERSION') — convert was NOT declined" >&2
+        exit 1
+    fi
+    err=$(bos_error)
+    if [ -n "$err" ]; then
+        echo "BaseOsStatus.Error: $err"
+        break
+    fi
+    sleep 10
+done
+[ -n "$err" ] || { echo "FAIL: no BaseOsStatus.Error within 8m — decline must be reported, not a silent stall" >&2; exit 1; }
+
+# 2. Re-confirm still on the kvm image.
+running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+echo "running=$running (expected kvm=$KVM_VERSION)"
+[ "$running" = "$KVM_VERSION" ] || { echo "FAIL: not on the kvm image after decline ('$running')" >&2; exit 1; }
+
+# 3. EVE -> adam still reachable (device manageable).
+code=$(probe 'eve exec pillar curl -sk --max-time 5 https://$(tr -d "\r\n" < /config/server)/api/v2/edgedevice/ping -o /dev/null -w "%{http_code}"' | tr -d '\r' | tail -1)
+echo "EVE->adam ping http_code=$code"
+[ "$code" = "200" ] || { echo "FAIL: EVE->adam not reachable ($code) — device not manageable after decline" >&2; exit 1; }
+echo "OK: convert declined cleanly — still kvm, Error reported, controller-reachable"
+
+-- wait-for-upgrade.sh --
+#!/bin/bash
+# Wait for a same- or cross-flavor BaseOs upgrade to land: poll until
+# /run/eve-release equals the expected version AND IMGB is the active partition.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT_VERSION="${1:?expected version}"
+DEADLINE=$(( $(date +%s) + 1500 ))   # 25m
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then echo "$(date +%H:%M:%S): EVE unreachable (rebooting?)"; sleep 20; continue; fi
+    imgb_state=$(probe 'eve exec pillar cat /run/baseosmgr/ZbootStatus/IMGB.json' | grep -oP '"PartitionState":"\K[^"]+' | head -1)
+    [ -z "$imgb_state" ] && imgb_state='unknown'
+    echo "$(date +%H:%M:%S): running='$running' IMGB.PartitionState='$imgb_state'"
+    if [ "$running" = "$EXPECT_VERSION" ] && [ "$imgb_state" = "active" ]; then
+        echo "OK: upgrade to $running complete (IMGB active)"; exit 0
+    fi
+    sleep 20
+done
+echo "FAIL: upgrade to $EXPECT_VERSION did not complete in 25m (running='$running')" >&2
+exit 1
+
+-- assert-no-volumes.sh --
+#!/bin/bash
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 12); do
+    out=$("$EDEN" volume ls 2>/dev/null)
+    live=$(echo "$out" | awk 'NR>1 && ($(NF-1) == "IN_CONFIG" || $NF == "DELIVERED")')
+    if [ -z "$live" ]; then echo "OK: no live volumes"; exit 0; fi
+    sleep 5
+done
+echo "FAIL: live volume(s) present" >&2; "$EDEN" volume ls >&2; exit 1
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_resize.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_resize.txt
@@ -1,0 +1,1184 @@
+# Test: EVE-kvm -> EVE-k in-field boot-disk repartition (small -> large GPT
+# geometry conversion), driven end-to-end through the controller, with a
+# deferred-content-delete app so a post-conversion redeploy needs no download.
+#
+# VARIANT: shrink (the default field layout). P3 fills the disk, so
+# storage-resizer's check returns `shrink`: baseosmgr backs up identity to the
+# CONFIG partition and reboots, and storage-init SHRINKS the ext4 /persist then
+# grows ESP/IMGA/IMGB into the freed space OFFLINE. (The sibling
+# update_eve_image_kvm_to_k_grow.txt covers the grow-only variant, where the disk
+# already has a free tail and P3 is left unchanged.) The repartition runs offline
+# because the boot disk's GPT can't be re-read live while its rootfs is mounted.
+#
+# Image sequence (exact — see README_kvm_to_k_resize.md for how to build them):
+#   1. SMALL start : EVE up on a stock 12.1.0-kvm install (small: 36 MiB ESP,
+#                     512 MiB IMGA/IMGB, big P3 that fills the disk).
+#   2. kvm conversion-capable: BaseOs-update kvm->kvm to the kvm-to-k-resize
+#                     build. Same geometry; lands the conversion code. Then settle
+#                     the vault to a local TPM unlock.
+#   3. k image      : BaseOs-update kvm->k. The cross-flavor seam arms the offline
+#                     repartition; storage-init shrinks P3 and grows ESP/IMGA/IMGB,
+#                     then boots EVE-k on the now-large geometry.
+#
+# What it asserts:
+#   - the boot disk started SMALL and ended LARGE (per-partition sizes; P3
+#     shrank to make room);
+#   - the conversion was observed (device state/sub-state transitions logged);
+#   - the repartition preserved the TPM seal (post-hoc from /persist/newlog: the
+#     last boot on the conversion-capable kvm image unsealed locally, no PCR5
+#     re-seal; the EVE-k boot's controller-key is the expected new-rootfs behavior);
+#   - the redeploy reused cached blobs (downloader received < 1 MiB).
+#
+# Parameters (env):
+#   RESIZE_EVE_VER  (required) version base of the local kvm-to-k-resize images,
+#                   without the -<hv>-<arch> suffix, e.g. "0.0.0-kvm-to-k-resize-<sha>".
+#                   No default for a local build; the test fails fast if unset.
+#   RESIZE_EVE_REG  (default lfedge/eve) image registry/repo namespace; the full
+#                   docker tag is <RESIZE_EVE_REG>:<RESIZE_EVE_VER>-<hv>-<arch>.
+#                   eve-build.sh tags under lfedge/eve, so override only if you
+#                   keep EVE images under a different namespace.
+#   BRINGUP_EVE_VER (default 12.1.0) substring the running base release must
+#                   contain at Step 1 — this escript does NOT install the base
+#                   image; bringup is manual (see the README).
+
+{{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+
+{{$arch := EdenConfig "eve.arch"}}
+
+{{$resize_ver_env := EdenGetEnv "RESIZE_EVE_VER"}}
+{{$resize_ver := "REPLACE-WITH-RESIZE-VERSION"}}
+{{if $resize_ver_env}}{{$resize_ver = $resize_ver_env}}{{end}}
+
+{{$resize_reg_env := EdenGetEnv "RESIZE_EVE_REG"}}
+{{$resize_reg := "lfedge/eve"}}
+{{if $resize_reg_env}}{{$resize_reg = $resize_reg_env}}{{end}}
+
+{{$bringup_ver_env := EdenGetEnv "BRINGUP_EVE_VER"}}
+{{$bringup_ver := "12.1.0"}}
+{{if $bringup_ver_env}}{{$bringup_ver = $bringup_ver_env}}{{end}}
+
+{{/* GiB to pre-fill into /persist before the convert so the offline resize2fs
+     SHRINK has real blocks to relocate and runs long enough for the stress
+     watchdog to interrupt it (not only the grow). Keep it BELOW the post-shrink
+     P3 size (~41 GiB on a 64 GiB boot disk) or the shrink can't fit. 0 disables. */}}
+{{$fill_gib_env := EdenGetEnv "FILL_PERSIST_GIB"}}
+{{$fill_gib := "33"}}
+{{if $fill_gib_env}}{{$fill_gib = $fill_gib_env}}{{end}}
+
+{{$kvm_short := printf "%s-kvm-%s" $resize_ver $arch}}
+{{$k_short   := printf "%s-k-%s" $resize_ver $arch}}
+
+# Step 0: pre-flight. Fail fast if the version param wasn't supplied, confirm
+# a clean device, and shorten the baseimage commit timer so updates apply fast.
+message 'pre-flight: parameters + clean state'
+exec -t 1m bash require-resize-ver.sh
+exec -t 1m bash assert-no-volumes.sh
+eden -t 1m pod ps
+! stdout 'IN_CONFIG'
+eden controller edge-node update --config timer.test.baseimage.update=30
+
+# Step 1: confirm the starting geometry. The disk must be SMALL (load-bearing: if
+# it is already large the conversion is a no-op and the test proves nothing).
+# Save the small sizes as the baseline the post-conversion check compares against.
+message 'baseline: confirm we are on the expected SMALL bringup release'
+exec -t 3m bash assert-running-version.sh {{ $bringup_ver }}
+message 'baseline: confirm SMALL boot-disk geometry'
+exec -t 2m bash capture-partitions.sh save small
+exec -t 1m bash capture-partitions.sh assert-small
+
+# Step 2: BaseOs-update kvm->kvm to the conversion-capable kvm-to-k-resize
+# build. Same geometry (no repartition); this only lands the conversion code.
+message 'downloading kvm-to-k-resize kvm rootfs (conversion-capable)'
+eden -t 10m utils download eve-rootfs --eve-tag={{$resize_ver}} --eve-hv=kvm --eve-registry={{$resize_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs'
+
+message 'pushing kvm->kvm BaseOs update (lands conversion code on small layout)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs --os-version={{ $kvm_short }} -m adam://
+! stderr .
+
+message 'waiting for kvm->kvm upgrade to complete'
+exec -t 25m bash wait-for-upgrade.sh {{ $kvm_short }}
+
+# Geometry must be UNCHANGED by a kvm->kvm upgrade — re-confirm SMALL so a
+# regression that repartitions on a same-flavor upgrade is caught here.
+message 'post-kvm-upgrade: geometry must still be SMALL'
+exec -t 1m bash capture-partitions.sh assert-small
+
+# Step 3: settle the vault to a LOCAL TPM unlock. A new rootfs moves PCRs 8,13,
+# so the first post-upgrade boot unlocks via the controller key; one or more
+# controller-driven reboots return it to a local seal. UnlockMethod==0 means
+# "not decided yet this boot" — wait, don't treat it as a value.
+message 'settling vault to local TPM unlock (reboot loop)'
+exec -t 40m bash settle-vault-local.sh
+
+# Step 3b: pre-fill /persist so the offline resize2fs SHRINK has real blocks to
+# relocate. On the near-empty eden /persist the shrink finishes in ~1s and the
+# stress watchdog only ever interrupts the GROW; filling makes the shrink slow
+# enough to be cut too, exercising shrink-resume + the P3-recreate
+# (FAIL[recreate-induced]) path — required for a meaningful shrink+grow test.
+message 'pre-filling /persist (target ~{{ $fill_gib }} GiB in high blocks) so the shrink must relocate'
+exec -t 30m bash fill-persist.sh {{ $fill_gib }}
+
+# Step 4: deploy the eclient app on EVE-kvm; wait RUNNING + functional.
+message 'deploying eclient app on EVE-kvm'
+eden -t 1m network create 10.11.12.0/24 -n xhv-app-net
+eden -t 5m pod deploy -n xhv-app {{template "eclient_image"}} -p 2223:22 --networks=xhv-app-net --memory=512MB
+exec -t 10m bash wait-for-app-running.sh
+message 'pre-conversion functional check'
+exec -t 5m bash wait-for-ssh-to-app.sh
+stdout 'OK: app SSH reachable'
+
+# Step 5: set timer.defer.content.delete=24h so deleting the app below does NOT
+# immediately GC its ContentTree blobs — they must survive the conversion so the
+# post-conversion redeploy reuses them (asserted at Step 11).
+message 'setting timer.defer.content.delete=86400 (24h)'
+eden controller edge-node update --config timer.defer.content.delete=86400
+
+# Wait out one controller config-fetch interval (timer.config.interval=60s)
+# plus margin so volumemgr applies the new deferContentDelete BEFORE the app
+# delete below. Otherwise the device can fetch the timer set and the app delete
+# in one config cycle and volumemgr's select loop may process the delete first,
+# deleting the app's ContentTree with deferContentDelete still 0 and GC-ing its
+# blobs -> the redeploy re-downloads (the FAIL[blob-reuse] mode).
+message 'waiting ~90s for the device to apply deferContentDelete=86400'
+exec sleep 90
+
+# Step 6: delete the app (keep the network), then wait for full EVE-side
+# teardown. The cross-HV gate refuses kvm<->k while any Volume exists, so we must
+# reach zero volumes before pushing the -k update.
+message 'deleting app on EVE-kvm (network kept, blobs retained for 24h)'
+eden -t 1m pod delete xhv-app
+exec -t 15m bash wait-for-app-gone.sh
+exec -t 1m bash assert-no-volumes.sh
+
+# Step 7: BaseOs-update kvm->k. This is the cross-flavor seam that triggers the
+# boot-disk repartition.
+message 'downloading kvm-to-k-resize k rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$resize_ver}} --eve-hv=k --eve-registry={{$resize_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs'
+
+message 'pushing kvm->k BaseOs update (triggers boot-disk repartition)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs --os-version={{ $k_short }} -m adam://
+! stderr .
+
+# Step 8: drive AND watch the conversion. The repartition runs OFFLINE in
+# storage-init, so this logs device state/sub-state TRANSITIONS as it polls to
+# completion and tolerates the reboots the offline resize needs. It returns once
+# EVE-k is running; the seal is checked post-hoc (Step 10).
+message 'waiting for + watching the kvm->k repartition (logging state transitions)'
+exec -t 45m bash watch-conversion.sh {{ $k_short }}
+
+# (The /persist stress-fill is freed inside watch-conversion.sh, during the
+# post-grow eve-kvm window before the EVE-k reboot — so EVE-k's cluster does not
+# install under ephemeral-storage DiskPressure. Freeing it after EVE-k boots is
+# too late: longhorn-manager is already evicted during the install.)
+
+# Step 9: deploy the app on EVE-k IMMEDIATELY after boot — do NOT wait for
+# volumemgr / cluster readiness first. Blob reuse (no image re-download) is still
+# required, but it is asserted at the END of Step 11 (downloader byte count
+# unchanged): with the app deployed early, volumemgr re-establishes the retained
+# ContentTree store while the app volume is deferred until cluster storage is up.
+# Snapshot the downloader baseline (RecvByteCount resets on the EVE-k reboot) just
+# before deploying so the post-assert measures only re-download after the deploy.
+message 'snapshot eve-k downloader RecvByteCount (baseline, pre-deploy)'
+exec -t 1m bash snapshot-rcv-bytes.sh pre
+message 'deploying eclient app on EVE-k immediately on boot (independent of commit/cluster state)'
+eden -t 5m pod deploy -n xhv-app {{template "eclient_image"}} -p 2223:22 --networks=xhv-app-net --memory=512MB
+
+# Step 10: while the app installs, run the static post-conversion checks. The
+# boot disk grew to LARGE (P3 shrank to make room); and the
+# repartition preserved the local TPM seal (post-hoc from /persist/newlog: each
+# unseal mapped to its exact eve version; the LAST boot on the conversion-capable
+# kvm image unsealed locally — keyed on the specific version so a future baseline
+# that logs a local unlock can't satisfy it — plus no PCR5-driven re-seal; the
+# EVE-k boot's controller-key is expected and not asserted local).
+message 'asserting boot-disk repartition: SMALL -> LARGE (P3 shrank)'
+exec -t 2m bash capture-partitions.sh save large
+exec -t 1m bash capture-partitions.sh assert-grown
+message 'asserting repartition preserved the TPM seal (post-hoc from /persist/newlog)'
+exec -t 3m bash assert-seal-from-newlog.sh {{ $k_short }} {{ $kvm_short }}
+message 'detecting whether the offline resize recreated /persist (for the blob-reuse verdict)'
+exec -t 2m bash assert-persist-not-recreated.sh
+
+# Step 11: split the readiness waits into SEPARATE steps for diagnosability, in
+# order, so a failure localizes to one stage:
+#   (a) volumemgr ready (incl kubeapi.WaitForKubernetes),
+#   (b) longhorn StorageClass ready (cluster storage up),
+#   (c) app RUNNING,
+#   (d) app SSH-reachable,
+# and only THEN assert blob reuse (downloader byte count did not increase since
+# the deploy — proving the early deploy reused the retained ContentTree).
+message '(a) waiting for volumemgr ready (incl kubeapi.WaitForKubernetes)'
+exec -t 45m bash wait-for-volumemgr-ready.sh
+message '(b) waiting for EVE-k longhorn StorageClass ready (cluster storage up)'
+exec -t 50m bash wait-for-longhorn-sc.sh
+stdout 'OK: longhorn StorageClass ready'
+message '(c) waiting for the app to reach RUNNING on EVE-k'
+exec -t 45m bash wait-for-app-running.sh
+message '(d) post-conversion functional check (SSH into the app guest)'
+exec -t 5m bash wait-for-ssh-to-app.sh 2223 30 fresh
+stdout 'OK: app SSH reachable'
+message 'capturing blob-reuse diagnostics (downloader / contenttree / verifier)'
+exec -t 3m bash capture-blob-diagnostics.sh
+message 'asserting blob reuse across the conversion: no image re-download after deploy'
+exec -t 1m bash snapshot-rcv-bytes.sh post-and-assert
+
+# Step 13: reset the defer-delete timer to default and clean up.
+message 'reset timer.defer.content.delete=0 (back to default)'
+eden controller edge-node update --config timer.defer.content.delete=0
+
+eden -t 1m pod delete xhv-app
+eden -t 1m network delete xhv-app-net
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs.ver
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs.ver
+exec sleep 10
+eden eve reset
+
+-- require-resize-ver.sh --
+#!/bin/bash
+# Fail fast if RESIZE_EVE_VER wasn't supplied (the escript default is a
+# placeholder). Without it, the eveimage-update steps would silently try to
+# download a bogus version.
+set -uo pipefail
+VER='{{ $resize_ver }}'
+if [ -z "$VER" ] || [ "$VER" = "REPLACE-WITH-RESIZE-VERSION" ]; then
+    echo "FAIL: RESIZE_EVE_VER not set." >&2
+    echo "      Export it to the version base of your local kvm-to-k-resize" >&2
+    echo "      build, e.g. RESIZE_EVE_VER=0.0.0-kvm-to-k-resize-1a2b3c4d" >&2
+    echo "      (the part before -kvm-amd64 / -k-amd64 in the docker tag)." >&2
+    exit 1
+fi
+echo "OK: RESIZE_EVE_VER=$VER"
+
+-- assert-running-version.sh --
+#!/bin/bash
+# Sanity-check that EVE is running the expected SMALL bringup release before the
+# conversion starts. This escript does not install the base image — bringup
+# happens manually before the test (see README_kvm_to_k_resize.md). This guards
+# against running the test against the wrong base image or an already-upgraded
+# device.
+#
+# Matches the expected version as a substring of /run/eve-release (which is the
+# full "<ver>-<hv>-<arch>" form, e.g. "12.1.0-kvm-amd64"), so passing "12.1.0"
+# accepts the kvm bringup image without pinning the hv/arch suffix.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT="${1:?expected bringup version substring}"
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+for _ in $(seq 1 18); do   # ~3m at 10s; tolerate ssh not up yet
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -n "$running" ]; then
+        case "$running" in
+            *"$EXPECT"*)
+                echo "OK: running the expected bringup release ('$running' contains '$EXPECT')"
+                exit 0 ;;
+            *)
+                echo "FAIL: running version '$running' does not match expected bringup '$EXPECT'." >&2
+                echo "      Bring eve up on the small '$EXPECT' image before this test, or set" >&2
+                echo "      BRINGUP_EVE_VER to the release you brought up on." >&2
+                echo "      See README_kvm_to_k_resize.md." >&2
+                exit 1 ;;
+        esac
+    fi
+    sleep 10
+done
+echo "FAIL: could not read /run/eve-release (ssh down / device not up?)" >&2
+exit 1
+
+-- capture-partitions.sh --
+#!/bin/bash
+# Read the boot-disk GPT geometry from EVE via lsblk and either save it, assert
+# it is the SMALL layout, or assert it grew to the LARGE layout. Two grow asserts:
+# assert-grown requires P3 to have SHRUNK (the shrink variant); assert-grown-no-
+# shrink requires P3 UNCHANGED (the grow-only variant). The escript picks one.
+#
+# Usage:
+#   capture-partitions.sh save  <tag>          # snapshot sizes to /tmp/xhv-parts-<tag>.env
+#   capture-partitions.sh assert-small         # assert ESP/IMGA/IMGB are small
+#   capture-partitions.sh assert-grown         # ESP/IMGA/IMGB grew; P3 shrank
+#   capture-partitions.sh assert-grown-no-shrink  # ESP/IMGA/IMGB grew; P3 unchanged
+#
+# Sizes come straight from `lsblk -b -P -o NAME,PARTLABEL,SIZE /dev/sda` — the
+# same lsblk pillar's diskmetrics uses, so it is present in the pillar ns. The
+# disk is /dev/sda under eden (qemu SATA/IDE).
+#
+# SMALL layout (12.1.0 make-raw): ESP 36 MiB, IMGA/IMGB 512 MiB, big P3.
+# LARGE layout (EVE-k target):    ESP 2 GiB,  IMGA/IMGB 10 GiB; P3 shrinks
+# (shrink variant) or is unchanged with the grow taken from a free tail.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+MODE=${1:-}
+TAG=${2:-}
+
+GiB=$(( 1024 * 1024 * 1024 ))
+MiB=$(( 1024 * 1024 ))
+
+# Read sizes into env-file form: ESP=<bytes> IMGA=<bytes> IMGB=<bytes> P3=<bytes>
+read_sizes() {
+    timeout 20 "$EDEN" eve ssh -- \
+        'eve exec pillar lsblk -b -P -o NAME,PARTLABEL,SIZE /dev/sda 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c '
+import sys, re
+keys = {"EFI System": "ESP", "IMGA": "IMGA", "IMGB": "IMGB", "P3": "P3"}
+out = {}
+for line in sys.stdin:
+    m = dict(re.findall(r"(\w+)=\"([^\"]*)\"", line))
+    label = m.get("PARTLABEL", "")
+    if label in keys and m.get("SIZE"):
+        out[keys[label]] = m["SIZE"]
+for k in ("ESP", "IMGA", "IMGB", "P3"):
+    print("%s=%s" % (k, out.get(k, "0")))
+'
+}
+
+load_current() {
+    local env
+    env=$(read_sizes)
+    eval "$env"
+    if [ "${ESP:-0}" = "0" ] || [ "${IMGA:-0}" = "0" ] || [ "${IMGB:-0}" = "0" ]; then
+        echo "FAIL: could not read partition sizes from /dev/sda" >&2
+        echo "      raw lsblk:" >&2
+        timeout 20 "$EDEN" eve ssh -- 'eve exec pillar lsblk -b -o NAME,PARTLABEL,SIZE /dev/sda' >&2 2>/dev/null
+        exit 1
+    fi
+}
+
+print_table() {
+    printf '  %-10s %12s  (%s)\n' EFI "$ESP"  "$(( ESP  / MiB )) MiB"
+    printf '  %-10s %12s  (%s)\n' IMGA "$IMGA" "$(( IMGA / MiB )) MiB"
+    printf '  %-10s %12s  (%s)\n' IMGB "$IMGB" "$(( IMGB / MiB )) MiB"
+    printf '  %-10s %12s  (%s)\n' P3   "$P3"   "$(( P3   / MiB )) MiB"
+}
+
+case "$MODE" in
+    save)
+        [ -n "$TAG" ] || { echo "Usage: $0 save <tag>" >&2; exit 1; }
+        load_current
+        printf 'ESP=%s\nIMGA=%s\nIMGB=%s\nP3=%s\n' "$ESP" "$IMGA" "$IMGB" "$P3" > "/tmp/xhv-parts-$TAG.env"
+        echo "Saved $TAG partition sizes:"
+        print_table
+        ;;
+    assert-small)
+        load_current
+        echo "Current partition sizes:"
+        print_table
+        # Small ESP is 36 MiB, IMGA/IMGB 512 MiB; allow generous headroom but
+        # stay far below the large floors so this is unambiguous.
+        if [ "$ESP"  -ge $(( 256 * MiB )) ] || \
+           [ "$IMGA" -ge "$GiB" ] || \
+           [ "$IMGB" -ge "$GiB" ]; then
+            echo "FAIL: geometry is not SMALL (ESP/IMGA/IMGB too big)" >&2
+            exit 1
+        fi
+        echo "OK: boot disk is on the SMALL geometry"
+        ;;
+    assert-grown|assert-grown-no-shrink)
+        load_current
+        # shellcheck disable=SC1091
+        if [ ! -f /tmp/xhv-parts-small.env ]; then
+            echo "FAIL: no small baseline (/tmp/xhv-parts-small.env) to compare against" >&2
+            exit 1
+        fi
+        S_ESP=$(grep '^ESP='  /tmp/xhv-parts-small.env | cut -d= -f2)
+        S_IMGA=$(grep '^IMGA=' /tmp/xhv-parts-small.env | cut -d= -f2)
+        S_IMGB=$(grep '^IMGB=' /tmp/xhv-parts-small.env | cut -d= -f2)
+        S_P3=$(grep '^P3='   /tmp/xhv-parts-small.env | cut -d= -f2)
+        echo "Partition sizes before -> after conversion (bytes):"
+        printf '  %-10s %14s -> %14s\n' EFI  "$S_ESP"  "$ESP"
+        printf '  %-10s %14s -> %14s\n' IMGA "$S_IMGA" "$IMGA"
+        printf '  %-10s %14s -> %14s\n' IMGB "$S_IMGB" "$IMGB"
+        printf '  %-10s %14s -> %14s\n' P3   "$S_P3"   "$P3"
+        rc=0
+        # ESP/IMGA/IMGB must have grown vs baseline AND reached the large floor.
+        # Large targets are ESP 2 GiB, IMGA/IMGB 10 GiB; floors are set below the
+        # target to tolerate GPT alignment while still being unambiguously large.
+        [ "$ESP"  -gt "$S_ESP"  ] || { echo "FAIL: ESP did not grow"  >&2; rc=1; }
+        [ "$IMGA" -gt "$S_IMGA" ] || { echo "FAIL: IMGA did not grow" >&2; rc=1; }
+        [ "$IMGB" -gt "$S_IMGB" ] || { echo "FAIL: IMGB did not grow" >&2; rc=1; }
+        [ "$ESP"  -ge $(( 1 * GiB )) ] || { echo "FAIL: ESP < 1 GiB floor (target 2 GiB)"  >&2; rc=1; }
+        [ "$IMGA" -ge $(( 8 * GiB )) ] || { echo "FAIL: IMGA < 8 GiB floor (target 10 GiB)" >&2; rc=1; }
+        [ "$IMGB" -ge $(( 8 * GiB )) ] || { echo "FAIL: IMGB < 8 GiB floor (target 10 GiB)" >&2; rc=1; }
+        if [ "$MODE" = assert-grown ]; then
+            # Shrink variant: P3 must have shrunk to make room.
+            [ "$P3" -lt "$S_P3" ] || { echo "FAIL: P3 did not shrink" >&2; rc=1; }
+            ok="OK: boot disk repartitioned SMALL -> LARGE (ESP/IMGA/IMGB grew, P3 shrank)"
+        else
+            # Grow-only variant: P3 must NOT have shrunk (the grow took the free
+            # tail). Allow 1 MiB tolerance for GPT alignment jitter.
+            [ "$P3" -ge $(( S_P3 - MiB )) ] || { echo "FAIL: P3 shrank ($S_P3 -> $P3) — expected unchanged on the grow-only path" >&2; rc=1; }
+            ok="OK: ESP/IMGA/IMGB grew to LARGE and P3 was not shrunk (grow-only path)"
+        fi
+        [ "$rc" = "0" ] && echo "$ok"
+        exit "$rc"
+        ;;
+    *)
+        echo "Usage: $0 save <tag> | assert-small | assert-grown | assert-grown-no-shrink" >&2
+        exit 1
+        ;;
+esac
+
+-- settle-vault-local.sh --
+#!/bin/bash
+# Settle the TPM-sealed vault to a LOCAL unlock by rebooting through the
+# controller until VaultStatus.UnlockMethod is 1 (tpm-local-sealed).
+#
+# UnlockMethod values (pkg/pillar/types/vaultmgrtypes.go):
+#   0 none (not decided yet this boot)   1 tpm-local-sealed
+#   2 controller-key                     3 no-tpm
+# Per the conversion test design, 0 means "wait until it is set" — never treat
+# an unpublished/0 value as a result. The expected path after a new rootfs is
+# one controller-key boot (PCRs 8,13 moved) then a local seal.
+#
+# Reboots go through the controller (eden ... reboot), never `eve ssh reboot`:
+# the controller path is update-aware and recorded in reboot-reason.log. By the
+# time this runs the kvm->kvm update is already active, so the reboot is safe.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+
+# Read the highest UnlockMethod seen across all VaultStatus files (there is
+# normally one). Prints 0 if not yet published / ssh down.
+read_unlock() {
+    _u=$(timeout 15 "$EDEN" eve ssh -- \
+        'eve exec pillar sh -c "cat /run/vaultmgr/VaultStatus/*.json 2>/dev/null"' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c '
+import sys, json, re
+best = 0
+data = sys.stdin.read()
+for m in re.finditer(r"\{.*?\}", data, re.S):
+    try:
+        o = json.loads(m.group(0))
+    except Exception:
+        continue
+    v = o.get("UnlockMethod", 0)
+    if isinstance(v, int) and v > best:
+        best = v
+print(best)
+' 2>/dev/null)
+    # Emit only a validated 0-3. A transient/garbled read (e.g. pillar still
+    # starting right after a reboot, when eve ssh answers but eve exec pillar
+    # does not yet) becomes 0 so the caller keeps polling rather than treating
+    # the stray value as a settled decision and aborting.
+    case "$_u" in 0|1|2|3) echo "$_u" ;; *) echo 0 ;; esac
+}
+
+# Wait (up to ~12m) for UnlockMethod to become non-zero this boot, then echo it.
+wait_decided() {
+    local m
+    for _ in $(seq 1 72); do   # 12m at 10s
+        m=$(read_unlock)
+        if [ "${m:-0}" != "0" ]; then echo "$m"; return 0; fi
+        sleep 10
+    done
+    echo 0
+}
+
+reboot_and_wait_back() {
+    echo "$(date +%H:%M:%S) rebooting via controller to re-seal..."
+    timeout 60 "$EDEN" controller edge-node -m adam:// reboot -v debug || true
+    # Wait for SSH to drop then return.
+    for _ in $(seq 1 24); do timeout 5 "$EDEN" eve ssh 'true' 2>/dev/null || break; sleep 5; done
+    for _ in $(seq 1 90); do timeout 8 "$EDEN" eve ssh 'true' 2>/dev/null && return 0; sleep 10; done
+    echo "WARN: SSH did not return within 15m after reboot" >&2
+    return 0
+}
+
+for attempt in $(seq 1 4); do
+    echo "$(date +%H:%M:%S) settle attempt $attempt: waiting for vault unlock decision"
+    m=$(wait_decided)
+    case "$m" in
+        1) echo "OK: vault unlocked locally (tpm-local-sealed) — settled"; exit 0 ;;
+        2) echo "  unlock=controller-key (2): rebooting to re-seal to the settled state" ;;
+        3) echo "FAIL: unlock=no-tpm (3) — this test requires eve.tpm=true" >&2; exit 1 ;;
+        *) echo "FAIL: vault never reported an unlock method (stuck at 0/none)" >&2; exit 1 ;;
+    esac
+    reboot_and_wait_back
+done
+echo "FAIL: vault did not settle to a local unlock after 4 reboots" >&2
+exit 1
+
+-- watch-conversion.sh --
+#!/bin/bash
+# Drive AND watch the kvm->k conversion (shrink+grow, or grow) to completion,
+# state/sub-state TRANSITION. The post-grow vault seal check is done POST-HOC
+# from /persist/newlog (assert-seal-from-newlog.sh): the live post-grow EVE-kvm
+# window is only ~1-2 min and an ssh poll loop misses it.
+#
+# The repartition runs OFFLINE in storage-init (the boot disk's GPT can't be re-read
+# live while its rootfs is mounted): baseosmgr arms the shrink/grow flag and
+# reboots, storage-init grows ESP/IMGA/IMGB (possibly with a busy-disk
+# reboot-to-apply), the device re-checks (proceed) and does the cross-flavor A/B
+# install, then reboots into EVE-k.
+#
+# Logs, only when it changes, the tuple of: running version, IMGA/IMGB active
+# partition+version, controller-reported device state + sub-state (from adam),
+# and on-device Converting + ConvertSubState. Completion is slot-agnostic (the
+# grow can relocate the active slot).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+K_VERSION="${1:?expected -k version}"
+SERIAL_LOG='{{EdenConfig "eve.log"}}'
+DEADLINE=$(( $(date +%s) + 2700 ))   # 45m
+
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+substate_name() {
+    case "$1" in
+        1) echo preflight ;;
+        2) echo rebooting-to-resize ;;
+        3) echo making-space ;;
+        4) echo creating-partitions ;;
+        5) echo renaming-partitions ;;
+        6) echo installing ;;
+        7) echo rebooting-to-target ;;
+        *) echo "sub_$1" ;;
+    esac
+}
+
+# Controller's view from adam: the latest ZiDevice report's state + sub_state.
+# (eden info -o/--format json panics on this build, so grep the text-proto.)
+ctrl_state() {
+    local c st sub
+    c=$(timeout 20 "$EDEN" info --tail 8 2>/dev/null | grep -a '^content: ztype:ZiDevice' | tail -1)
+    st=$(echo "$c" | grep -oE 'state:ZDEVICE_STATE_[A-Z_]+' | head -1 | cut -d: -f2)
+    sub=$(echo "$c" | grep -oE 'sub_state:ZDEVICE_SUBSTATE_[A-Z_]+' | head -1 | cut -d: -f2)
+    echo "${st:-?}/${sub:-NONE}"
+}
+
+# Which partition (IMGA/IMGB) is active, and the version on it.
+active_part() {
+    probe 'eve exec pillar sh -c "cat /run/baseosmgr/ZbootStatus/IMGA.json /run/baseosmgr/ZbootStatus/IMGB.json 2>/dev/null"' | python3 -c '
+import sys, json, re
+act = "?"; ver = "?"
+for m in re.finditer(r"\{.*?\}", sys.stdin.read(), re.S):
+    try:
+        o = json.loads(m.group(0))
+    except Exception:
+        continue
+    if o.get("PartitionState") == "active":
+        act = o.get("PartitionLabel", "?"); ver = o.get("ShortVersion", "?")
+print("%s:%s" % (act, ver))' 2>/dev/null || echo "?:?"
+}
+
+serial_off=0
+report_serial() {
+    [ -f "$SERIAL_LOG" ] || return 0
+    local size new
+    size=$(stat -c%s "$SERIAL_LOG" 2>/dev/null || echo 0)
+    if [ "$size" -gt "$serial_off" ]; then
+        new=$(tail -c +$(( serial_off + 1 )) "$SERIAL_LOG" 2>/dev/null)
+        serial_off=$size
+        echo "$new" | grep -aE 'storage-resizer:|repartition|grow|reboot to apply|convert' | while IFS= read -r l; do
+            echo "  serial> $l"
+        done
+    fi
+}
+
+last_sig=""
+reboots=0
+unreachable_run=0
+seen_converting=0
+
+# Parallel stress-fill cleanup. The boot-disk RESIZE (shrink+grow) runs offline
+# in storage-init with pillar down (device unreachable); when it finishes the
+# device boots back into eve-kvm for a ~1-2 min window before rebooting into
+# EVE-k. We must free /persist/tmp/stressfill in THAT window — once EVE-k starts
+# installing its cluster a full /persist hits the ephemeral-storage eviction
+# threshold and wedges longhorn. The main watch loop's 15s cadence can miss the
+# window, so run a dedicated tight ssh loop here in the background. It is
+# SELF-GATING on the grown layout (IMGA >= 1 GiB): that is only true AFTER the
+# resize, so it never wipes the fill on the pre-resize eve-kvm boot (where the
+# fill must still be present to slow the shrink). Gate logic is base64'd so no
+# quoting has to survive ssh -> eve exec pillar sh.
+read -r -d '' _GATE <<'GATE_EOF' || true
+imga=$(lsblk -b -P -o PARTLABEL,SIZE /dev/sda 2>/dev/null | grep 'PARTLABEL="IMGA"' | grep -oE 'SIZE="[0-9]+"' | grep -oE '[0-9]+' | head -1)
+[ -n "$imga" ] || exit 0
+[ "$imga" -ge 1073741824 ] || exit 0      # grown => resize already done (post-grow eve-kvm)
+[ -d /persist/tmp/stressfill ] || exit 0
+rm -rf /persist/tmp/stressfill && sync && echo FILL-CLEANED
+GATE_EOF
+_GATE_B64=$(printf '%s' "$_GATE" | base64 | tr -d '\n')
+# The bg subshell writes its success to a marker FILE (its stdout is racy — it is
+# killed by the EXIT trap when this script returns, losing any late writes). The
+# main loop below echoes the marker, so the confirmation lands reliably in the
+# captured stdout.
+_fill_marker=$(mktemp)
+_fill_reported=0
+(
+    while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+        if timeout 10 "$EDEN" eve ssh "eve exec pillar sh -c 'echo $_GATE_B64 | base64 -d | sh'" 2>/dev/null | grep -q FILL-CLEANED; then
+            echo "$(date +%H:%M:%S) [fill-cleanup] freed /persist/tmp/stressfill on the post-resize grown layout (before EVE-k cluster install)" > "$_fill_marker"
+            break
+        fi
+        sleep 3
+    done
+) &
+_fill_pid=$!
+trap '[ -n "${_fill_pid:-}" ] && kill "$_fill_pid" 2>/dev/null; rm -f "$_fill_marker"' EXIT
+
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    if [ "$_fill_reported" = 0 ] && [ -s "$_fill_marker" ]; then
+        cat "$_fill_marker"; _fill_reported=1
+    fi
+    report_serial
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then
+        unreachable_run=$(( unreachable_run + 1 ))
+        if [ "$last_sig" != "UNREACHABLE" ]; then
+            echo "$(date +%H:%M:%S) [transition] EVE unreachable (rebooting?)"
+            last_sig="UNREACHABLE"
+        fi
+        sleep 15
+        continue
+    fi
+    if [ "$unreachable_run" -ge 2 ]; then
+        reboots=$(( reboots + 1 ))
+        echo "$(date +%H:%M:%S) observed a reboot (count=$reboots)"
+    fi
+    unreachable_run=0
+
+    actver=$(active_part)
+    bos=$(probe 'eve exec pillar sh -c "cat /run/baseosmgr/BaseOsStatus/*.json 2>/dev/null"')
+    conv=$(echo "$bos" | grep -o '"Converting":[a-z]*' | head -1 | cut -d: -f2); [ -z "$conv" ] && conv=false
+    csub=$(echo "$bos" | grep -o '"ConvertSubState":[0-9]*' | head -1 | cut -d: -f2); [ -z "$csub" ] && csub=0
+    [ "$conv" = "true" ] && seen_converting=1
+    dev=$(ctrl_state)
+
+    sig="run=$running active=$actver dev=$dev converting=$conv csub=$csub($(substate_name "$csub"))"
+    if [ "$sig" != "$last_sig" ]; then
+        echo "$(date +%H:%M:%S) [transition] $sig"
+        last_sig="$sig"
+    fi
+
+    # Done: the device has BOOTED the -k version. We deliberately do NOT wait for
+    # the A/B commit to 'active' or for the cluster to be online here — the app is
+    # deployed immediately after this, and readiness is verified in the split steps
+    # of Step 11. PartitionState is typically still 'updating'/'inprogress' now.
+    if [ "$running" = "$K_VERSION" ]; then
+        report_serial
+        echo "OK: EVE-k booted (running=$running, active=$actver, converting=$conv)"
+        echo "    observed: CONVERTING=$seen_converting reboots=$reboots"
+        exit 0
+    fi
+    sleep 15
+done
+echo "FAIL: 45m timeout. running='${running:-?}' active='${actver:-?}' dev='${dev:-?}'" >&2
+echo "      observed: CONVERTING=$seen_converting reboots=$reboots" >&2
+exit 1
+
+-- assert-seal-from-newlog.sh --
+#!/bin/bash
+# Post-hoc, VERSION-MAPPED TPM-seal check from /persist/newlog (durable across the
+# conversion's reboots; survives the repartition since /persist is on P3). Robust
+# and future-proof vs racing the ~1-2 min live post-grow window.
+#
+# Args: <k-version> <kvm-version>  (the -k target, and the conversion-capable kvm
+# image whose post-grow boot must unseal locally).
+#
+# Each unlock line is mapped to the EXACT eve version of its boot using the
+# per-boot "EVE version: <ver>" marker that device-steps.sh logs on pillar.out
+# (NOT baseosmgr's embedded "to EVE version X", which is source pillar). Then:
+#   (1) the LAST boot on the conversion-capable kvm version must have unsealed
+#       LOCALLY (tpm-local-sealed) — that is the post-grow / pre-EVE-k boot, on
+#       which only PCR5 (the repartition, excluded from the seal) changed. Keying
+#       on the specific kvm version (not "any kvm boot") keeps the test correct
+#       even if a future baseline OS also logs a local unlock; and
+#   (2) no controller-key / unseal-FAILED boot lists PCR5 in its mismatch set
+#       (an independent gate: a PCR5-driven re-seal means the repartition broke
+#       the seal). The -k boot is legitimately controller-key (PCRs 8/9/13).
+#
+# Retrieval per the eve-device-logs skill: /persist/newlog has no top-level
+# dev.log; logs are in collect/ (plaintext) + keepSentQueue/ (gz); busybox find
+# has no -exec {} +, so use -exec ... \; per-file (zcat -f handles both).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+K_VERSION="${1:?expected -k version}"
+KVM_VERSION="${2:?expected kvm (conversion-capable) version}"
+
+raw=$(timeout 120 "$EDEN" eve ssh 'eve exec pillar sh -c "find /persist/newlog -name \"dev.log.*\" -exec zcat -f {} \; 2>/dev/null | grep -aE \"EVE version: |unlocked: method=|local TPM unseal FAILED\""' 2>/dev/null | grep -v 'level=fatal')
+
+echo "$raw" | KVM="$KVM_VERSION" K="$K_VERSION" python3 -c '
+import sys, os, re
+kvm = os.environ["KVM"]
+ev = []
+for line in sys.stdin:
+    sm = re.search(r"\"seconds\":(\d+)", line); nm = re.search(r"\"nanos\":(\d+)", line)
+    sec = int(sm.group(1)) if sm else 0; ns = int(nm.group(1)) if nm else 0
+    # per-boot version marker: device-steps echo on pillar.out, "<date> EVE version: <ver>".
+    # Exclude baseosmgr "to EVE version X" (source pillar, embedded) by requiring pillar.out.
+    if "pillar.out" in line and "EVE version:" in line:
+        mv = re.search(r"EVE version: ([0-9][A-Za-z0-9._+-]*)", line)
+        if mv:
+            ev.append((sec, ns, "VER", mv.group(1), []))
+        continue
+    if "unlocked: method=tpm-local-sealed" in line:
+        ev.append((sec, ns, "UNLOCK", "local", []))
+    elif "method=controller-key" in line:
+        pc = re.search(r"mismatching ?PCRs=\[([0-9 ]*)\]", line)
+        ev.append((sec, ns, "UNLOCK", "controller", pc.group(1).split() if pc else []))
+    elif "unseal FAILED" in line:
+        pc = re.search(r"mismatching ?PCRs=\[([0-9 ]*)\]", line)
+        ev.append((sec, ns, "FAILED", "failed", pc.group(1).split() if pc else []))
+ev.sort(key=lambda x: (x[0], x[1]))
+cur = None; unlocks = []; pcr5 = []
+for e in ev:
+    if e[2] == "VER":
+        cur = e[3]
+    else:
+        unlocks.append((cur, e[3], e[4]))
+        if "5" in e[4]:
+            pcr5.append((cur, e[3], e[4]))
+for u in unlocks:
+    print("  unlock> version=%s method=%s pcrs=%s" % (u[0], u[1], u[2] or "-"))
+kvmu = [u for u in unlocks if u[0] == kvm]
+print("SUMMARY: kvm_version=%s kvm_unlocks=%d pcr5_reseals=%d" % (kvm, len(kvmu), len(pcr5)))
+rc = 0
+if pcr5:
+    print("FAIL: PCR5 in a re-seal/unseal-FAILED set %s -> the repartition broke the TPM seal" % pcr5); rc = 1
+if not kvmu:
+    print("FAIL: no unlock recorded on the conversion-capable kvm version %s (post-grow boot not observed)" % kvm); rc = 1
+elif kvmu[-1][1] != "local":
+    print("FAIL: the LAST %s boot (post-grow) unlocked %s, not local -> repartition broke the seal" % (kvm, kvmu[-1][1])); rc = 1
+else:
+    print("OK: post-grow %s boot unlocked LOCALLY (%d kvm local unseal(s); no PCR5 re-seal)" % (kvm, sum(1 for u in kvmu if u[1] == "local")))
+sys.exit(rc)
+'
+
+-- assert-persist-not-recreated.sh --
+#!/bin/bash
+# Detect whether the offline resize recreated (wiped) /persist, and RECORD it for
+# the final blob-reuse verdict (this step does not itself fail). storage-init
+# mkfs's P3 when its filesystem fails identification/fsck -- a watchdog-interrupted
+# shrink can corrupt it -- which destroys /persist (newlog, the retained
+# ContentTree, restored identity), so the post-conversion app redeploy must then
+# re-download. A recreate during INITIAL bringup (a blank, freshly-partitioned P3)
+# is expected and excluded; we flag only a recreate at/after the resize began
+# (storage-init's "shrink+grow requested"/"grow-only requested" marker), and note
+# WHICH resize step the watchdog interrupted (the last step logged before the
+# recreate) so the blob-reuse check can report FAIL[recreate-induced]. Markers in
+# storage-init.sh; retrieval per the eve-device-logs skill; ISO8601 sorts lexically.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+INFO=/tmp/xhv-persist-recreate.info
+echo "clean" > "$INFO"
+
+logs=$(timeout 90 "$EDEN" eve ssh 'eve exec pillar sh -c "find /persist/newlog -name \"dev.log.*\" -exec zcat -f {} \; 2>/dev/null | grep -aoE \"2026[^\\\"]*(recreating it as|shrink\+grow requested|grow-only requested|shrink P3 to|shrink complete|Resizing the filesystem|grow EFI|grow complete)[^\\\"]*\""' 2>/dev/null | grep -v 'level=fatal' | sort -u)
+
+tsof() { grep -aoE '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}'; }
+resize_ts=$(printf '%s\n' "$logs" | grep -aE 'shrink\+grow requested|grow-only requested' | tsof | sort | head -1)
+if [ -z "$resize_ts" ]; then
+    echo "WARNING: no resize marker in newlog; persist-recreate detection inconclusive"
+    echo "OK: /persist preserved (recorded clean)"; exit 0
+fi
+recreate_ts=$(printf '%s\n' "$logs" | grep -a 'recreating it as' | tsof | sort -u | awk -v r="$resize_ts" '$0>=r' | head -1)
+if [ -z "$recreate_ts" ]; then
+    echo "OK: /persist preserved across the resize (no P3 recreate at/after $resize_ts; bringup format excluded)"; exit 0
+fi
+# A recreate happened at/after the resize. The last resize step logged before it is
+# (best effort) what the watchdog interrupted.
+step=$(printf '%s\n' "$logs" | grep -aE 'shrink P3 to|shrink complete|Resizing the filesystem|grow EFI|grow complete' | tail -1)
+[ -n "$step" ] || step="(no resize step logged before the recreate)"
+printf 'recreated|%s|%s\n' "$recreate_ts" "$step" > "$INFO"
+echo "NOTE: /persist was recreated at $recreate_ts (at/after the resize); last step before it: $step"
+echo "(recorded -- the blob-reuse check reports FAIL[recreate-induced] if the app re-downloads)"
+
+-- wait-for-volumemgr-ready.sh --
+#!/bin/bash
+# Gate before the post-conversion redeploy. On EVE-k, volumemgr must finish its
+# "wait for kubernetes" / longhorn-ready init and RE-ESTABLISH the retained
+# ContentTree blobs in the EVE-k content store before a redeploy can REUSE them.
+# Deploying earlier causes the image to be re-downloaded (verified: ~44 MiB vs 0
+# with this gate). Wait for /run/volumemgr/VolumeMgrStatus/volumemgr.json
+# "Initialized":true (set after kubeapi.WaitForKubernetes returns).
+#
+# Instrumented: logs a timeline of (volumemgr Initialized, number of
+# ContentTreeStatus objects volumemgr currently tracks) so we can see WHEN the
+# store becomes ready and whether the retained ContentTree is recognized before
+# full Initialized — i.e. whether a narrower "blobs recognized" signal would let
+# the deploy fire sooner than waiting for the whole longhorn bring-up.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+probe() { timeout 8 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+ct_count() {
+    probe 'eve exec pillar sh -c "ls /run/volumemgr/ContentTreeStatus/*.json 2>/dev/null | wc -l"' \
+        | tr -d '\r' | grep -E '^[0-9]+$' | tail -1
+}
+last=""
+for _ in $(seq 1 240); do   # 40m at 10s (deploy-on-boot: this wait now starts at EVE-k boot, and Initialized lands ~24m later after kubeapi.WaitForKubernetes)
+    init=$(probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>/dev/null' \
+            | tr -d '\r' | grep -oE '"Initialized":[a-z]+')
+    ct=$(ct_count); [ -z "$ct" ] && ct='?'
+    sig="init=${init:-<none>} contenttrees=$ct"
+    if [ "$sig" != "$last" ]; then
+        echo "$(date +%H:%M:%S) [readiness] $sig"; last="$sig"
+    fi
+    if [ "$init" = '"Initialized":true' ]; then
+        echo "OK: volumemgr Initialized:true (contenttrees=$ct)"; exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: volumemgr did not reach Initialized:true within 40m" >&2
+probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>&1' >&2
+exit 1
+
+-- capture-blob-diagnostics.sh --
+#!/bin/bash
+# Observational diagnostics for the post-conversion blob-reuse question (does the
+# redeploy reuse the retained ContentTree, or re-download?). Runs after the app
+# reaches RUNNING, before the byte-count assertion, so it captures regardless of
+# pass/fail. Pulls the downloader / ContentTree / verifier lines from the EVE-k
+# boot out of /persist/newlog (see the eve-device-logs skill for the retrieval
+# form: logs live in collect/+keepSentQueue/, busybox find has no -exec {} +).
+# Never fails the test — purely informational.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+echo "--- live downloader RecvByteCount (per-URL) ---"
+timeout 15 "$EDEN" eve ssh -- 'eve exec pillar cat /run/downloader/MetricsMap/global.json 2>/dev/null' 2>/dev/null \
+    | grep -v 'level=fatal' | python3 -c '
+import sys, json
+try: d=json.load(sys.stdin)
+except Exception: sys.exit(0)
+for iface,conn in d.items():
+    for url,m in (conn.get("URLCounters") or {}).items():
+        rb=m.get("RecvByteCount",0)
+        if rb: print("  %d bytes  %s" % (rb, url))
+' 2>/dev/null || true
+echo "--- newlog: downloader/contenttree/verifier on the EVE-k boot (cache hit vs fetch) ---"
+timeout 90 "$EDEN" eve ssh 'eve exec pillar sh -c "find /persist/newlog -name \"dev.log.*\" -exec zcat -f {} \; 2>/dev/null | grep -aE \"already (in cache|verified|downloaded)|reusing|RecvByteCount|starting download|download done|ContentTree.*(DOWNLOAD|DELIVERED|LOADED)\""' 2>/dev/null \
+    | grep -v 'level=fatal' | grep -aoE 'msg\\":\\"[^"]*' | sed 's/^msg.":."/  newlog> /' | tail -30 || true
+echo "OK: blob diagnostics captured (informational)"
+
+-- wait-for-upgrade.sh --
+#!/bin/bash
+# Generic "wait for a same- or cross-flavor BaseOs upgrade to land": poll until
+# /run/eve-release equals the expected version AND IMGB is the active partition.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT_VERSION="${1:?expected version}"
+DEADLINE=$(( $(date +%s) + 1500 ))   # 25m
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then echo "$(date +%H:%M:%S): EVE unreachable (rebooting?)"; sleep 20; continue; fi
+    imgb_state=$(probe 'eve exec pillar cat /run/baseosmgr/ZbootStatus/IMGB.json' | grep -oP '"PartitionState":"\K[^"]+' | head -1)
+    [ -z "$imgb_state" ] && imgb_state='unknown'
+    echo "$(date +%H:%M:%S): running='$running' IMGB.PartitionState='$imgb_state'"
+    if [ "$running" = "$EXPECT_VERSION" ] && [ "$imgb_state" = "active" ]; then
+        echo "OK: upgrade to $running complete (IMGB active)"; exit 0
+    fi
+    sleep 20
+done
+echo "FAIL: upgrade to $EXPECT_VERSION did not complete in 25m (running='$running')" >&2
+exit 1
+
+-- assert-no-volumes.sh --
+#!/bin/bash
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 12); do
+    out=$("$EDEN" volume ls 2>/dev/null)
+    live=$(echo "$out" | awk 'NR>1 && ($(NF-1) == "IN_CONFIG" || $NF == "DELIVERED")')
+    if [ -z "$live" ]; then echo "OK: no live volumes"; exit 0; fi
+    sleep 5
+done
+echo "FAIL: live volume(s) present" >&2; "$EDEN" volume ls >&2; exit 1
+
+-- wait-for-app-running.sh --
+#!/bin/bash
+# Poll `eden pod ps` until xhv-app reaches LAST_STATE(EVE)=RUNNING. 25m budget
+# covers both the fast pre-conversion kvm case and the slow post-conversion
+# eve-k redeploy (longhorn install + VMI start).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 240); do   # 40m at 10s (deploy-on-boot: app RUNNING is gated on the full post-longhorn volume create + CDI upload + guest boot, ~27m observed)
+    line=$("$EDEN" pod ps 2>/dev/null | grep -E '^xhv-app\s')
+    if echo "$line" | grep -q 'RUNNING'; then
+        echo "OK: xhv-app RUNNING"; echo "$line"; exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: xhv-app did not reach RUNNING in 40m" >&2
+"$EDEN" pod ps >&2
+exit 1
+
+-- wait-for-app-gone.sh --
+#!/bin/bash
+# Poll until xhv-app fully disappears AND no per-instance VolumeStatus files
+# remain under /run/volumemgr/VolumeStatus/. Pillar tears down VM -> PVC ->
+# pubsub records; the cross-HV gate refuses kvm<->k while any Volume exists, so
+# we must reach zero before pushing the -k update.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+last_pod=""; last_vol=""
+for _ in $(seq 1 90); do   # 15m at 10s
+    pod_present=$("$EDEN" pod ps 2>/dev/null | grep -cE '^xhv-app\s')
+    # Count only per-instance .json; pubsub writes a never-removed `restarted`
+    # sentinel into this dir, so `ls | wc -l` is 1 even with no volumes.
+    vol_count=$(timeout 12 "$EDEN" eve ssh \
+        'eve exec pillar ls /run/volumemgr/VolumeStatus/*.json 2>/dev/null | wc -l' \
+        2>/dev/null | tr -d '\r' | tail -1)
+    [ -z "$vol_count" ] && vol_count="?"
+    if [ "$pod_present" = "0" ] && [ "$vol_count" = "0" ]; then
+        echo "OK: xhv-app removed and no VolumeStatus files remain"; exit 0
+    fi
+    if [ "$last_pod $last_vol" != "$pod_present $vol_count" ]; then
+        echo "$(date +%H:%M:%S) waiting for teardown: pod_rows=$pod_present vol_files=$vol_count"
+        last_pod=$pod_present; last_vol=$vol_count
+    fi
+    sleep 10
+done
+echo "FAIL: app+volumes did not fully clear in 15m" >&2
+"$EDEN" pod ps >&2
+"$EDEN" eve ssh 'eve exec pillar ls -la /run/volumemgr/VolumeStatus/ 2>&1' >&2
+exit 1
+
+-- snapshot-rcv-bytes.sh --
+#!/bin/bash
+# Snapshot cumulative RecvByteCount from /run/downloader/MetricsMap on EVE.
+# "pre" saves the baseline; "post-and-assert" recomputes the delta and asserts
+# it is below MAX_DELTA_BYTES (default 1 MiB). /run is tmpfs (reset on reboot),
+# so pre/post must bracket a single phase with no intervening reboot.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+MODE=${1:-pre}
+MAX_DELTA_BYTES=${2:-1048576}
+
+capture_recv_bytes() {
+    timeout 15 "$EDEN" eve ssh -- 'eve exec pillar cat /run/downloader/MetricsMap/global.json 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print(0); sys.exit(0)
+total = 0
+for iface, conn in d.items():
+    for url, m in (conn.get('URLCounters') or {}).items():
+        total += m.get('RecvByteCount', 0)
+print(total)
+"
+}
+
+case "$MODE" in
+    pre)
+        bytes=$(capture_recv_bytes)
+        echo "$bytes" > /tmp/xhv-rcv-pre.txt
+        echo "Pre-snapshot: RecvByteCount total = $bytes bytes"
+        ;;
+    post-and-assert)
+        post=$(capture_recv_bytes)
+        pre=$(cat /tmp/xhv-rcv-pre.txt 2>/dev/null || echo 0)
+        delta=$(( post - pre ))
+        echo "Post-snapshot: RecvByteCount total = $post bytes (pre was $pre, delta = $delta)"
+        if [ "$delta" -lt 0 ]; then
+            echo "FAIL: post < pre — counter went backwards (unexpected reboot?)" >&2; exit 1
+        fi
+        if [ "$delta" -lt "$MAX_DELTA_BYTES" ]; then
+            echo "OK: only $delta bytes received (< ${MAX_DELTA_BYTES}) — no image re-download"; exit 0
+        fi
+        info=$(cat /tmp/xhv-persist-recreate.info 2>/dev/null || echo clean)
+        if [ "${info%%|*}" = "recreated" ]; then
+            rts=$(printf '%s' "$info" | cut -d'|' -f2); rstep=$(printf '%s' "$info" | cut -d'|' -f3)
+            echo "FAIL[recreate-induced]: $delta bytes re-downloaded, BUT /persist was recreated during the resize -- storage-init mount-fsck found P3 corrupt at $rts, after the watchdog interrupted: $rstep. The re-download is the expected consequence; the conversion otherwise completed (this is the ONLY failure)." >&2
+            exit 1
+        fi
+        echo "FAIL[blob-reuse]: $delta bytes re-downloaded with NO /persist recreate -- real blob-reuse regression (image not reused across the conversion)." >&2
+        exit 1
+        ;;
+    *) echo "Usage: $0 pre | post-and-assert [max-delta-bytes]" >&2; exit 1 ;;
+esac
+
+-- wait-for-ssh-to-app.sh --
+#!/bin/bash
+# wait-for-ssh-to-app.sh — the REAL guest-readiness / functional gate for the
+# eclient app instance, shared verbatim across the cross-HV / kvm->k tests.
+#
+# `eden pod ps` RUNNING (wait-for-app-running.sh) only reflects
+# AppInstState.EVEState — the ZSwState EVE reports. On EVE-k that is the
+# kubevirt VMI Running phase (qemu launched), NOT the guest kernel booted with
+# sshd accepting connections; on EVE-kvm the gap is smaller but still not
+# guest-ready. So pod-ps RUNNING is a cheap pre-filter only — success is
+# declared HERE, once an AUTHENTICATED ssh command has actually run inside the
+# guest and returned the expected output.
+#
+# Transport: host hostfwd 127.0.0.1:2223 -> EVE-eth0:2223 (eve.hostfwd
+# extension set by eden-bringup.sh) -> zedrouter NAT -> app:22 (eclient sshd).
+# The `eden sdn fwd` wrapper collapses to the same 127.0.0.1:hostport under the
+# non-SDN QEMU user-net these tests run in, so the direct path is used.
+#
+# FRESHNESS: host port 2223 is a static QEMU forward for the whole VM lifetime,
+# so after a delete+redeploy (or a reboot) a *stale* previous eclient could keep
+# answering on it and falsely satisfy a post-conversion check. To guard that,
+# each successful check records the guest's boot_id
+# (/proc/sys/kernel/random/boot_id — a fresh UUID per VM boot) to
+# /tmp/xhv-app-bootid. In "fresh" mode the check requires the connected guest's
+# boot_id to DIFFER from that recorded value; a matching (stale) instance is
+# treated as not-ready-yet and retried until the fresh deploy takes over the
+# port or the budget runs out.
+#
+# Fail-closed: a refused / closed / timed-out ssh, a non-eclient guest, or (in
+# fresh mode) only the stale instance answering, never prints the success
+# marker. On success it prints "OK: app SSH reachable" so the escript pins the
+# framework verdict to a real session:
+#     exec -t 5m bash wait-for-ssh-to-app.sh
+#     stdout 'OK: app SSH reachable'
+#
+# Args (optional): $1 host port (default 2223); $2 attempts, 10s apart
+# (default 30 => 5m); $3 = "fresh" to require a NEW guest instance vs the
+# boot_id the previous successful check recorded (use after a redeploy/reboot).
+#
+# Cert: ssh refuses group-readable keys, so the eclient id_rsa is copied to a
+# 0600 temp file. testscript sets HOME=/no-home, so the real home is resolved
+# from the running UID; dist/tests is only populated by a full `make eden`, so
+# fall back to the master/main reference clones.
+set -uo pipefail
+PORT="${1:-2223}"
+ATTEMPTS="${2:-30}"
+FRESH="${3:-}"
+BOOTID_FILE=/tmp/xhv-app-bootid
+EDEN_TESTS="{{EdenConfig "eden.tests"}}"
+USER_HOME=$(getent passwd "$(id -u)" | cut -d: -f6)
+SRC=""
+for c in "$EDEN_TESTS/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/master/eden/tests/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/main/eden/tests/eclient/image/cert/id_rsa"; do
+    if [ -f "$c" ]; then SRC="$c"; break; fi
+done
+if [ -z "$SRC" ]; then
+    echo "FAIL: could not locate eclient id_rsa cert (EDEN_TESTS=$EDEN_TESTS, USER_HOME=$USER_HOME)" >&2
+    exit 1
+fi
+KEY=$(mktemp); install -m 600 "$SRC" "$KEY"; trap 'rm -f "$KEY"' EXIT
+SSH_OPTS=(-o ConnectTimeout=10 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -i "$KEY")
+prev=""
+[ -f "$BOOTID_FILE" ] && prev=$(cat "$BOOTID_FILE" 2>/dev/null)
+connected=0
+saw_stale=0
+for _ in $(seq 1 "$ATTEMPTS"); do
+    # One round-trip proves auth, the eclient identity, and the guest boot_id.
+    # "AUTHED" is echoed before the identity check, so a connect+auth that fails
+    # only the /etc/issue match is distinguishable from a never-connected ssh.
+    out=$(ssh "${SSH_OPTS[@]}" root@127.0.0.1 -p "$PORT" \
+        'echo AUTHED; grep -q Ubuntu /etc/issue && cat /proc/sys/kernel/random/boot_id' \
+        2>/dev/null)
+    case "$out" in *AUTHED*) connected=1 ;; esac
+    bootid=$(printf '%s\n' "$out" | tr -d '\r' | grep -Ex '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | tail -1)
+    if [ -n "$bootid" ]; then
+        if [ "$FRESH" = "fresh" ] && [ -n "$prev" ] && [ "$bootid" = "$prev" ]; then
+            # Still the previous instance on the static port — wait for the fresh
+            # deploy/boot to take over the NAT before declaring success.
+            saw_stale=1; sleep 10; continue
+        fi
+        echo "$bootid" > "$BOOTID_FILE"
+        echo "OK: app SSH reachable (port=$PORT, boot_id=$bootid, fresh=${FRESH:-no}, cert=$SRC)"
+        exit 0
+    fi
+    sleep 10
+done
+budget=$(( ATTEMPTS * 10 ))
+if [ "$saw_stale" = 1 ]; then
+    echo "FAIL: only the previous app instance (boot_id=$prev) answered within ${budget}s — the fresh deploy never took over the port (stale instance)" >&2
+elif [ "$connected" = 1 ]; then
+    echo "FAIL: ssh connected+authed but the guest never matched the eclient (grep Ubuntu /etc/issue) within ${budget}s (port=$PORT)" >&2
+else
+    echo "FAIL: app never answered an authenticated ssh within ${budget}s (port=$PORT, cert=$SRC)" >&2
+fi
+echo "--- host TCP probe ---" >&2
+( exec 3<>/dev/tcp/127.0.0.1/"$PORT" ) 2>&1 || true
+exit 1
+
+-- fill-persist.sh --
+#!/bin/bash
+# fill-persist.sh — leave /persist holding data that sits ABOVE the post-shrink
+# boundary, so the offline resize2fs SHRINK must relocate it (real work) and runs
+# long enough for the stress watchdog (run-watchdog --no-pet, escalating from
+# ~1s) to interrupt the SHRINK, not only the GROW. On the near-empty eden
+# /persist the shrink finishes in ~1s, so without this the shrink-resume /
+# P3-recreate (FAIL[recreate-induced]) paths are never tested.
+#
+# Method (fill-high-then-trim-low): a freshly-formatted ext4 allocates
+# sequentially-created files roughly low-block to high-block. So:
+#   1. fill /persist to ~90% of its ORIGINAL size with equal-size numbered files
+#      (urandom — real, non-zero, INCOMPRESSIBLE bytes), pushing data all the way
+#      into the high block groups;
+#   2. delete the EARLIEST (lowest-block) files until usage drops to the target,
+#      leaving the survivors concentrated in the high blocks — ABOVE where the
+#      shrink boundary will fall.
+# resize2fs then has to move those high blocks down into the freed low space =
+# slow shrink. (A plain `dd if=/dev/zero` of the target size just packs low,
+# below the boundary, so nothing is relocated and the shrink stays fast — which
+# is why that approach does not work.)
+#
+# Arg: $1 = TARGET used GiB to leave after the trim (0 = skip). Keep it BELOW the
+# post-shrink P3 size (~41 GiB on a 64 GiB boot disk) or the shrink can't fit and
+# storage-resizer aborts. Default 33 (~80% of the ~41 GiB post-shrink P3).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+TARGET_GIB="${1:-33}"
+if [ "$TARGET_GIB" = "0" ]; then echo "fill-persist: target=0, skipping"; exit 0; fi
+if [ "$TARGET_GIB" = "clean" ]; then
+    echo "fill-persist: removing /persist/tmp/stressfill (free space for EVE-k longhorn/CDI)"
+    "$EDEN" eve ssh 'eve exec pillar sh -c "rm -rf /persist/tmp/stressfill; sync; df -h /persist | tail -1"' 2>/dev/null | grep -v 'level=fatal'
+    echo "OK: stress-fill removed"; exit 0
+fi
+HIGH_PCT=90        # fill to this % of the original /persist size before trimming
+CHUNK_MIB=256      # file size = delete granularity
+echo "fill-persist: fill /persist to ${HIGH_PCT}% then trim to ~${TARGET_GIB} GiB used (high blocks survive)"
+
+# The device-side logic is base64-encoded so nothing has to survive the
+# ssh -> `eve exec pillar sh -c` quoting layers. It runs as busybox sh with
+# args: $1=TARGET_GIB $2=HIGH_PCT $3=CHUNK_MIB.
+read -r -d '' RUNNER <<'RUNNER_EOF' || true
+set -u
+TARGET_GIB=$1; HIGH_PCT=$2; CHUNK_MIB=$3
+DIR=/persist/tmp/stressfill
+rm -rf "$DIR"; mkdir -p "$DIR"
+used_kb() { df -k /persist | tail -1 | awk '{print $3}'; }
+cap_kb=$(df -k /persist | tail -1 | awk '{print $2}')
+hi_kb=$(( cap_kb * HIGH_PCT / 100 ))
+tgt_kb=$(( TARGET_GIB * 1024 * 1024 ))
+n=0
+while [ "$(used_kb)" -lt "$hi_kb" ]; do
+  dd if=/dev/urandom of="$DIR/$(printf %06d "$n")" bs=1M count="$CHUNK_MIB" 2>/dev/null || break
+  n=$((n+1))
+done
+echo "  filled: $n files, used $(df -h /persist | tail -1 | awk '{print $3" ("$5")"}')"
+i=0
+while [ "$(used_kb)" -gt "$tgt_kb" ] && [ "$i" -lt "$n" ]; do
+  rm -f "$DIR/$(printf %06d "$i")"; i=$((i+1))
+done
+sync
+echo "  trimmed: deleted $i earliest files, used $(df -h /persist | tail -1 | awk '{print $3" ("$5")"}')"
+RUNNER_EOF
+B64=$(printf '%s' "$RUNNER" | base64 | tr -d '\n')
+"$EDEN" eve ssh "eve exec pillar sh -c 'echo $B64 | base64 -d > /tmp/fillrunner.sh; sh /tmp/fillrunner.sh ${TARGET_GIB} ${HIGH_PCT} ${CHUNK_MIB}; rm -f /tmp/fillrunner.sh'" 2>/dev/null | grep -v 'level=fatal'
+echo "OK: /persist filled-high-then-trimmed to ~${TARGET_GIB} GiB (survivors in high blocks)"
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- wait-for-longhorn-sc.sh --
+#!/bin/bash
+# Wait until the EVE-k `longhorn` StorageClass exists (longhorn deployed + its CSI
+# provisioner up). On a freshly-converted EVE-k node longhorn can take tens of
+# minutes to deploy -- well after the device reports ONLINE -- so wait for it
+# EXPLICITLY here, before deploying/waiting for an app whose volume needs longhorn.
+# This separates cluster-bringup time from app-bringup time: the wait-for-app-running
+# that follows can be short, and a failure here clearly says "longhorn", not "app".
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 90); do   # ~45m at 30s
+    if "$EDEN" eve ssh -- 'eve exec kube kubectl get sc 2>/dev/null' 2>/dev/null | grep -qE '^longhorn'; then
+        echo "OK: longhorn StorageClass ready"; exit 0
+    fi
+    sleep 30
+done
+echo "FAIL: longhorn StorageClass not ready within budget" >&2; exit 1

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_volmig.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_volmig.txt
@@ -1,0 +1,536 @@
+# Test: EVE-kvm -> EVE-k app-volume migration. An app instance and its disk
+# volume must SURVIVE the cross-flavor upgrade WITHOUT recreate (app-written data
+# preserved), on ext4 /persist with a TPM (swtpm). The boot disk starts at the
+# LARGE EVE-k geometry, so the conversion takes the no-shrink "proceed" path and
+# the cross-flavor gate allows the upgrade with volumes present. The code under
+# test: upgradeconverter relocates the carried-over kvm volume to
+# /persist/vault/volumes-kvm, and volumemgr (csihandler) rolls that file into the
+# Longhorn PVC so the app's data survives instead of being regenerated.
+#
+# Image sequence (exact):
+#   1. start : EVE up on <VOLMIG_EVE_VER>-kvm (large geometry, ext4, tpm).
+#   2. k     : BaseOs-update kvm->k to <VOLMIG_EVE_VER>-k; the app is KEPT across it.
+#
+# What it asserts:
+#   - the running vault is TPM-backed (UnlockMethod != no-tpm);
+#   - the app reaches RUNNING on EVE-k;
+#   - a data marker written into the guest disk BEFORE the conversion is still
+#     present AFTER it (the volume survived without recreate);
+#   - the image was not re-downloaded across the conversion (RecvByteCount ~0).
+#
+# Parameters (env):
+#   VOLMIG_EVE_VER  (required) version base of the local volmig images, without
+#                   the -<hv>-<arch> suffix, e.g. "0.0.0-kvm-to-k-volmig-<sha8>".
+#   VOLMIG_EVE_REG  (default lfedge/eve) image registry/repo namespace.
+# Bringup is manual (see the README): EVE must already be up on the -kvm image.
+
+{{$arch := EdenConfig "eve.arch"}}
+{{$ver_env := EdenGetEnv "VOLMIG_EVE_VER"}}
+{{$ver := "REPLACE-WITH-VOLMIG-VERSION"}}
+{{if $ver_env}}{{$ver = $ver_env}}{{end}}
+{{$reg_env := EdenGetEnv "VOLMIG_EVE_REG"}}
+{{$reg := "lfedge/eve"}}
+{{if $reg_env}}{{$reg = $reg_env}}{{end}}
+{{$kvm_short := printf "%s-kvm-%s" $ver $arch}}
+{{$k_short   := printf "%s-k-%s" $ver $arch}}
+{{$appimg := "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"}}
+
+# Step 0: pre-flight — params, clean state, on the expected -kvm image, TPM live.
+message 'pre-flight: parameters, clean state, TPM-backed vault'
+exec -t 1m bash require-ver.sh
+exec -t 1m bash assert-no-volumes.sh
+exec -t 3m bash assert-running-version.sh {{ $kvm_short }}
+exec -t 2m bash tpm-guard.sh
+stdout 'TPM-backed'
+eden controller edge-node update --config timer.test.baseimage.update=30
+
+# Step 1: deploy a VM app with a disk volume, then write a data marker into the
+# guest disk so we can later prove the SAME bytes survived the conversion.
+message 'deploying Ubuntu VM app with a disk volume on EVE-kvm'
+eden -t 1m network create 10.11.12.0/24 -n xhv-app-net
+# Inject the eclient SSH pubkey into the guest via cloud-init user-data so the
+# marker uses key auth (no sshpass / no password). cloud-init runs once on first
+# boot and writes authorized_keys onto the guest disk = the volume that migrates,
+# so key auth keeps working post-conversion on EVE-k. (Ubuntu cloud image: it
+# honors cloud-config ssh_authorized_keys; Cirros does NOT — see gen-metadata.sh.)
+exec -t 1m bash gen-metadata.sh
+eden -t 15m pod deploy --format=qcow2 --memory=1024MB -n xhv-vmapp -p 2223:22 {{ $appimg }} --networks=xhv-app-net --metadata=/tmp/xhv-volmig-userdata.yaml
+# Pre-conversion the device is EVE-kvm (no longhorn/kube), so wait only for the
+# app itself here; the longhorn-StorageClass wait belongs to the post-conversion
+# (EVE-k) app-wait in Step 4.
+exec -t 20m bash wait-for-app-running.sh
+message 'writing a data marker into the guest disk volume'
+exec -t 20m bash marker.sh write
+stdout 'MARKER_WRITTEN'
+
+# Step 2: BaseOs-update kvm->k while KEEPING the app+volume. The cross-flavor gate
+# allows this because the large geometry means no shrink.
+message 'downloading volmig k rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$ver}} --eve-hv=k --eve-registry={{$reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs'
+message 'pushing kvm->k BaseOs update (app + volume kept)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs --os-version={{ $k_short }} -m adam://
+! stderr .
+
+# Step 3: drive and watch the conversion to EVE-k.
+message 'watching the kvm->k conversion to completion'
+exec -t 45m bash watch-conversion.sh {{ $k_short }}
+
+# Step 4: on EVE-k, wait for the cluster + app, then the load-bearing assertion:
+# the data marker survived (the volume was migrated, not recreated).
+message 'waiting for EVE-k content store (volumemgr) ready'
+exec -t 45m bash wait-for-volumemgr-ready.sh
+message 'snapshot downloader RecvByteCount baseline on EVE-k'
+exec -t 1m bash snapshot-rcv-bytes.sh pre
+message 'waiting for EVE-k longhorn StorageClass ready (cluster storage up)'
+exec -t 50m bash wait-for-longhorn-sc.sh
+stdout 'OK: longhorn StorageClass ready'
+message 'waiting for the app to reach RUNNING on EVE-k'
+exec -t 45m bash wait-for-app-running.sh
+message 'ASSERT: the disk volume survived the conversion without recreate'
+exec -t 10m bash marker.sh verify
+stdout 'VOLUME SURVIVED'
+message 'asserting the image was not re-downloaded across the conversion'
+exec -t 1m bash snapshot-rcv-bytes.sh post-and-assert
+
+# Cleanup.
+eden -t 1m pod delete xhv-vmapp
+eden -t 1m network delete xhv-app-net
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs.ver
+exec sleep 5
+eden eve reset
+
+-- require-ver.sh --
+#!/bin/bash
+# Fail fast if VOLMIG_EVE_VER was not supplied.
+set -uo pipefail
+VER='{{ $ver }}'
+if [ -z "$VER" ] || [ "$VER" = "REPLACE-WITH-VOLMIG-VERSION" ]; then
+    echo "FAIL: VOLMIG_EVE_VER not set." >&2
+    echo "      Export it to the version base of your local volmig build," >&2
+    echo "      e.g. VOLMIG_EVE_VER=0.0.0-kvm-to-k-volmig-1a2b3c4d" >&2
+    echo "      (the part before -kvm-amd64 / -k-amd64 in the docker tag)." >&2
+    exit 1
+fi
+echo "OK: VOLMIG_EVE_VER=$VER"
+
+-- tpm-guard.sh --
+#!/bin/bash
+# Confirm the test is really running with a TPM (swtpm), not a no-tpm vault — an
+# app volume in /persist/vault is only meaningful when the vault is TPM-backed.
+# swtpm and the EVE QEMU both run on this host (the eden VM), so check them here.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+pgrep -x swtpm >/dev/null && echo "swtpm: running" || { echo "FAIL: swtpm not running" >&2; exit 1; }
+ps -eo args | grep "[d]efault-eve.log" | grep -q "tpm-tis" && echo "qemu: tpm-tis present" || { echo "FAIL: qemu has no tpm-tis device" >&2; exit 1; }
+um=$(timeout 15 "$EDEN" eve ssh -- 'eve exec pillar sh -c "cat /run/vaultmgr/VaultStatus/*.json 2>/dev/null"' 2>/dev/null | grep -v 'level=fatal' | grep -oE '"UnlockMethod":[0-9]+' | head -1 | cut -d: -f2)
+echo "VaultStatus.UnlockMethod=${um:-<none>} (1=tpm-local-sealed 2=controller-key 3=no-tpm)"
+case "${um:-x}" in
+    1|2) echo "OK: TPM-backed vault confirmed" ;;
+    3)   echo "FAIL: vault is no-tpm — swtpm is not in use" >&2; exit 1 ;;
+    *)   echo "OK: TPM-backed (swtpm + tpm-tis present; UnlockMethod not yet published)" ;;
+esac
+
+-- marker.sh --
+#!/bin/bash
+# write : ssh into the Ubuntu guest and write a unique data marker into its disk
+#         volume; remember it.
+# verify: after the conversion, re-read the marker; PASS only if it matches the
+#         one written pre-conversion (proves the volume's bytes survived without
+#         recreate). Auth is KEY-BASED: gen-metadata.sh injected the eclient
+#         pubkey via cloud-init, so we log in as ubuntu with the eclient id_rsa
+#         (no password, no sshpass) over hostfwd 127.0.0.1:2223 -> EVE -> app:22.
+set -uo pipefail
+MODE=${1:?write|verify}
+PORT=2223
+MF=/tmp/xhv-volmig-marker.txt
+# ssh refuses group-readable keys, so copy the eclient id_rsa to a 0600 temp file.
+# testscript sets HOME=/no-home, so resolve the real home from the running UID;
+# dist/tests is only populated by a full `make eden`, so fall back to the
+# master/main reference clones (same list gen-metadata.sh uses for the pubkey).
+EDEN_TESTS="{{EdenConfig "eden.tests"}}"
+USER_HOME=$(getent passwd "$(id -u)" | cut -d: -f6)
+SRC=""
+for c in "$EDEN_TESTS/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/master/eden/tests/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/main/eden/tests/eclient/image/cert/id_rsa"; do
+    if [ -f "$c" ]; then SRC="$c"; break; fi
+done
+[ -n "$SRC" ] || { echo "FAIL: could not locate eclient id_rsa cert (EDEN_TESTS=$EDEN_TESTS, USER_HOME=$USER_HOME)" >&2; exit 1; }
+KEY=$(mktemp); install -m 600 "$SRC" "$KEY"; trap 'rm -f "$KEY"' EXIT
+SSHP=(-o ConnectTimeout=10 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -o PreferredAuthentications=publickey -i "$KEY")
+guest() { ssh "${SSHP[@]}" ubuntu@127.0.0.1 -p "$PORT" "$@" 2>/dev/null; }
+
+case "$MODE" in
+    write)
+        m="VOLMIG-SURVIVES-$(date +%s)"
+        ok=0
+        for _ in $(seq 1 90); do guest true && { ok=1; break; }; sleep 10; done
+        [ "$ok" = 1 ] || { echo "FAIL: ubuntu guest ssh not reachable pre-conversion" >&2; exit 1; }
+        guest "echo $m > /home/ubuntu/volmig-marker && sync && cat /home/ubuntu/volmig-marker"
+        echo "$m" > "$MF"
+        echo "MARKER_WRITTEN=$m"
+        ;;
+    verify)
+        want=$(cat "$MF" 2>/dev/null)
+        for _ in $(seq 1 48); do
+            got=$(guest 'cat /home/ubuntu/volmig-marker 2>/dev/null' | tr -d '\r')
+            if [ -n "$got" ]; then
+                echo "guest marker='$got' expected='$want'"
+                if [ "$got" = "$want" ]; then
+                    echo "PASS: VOLUME SURVIVED kvm->k WITHOUT RECREATE (data marker intact)"
+                    exit 0
+                fi
+                echo "FAIL: marker mismatch — the volume was recreated/replaced" >&2
+                exit 1
+            fi
+            sleep 15
+        done
+        echo "FAIL: marker not readable on EVE-k (app not ssh-reachable or volume lost)" >&2
+        exit 1
+        ;;
+    *) echo "usage: marker.sh write|verify" >&2; exit 1 ;;
+esac
+
+-- gen-metadata.sh --
+#!/bin/bash
+# Write the cloud-init user-data that `eden pod deploy --metadata=` reads, so the
+# Ubuntu guest authorizes the eclient SSH pubkey for its default (ubuntu) user,
+# so marker.sh logs in with a key and needs no sshpass/password. (Cirros does NOT
+# honor cloud-config ssh_authorized_keys, verified 2026-07-01 — hence Ubuntu.) Same cert
+# search list as marker.sh (dist/tests, then the master/main reference clones).
+set -uo pipefail
+EDEN_TESTS="{{EdenConfig "eden.tests"}}"
+USER_HOME=$(getent passwd "$(id -u)" | cut -d: -f6)
+PUB=""
+for c in "$EDEN_TESTS/eclient/image/cert/id_rsa.pub" \
+         "$USER_HOME/lf-edge/master/eden/tests/eclient/image/cert/id_rsa.pub" \
+         "$USER_HOME/lf-edge/main/eden/tests/eclient/image/cert/id_rsa.pub"; do
+    if [ -f "$c" ]; then PUB="$c"; break; fi
+done
+[ -n "$PUB" ] || { echo "FAIL: could not locate eclient id_rsa.pub (EDEN_TESTS=$EDEN_TESTS, USER_HOME=$USER_HOME)" >&2; exit 1; }
+UD=/tmp/xhv-volmig-userdata.yaml
+{
+    echo "#cloud-config"
+    echo "ssh_authorized_keys:"
+    echo " - $(cat "$PUB")"
+} > "$UD"
+echo "OK: wrote cloud-init userdata (eclient pubkey) to $UD"
+
+-- assert-running-version.sh --
+#!/bin/bash
+# Sanity-check that EVE is running the expected SMALL bringup release before the
+# conversion starts. This escript does not install the base image — bringup
+# happens manually before the test (see README_kvm_to_k_resize.md). This guards
+# against running the test against the wrong base image or an already-upgraded
+# device.
+#
+# Matches the expected version as a substring of /run/eve-release (which is the
+# full "<ver>-<hv>-<arch>" form, e.g. "12.1.0-kvm-amd64"), so passing "12.1.0"
+# accepts the kvm bringup image without pinning the hv/arch suffix.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT="${1:?expected bringup version substring}"
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+for _ in $(seq 1 18); do   # ~3m at 10s; tolerate ssh not up yet
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -n "$running" ]; then
+        case "$running" in
+            *"$EXPECT"*)
+                echo "OK: running the expected bringup release ('$running' contains '$EXPECT')"
+                exit 0 ;;
+            *)
+                echo "FAIL: running version '$running' does not match expected bringup '$EXPECT'." >&2
+                echo "      Bring eve up on the small '$EXPECT' image before this test, or set" >&2
+                echo "      BRINGUP_EVE_VER to the release you brought up on." >&2
+                echo "      See README_kvm_to_k_resize.md." >&2
+                exit 1 ;;
+        esac
+    fi
+    sleep 10
+done
+echo "FAIL: could not read /run/eve-release (ssh down / device not up?)" >&2
+exit 1
+
+-- assert-no-volumes.sh --
+#!/bin/bash
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 12); do
+    out=$("$EDEN" volume ls 2>/dev/null)
+    live=$(echo "$out" | awk 'NR>1 && ($(NF-1) == "IN_CONFIG" || $NF == "DELIVERED")')
+    if [ -z "$live" ]; then echo "OK: no live volumes"; exit 0; fi
+    sleep 5
+done
+echo "FAIL: live volume(s) present" >&2; "$EDEN" volume ls >&2; exit 1
+
+-- wait-for-app-running.sh --
+#!/bin/bash
+# Poll `eden pod ps` until xhv-vmapp reaches LAST_STATE(EVE)=RUNNING. 25m budget
+# covers both the fast pre-conversion kvm case and the slow post-conversion
+# eve-k redeploy (longhorn install + VMI start).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 240); do   # 40m at 10s (deploy-on-boot: app RUNNING is gated on the full post-longhorn volume create + CDI upload + guest boot, ~27m observed)
+    line=$("$EDEN" pod ps 2>/dev/null | grep -E '^xhv-vmapp\s')
+    if echo "$line" | grep -q 'RUNNING'; then
+        echo "OK: xhv-vmapp RUNNING"; echo "$line"; exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: xhv-vmapp did not reach RUNNING in 40m" >&2
+"$EDEN" pod ps >&2
+exit 1
+
+-- watch-conversion.sh --
+#!/bin/bash
+# Drive AND watch the kvm->k conversion (shrink+grow, or grow) to completion,
+# state/sub-state TRANSITION. The post-grow vault seal check is done POST-HOC
+# from /persist/newlog (assert-seal-from-newlog.sh): the live post-grow EVE-kvm
+# window is only ~1-2 min and an ssh poll loop misses it.
+#
+# The repartition runs OFFLINE in storage-init (the boot disk's GPT can't be re-read
+# live while its rootfs is mounted): baseosmgr arms the shrink/grow flag and
+# reboots, storage-init grows ESP/IMGA/IMGB (possibly with a busy-disk
+# reboot-to-apply), the device re-checks (proceed) and does the cross-flavor A/B
+# install, then reboots into EVE-k.
+#
+# Logs, only when it changes, the tuple of: running version, IMGA/IMGB active
+# partition+version, controller-reported device state + sub-state (from adam),
+# and on-device Converting + ConvertSubState. Completion is slot-agnostic (the
+# grow can relocate the active slot).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+K_VERSION="${1:?expected -k version}"
+SERIAL_LOG='{{EdenConfig "eve.log"}}'
+DEADLINE=$(( $(date +%s) + 2700 ))   # 45m
+
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+substate_name() {
+    case "$1" in
+        1) echo preflight ;;
+        2) echo rebooting-to-resize ;;
+        3) echo making-space ;;
+        4) echo creating-partitions ;;
+        5) echo renaming-partitions ;;
+        6) echo installing ;;
+        7) echo rebooting-to-target ;;
+        *) echo "sub_$1" ;;
+    esac
+}
+
+# Controller's view from adam: the latest ZiDevice report's state + sub_state.
+# (eden info -o/--format json panics on this build, so grep the text-proto.)
+ctrl_state() {
+    local c st sub
+    c=$(timeout 20 "$EDEN" info --tail 8 2>/dev/null | grep -a '^content: ztype:ZiDevice' | tail -1)
+    st=$(echo "$c" | grep -oE 'state:ZDEVICE_STATE_[A-Z_]+' | head -1 | cut -d: -f2)
+    sub=$(echo "$c" | grep -oE 'sub_state:ZDEVICE_SUBSTATE_[A-Z_]+' | head -1 | cut -d: -f2)
+    echo "${st:-?}/${sub:-NONE}"
+}
+
+# Which partition (IMGA/IMGB) is active, and the version on it.
+active_part() {
+    probe 'eve exec pillar sh -c "cat /run/baseosmgr/ZbootStatus/IMGA.json /run/baseosmgr/ZbootStatus/IMGB.json 2>/dev/null"' | python3 -c '
+import sys, json, re
+act = "?"; ver = "?"
+for m in re.finditer(r"\{.*?\}", sys.stdin.read(), re.S):
+    try:
+        o = json.loads(m.group(0))
+    except Exception:
+        continue
+    if o.get("PartitionState") == "active":
+        act = o.get("PartitionLabel", "?"); ver = o.get("ShortVersion", "?")
+print("%s:%s" % (act, ver))' 2>/dev/null || echo "?:?"
+}
+
+serial_off=0
+report_serial() {
+    [ -f "$SERIAL_LOG" ] || return 0
+    local size new
+    size=$(stat -c%s "$SERIAL_LOG" 2>/dev/null || echo 0)
+    if [ "$size" -gt "$serial_off" ]; then
+        new=$(tail -c +$(( serial_off + 1 )) "$SERIAL_LOG" 2>/dev/null)
+        serial_off=$size
+        echo "$new" | grep -aE 'storage-resizer:|repartition|grow|reboot to apply|convert' | while IFS= read -r l; do
+            echo "  serial> $l"
+        done
+    fi
+}
+
+last_sig=""
+reboots=0
+unreachable_run=0
+seen_converting=0
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    report_serial
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then
+        unreachable_run=$(( unreachable_run + 1 ))
+        if [ "$last_sig" != "UNREACHABLE" ]; then
+            echo "$(date +%H:%M:%S) [transition] EVE unreachable (rebooting?)"
+            last_sig="UNREACHABLE"
+        fi
+        sleep 15
+        continue
+    fi
+    if [ "$unreachable_run" -ge 2 ]; then
+        reboots=$(( reboots + 1 ))
+        echo "$(date +%H:%M:%S) observed a reboot (count=$reboots)"
+    fi
+    unreachable_run=0
+
+    actver=$(active_part)
+    bos=$(probe 'eve exec pillar sh -c "cat /run/baseosmgr/BaseOsStatus/*.json 2>/dev/null"')
+    conv=$(echo "$bos" | grep -o '"Converting":[a-z]*' | head -1 | cut -d: -f2); [ -z "$conv" ] && conv=false
+    csub=$(echo "$bos" | grep -o '"ConvertSubState":[0-9]*' | head -1 | cut -d: -f2); [ -z "$csub" ] && csub=0
+    [ "$conv" = "true" ] && seen_converting=1
+    dev=$(ctrl_state)
+
+    sig="run=$running active=$actver dev=$dev converting=$conv csub=$csub($(substate_name "$csub"))"
+    if [ "$sig" != "$last_sig" ]; then
+        echo "$(date +%H:%M:%S) [transition] $sig"
+        last_sig="$sig"
+    fi
+
+    # Done: the device has BOOTED the -k version. We deliberately do NOT wait for
+    # the A/B commit to 'active' or for the cluster to be online here — readiness
+    # is verified in the split steps that follow. PartitionState is typically still
+    # 'updating'/'inprogress' now.
+    if [ "$running" = "$K_VERSION" ]; then
+        report_serial
+        echo "OK: EVE-k booted (running=$running, active=$actver, converting=$conv)"
+        echo "    observed: CONVERTING=$seen_converting reboots=$reboots"
+        exit 0
+    fi
+    sleep 15
+done
+echo "FAIL: 45m timeout. running='${running:-?}' active='${actver:-?}' dev='${dev:-?}'" >&2
+echo "      observed: CONVERTING=$seen_converting reboots=$reboots" >&2
+exit 1
+
+-- wait-for-volumemgr-ready.sh --
+#!/bin/bash
+# Gate before the post-conversion redeploy. On EVE-k, volumemgr must finish its
+# "wait for kubernetes" / longhorn-ready init and RE-ESTABLISH the retained
+# ContentTree blobs in the EVE-k content store before a redeploy can REUSE them.
+# Deploying earlier causes the image to be re-downloaded (verified: ~44 MiB vs 0
+# with this gate). Wait for /run/volumemgr/VolumeMgrStatus/volumemgr.json
+# "Initialized":true (set after kubeapi.WaitForKubernetes returns).
+#
+# Instrumented: logs a timeline of (volumemgr Initialized, number of
+# ContentTreeStatus objects volumemgr currently tracks) so we can see WHEN the
+# store becomes ready and whether the retained ContentTree is recognized before
+# full Initialized — i.e. whether a narrower "blobs recognized" signal would let
+# the deploy fire sooner than waiting for the whole longhorn bring-up.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+probe() { timeout 8 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+ct_count() {
+    probe 'eve exec pillar sh -c "ls /run/volumemgr/ContentTreeStatus/*.json 2>/dev/null | wc -l"' \
+        | tr -d '\r' | grep -E '^[0-9]+$' | tail -1
+}
+last=""
+for _ in $(seq 1 240); do   # 40m at 10s (deploy-on-boot: this wait now starts at EVE-k boot, and Initialized lands ~24m later after kubeapi.WaitForKubernetes)
+    init=$(probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>/dev/null' \
+            | tr -d '\r' | grep -oE '"Initialized":[a-z]+')
+    ct=$(ct_count); [ -z "$ct" ] && ct='?'
+    sig="init=${init:-<none>} contenttrees=$ct"
+    if [ "$sig" != "$last" ]; then
+        echo "$(date +%H:%M:%S) [readiness] $sig"; last="$sig"
+    fi
+    if [ "$init" = '"Initialized":true' ]; then
+        echo "OK: volumemgr Initialized:true (contenttrees=$ct)"; exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: volumemgr did not reach Initialized:true within 40m" >&2
+probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>&1' >&2
+exit 1
+
+-- snapshot-rcv-bytes.sh --
+#!/bin/bash
+# Snapshot cumulative RecvByteCount from /run/downloader/MetricsMap on EVE.
+# "pre" saves the baseline; "post-and-assert" recomputes the delta and asserts
+# it is below MAX_DELTA_BYTES (default 1 MiB). /run is tmpfs (reset on reboot),
+# so pre/post must bracket a single phase with no intervening reboot.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+MODE=${1:-pre}
+MAX_DELTA_BYTES=${2:-1048576}
+
+capture_recv_bytes() {
+    timeout 15 "$EDEN" eve ssh -- 'eve exec pillar cat /run/downloader/MetricsMap/global.json 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print(0); sys.exit(0)
+total = 0
+for iface, conn in d.items():
+    for url, m in (conn.get('URLCounters') or {}).items():
+        total += m.get('RecvByteCount', 0)
+print(total)
+"
+}
+
+case "$MODE" in
+    pre)
+        bytes=$(capture_recv_bytes)
+        echo "$bytes" > /tmp/xhv-rcv-pre.txt
+        echo "Pre-snapshot: RecvByteCount total = $bytes bytes"
+        ;;
+    post-and-assert)
+        post=$(capture_recv_bytes)
+        pre=$(cat /tmp/xhv-rcv-pre.txt 2>/dev/null || echo 0)
+        delta=$(( post - pre ))
+        echo "Post-snapshot: RecvByteCount total = $post bytes (pre was $pre, delta = $delta)"
+        if [ "$delta" -lt 0 ]; then
+            echo "FAIL: post < pre — counter went backwards (unexpected reboot?)" >&2; exit 1
+        fi
+        if [ "$delta" -lt "$MAX_DELTA_BYTES" ]; then
+            echo "OK: only $delta bytes received (< ${MAX_DELTA_BYTES}) — no image re-download"; exit 0
+        fi
+        info=$(cat /tmp/xhv-persist-recreate.info 2>/dev/null || echo clean)
+        if [ "${info%%|*}" = "recreated" ]; then
+            rts=$(printf '%s' "$info" | cut -d'|' -f2); rstep=$(printf '%s' "$info" | cut -d'|' -f3)
+            echo "FAIL[recreate-induced]: $delta bytes re-downloaded, BUT /persist was recreated during the resize -- storage-init mount-fsck found P3 corrupt at $rts, after the watchdog interrupted: $rstep. The re-download is the expected consequence; the conversion otherwise completed (this is the ONLY failure)." >&2
+            exit 1
+        fi
+        echo "FAIL[blob-reuse]: $delta bytes re-downloaded with NO /persist recreate -- real blob-reuse regression (image not reused across the conversion)." >&2
+        exit 1
+        ;;
+    *) echo "Usage: $0 pre | post-and-assert [max-delta-bytes]" >&2; exit 1 ;;
+esac
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+
+-- wait-for-longhorn-sc.sh --
+#!/bin/bash
+# Wait until the EVE-k `longhorn` StorageClass exists (longhorn deployed + its CSI
+# provisioner up). On a freshly-converted EVE-k node longhorn can take tens of
+# minutes to deploy -- well after the device reports ONLINE -- so wait for it
+# EXPLICITLY here, before deploying/waiting for an app whose volume needs longhorn.
+# This separates cluster-bringup time from app-bringup time: the wait-for-app-running
+# that follows can be short, and a failure here clearly says "longhorn", not "app".
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 90); do   # ~45m at 30s
+    if "$EDEN" eve ssh -- 'eve exec kube kubectl get sc 2>/dev/null' 2>/dev/null | grep -qE '^longhorn'; then
+        echo "OK: longhorn StorageClass ready"; exit 0
+    fi
+    sleep 30
+done
+echo "FAIL: longhorn StorageClass not ready within budget" >&2; exit 1


### PR DESCRIPTION
# Description

End-to-end eden tests for the EVE-kvm ↔ EVE-k cross-flavor BaseOs
upgrade, including the in-field boot-disk repartition (small → large
GPT geometry). They verify that OCI blobs are reused across the flavor
switch (no re-download), that a deployed app and its volume survive the
conversion and a controller-initiated reboot, and — for the resize
variants — that the partitions actually grow and the TPM-sealed vault
stays locally unlocked across the geometry change.

All scenarios live under `tests/update_eve_image/testdata/`, each a
self-contained escript (plus helper scripts and READMEs):

- `update_eve_image_cross_hv.txt` — base cross-HV upgrade; IMGB reaches
  `active` on the alternate flavor.
- `update_eve_image_cross_hv_with_contenttree.txt` — pre-stages a
  ContentTree, asserts zero bytes re-downloaded after the switch.
- `update_eve_image_cross_hv_with_app_recreate.txt` — app + volume
  survive the switch and a reboot with no re-download.
- `update_eve_image_kvm_to_k{,_grow,_resize,_refused,_volmig}.txt` —
  repartition variants asserting SMALL→LARGE partition growth,
  `BaseOsStatus.Converting` device state, blob reuse, local vault unlock
  (`VaultStatus.UnlockMethod`), and (volmig) live app-volume migration
  to a Longhorn PVC.
- `update_eve_image_kvm_to_k_geom.txt` — a **geometry-only** matrix,
  parameterized by the *starting release*, asserting the boot disk ends
  at the full EVE-k target **2+2+10+10** (ESP-A 2G, the reserved ESP-B 2G
  at GPT #7, IMGA/IMGB 10G) — including *creating* the reserved ESP-B
  when the start image lacks it. One escript covers the range of
  boot-disk geometries a fielded device may carry (10.1.0 at 36M/300M,
  12.1.0 at 36M/512M, 16.13.0 at 2G/4G, 17.0.0-rc1 at 2G/10G). It checks
  geometry only (no app/content-tree/vault-seal), so it needs no TPM or
  `/config` settle; the two ESPs share the `EFI System` label and are
  told apart by PARTUUID. All four starts validated GREEN (see
  `README_kvm_to_k_geom.md`).

## Dependency

These exercise EVE-side behavior that is not yet in eden's CI EVE image.
**Do not enable in CI/CD until lf-edge/eve#6036 (kvm↔k BaseOs upgrade
with blob reuse) merges**; the resize/volmig variants additionally need
an EVE build carrying the boot-disk repartition work, and the `geom`
variant needs a build whose `storage-resizer` *creates* the reserved
ESP-B (the ESP-B retrofit). Kept as a **draft** until then.
