### PR TITLE
Bump sdn/vm build image to Go 1.25 eve-alpine

### DIFF
--- a/sdn/vm/Dockerfile
+++ b/sdn/vm/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:745ae9066273c73b0fd879c4ba4ff626a8392d04 AS build
+FROM lfedge/eve-alpine:39f46094f640424c345164420ed789afd8a4088b AS build
 
 ENV BUILD_PKGS="git gcc make wget libc-dev linux-headers"
 ENV PKGS="bash iptables ip6tables iproute2 dhcpcd ipset curl radvd ethtool jq tcpdump \

--- a/sdn/vm/Dockerfile.vm
+++ b/sdn/vm/Dockerfile.vm
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:745ae9066273c73b0fd879c4ba4ff626a8392d04 AS tools
+FROM lfedge/eve-alpine:39f46094f640424c345164420ed789afd8a4088b AS tools
 
 ENV PKGS qemu-img tar
 RUN eve-alpine-deploy.sh


### PR DESCRIPTION
#1205 raises `sdn/vm/go.mod` to `go 1.25.0`, but the `sdn/vm` build image is still the go-1.24.6 eve-alpine, so the `eden-sdn-svc-container` build fails with `go.mod requires go >= 1.25.0 (running go 1.24.6; GOTOOLCHAIN=local)` (observed on the arm64 leg of the `build` job).

This points `sdn/vm`'s build and tools stages at the go-1.25 eve-alpine tag EVE pins (`39f46094…`, go1.25.11 on both amd64 and arm64), matching the root image bumped in #1204 — that PR merged before this `sdn/vm` change made it in, so `sdn/vm` was left behind. Unblocks #1205.

Verified: `sdn/vm` cross-compiles and `go vet`s clean for arm64 on go1.25.11 with #1205's `go.mod`, and the amd64 svc-container builds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)