### PR TITLE
tests: bump wait_ssh timeout from 5m to 10m

### DIFF
--- a/tests/eclient/testdata/air-gapped-switch.txt
+++ b/tests/eclient/testdata/air-gapped-switch.txt
@@ -43,7 +43,7 @@ message 'Waiting for running state'
 test eden.app.test -test.v -timewait 15m RUNNING eclient1 eclient2
 
 message 'Checking accessibility'
-exec -t 5m bash wait_ssh.sh {{template "port1"}} {{template "port2"}}
+exec -t 10m bash wait_ssh.sh {{template "port1"}} {{template "port2"}}
 
 message 'Assign address to eth1 and check mac for eclient1'
 exec -t 1m bash prepare1.sh

--- a/tests/eclient/testdata/app_dhcp.txt
+++ b/tests/eclient/testdata/app_dhcp.txt
@@ -41,7 +41,7 @@ eden pod deploy -v debug -n eclient --memory=512MB --networks=nat --networks=swi
 test eden.app.test -test.v -timewait 20m RUNNING dhcp-server eclient
 
 message 'Checking accessibility'
-exec -t 5m bash wait_ssh.sh
+exec -t 10m bash wait_ssh.sh
 
 message 'Waiting for IP allocation'
 exec -t 5m bash wait_for_app_ip.sh eclient

--- a/tests/eclient/testdata/app_dns.txt
+++ b/tests/eclient/testdata/app_dns.txt
@@ -38,8 +38,8 @@ eden pod deploy -v debug -n app2 --memory=512MB --networks=localnet -p {{templat
 test eden.app.test -test.v -timewait 10m RUNNING app2
 
 message 'Checking accessibility'
-exec -t 5m bash wait_ssh.sh {{template "app1_port"}}
-exec -t 5m bash wait_ssh.sh {{template "app2_port"}}
+exec -t 10m bash wait_ssh.sh {{template "app1_port"}}
+exec -t 10m bash wait_ssh.sh {{template "app2_port"}}
 
 message 'Checking DNS resolution from apps'
 exec -t 5m bash nslookup_from_app.sh {{template "app1_port"}} app2
@@ -65,8 +65,8 @@ test eden.app.test -test.v -timewait 5m PURGING app1
 test eden.app.test -test.v -timewait 5m RUNNING app1
 
 message 'Re-checking accessibility after purge of app1'
-exec -t 5m bash wait_ssh.sh {{template "app1_port"}}
-exec -t 5m bash wait_ssh.sh {{template "app2_port"}}
+exec -t 10m bash wait_ssh.sh {{template "app1_port"}}
+exec -t 10m bash wait_ssh.sh {{template "app2_port"}}
 
 message 'Re-checking DNS resolution after purge of app1'
 exec -t 5m bash nslookup_from_app.sh {{template "app1_port"}} app2

--- a/tests/eclient/testdata/app_nonat.txt
+++ b/tests/eclient/testdata/app_nonat.txt
@@ -37,7 +37,7 @@ message 'Waiting of running'
 test eden.app.test -test.v -timewait 30m RUNNING eclient
 
 message 'Checking accessibility'
-exec -t 5m bash wait_ssh.sh
+exec -t 10m bash wait_ssh.sh
 
 message 'Testing of network'
 exec sleep 20

--- a/tests/eclient/testdata/nw_switch.txt
+++ b/tests/eclient/testdata/nw_switch.txt
@@ -38,7 +38,7 @@ message 'Getting "pong" IP'
 exec bash pong_ip.sh
 
 message 'Checking accessibility'
-exec -t 5m bash wait_ssh.sh 2223 2224
+exec -t 10m bash wait_ssh.sh 2223 2224
 
 message 'Testing of 1st network'
 exec sleep 20
@@ -53,7 +53,7 @@ test eden.app.test -test.v -timewait 15m RUNNING pong
 
 message 'Getting new "pong" IP'
 exec bash pong_ip.sh
-exec -t 5m bash wait_ssh.sh 2223 2224
+exec -t 10m bash wait_ssh.sh 2223 2224
 
 message 'Testing of 2nd network'
 exec sleep 20
@@ -75,7 +75,7 @@ exec -t 1m bash ping.sh 2223
 stdout '0% packet loss'
 ! exec -t 1m bash ping.sh 2224
 stdout '100% packet loss'
-exec -t 5m bash wait_ssh.sh 2223 2224
+exec -t 10m bash wait_ssh.sh 2223 2224
 
 message 'Resource cleanup'
 eden pod delete ping1

--- a/tests/eclient/testdata/port_forward.txt
+++ b/tests/eclient/testdata/port_forward.txt
@@ -37,8 +37,8 @@ message 'SCENARIO 1: Waiting for apps to enter RUNNING state'
 test eden.app.test -test.v -timewait 20m RUNNING app1 app2
 
 message 'SCENARIO 1: Checking accessibility'
-exec -t 5m bash wait_ssh.sh eth0 2223
-exec -t 5m bash wait_ssh.sh eth0 2224
+exec -t 10m bash wait_ssh.sh eth0 2223
+exec -t 10m bash wait_ssh.sh eth0 2224
 
 eden eve status
 cp stdout eve_status
@@ -58,8 +58,8 @@ exec sleep 60
 eden eve link up
 # give EVE some time to recover (largely depends on the DHCP server)
 exec sleep 20
-exec -t 5m bash wait_ssh.sh eth0 2223
-exec -t 5m bash wait_ssh.sh eth0 2224
+exec -t 10m bash wait_ssh.sh eth0 2223
+exec -t 10m bash wait_ssh.sh eth0 2224
 exec -t 1m bash test_connectivity.sh eth0 2223 eth0 2224
 stdout 'Ubuntu'
 {{end}}
@@ -103,8 +103,8 @@ message 'SCENARIO 2: Waiting for apps to enter RUNNING state'
 test eden.app.test -test.v -timewait 20m RUNNING app1 app2
 
 message 'SCENARIO 2: Checking accessibility'
-exec -t 5m bash wait_ssh.sh eth0 2223
-exec -t 5m bash wait_ssh.sh eth1 2234
+exec -t 10m bash wait_ssh.sh eth0 2223
+exec -t 10m bash wait_ssh.sh eth1 2234
 
 eden eve status
 cp stdout eve_status
@@ -123,8 +123,8 @@ exec sleep 60
 eden eve link up
 # give EVE some time to recover (largely depends on the DHCP server)
 exec sleep 20
-exec -t 5m bash wait_ssh.sh eth0 2223
-exec -t 5m bash wait_ssh.sh eth1 2234
+exec -t 10m bash wait_ssh.sh eth0 2223
+exec -t 10m bash wait_ssh.sh eth1 2234
 exec -t 1m bash test_connectivity.sh eth0 2223 eth1 2234
 stdout 'Ubuntu'
 

--- a/tests/eclient/testdata/profile.txt
+++ b/tests/eclient/testdata/profile.txt
@@ -71,7 +71,7 @@ eden pod start local-manager
 test eden.app.test -test.v -timewait 15m RUNNING local-manager
 
 # Wait for ssh access
-exec -t 5m bash wait_ssh.sh 2223
+exec -t 10m bash wait_ssh.sh 2223
 
 # start local manager application
 exec -t 1m bash local-manager-start.sh 2223

--- a/tests/lim/testdata/log_test.txt
+++ b/tests/lim/testdata/log_test.txt
@@ -4,7 +4,7 @@
 eden -t 1m controller edge-node get-config --file /tmp/full-config.json
 
 # wait for EVE's sshd before we capture the pre-update lastconfig mtime
-exec -t 5m bash wait_ssh.sh
+exec -t 10m bash wait_ssh.sh
 
 # snapshot /persist/checkpoint/lastconfig mtime *before* pushing the log-level
 # update so the subsequent active wait can detect when EVE has actually applied


### PR DESCRIPTION
The eclient SSH-readiness wait recurrently flakes on the hosted CI runners: the Ubuntu app instance reaches RUNNING but its guest sshd does not present an SSH banner in time, so the testscript fails with `context deadline exceeded` (repeated banner-exchange timeouts). This has hit the LPS/LOC, Smoke, Storage and Virtualization groups across master and stable branches.

The embedded `wait_ssh.sh` retries 20 times with a 20s sleep plus a 10s connect-timeout per attempt — roughly ten minutes to exhaust its loop. Wrapping it in `exec -t 5m` kills it after only about half those attempts, so a guest that is merely slow to boot on a loaded runner is reported as a hard failure. This raises every 5m wrapper to 10m, matching the 10m/20m budgets already used by `acl`, `host-only`, `maridb` and `nginx`. The probe still breaks early on success, so there is no cost on the happy path.