### PR TITLE
kubevirt: test cluster storage health reporting

### DIFF
--- a/tests/kubevirt/kubevirt_test.go
+++ b/tests/kubevirt/kubevirt_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lf-edge/eden/pkg/controller/einfo"
 	"github.com/lf-edge/eden/pkg/defaults"
 	tk "github.com/lf-edge/eden/pkg/evetestkit"
 	"github.com/lf-edge/eden/pkg/openevec"
 	"github.com/lf-edge/eden/pkg/utils"
+	"github.com/lf-edge/eve-api/go/info"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -86,4 +88,66 @@ func TestNodeReady(t *testing.T) {
 	}
 
 	t.Fatalf("k3s node did not become ready")
+}
+
+// TestClusterStorageHealth verifies that EVE-k reports distributed-storage
+// (Longhorn) health to the controller in the ZInfoKubeCluster info message,
+// and that eden can read it back from Adam. This is the observable end of the
+// disk-sizing guard added in lf-edge/eve#6108: KubeStorageInfo.Health is set
+// from Longhorn's daemonset readiness and node-disk schedulability, so a
+// too-small /persist (disk unschedulable, no replica placeable) surfaces as
+// DEGRADED instead of the field going unreported.
+//
+// The assertion is deliberately that a *defined* health status round-trips to
+// the controller (not that it reaches HEALTHY): reaching HEALTHY requires
+// Longhorn to fully install and schedule replicas, which is exactly the slow,
+// disk-size-sensitive path this work is about. A reported DEGRADED/FAILED here
+// is a strong hint the node's disk is too small for Longhorn (EVE-k needs a
+// 64 GiB disk; 32 GiB is not enough).
+func TestClusterStorageHealth(t *testing.T) {
+	log.Println("TestClusterStorageHealth started")
+	defer log.Println("TestClusterStorageHealth finished")
+
+	// Longhorn install is slow; poll until the cluster info carries a defined
+	// storage health, up to a generous deadline.
+	deadline := time.Now().Add(20 * time.Minute)
+	lastHealth := info.ServiceStatus_SERVICE_STATUS_UNSPECIFIED
+	for time.Now().Before(deadline) {
+		msgs, err := eveNode.GetInfoFromAdam(map[string]string{
+			"ztype": ".*ZiKubeCluster.*",
+		}, einfo.InfoExist, 2*time.Minute)
+		if err != nil {
+			t.Logf("no ZiKubeCluster info from Adam yet: %v", err)
+			time.Sleep(30 * time.Second)
+			continue
+		}
+		// Take the storage health from the most recent cluster info message.
+		var storage *info.KubeStorageInfo
+		for _, m := range msgs {
+			if m.Ztype == info.ZInfoTypes_ZiKubeCluster {
+				if s := m.GetClusterInfo().GetStorage(); s != nil {
+					storage = s
+				}
+			}
+		}
+		if storage == nil {
+			t.Logf("ZiKubeCluster info present but no storage section yet")
+			time.Sleep(30 * time.Second)
+			continue
+		}
+		lastHealth = storage.GetHealth()
+		t.Logf("cluster storage health reported on Adam: %s", lastHealth)
+		if lastHealth != info.ServiceStatus_SERVICE_STATUS_UNSPECIFIED {
+			if lastHealth != info.ServiceStatus_SERVICE_STATUS_HEALTHY {
+				t.Logf("WARNING: storage health is %s, not HEALTHY - the "+
+					"Longhorn disk may be unschedulable (disk too small for "+
+					"EVE-k? needs 64 GiB)", lastHealth)
+			}
+			return
+		}
+		time.Sleep(30 * time.Second)
+	}
+	t.Fatalf("EVE-k never reported a defined cluster storage health to Adam "+
+		"(last=%s); expected KubeStorageInfo.Health to be populated once "+
+		"Longhorn is installed", lastHealth)
 }


### PR DESCRIPTION
## What

Adds `TestClusterStorageHealth` to the EVE-k (`kubevirt`) suite. It reads
the `ZInfoKubeCluster` info message back from Adam and asserts that EVE-k
reports a defined distributed-storage (Longhorn) health status, exercising
the new `KubeStorageInfo.Health` signal end to end: device → controller →
eden.

## Why

Paired with lf-edge/eve#6108. On EVE-k the fixed partitions consume ~22 GiB,
so a 32 GiB disk leaves `/persist` too small for Longhorn — after Longhorn's
reserve + 25% minimal-available floor no replica can schedule, and app
deploys become extremely slow or fail. That EVE PR makes the condition
observable by degrading `KubeStorageInfo.Health` when the Longhorn disk is
unschedulable; this test is the eden-side check that the signal round-trips
to the controller and is queryable by tests.

The assertion is deliberately that a *defined* status round-trips (not that
it reaches HEALTHY): reaching HEALTHY requires Longhorn to fully install and
schedule replicas — the slow, disk-size-sensitive path this work is about. A
reported `DEGRADED`/`FAILED` is logged as a likely too-small-disk signal.

## Testing

Compiles/vets clean. Not yet run against a live EVE-k cluster — that requires
a longhorn-capable node (64 GiB disk) and the full EVE-k bringup.

## CI status

Note: the `tests/kubevirt` suite is **not currently wired into any CI job**,
so this test does not run automatically. eden's `test.yml` declares
`eve_kubevirt_image`/`eve_kubevirt_artifact_name` inputs but never consumes
them, and none of the `tests/workflow/*.tests.txt` scenarios invoke the
kubevirt suite; it runs only when invoked manually against an
`eve.hv=kubevirt` image. Wiring the suite into CI (consuming the existing
kubevirt image input, on a Longhorn-capable / 64 GiB node) is a separate
follow-up.
