### PR TITLE
[WIP] tests/update_eve_image: kvm→k cross-HV conversion + resize test suite

### DIFF
--- a/tests/update_eve_image/eden.update_eve_image.tests.txt
+++ b/tests/update_eve_image/eden.update_eve_image.tests.txt
@@ -1,2 +1,5 @@
 eden.escript.test -test.run TestEdenScripts/update_eve_image_http -test.timeout 60m
 eden.escript.test -test.run TestEdenScripts/update_eve_image_oci -test.timeout 60m
+eden.escript.test -test.run TestEdenScripts/update_eve_image_cross_hv -test.timeout 90m
+eden.escript.test -test.run TestEdenScripts/update_eve_image_cross_hv_with_contenttree -test.timeout 90m
+eden.escript.test -test.run TestEdenScripts/update_eve_image_cross_hv_with_app_recreate -test.timeout 180m

--- a/tests/update_eve_image/testdata/README_first_boot_evek_app.md
+++ b/tests/update_eve_image/testdata/README_first_boot_evek_app.md
@@ -1,0 +1,70 @@
+# First-boot EVE-k app-volume test (`first_boot_evek_app_volume`)
+
+Verifies **lf-edge/eve #6121** (merged to master 2026-07-16): on a **fresh EVE-k**
+first boot, an app instance whose volume is requested **before cluster storage
+(k3s + longhorn + CDI) is ready** must **converge**, not wedge. Before #6121 the
+app volume could park indefinitely at `CREATING_VOLUME` (or, depending on where
+the storage pipeline stuck, `INITIAL` / `LOADED`). #6121 defers EVE-k volume
+creation until `ClusterStorageReadyForVolumes` (longhorn StorageClass + the CDI
+control-plane Deployments), retries transient cluster-volume failures, and makes
+`CreatePVC` idempotent.
+
+This is a **native EVE-k boot** — NOT a kvm→k conversion. No repartition, no
+cross-flavor upgrade, no vault settle.
+
+## What it does
+
+1. **Bringup (manual)** boots EVE directly on a `-k` (kubevirt) image and onboards
+   it — this is the device's *first boot*. No app is deployed yet.
+2. The **escript** then, as its first action, deploys an Ubuntu VM app (with a
+   disk volume) — seconds after onboard, while EVE-k's cluster storage is still
+   ~12–15 min from ready. So the app volume sits in the config through the entire
+   no-storage window that #6121 protects.
+3. It waits for storage to come up (`volumemgr` Initialized, longhorn
+   StorageClass), then asserts the app volume was **not wedged** and the app
+   reaches **RUNNING**, logging the `LAST_STATE(EVE)` progression so you can see it
+   advance out of `CREATING_VOLUME`/`INITIAL`/`LOADED` into activation.
+4. Strong liveness: key-based SSH into the guest (not just VMI-phase RUNNING).
+
+**Ordering note:** eden's `pod deploy` targets an already-onboarded device (it
+resolves the device UUID from the local eden context), so onboard must precede
+deploy. Deploying immediately after a fresh onboard is the faithful reproduction —
+the cluster is ~15 min from ready, so the volume is requested from the start of
+EVE-k's operational life.
+
+## Image
+
+Uses a `-k` build carrying the #6121 stack. The most recent **pre-merge #6121**
+build is the `volumemgr-cdi-retry` branch (identical commit subjects to master's
+`5b53d02f7`…`3d35218e9`); its newest local `-k` image auto-discovers. To run
+against a genuine **master** `-k` once one is built, pass `TAG=`/`FBK_EVE_VER=`.
+
+## Run (host eden)
+
+```sh
+S=~/.claude/skills/kvm-to-k-conversion-testing/scripts
+# 1) bringup (takes over the host eden slot; destructive reset)
+bash "$S/firstboot-evek-bringup.sh"            # or TAG=0.0.0-master-<sha8> ...
+# 2) run the escript
+bash "$S/firstboot-evek-run.sh"                # or FBK_EVE_VER=<ver> ...
+```
+
+`firstboot-evek-run.sh` sets `FBK_EVE_VER`, checks EVE→adam connectivity, and runs
+`eden.escript.test -test.run TestEdenScripts/first_boot_evek_app_volume`.
+
+## Timing
+
+Budgets follow the kvm→k tests (EVE-k cluster bring-up dominates): volumemgr
+Initialized ~15–25 min into first boot, longhorn StorageClass shortly after, app
+RUNNING once storage is ready. A healthy host run is ~25–40 min; the escript's
+`-t 45m` waits are ceilings. The reboot watchdog is a 75 min safety ceiling
+(a fresh EVE-k boot performs no reboots of its own).
+
+## Reading a failure
+
+- `FAIL[volume-wedge]: app stuck at <state> (below activation)` — the app never
+  activated; `<state>` names where the storage pipeline stuck (`CREATING_VOLUME`,
+  `INITIAL`, `LOADED`, …). This is the #6121 regression signal. Any
+  `VolumeStatus`/`ContentTreeStatus` `Error` is dumped alongside.
+- A stall in `wait-for-longhorn-sc.sh` means cluster storage itself never came up
+  (a cluster-bringup problem, not the volume-gate path under test).

--- a/tests/update_eve_image/testdata/README_kvm_to_k.md
+++ b/tests/update_eve_image/testdata/README_kvm_to_k.md
@@ -1,0 +1,151 @@
+# EVE-kvm ↔ EVE-k conversion test suite
+
+These escripts exercise the cross-flavor (EVE-kvm ↔ EVE-k) BaseOs upgrade and the
+in-field **boot-disk repartition** it triggers: a fielded device installed with the
+SMALL GPT geometry (36 MiB ESP, 512 MiB IMGA/IMGB, big P3) is converted, offline and
+in the field, to the LARGE EVE-k geometry — ESP-A 2 GiB, a reserved **ESP-B** (GPT #7,
+GUID …30056) 2 GiB, IMGA/IMGB 10 GiB — while preserving the deployed app, its
+volume, cached OCI blobs, and the TPM-sealed vault across the geometry change.
+
+The conversion runs **offline** in `storage-init` (the boot disk's GPT can't be
+re-read live while its rootfs is mounted): the cross-flavor seam arms a shrink/grow
+flag and reboots; `storage-init` grows ESP/IMGA/IMGB (shrinking the ext4 P3 first if
+there is no free tail), then boots EVE-k on the enlarged geometry.
+
+## Tests
+
+| Escript | Validates | Start |
+|---|---|---|
+| `update_eve_image_kvm_to_k.txt` | The successful repartition (shrink **or** grow, single/two-disk/zfs), parameterized by env knobs. Asserts SMALL→LARGE geometry incl. ESP-B, `Converting` device state, TPM seal preserved, and cached-blob reuse on redeploy. | SMALL |
+| `update_eve_image_kvm_to_k_refused.txt` | The declined (`insufficient`) path: conversion refused (too-full ext4, or ZFS persist), geometry unchanged, `BaseOsStatus.Error`, device stays manageable. | SMALL |
+| `update_eve_image_kvm_to_k_geom.txt` | Geometry-only matrix: from every historical start geometry the conversion reaches the full 2+2+10+10 EVE-k target incl. ESP-B. No app/vault. | SMALL (per release) |
+| `update_eve_image_kvm_to_k_volmig.txt` | App-volume migration without recreate (qcow2 → Longhorn PVC), for a VM app **and** a container app; data marker survives. | LARGE (`proceed`) |
+| `update_eve_image_kvm_to_k_persist_wipe_restore.txt` | Fault: full `/persist` loss → identity restored from the `/config` backup, offline, incl. decrypt of a controller-encrypted credential from the restored ecdh cert. | SMALL |
+| `update_eve_image_kvm_to_k_backup_corrupt_restore.txt` | Fault: partial corruption (backed-up files truncated) → recovery via the per-type validity gate + `.bak` fallback. | SMALL |
+| `first_boot_evek_app_volume.txt` | Native EVE-k first boot (no conversion): an app volume already in config converges once cluster storage is ready (lf-edge/eve #6121). Asserts ESP-B present. | native EVE-k |
+| `update_eve_image_cross_hv.txt` | Bare cross-HV upgrade (no volumes), both directions. | released |
+| `update_eve_image_cross_hv_with_contenttree.txt` | A pre-staged ContentTree survives the cross-HV switch (blob reuse). | released |
+| `update_eve_image_cross_hv_with_app_recreate.txt` | App + volume survive delete→redeploy across kvm→k and a controller-initiated device reboot (Longhorn re-attach). | released |
+
+Only the `cross_hv*` escripts are registered in `eden.update_eve_image.tests.txt`
+(they run on released images with no local build). The rest require a locally-built
+conversion image and manual bringup, so they are **run explicitly**, not from the
+`eden test` manifest — see below.
+
+## Prerequisites
+
+- A local EVE image **pair** built from the branch carrying the conversion code,
+  tagged `<RESIZE_EVE_REG>:<RESIZE_EVE_VER>-kvm-<arch>` **and** `-k-<arch>` (both
+  hypervisor flavors must be present locally).
+- The SMALL bringup release (`BRINGUP_EVE_VER`, default `12.1.0`) available to
+  `eden` (it is pulled if not local).
+- `swtpm` + OVMF on the host, and eden configured with `eve.tpm=true` — the vault /
+  TPM-seal assertions are meaningless without a TPM.
+- The host eden slot **free**: eden is single-tenant, and every leg does its own
+  destructive bringup (full reset).
+- For `persist_wipe_restore` / `backup_corrupt_restore`: an `eden` binary that
+  carries the `add-wireless` CLI (lf-edge/eden #1202), used to inject the encrypted
+  credential whose offline decrypt is the load-bearing proof.
+
+## Build the conversion image pair
+
+Build EVE for both hypervisors from the branch that carries the conversion code
+(e.g. `make HV=kvm eve` and `make HV=k eve` in the eve repo). Each build tags
+`lfedge/eve:0.0.0-<branch>-<sha8>-<hv>-amd64`. Set `RESIZE_EVE_VER` to the shared
+prefix (without the `-<hv>-<arch>` suffix), e.g.:
+
+```sh
+RESIZE_EVE_VER=0.0.0-resize-allprs-0c318dfa   # the -kvm and -k tags of this prefix must both exist
+```
+
+Commit before building so both flavors share a clean `0.0.0-<branch>-<sha8>` prefix
+(a dirty tree injects a per-build `-dirty-<timestamp>` that differs between the kvm
+and k builds).
+
+## Run the repartition matrix
+
+`run-kvm-to-k-tests.sh` drives the repartition + insufficient-space legs end to end:
+for each disk topology it calls `prep-kvm-to-k-topology.sh <topology> --yes` (the
+committed host-side bringup helper) and then runs the mapped escript with the right
+knobs, collecting a PASS/FAIL summary.
+
+```sh
+RESIZE_EVE_VER=0.0.0-resize-allprs-<sha8> bash run-kvm-to-k-tests.sh
+# subset:
+ONLY=ext4-shrink,ext4-grow RESIZE_EVE_VER=0.0.0-resize-allprs-<sha8> bash run-kvm-to-k-tests.sh
+```
+
+Legs (topology → escript + knobs):
+
+| Leg id | topology | escript + knobs |
+|---|---|---|
+| `ext4-shrink` | ext4 full, 1 disk | `kvm_to_k` `EXPECT_DECISION=shrink` |
+| `ext4-grow` | ext4 + ≥22 GiB tail, 1 disk | `kvm_to_k` `EXPECT_DECISION=grow` |
+| `twodisk-ext4` | ext4 on sdb, 2 disks | `kvm_to_k` `EXPECT_DECISION=grow DISK_TOPOLOGY=two-disk` |
+| `twodisk-zfs` | zfs on sdb, 2 disks | `kvm_to_k` `EXPECT_DECISION=grow DISK_TOPOLOGY=two-disk` |
+| `zfs-grow` | zfs on boot P3 + tail | `kvm_to_k` `EXPECT_DECISION=grow DISK_TOPOLOGY=zfs` |
+| `ext4-toofull` | ext4 full (fill-driven) | `kvm_to_k_refused` `REFUSE_REASON=too-full` |
+| `zfs-notail` | zfs on boot P3, no tail | `kvm_to_k_refused` `REFUSE_REASON=zfs` |
+
+`prep-kvm-to-k-topology.sh <topology>` can also be run standalone to leave eden in a
+given layout, then run the escript by hand.
+
+## Other tests (own bringup)
+
+These need a different start image or bringup than the repartition matrix, so run
+them individually after bringing eden up as noted.
+
+```sh
+# App-volume migration — start LARGE on the conversion -kvm image (no repartition):
+VOLMIG_EVE_VER=<ver> eden test tests/update_eve_image -e 'update_eve_image_kvm_to_k_volmig$' -v debug
+
+# Geometry matrix — per starting release, set the start geometry it should have:
+BRINGUP_EVE_VER=<rel> RESIZE_EVE_VER=<ver> \
+  START_ESP_MIB=36 START_IMGA_MIB=512 START_IMGB_MIB=512 START_HAS_ESPB=0 \
+  eden test tests/update_eve_image -e 'update_eve_image_kvm_to_k_geom$' -v debug
+
+# Native EVE-k first boot — bring up directly on a -k image:
+FBK_EVE_VER=<k-ver> eden test tests/update_eve_image -e 'first_boot_evek_app_volume$' -v debug
+
+# Persist-wipe / backup-corruption restore — SMALL start; needs the add-wireless CLI:
+RESIZE_EVE_VER=<ver> BRINGUP_EVE_VER=12.1.0 \
+  eden test tests/update_eve_image -e 'update_eve_image_kvm_to_k_persist_wipe_restore$' -v debug
+RESIZE_EVE_VER=<ver> BRINGUP_EVE_VER=12.1.0 \
+  eden test tests/update_eve_image -e 'update_eve_image_kvm_to_k_backup_corrupt_restore$' -v debug
+
+# Cross-HV family — ALT_HV selects the target flavor (also in the CI manifest):
+ALT_HV=k ALT_EVE_VER=<ver> eden test tests/update_eve_image -e 'update_eve_image_cross_hv$' -v debug
+```
+
+## Env-knob reference
+
+`update_eve_image_kvm_to_k.txt`:
+
+| Knob | Default | Meaning |
+|---|---|---|
+| `RESIZE_EVE_VER` | *(required)* | version base of the local conversion build |
+| `RESIZE_EVE_REG` | `lfedge/eve` | image registry/repo namespace |
+| `BRINGUP_EVE_VER` | `12.1.0` | SMALL start release the device must be on at Step 1 |
+| `EXPECT_DECISION` | `shrink` | `shrink` \| `grow` — Step-1 precondition + final geometry assert |
+| `DISK_TOPOLOGY` | `single` | `single` \| `two-disk` \| `zfs` — data-preservation invariant |
+| `POST_REBOOT_CHECK` | *(unset)* | non-empty ⇒ after the conversion, reboot the device from the controller and re-verify the app recovers |
+| `FILL_PERSIST_GIB` | `33` | (shrink only) GiB to pre-fill `/persist` so the offline shrink has real blocks to relocate; `0` disables |
+| `RELOCATE_CRITICAL_HIGH` | `0` | also relocate the identity-critical files into high blocks so the shrink must move them (soak) |
+| `RELOCATE_STRICT` | `0` | hard-fail unless every critical file landed high |
+
+Other escripts: `update_eve_image_kvm_to_k_refused.txt` adds `REFUSE_REASON`
+(`too-full` \| `zfs`); `_volmig` uses `VOLMIG_EVE_VER`/`VOLMIG_EVE_REG` (LARGE
+start); `_geom` uses `START_ESP_MIB`/`START_IMGA_MIB`/`START_IMGB_MIB`/`START_HAS_ESPB`
+(+ `BRINGUP_EVE_VER`/`RESIZE_EVE_VER`); `_persist_wipe_restore` and
+`_backup_corrupt_restore` add `SKIP_KVM_HOP`; `first_boot_evek_app_volume` uses
+`FBK_EVE_VER`; the `cross_hv*` escripts use `ALT_HV`/`ALT_EVE_VER`/`ALT_EVE_REG`.
+
+## Why the image sequence is small → kvm-hop → k
+
+A released SMALL image lacks the conversion code, and only a SMALL-layout build
+yields the SMALL start geometry the conversion must operate on. So the conversion
+escripts always: (1) start SMALL on `BRINGUP_EVE_VER`; (2) BaseOs-update kvm→kvm
+onto the conversion-capable build — same geometry, this only lands the code — then
+settle the vault to a local TPM unlock; (3) BaseOs-update kvm→k — the cross-flavor
+seam that arms the offline repartition. Getting this sequence wrong invalidates the
+test.

--- a/tests/update_eve_image/testdata/README_kvm_to_k.md
+++ b/tests/update_eve_image/testdata/README_kvm_to_k.md
@@ -1,6 +1,6 @@
-# EVE-kvm ↔ EVE-k conversion test suite
+# EVE-kvm → EVE-k conversion test suite
 
-These escripts exercise the cross-flavor (EVE-kvm ↔ EVE-k) BaseOs upgrade and the
+These escripts exercise the cross-flavor (EVE-kvm → EVE-k) BaseOs upgrade and the
 in-field **boot-disk repartition** it triggers: a fielded device installed with the
 SMALL GPT geometry (36 MiB ESP, 512 MiB IMGA/IMGB, big P3) is converted, offline and
 in the field, to the LARGE EVE-k geometry — ESP-A 2 GiB, a reserved **ESP-B** (GPT #7,

--- a/tests/update_eve_image/testdata/README_kvm_to_k_geom.md
+++ b/tests/update_eve_image/testdata/README_kvm_to_k_geom.md
@@ -1,0 +1,111 @@
+# kvm->k geometry matrix (`update_eve_image_kvm_to_k_geom`)
+
+A geometry-only sibling of `update_eve_image_kvm_to_k_resize`. It proves that,
+whatever the boot disk's **starting** GPT layout, driving an EVE-kvm -> EVE-k
+base-OS upgrade ends with the full EVE-k target of **2+2+10+10 GiB**:
+
+| partition | target |
+|-----------|--------|
+| ESP-A ("EFI System", PARTUUID `…30051`) | 2 GiB |
+| ESP-B, reserved ("EFI System", PARTUUID `…30056`) | 2 GiB |
+| IMGA | 10 GiB |
+| IMGB | 10 GiB |
+
+It deliberately skips apps, deferred content-tree deletes, blob-reuse, and the
+TPM-seal check — those live in the resize/volmig tests. One escript, parameterized
+by the starting release; the matrix runner runs it once per release.
+
+## The one escript, driven by parameters
+
+`update_eve_image_kvm_to_k_geom.txt` reads:
+
+| env | meaning |
+|-----|---------|
+| `RESIZE_EVE_VER` (req) | conversion-capable build base, e.g. `0.0.0-kvm-to-k-resize-<sha8>` |
+| `RESIZE_EVE_REG` | image namespace (default `lfedge/eve`) |
+| `BRINGUP_EVE_VER` (req) | the release EVE was brought up on (asserted at Step 1) |
+| `START_ESP_MIB` / `START_IMGA_MIB` / `START_IMGB_MIB` | expected start sizes (0 = skip that band check) |
+| `START_HAS_ESPB` | 1 if the start image already has the reserved ESP-B |
+
+Flow: assert START release + geometry → kvm→kvm hop onto `RESIZE_EVE_VER` (lands
+the conversion code, geometry unchanged) → kvm→k (arms the offline repartition) →
+`assert-final` = 2+2+10+10.
+
+The two ESPs share the GPT label `"EFI System"`; `capture-geom.sh` tells them
+apart by PARTUUID and by **count**, so `assert-final` requires **two** ~2 GiB
+"EFI System" partitions, one carrying the reserved ESP-B UUID (`…30056`).
+
+## Starting-release matrix
+
+Sizes verified against each tag's `pkg/mkimage-raw-efi/make-raw`:
+
+| release | ESP | ESP-B | IMGA | IMGB | what the convert must add |
+|---------|-----|-------|------|------|---------------------------|
+| **10.1.0**    | 36 MiB | — | 300 MiB | 300 MiB | grow ESP + both IMGx (+ shrink P3) + create ESP-B |
+| **16.13.0**   | 2 GiB  | — | 4 GiB   | 4 GiB   | grow both IMGx (+ shrink P3) + create ESP-B |
+| **17.0.0-rc1**| 2 GiB  | — | 10 GiB  | 10 GiB  | **only** create ESP-B |
+| **17.1.0** (TBD, unreleased) | 2 GiB | 2 GiB | 10 GiB | 10 GiB | nothing (no-op; must stay 2+2+10+10) |
+
+10.1.0 is the pre-512 MiB baseline (`ROOTFS_PART_SIZE=300 MiB`); 512 MiB first
+shipped in 10.2.0. 2 GiB ESP first shipped in 16.13.0; 10 GiB IMGx in the 17.0.0
+series; the reserved ESP-B is not in any release yet (build-time `make-raw` only).
+
+## Status: e2e check for the ESP-B retrofit (RED until the EVE wiring lands)
+
+This matrix is the end-to-end verification for the **ESP-B retrofit** (design:
+`~/notes/esp-b-retrofit-3-design.md` — retrofit the reserved ESP-B onto old
+pre-ESP-B disks during the kvm→k grow so a converted device is byte-identical to a
+fresh EVE-k install: partition **#7**, GUID `…30056`, `ef00`, 2 GiB).
+
+- **Library side (done + validated):** partitionresizer branch `esp-b-create` has
+  the declarative create path (empty FAT32 by offset, ESP-B folded into the final
+  GPT write, #7 reserved); diskfs PRs #21/#23/#414.
+- **EVE side (in progress):** `pkg/storage-resizer` gains the dynamic 22/24 GiB
+  budget (24 when ESP-B must be created) and wires `Apply` (select ESP-A by GUID
+  `…30051`, create ESP-B `…30056` when absent) — branch `esp-b-create-resize` at
+  `~/lf-edge/esp-b-create/eve`.
+
+So `assert-final` (which requires two ~2 GiB "EFI System" partitions, one carrying
+`…30056`) goes **green only when `RESIZE_EVE_VER` is a create-capable build**.
+Against a build whose resizer still targets `spaceNeededBytes = 2+10+10` with no
+ESP-B it is RED, correctly showing the not-yet-created state.
+
+**Validated 2026-07-09 (all four starts GREEN)** in a multipass sandbox against
+`0.0.0-esp-b-create-resize-nostress-6fb1e67c` (resizer `3eeaf245`): 10.1.0, 12.1.0,
+16.13.0, 17.0.0-rc1 each converted to 2+2+10+10 with the reserved ESP-B created.
+The sandbox suffices because this test boots no app guest (no depth-2 nested-KVM
+wall). 17.1.0 additionally covers the already-converted no-op once such an image
+exists.
+
+## Running
+
+Single-tenant eden — the runner takes over the host eden slot (destructive reset).
+
+```sh
+S=~/.claude/skills/kvm-to-k-conversion-testing/scripts
+RESIZE_EVE_VER=0.0.0-kvm-to-k-resize-<sha8> bash "$S/run-kvm-to-k-geom-matrix.sh"
+# add the unreleased ESP-B build once you have it built locally:
+RESIZE_EVE_VER=... RELEASES="10.1.0 16.13.0 17.0.0-rc1 17.1.0" bash "$S/run-kvm-to-k-geom-matrix.sh"
+```
+
+Results (per-release logs + `summary.txt`) land in `~/kvm-to-k-geom-matrix-<utc>/`.
+To run a single start by hand against an already-onboarded device, invoke the
+escript directly (see `resize-fullrun.sh` for the `eden test … -e …` form) with
+`BRINGUP_EVE_VER` + the `START_*` values from the table above.
+
+## Operational notes (from the 2026-07-09 validation)
+
+- **Watch budget scales with the IMGx-grow copy.** A start whose IMGA/IMGB must
+  GROW (16.13.0: 4→10 GiB, ~8 GiB online-grow copy) can take ~30 min before the
+  offline shrink + EVE-k boot even begin; on constrained I/O the whole run is
+  ~70 min. The watch step is `exec -t 90m` for this reason. Tiny-IMGx starts
+  (10.1.0/12.1.0) and no-grow starts (17.0.0-rc1) finish in ~32-40 min.
+- **`RESIZE_EVE_VER` must be genuinely create-capable.** storage-init runs the
+  storage-resizer *binary* pinned in `pkg/storage-init/Dockerfile`
+  (`FROM lfedge/eve-storage-resizer:<hash>`), not the eve tree's Go source, so a
+  build whose source has the create but pins a pre-feature binary produces
+  2+10+10 (RED). Confirm the pin is create-capable before a green run.
+- **10.1.0 boots + onboards fine** under current eden (was flagged as a risk; the
+  2021→2026 kvm→kvm hop applied cleanly). No need to substitute 12.1.0.
+- **17.1.0** needs a local build carrying both the ESP-B `make-raw` change and the
+  conversion wiring; it is unreleased, so the runner skips it unless present.

--- a/tests/update_eve_image/testdata/first_boot_evek_app_volume.txt
+++ b/tests/update_eve_image/testdata/first_boot_evek_app_volume.txt
@@ -1,0 +1,367 @@
+# Test: FRESH first-boot EVE-k with an app instance (and its volume) already in
+# the device config, verifying that volume creation is NOT wedged and the app
+# reaches RUNNING. This exercises lf-edge/eve #6121 (merged to master 2026-07-16):
+# volumemgr now DEFERS EVE-k volume creation until cluster storage is ready
+# (ClusterStorageReadyForVolumes gates on the longhorn StorageClass + the CDI
+# control-plane Deployments), RETRIES transient cluster-volume failures, and
+# CreatePVC is idempotent — so an app volume requested before longhorn/CDI are up
+# converges instead of parking forever at CREATING_VOLUME.
+#
+# This is a NATIVE EVE-k boot — NOT a kvm->k conversion. The boot image is a plain
+# master(-equivalent) -k build; there is no repartition, no cross-flavor upgrade,
+# no vault settle.
+#
+# Bringup is manual (see README_first_boot_evek_app.md): the device must already be
+# freshly onboarded on the -k image via firstboot-evek-bringup.sh. That is the
+# "first boot" — the escript then deploys the app IMMEDIATELY, while EVE-k's
+# cluster storage (k3s + longhorn + CDI, ~12-15 min out) is still initializing, so
+# the app's volume is requested during the no-storage window that #6121 protects.
+#
+# Ordering note: eden's `pod deploy` writes the app into the controller for an
+# ALREADY-onboarded device (it resolves the device UUID from the local eden
+# context), so onboard must precede deploy. Deploying as the escript's first action
+# — seconds after a fresh onboard, with cluster readiness ~15 min away — reproduces
+# "an app volume is in the config from the start of EVE-k's operational life".
+#
+# What it asserts:
+#   - EVE is running the expected -k version and starts with no live volumes;
+#   - EVE-k cluster storage comes up (volumemgr Initialized, longhorn StorageClass);
+#   - the app's volume is NOT wedged: LAST_STATE(EVE) advances through the storage
+#     pipeline into activation (BOOTING/RUNNING) rather than sticking below it.
+#     Depending on where storage wedges the stall can show as INITIAL, LOADED, or
+#     CREATING_VOLUME, so the check treats ANY pre-activation stall (and no
+#     progress) as a wedge and names the state it got stuck in;
+#   - the app reaches RUNNING (7) on EVE-k;
+#   - the guest is genuinely up (key-based SSH), not merely VMI-phase RUNNING.
+#
+# Parameters (env):
+#   FBK_EVE_VER  (required) version base of the local -k image, WITHOUT the
+#                -<hv>-<arch> suffix, e.g. "0.0.0-volumemgr-cdi-retry-ee3da038".
+#   FBK_EVE_REG  (default lfedge/eve) image registry/repo namespace.
+
+{{$arch := EdenConfig "eve.arch"}}
+{{$ver_env := EdenGetEnv "FBK_EVE_VER"}}
+{{$ver := "REPLACE-WITH-K-VERSION"}}
+{{if $ver_env}}{{$ver = $ver_env}}{{end}}
+{{$k_short := printf "%s-k-%s" $ver $arch}}
+{{$appimg := "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"}}
+
+# A fresh EVE-k boot performs no reboots of its own; fail if 3+ are observed.
+# timewait is a safety ceiling above the longest foreground wait (cluster bring-up
+# + app RUNNING).
+! test eden.reboot.test -test.v -timewait=75m -reboot=0 -count=3 &
+
+# Step 0: pre-flight — right version, clean slate.
+message 'pre-flight: parameters, expected -k version, no pre-existing volumes'
+exec -t 1m bash require-ver.sh
+exec -t 3m bash assert-running-version.sh {{ $k_short }}
+stdout 'OK: running'
+exec -t 1m bash assert-no-volumes.sh
+message 'ASSERT: native EVE-k boot disk carries the reserved ESP-B (#7, …30056)'
+exec -t 2m bash assert-espb-present.sh
+stdout 'OK: ESP-B present'
+# Shorten the controller config cadence so the app lands in EVE's config promptly.
+eden controller edge-node update --config timer.config.interval=10
+
+# Step 1: deploy the app instance NOW (fresh EVE-k, cluster storage not yet up).
+# This is the moment under test: the app's disk volume enters the config while
+# longhorn/CDI are still initializing.
+message 'deploying Ubuntu VM app (disk volume) on freshly-booted EVE-k'
+eden -t 1m network create 10.11.12.0/24 -n fbk-net
+# cloud-init injects the eclient SSH pubkey so the liveness check uses key auth
+# (no password / no sshpass). Ubuntu honors ssh_authorized_keys; Cirros does not.
+exec -t 1m bash gen-metadata.sh
+eden -t 15m pod deploy --format=qcow2 --memory=1024MB -n fbk-vmapp -p 2223:22 {{ $appimg }} --networks=fbk-net --metadata=/tmp/fbk-userdata.yaml
+! stderr .
+
+# Step 2: watch EVE-k cluster storage come up. Split from the app wait so a stall
+# here is unambiguously "cluster storage", not "app".
+message 'waiting for EVE-k content store (volumemgr) Initialized'
+exec -t 65m bash wait-for-volumemgr-ready.sh
+message 'waiting for EVE-k longhorn StorageClass (cluster storage ready)'
+exec -t 45m bash wait-for-longhorn-sc.sh
+stdout 'OK: longhorn StorageClass ready'
+
+# Step 3: the load-bearing check — the app's volume creation was NOT wedged and the
+# app reached RUNNING. wait-for-app-running logs LAST_STATE transitions so the
+# progression into activation is visible, and on timeout names the pre-activation
+# state it stuck in (INITIAL / LOADED / CREATING_VOLUME) plus any volume Error.
+message 'waiting for the app volume to be created and the app to reach RUNNING'
+exec -t 45m bash wait-for-app-running.sh fbk-vmapp
+stdout 'OK: fbk-vmapp RUNNING'
+
+# Step 4: strong liveness — the guest actually booted (key-based SSH), not just a
+# RUNNING VMI phase.
+message 'verifying the app guest is genuinely up (SSH)'
+exec -t 20m bash verify-app-ssh.sh
+stdout 'APP_ALIVE'
+
+# Cleanup.
+eden -t 1m pod delete fbk-vmapp
+eden -t 1m network delete fbk-net
+# Cancel the reboot watchdog so `wait` returns immediately (see kill-watchdog.sh).
+exec bash kill-watchdog.sh
+wait
+
+-- require-ver.sh --
+#!/bin/bash
+# Fail fast if FBK_EVE_VER was not supplied.
+set -uo pipefail
+VER='{{ $ver }}'
+if [ -z "$VER" ] || [ "$VER" = "REPLACE-WITH-K-VERSION" ]; then
+    echo "FAIL: FBK_EVE_VER not set." >&2
+    echo "      Export it to the version base of your local -k build, e.g." >&2
+    echo "      FBK_EVE_VER=0.0.0-volumemgr-cdi-retry-ee3da038" >&2
+    echo "      (the part before -k-amd64 in the docker tag)." >&2
+    exit 1
+fi
+echo "OK: FBK_EVE_VER=$VER"
+
+-- assert-running-version.sh --
+#!/bin/bash
+# Sanity-check that EVE is running the expected -k image before the test deploys
+# the app. Bringup happens manually (firstboot-evek-bringup.sh); this guards
+# against running against the wrong base image. Matches the expected version as a
+# substring of /run/eve-release (full "<ver>-k-<arch>" form).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT="${1:?expected -k version}"
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+for _ in $(seq 1 18); do   # ~3m at 10s; tolerate ssh not up yet
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -n "$running" ]; then
+        case "$running" in
+            *"$EXPECT"*) echo "OK: running the expected -k image ('$running')"; exit 0 ;;
+            *) echo "FAIL: running '$running', expected to contain '$EXPECT'." >&2
+               echo "      Bring EVE up on the -k image first (firstboot-evek-bringup.sh)," >&2
+               echo "      or set FBK_EVE_VER to the release you brought up on." >&2
+               exit 1 ;;
+        esac
+    fi
+    sleep 10
+done
+echo "FAIL: could not read /run/eve-release (ssh down / device not up?)" >&2
+exit 1
+
+-- assert-no-volumes.sh --
+#!/bin/bash
+# A fresh onboard must have no live app volumes — otherwise the "app volume enters
+# config at first boot" premise is violated (a leftover from a prior run).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 12); do
+    out=$("$EDEN" volume ls 2>/dev/null)
+    live=$(echo "$out" | awk 'NR>1 && ($(NF-1) == "IN_CONFIG" || $NF == "DELIVERED")')
+    if [ -z "$live" ]; then echo "OK: no live volumes"; exit 0; fi
+    sleep 5
+done
+echo "FAIL: live volume(s) present on a supposedly-fresh device" >&2; "$EDEN" volume ls >&2; exit 1
+
+-- gen-metadata.sh --
+#!/bin/bash
+# Write the cloud-init user-data that `eden pod deploy --metadata=` reads, so the
+# Ubuntu guest authorizes the eclient SSH pubkey for its default (ubuntu) user, so
+# verify-app-ssh.sh logs in with a key and needs no sshpass/password. dist/tests is
+# only populated by a full `make eden`, so fall back to the master/main reference
+# clones for the cert.
+set -uo pipefail
+EDEN_TESTS="{{EdenConfig "eden.tests"}}"
+USER_HOME=$(getent passwd "$(id -u)" | cut -d: -f6)
+PUB=""
+for c in "$EDEN_TESTS/eclient/image/cert/id_rsa.pub" \
+         "$USER_HOME/lf-edge/master/eden/tests/eclient/image/cert/id_rsa.pub" \
+         "$USER_HOME/lf-edge/main/eden/tests/eclient/image/cert/id_rsa.pub"; do
+    if [ -f "$c" ]; then PUB="$c"; break; fi
+done
+[ -n "$PUB" ] || { echo "FAIL: could not locate eclient id_rsa.pub (EDEN_TESTS=$EDEN_TESTS, USER_HOME=$USER_HOME)" >&2; exit 1; }
+UD=/tmp/fbk-userdata.yaml
+{
+    echo "#cloud-config"
+    echo "ssh_authorized_keys:"
+    echo " - $(cat "$PUB")"
+} > "$UD"
+echo "OK: wrote cloud-init userdata (eclient pubkey) to $UD"
+
+-- wait-for-volumemgr-ready.sh --
+#!/bin/bash
+# On EVE-k, volumemgr must finish its "wait for kubernetes" init before the app
+# volume can be created. Wait for /run/volumemgr/VolumeMgrStatus/volumemgr.json
+# "Initialized":true (set after kubeapi.WaitForKubernetes returns). Logs a timeline
+# of (Initialized, #ContentTreeStatus) so the readiness moment is visible.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+probe() { timeout 8 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+ct_count() {
+    probe 'eve exec pillar sh -c "ls /run/volumemgr/ContentTreeStatus/*.json 2>/dev/null | wc -l"' \
+        | tr -d '\r' | grep -E '^[0-9]+$' | tail -1
+}
+last=""
+# 60m at 10s. This MUST exceed volumemgr's own pre-publish block, which is up to
+# 20m in WaitForKubernetes (node + kubevirt + longhorn) plus up to 20m more in
+# storageWait before VolumeMgrStatus is published at all. This loop also begins
+# timing before volumemgr begins its own, so a 40m budget could not observe the
+# publish even on a device that converges -- it expired at the very moment volumemgr
+# was released. Initialized is set unconditionally once both waits end
+# (handlediskmetrics.go generateAndPublishVolumeMgrStatus), so reaching it under a
+# longer budget means "the device recovered", not "cluster storage is healthy" --
+# the longhorn and app steps that follow are what establish that.
+for _ in $(seq 1 360); do
+    init=$(probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>/dev/null' \
+            | tr -d '\r' | grep -oE '"Initialized":[a-z]+')
+    ct=$(ct_count); [ -z "$ct" ] && ct='?'
+    sig="init=${init:-<none>} contenttrees=$ct"
+    if [ "$sig" != "$last" ]; then echo "$(date +%H:%M:%S) [readiness] $sig"; last="$sig"; fi
+    if [ "$init" = '"Initialized":true' ]; then
+        echo "OK: volumemgr Initialized:true (contenttrees=$ct)"; exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: volumemgr did not reach Initialized:true within 40m" >&2
+probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>&1' >&2
+exit 1
+
+-- wait-for-longhorn-sc.sh --
+#!/bin/bash
+# Wait until the EVE-k `longhorn` StorageClass exists (longhorn deployed + its CSI
+# provisioner up). This is the storage-readiness signal #6121's gate keys on, so
+# waiting here explicitly separates cluster-bringup time from app-bringup time.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 80); do   # ~40m at 30s, under the -t 45m wrapper
+    if "$EDEN" eve ssh -- 'eve exec kube kubectl get sc 2>/dev/null' 2>/dev/null | grep -qE '^longhorn'; then
+        echo "OK: longhorn StorageClass ready"; exit 0
+    fi
+    sleep 30
+done
+echo "FAIL: longhorn StorageClass not ready within budget" >&2; exit 1
+
+-- wait-for-app-running.sh --
+#!/bin/bash
+# Poll `eden pod ps` until the app reaches LAST_STATE(EVE)=RUNNING, logging every
+# state transition so the storage-pipeline progression into activation
+# (BOOTING/RUNNING) is visible. This is the load-bearing #6121 check: if volume
+# creation wedged, the app never activates and parks below BOOTING. Where it parks
+# depends on where storage stuck — INITIAL, LOADED, CREATING_VOLUME are all seen —
+# so on timeout ANY pre-activation stall is reported as a wedge, naming the state,
+# plus any VolumeStatus/ContentTreeStatus Error.
+set -uo pipefail
+APP="${1:?app name}"
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+probe() { timeout 10 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+last=""
+laststate=""
+for _ in $(seq 1 240); do   # ~40m at 10s, under the -t 45m wrapper
+    line=$("$EDEN" pod ps 2>/dev/null | grep -E "^${APP}\b")
+    # LAST_STATE(EVE) is the final column of `eden pod ps` (space-aligned via
+    # tabwriter); the state strings have no spaces, so the last field is it.
+    laststate=$(echo "$line" | awk '{print $NF}')
+    if [ "$laststate" != "$last" ] && [ -n "$laststate" ]; then
+        echo "$(date +%H:%M:%S) [app] LAST_STATE(EVE)=$laststate"; last="$laststate"
+    fi
+    if [ "$laststate" = "RUNNING" ]; then
+        echo "OK: $APP RUNNING"; echo "$line"; exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: $APP did not reach RUNNING in 40m (last state: ${laststate:-<none>})" >&2
+"$EDEN" pod ps >&2
+# Wedge diagnosis: any stall BELOW activation (BOOTING/RUNNING) means the storage
+# pipeline did not converge. Where it parks depends on where it wedged — INITIAL,
+# LOADED, CREATING_VOLUME are all symptoms of the #6121 failure this test guards.
+case "$laststate" in
+    INITIAL|DOWNLOAD_STARTED|DOWNLOADED|DELIVERED|INSTALLED|RESOLVING_TAG|RESOLVED_TAG|CREATING_VOLUME|CREATED_VOLUME|VERIFYING|VERIFIED|LOADING|LOADED|PENDING|SCHEDULING|ERROR)
+        echo "FAIL[volume-wedge]: app stuck at $laststate (below activation) — EVE-k volume/storage creation did not converge (the #6121 regression this test guards against)." >&2 ;;
+esac
+verr=$(probe 'eve exec pillar sh -c "cat /run/volumemgr/VolumeStatus/*.json /run/volumemgr/ContentTreeStatus/*.json 2>/dev/null"' \
+        | grep -oE '"Error":"[^"]+"' | grep -v '"Error":""' | head)
+[ -n "$verr" ] && echo "Volume/ContentTree errors: $verr" >&2
+exit 1
+
+-- verify-app-ssh.sh --
+#!/bin/bash
+# Strong liveness: `eden pod ps` RUNNING on EVE-k reflects the kubevirt VMI phase,
+# not that the guest OS booted. Confirm the guest is genuinely up by logging in
+# over key auth (eclient pubkey injected via cloud-init) as ubuntu on the hostfwd
+# 127.0.0.1:2223 -> EVE -> app:22, and reading a live fact from inside the guest.
+set -uo pipefail
+PORT=2223
+EDEN_TESTS="{{EdenConfig "eden.tests"}}"
+USER_HOME=$(getent passwd "$(id -u)" | cut -d: -f6)
+SRC=""
+for c in "$EDEN_TESTS/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/master/eden/tests/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/main/eden/tests/eclient/image/cert/id_rsa"; do
+    if [ -f "$c" ]; then SRC="$c"; break; fi
+done
+[ -n "$SRC" ] || { echo "FAIL: could not locate eclient id_rsa (EDEN_TESTS=$EDEN_TESTS, USER_HOME=$USER_HOME)" >&2; exit 1; }
+KEY=$(mktemp); install -m 600 "$SRC" "$KEY"; trap 'rm -f "$KEY"' EXIT
+SSHP=(-o ConnectTimeout=10 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -o PreferredAuthentications=publickey -i "$KEY")
+guest() { ssh "${SSHP[@]}" ubuntu@127.0.0.1 -p "$PORT" "$@" 2>/dev/null; }
+for _ in $(seq 1 60); do   # ~20m at 20s — guest boot after VMI RUNNING
+    up=$(guest 'cat /proc/uptime 2>/dev/null | awk "{print int(\$1)}"')
+    if [ -n "$up" ]; then
+        echo "guest uptime=${up}s"
+        echo "APP_ALIVE: guest OS is up and reachable over key-based SSH"
+        exit 0
+    fi
+    sleep 20
+done
+echo "FAIL: app guest not reachable over SSH (VMI may be RUNNING but the guest did not boot)" >&2
+exit 1
+
+-- kill-watchdog.sh --
+#!/bin/bash
+# Cancel the background reboot watchdog so the escript's `wait` returns immediately
+# instead of blocking until the watchdog's -timewait ceiling. SIGTERM makes it exit
+# non-zero, which satisfies the `!` prefix on its launch line — identical to letting
+# it time out. Bracket the pattern ([e]den) so pkill matches the real
+# eden.reboot.test process but NOT its own argv or this script's argv (which contain
+# the literal "[e]den.reboot.test", not "eden..."). Run as a helper file rather than
+# `exec sh -c "..."` inline because the escript tokenizer mishandles nested quotes.
+pkill -f '[e]den.reboot.test' 2>/dev/null || true
+exit 0
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- assert-espb-present.sh --
+#!/bin/bash
+# Assert the boot disk carries the reserved ESP-B (GPT #7, fresh-install GUID
+# …30056) at ~2 GiB — the full 2+2+10+10 EVE-k layout. This test runs on an
+# already-LARGE device (no repartition here), so it does NOT create ESP-B; it
+# DEPENDS on the image already shipping it (eve#6158 runme.sh do_live). Asserting
+# it makes that silent precondition explicit. Reads via lsblk PARTUUID, keyed on
+# the …30056 GUID, exactly like capture-partitions.sh.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+GiB=$(( 1024 * 1024 * 1024 )); MiB=$(( 1024 * 1024 ))
+read_espb() {
+    timeout 20 "$EDEN" eve ssh -- \
+        'eve exec pillar lsblk -b -P -o NAME,PARTLABEL,PARTUUID,SIZE /dev/sda 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c '
+import sys, re
+for line in sys.stdin:
+    m = dict(re.findall(r"(\w+)=\"([^\"]*)\"", line))
+    if m.get("PARTLABEL") == "EFI System" and m.get("PARTUUID", "").lower().endswith("30056"):
+        print("%s %s" % (m.get("NAME", ""), m.get("SIZE", "0"))); break
+'
+}
+for _ in $(seq 1 6); do   # ~1m; tolerate ssh/pillar not up yet
+    read -r name size <<<"$(read_espb)"
+    if [ -n "${size:-}" ] && [ "${size:-0}" != "0" ]; then
+        echo "ESP-B: name=${name:-?} size=$size ($(( size / MiB )) MiB)"
+        [ "$size" -ge "$GiB" ] 2>/dev/null || { echo "FAIL: ESP-B < 1 GiB floor (target 2 GiB): $size" >&2; exit 1; }
+        [ "${name:-}" = "sda7" ] || { echo "FAIL: ESP-B at ${name:-<none>}, expected sda7 (partition #7)" >&2; exit 1; }
+        echo "OK: ESP-B present (#7 …30056 at $(( size / MiB )) MiB)"; exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: no ESP-B (#7 GUID …30056) on /dev/sda — the live image lacks the reserved ESP-B (eve#6158)?" >&2
+timeout 20 "$EDEN" eve ssh -- 'eve exec pillar lsblk -o NAME,PARTLABEL,PARTUUID,SIZE /dev/sda' >&2 2>/dev/null
+exit 1

--- a/tests/update_eve_image/testdata/first_boot_evek_app_volume.txt
+++ b/tests/update_eve_image/testdata/first_boot_evek_app_volume.txt
@@ -77,7 +77,7 @@ eden -t 15m pod deploy --format=qcow2 --memory=1024MB -n fbk-vmapp -p 2223:22 {{
 # Step 2: watch EVE-k cluster storage come up. Split from the app wait so a stall
 # here is unambiguously "cluster storage", not "app".
 message 'waiting for EVE-k content store (volumemgr) Initialized'
-exec -t 65m bash wait-for-volumemgr-ready.sh
+exec -t 90m bash wait-for-volumemgr-ready.sh
 message 'waiting for EVE-k longhorn StorageClass (cluster storage ready)'
 exec -t 45m bash wait-for-longhorn-sc.sh
 stdout 'OK: longhorn StorageClass ready'
@@ -196,27 +196,40 @@ ct_count() {
         | tr -d '\r' | grep -E '^[0-9]+$' | tail -1
 }
 last=""
-# 60m at 10s. This MUST exceed volumemgr's own pre-publish block, which is up to
+# 85m budget. This MUST exceed volumemgr's own pre-publish block, which is up to
 # 20m in WaitForKubernetes (node + kubevirt + longhorn) plus up to 20m more in
 # storageWait before VolumeMgrStatus is published at all. This loop also begins
 # timing before volumemgr begins its own, so a 40m budget could not observe the
-# publish even on a device that converges -- it expired at the very moment volumemgr
-# was released. Initialized is set unconditionally once both waits end
-# (handlediskmetrics.go generateAndPublishVolumeMgrStatus), so reaching it under a
-# longer budget means "the device recovered", not "cluster storage is healthy" --
-# the longhorn and app steps that follow are what establish that.
-for _ in $(seq 1 360); do
-    init=$(probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>/dev/null' \
-            | tr -d '\r' | grep -oE '"Initialized":[a-z]+')
+# publish even on a device that converges -- it expired at the very moment
+# volumemgr was released.
+#
+# The budget is wall-clock, not an iteration count: each pass also spends up to
+# 16s in two ssh probes that hit their timeout precisely when the device is
+# stalled, so a fixed count can outlive the caller's `exec -t` deadline and get
+# killed before reaching the diagnostics below -- which is when they matter most.
+# Keep it under that deadline with room for the final status dump.
+BUDGET_MIN=85
+deadline=$(( $(date +%s) + BUDGET_MIN * 60 ))
+unmet=""
+while [ "$(date +%s)" -lt "$deadline" ]; do
+    status=$(probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>/dev/null' \
+            | tr -d '\r')
+    init=$(echo "$status" | grep -oE '"Initialized":[a-z]+')
+    # UnmetCondition names the readiness gate still outstanding while Initialized
+    # is false. Absent on images predating lf-edge/eve#6240.
+    unmet=$(echo "$status" | grep -oE '"UnmetCondition":"[^"]+"')
     ct=$(ct_count); [ -z "$ct" ] && ct='?'
-    sig="init=${init:-<none>} contenttrees=$ct"
+    sig="init=${init:-<none>} contenttrees=$ct${unmet:+ $unmet}"
     if [ "$sig" != "$last" ]; then echo "$(date +%H:%M:%S) [readiness] $sig"; last="$sig"; fi
     if [ "$init" = '"Initialized":true' ]; then
         echo "OK: volumemgr Initialized:true (contenttrees=$ct)"; exit 0
     fi
     sleep 10
 done
-echo "FAIL: volumemgr did not reach Initialized:true within 40m" >&2
+echo "FAIL: volumemgr did not reach Initialized:true within ${BUDGET_MIN}m" >&2
+# A reported UnmetCondition distinguishes cluster storage that never converged
+# from a device that published nothing at all.
+echo "FAIL: last reported unmet condition: ${unmet:-<none reported>}" >&2
 probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>&1' >&2
 exit 1
 

--- a/tests/update_eve_image/testdata/first_boot_evek_app_volume.txt
+++ b/tests/update_eve_image/testdata/first_boot_evek_app_volume.txt
@@ -240,8 +240,11 @@ exit 1
 # waiting here explicitly separates cluster-bringup time from app-bringup time.
 set -uo pipefail
 EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+began=$(date +%s)
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [longhorn-sc] waiting for the StorageClass"
 for _ in $(seq 1 80); do   # ~40m at 30s, under the -t 45m wrapper
     if "$EDEN" eve ssh -- 'eve exec kube kubectl get sc 2>/dev/null' 2>/dev/null | grep -qE '^longhorn'; then
+        echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [longhorn-sc] ready after $(( $(date +%s) - began ))s"
         echo "OK: longhorn StorageClass ready"; exit 0
     fi
     sleep 30

--- a/tests/update_eve_image/testdata/prep-kvm-to-k-topology.sh
+++ b/tests/update_eve_image/testdata/prep-kvm-to-k-topology.sh
@@ -438,9 +438,18 @@ eve_make_persist_pool() {
     # datasets are created with `-u` (do not mount now) because the live ext4 /persist is
     # still mounted during this build; they mount on the later storage-init import.
     note "EVE creating persist zpool on $dev (installer-faithful: +reserved +primarycache +snapshots)"
-    eve_ssh "eve exec pillar sh -c \"zpool labelclear -f $dev 2>/dev/null; \
-        zpool create -f -m none -o feature@encryption=enabled -O atime=off -O overlay=on persist $dev && echo CREATED\"" \
-        | grep -q CREATED || die "zpool create failed on $dev"
+    # Keep stderr: `zpool create`'s own message is the only thing that says WHY it
+    # refused (device in use, pool already imported, label present, too small), and
+    # discarding it leaves nothing to diagnose from but "it failed".
+    local out
+    out=$(eve_ssh "eve exec pillar sh -c \"zpool labelclear -f $dev 2>&1; \
+        zpool create -f -m none -o feature@encryption=enabled -O atime=off -O overlay=on persist $dev 2>&1 && echo CREATED\"")
+    if ! echo "$out" | grep -q CREATED; then
+        echo "--- zpool output ---"; echo "$out"
+        echo "--- pools visible on the device ---"
+        eve_ssh "eve exec pillar sh -c \"zpool list; echo ---; zpool import; echo ---; blkid $dev; echo ---; lsblk\"" 2>&1
+        die "zpool create failed on $dev"
+    fi
     # refreservation = available/5, computed exactly as the installer does (bytes -> MiB, /5)
     local avail_bytes resv_mib
     avail_bytes=$(eve_ssh "eve exec pillar zfs get -o value -Hp available persist" | grep -oE '^[0-9]+$' | head -1)

--- a/tests/update_eve_image/testdata/prep-kvm-to-k-topology.sh
+++ b/tests/update_eve_image/testdata/prep-kvm-to-k-topology.sh
@@ -1,0 +1,715 @@
+#!/bin/bash
+# prep-kvm-to-k-topology.sh — bring eden up in one of the disk topologies the
+# kvm->k repartition tests need, BEFORE running the escript. Host-side helper,
+# NOT an escript (it is never enumerated by `eden test`).
+#
+# The conversion tests always start on a SMALL, old bringup image; what differs
+# between scenarios is the /persist filesystem (ext4 vs ZFS) and disk layout
+# (single vs two disks), which determine the storage-resizer `check` decision and
+# therefore which escript applies:
+#
+#   topology       persist        layout            check decision   escript / knobs                          status
+#   -------------  -------------  ----------------  ---------------  --------------------------------         ------
+#   ext4-shrink    ext4, full     1 disk            shrink           kvm_to_k.txt EXPECT_DECISION=shrink       VERIFIED 2026-07-26
+#   ext4-grow      ext4, +tail    1 disk            grow             kvm_to_k.txt EXPECT_DECISION=grow         VERIFIED 2026-07-26 (README recipe)
+#   twodisk-zfs    zfs on sdb     2 disks           grow             kvm_to_k.txt ... DISK_TOPOLOGY=two-disk   VERIFIED 2026-07-26
+#   twodisk-ext4   ext4 on sdb    2 disks           grow             kvm_to_k.txt ... DISK_TOPOLOGY=two-disk   VERIFIED 2026-07-26
+#   ext4-toofull   ext4, full     1 disk            insufficient     kvm_to_k_refused.txt REFUSE_REASON=too-full  VERIFIED 2026-07-26
+#   zfs-grow       zfs,  +tail    1 disk            grow             kvm_to_k.txt ... DISK_TOPOLOGY=zfs        VERIFIED 2026-07-26 (notail base)
+#   zfs-notail     zfs, full      1 disk            insufficient     kvm_to_k_refused.txt REFUSE_REASON=zfs    VERIFIED 2026-07-26
+#
+# The VERIFIED dates are all one clean sweep of run-kvm-to-k-tests.sh (PASS=7) on
+# image lfedge/eve:0.0.0-resize-allprs-4d0f1e75-{kvm,k}, bringup 12.1.0.
+#
+# A date here means "passed once on that sweep", NOT "reliable". The two ZFS legs are
+# known flaky on BOTH resize-allprs and newgo-allprs: twodisk-zfs passed this sweep
+# and failed a rerun at identical geometry the next day. What decides it is how long
+# the ~600 MB of longhornio/* images take from docker.io (186-545 KB/s, 3-4x variance
+# run to run) against the readiness budgets, so treat a single pass as weak evidence.
+#
+# Decision logic is from pkg/storage-resizer (decide()/evaluate()): shrink applies
+# ONLY to an ext4 /persist on the boot disk; a ZFS persist or a persist on another
+# disk can only get room from the boot disk's free tail, else `insufficient`.
+# (`grow` is documented as "also the multi-disk / ZFS-persist case".)
+#
+# HOW ZFS /persist IS BUILT (verified empirically in an eden Multipass sandbox):
+#   * SINGLE-disk ZFS-on-boot (VERIFIED 2026-06-25): the `--grub-options` route DOES
+#     work; the earlier "doesn't work" was a misdiagnosis. Two real reasons it had
+#     been failing:
+#       1. setupConfigDir (pkg/openevec/eden.go) only calls GenerateEveCerts — which
+#          is what WRITES grub.cfg — when CertsDir has NO root-certificate.pem. On a
+#          reused context the certs already exist, so `eden setup --grub-options ...`
+#          SILENTLY skips grub.cfg generation and the token never lands. `--force`
+#          does NOT override this. Fix: wipe the certs dir (certs_dir(), under
+#          eden.root) + adam/redis volumes before setup so grub.cfg is regenerated.
+#          (A fresh EDEN_HOME,
+#          as in the run-eden-test skill's ZFS recipe, has the same effect.)
+#       2. The live.img has NO pre-baked P3 (only EFI/IMGA/IMGB/CONFIG); storage-init
+#          CREATES P3 on first boot and honors P3_FS_TYPE_DEFAULT=zfs (set by the
+#          token at storage-init.sh:113) -> P3 formatted ZFS on the boot disk.
+#     Verified result: /proc/cmdline carries eve_install_zfs_with_raid_level,
+#     /run/eve.persist_type=zfs, zpool ONLINE on sda9 (boot disk P3), /persist mounted.
+#     The P3 takes the whole free tail (largest-new) -> no tail left -> this is the
+#     zfs-notail (insufficient) base; zfs-grow adds a tail AFTER it (see that case).
+#   * The canonical eden MULTI-disk ZFS recipe (run-eden-test skill) is
+#     `eve.disks=4 eve.disk=16384` + the same grub-option; that puts the pool on the
+#     extra blank disks rather than the boot P3.
+#   * `eden setup --installer` requires the `general` devmodel and is NOT
+#     qemu-managed (only ZedVirtual-4G gets a qemu config + `eden start`), so eden
+#     cannot run an installer-built node itself.
+#   * Working route (two-disk): boot the live node with a blank second disk, have
+#     EVE ITSELF create the `persist` zpool on sdb (feature-correct — EVE's own
+#     zfs), `zfs set -u mountpoint=/persist`, export it, then OFFLINE delete the
+#     boot disk's P3 so storage-init's no-P3 branch does `zpool import -f persist`
+#     and mounts /persist from sdb. Verified: persist_type=zfs, no P3 on boot, pool
+#     ONLINE on sdb, /persist mounted.
+#
+# eve.disk (ImageSizeMB) sizes BOTH the boot live.img AND every extra disk: eden
+# passes it to the EVE image's `live <MB>` generator (pkg/utils/downloaders.go
+# genEVELiveImage) for the boot disk, and to CreateDisk (pkg/openevec/eden.go:103)
+# for each of the eve.disks extra disks. So base_config sets eve.disk=64 GiB for a
+# single 64 GiB boot disk (the EVE-k/longhorn floor); the two-disk legs override it
+# to 32768 to get a 32 GiB boot + 32 GiB sdb (=> 64 total).
+#
+# The ext4 grow tail is created the way README_kvm_to_k_grow.md describes: boot
+# small once (storage-init creates P3 at the original size), stop, enlarge the
+# qcow2 + `sgdisk -e` to add the free tail, restart.
+#
+# Usage:
+#   ./prep-kvm-to-k-topology.sh <topology> [--yes]
+# eden-touching stages are gated behind a check that no OTHER eden is already
+# running on this host (single-tenant — see CLAUDE.md).
+
+set -uo pipefail
+
+TOPOLOGY="${1:-}"
+
+# Detach stdin from any controlling terminal, mirroring the escript engine
+# (cmd.Stdin = strings.NewReader("")): `timeout eden eve ssh` runs ssh in a
+# background process group, where a tty stdin would SIGTTIN-stop it forever.
+exec </dev/null
+
+BRINGUP_TAG="${BRINGUP_EVE_VER:-12.1.0}"   # small-layout released image
+BOOT_DISK_MB="${BOOT_DISK_MB:-65536}"      # single boot-disk size: 64 GiB meets the EVE-k/
+                                           # longhorn floor. No-tail legs (shrink, toofull,
+                                           # zfs-notail) use it directly; grow/two-disk legs
+                                           # override eve.disk to 32768 (=> 32 GiB boot + 32 GiB
+                                           # tail, or + 32 GiB sdb = 64 total).
+GROW_TAIL_GB="${GROW_TAIL_GB:-32}"         # free tail for the single-disk grow legs, added after
+                                           # a 32 GiB boot: >22 GiB so check decides grow and
+                                           # 32+32 = the 64 GiB total floor.
+EVE_DISK_MB="${EVE_DISK_MB:-32768}"        # grow/two-disk boot + extra-disk size (32 GiB)
+TWODISK_SDB_MB="${TWODISK_SDB_MB:-$EVE_DISK_MB}"  # twodisk-zfs pool disk, sized apart from boot
+                                           # (eve.disk sizes boot AND every extra disk together).
+                                           # Defaults to EVE_DISK_MB = the intended 2x32 = 64 GiB.
+                                           # A ZFS pool on a 32 GiB sdb leaves ~24 GiB free (~0.5
+                                           # ZFS metadata + ~6.2 persist/reserved), and the ~7.3 GiB
+                                           # cluster-image store then leaves Longhorn ~12.7 GiB
+                                           # schedulable, under its 16 GiB floor. Raising this to
+                                           # 65536 does make the leg pass, but that is NOT a
+                                           # demonstrated fix: outcomes track docker.io pull time
+                                           # (3-4x run variance), not pool size. Use for
+                                           # experiments, not as a default.
+ZFS_GROW_BASE_MB="${ZFS_GROW_BASE_MB:-40960}"     # zfs-grow base disk (40 GiB), tail below makes
+ZFS_GROW_TAIL_GB="${ZFS_GROW_TAIL_GB:-24}"        # 40+24 = the same 64 GiB total as every other leg.
+                                           # Split differently from ext4-grow's 32+32 because a ZFS
+                                           # P3 is created at setup and never grows into a tail added
+                                           # afterwards, so only the BASE sets the pool size. The tail
+                                           # just has to cover the conversion's growth (ESP 36M->2G,
+                                           # IMGA/IMGB 512M->10G each = ~+21 GiB) and clear
+                                           # assert-free-tail's 22 GiB check, so 24 GiB is enough and
+                                           # the remaining 8 GiB goes to the pool instead.
+                                           # The two-disk legs stay 32+32: sdb carries /persist and is
+                                           # untouched by the conversion.
+MIN_PERSIST_FREE_GB="${MIN_PERSIST_FREE_GB:-22}"  # floor on MEASURED /persist FREE space. Longhorn
+                                           # warns below 16 GiB schedulable after its 25% reserve
+                                           # (lf-edge/eve#6108), so it needs ~16/0.75 = 22 GiB free.
+                                           # Gauge free, not size, and measure it rather than infer
+                                           # it from the configured disk: ZFS spends ~20% on the
+                                           # persist/reserved refreservation.
+TWODISK_BOOT_GB="${TWODISK_BOOT_GB:-32}"   # twodisk-ext4 boot-disk size (matches EVE_DISK_MB):
+                                           # P3 created full then deleted => >=22 GiB free tail.
+EDEN_ROOT="${EDEN_ROOT:-$HOME/.e166o}"     # SHORT eden.root so swtpm's 108-byte AF_UNIX control
+                                           # socket path fits (a long path silently dead-TPMs).
+SSH_TRIES="${SSH_TRIES:-40}"               # ssh-up poll attempts (x12s)
+FILL_PCT="${FILL_PCT:-70}"                 # ext4-toofull: fill /persist to this used% so
+                                           # used > maxFull(90%) x (P3-22G) => check insufficient.
+
+# Workspace root (eden checkout): prep lives at <WS>/tests/update_eve_image/testdata,
+# so three levels up. Used to pin eden.tests and the OVMF firmware in base_config.
+WSROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+die() { echo "FATAL: $*" >&2; exit 1; }
+note() { echo "=== $* ==="; }
+
+usage() { sed -n '2,60p' "$0" | sed 's/^# \{0,1\}//'; exit 2; }
+[ -n "$TOPOLOGY" ] || usage
+
+# --- single-tenant guard: refuse if another eden is already up -----------------
+guard_no_other_eden() {
+    local busy=0
+    docker ps --format '{{.Names}}' 2>/dev/null | grep -qE '^eden_(adam|redis|eserver|registry)$' && busy=1
+    pgrep -f 'qemu-system.*-drive' >/dev/null 2>&1 && busy=1
+    if [ "$busy" = 1 ]; then
+        echo "An eden instance appears to be running on this host (eden_* containers or qemu)." >&2
+        echo "eden is single-tenant; this script would disturb it. Stop it first or use a" >&2
+        echo "dedicated host / the eden-vm-sandbox skill. Refusing." >&2
+        exit 1
+    fi
+}
+
+image_dir() {
+    # eden writes images under its configured eden.root, so that is the
+    # authoritative location; EDEN_HOME / a workspace-relative dist/ are fallbacks.
+    local root
+    root=$(eden config get default --key eden.root 2>/dev/null | grep -vi 'level=' | tr -d '\r' | tail -1)
+    [ -n "$root" ] && [ -d "$root/default-images/eve" ] && { echo "$root/default-images/eve"; return; }
+    if [ -n "${EDEN_HOME:-}" ] && [ -d "$EDEN_HOME/default-images/eve" ]; then
+        echo "$EDEN_HOME/default-images/eve"; return
+    fi
+    [ -d dist/default-images/eve ] && { echo dist/default-images/eve; return; }
+    die "could not locate the eve image dir (checked eden.root='$root', EDEN_HOME, ./dist)"
+}
+
+certs_dir() {
+    # Onboarding certs live at <eden.root>/default-certs; resolve the root like
+    # image_dir so a non-default eden.root (e.g. ~/.e166o) is honored. A hardcoded
+    # dist/default-certs misses them, so the certs survive and eden setup skips
+    # grub.cfg -- which is what the grub-option ZFS legs rely on being rewritten.
+    local root
+    root=$(eden config get default --key eden.root 2>/dev/null | grep -vi 'level=' | tr -d '\r' | tail -1)
+    [ -n "$root" ] && { echo "$root/default-certs"; return; }
+    [ -n "${EDEN_HOME:-}" ] && { echo "$EDEN_HOME/default-certs"; return; }
+    echo dist/default-certs
+}
+
+# The single-disk ZFS legs deliver eve_install_zfs_with_raid_level via grub.cfg,
+# which eden only rewrites when the certs dir has no root-certificate.pem. A later
+# leg that reuses the context therefore inherits that token and formats the boot
+# P3 as ZFS -- silently mis-topologying the ext4 legs and colliding the twodisk-zfs
+# `zpool create persist` against the accidental boot-disk pool. Non-ZFS-boot legs
+# call this before do_setup so eden regenerates a token-free grub.cfg (P3 defaults
+# to ext4). Mirrors the wipe the zfs legs use to force the token IN.
+force_clean_grub() {
+    eden stop || true
+    rm -rf "$(image_dir)/live.img" "$(image_dir)/live.raw.qcow2" "$(certs_dir)"
+    docker volume rm eden_adam_volume eden_redis_volume 2>/dev/null || true
+}
+
+# Fail loudly if the device came up on the wrong /persist filesystem, so a
+# mis-topology is a legible error instead of a silent false pass. $1 = ext4|zfs.
+assert_persist_type() {
+    local got
+    got=$(eve_ssh 'cat /run/eve.persist_type' | tr -d '\r' | tail -1)
+    [ "$got" = "$1" ] || die "persist_type='$got' (expected $1 for $TOPOLOGY)"
+}
+
+# Fail if the live /persist has less free space than Longhorn needs. Longhorn's
+# default disk is /persist/vault/volumes and it warns below 16 GiB schedulable after
+# a 25% reserve (lf-edge/eve#6108), so ~22 GiB must actually be free. Gauge the
+# FILESYSTEM, not the configured disk: ZFS spends ~20% on the persist/reserved
+# refreservation, so a nominally adequate disk can still land under the floor. When
+# it does, cluster storage never becomes ready and the escript reports it much later
+# as an opaque "volumemgr did not reach Initialized:true" timeout.
+assert_persist_free() {
+    # Measure inside the PILLAR namespace: in the EVE host shell the same filesystem
+    # is mounted at /hostfs/persist, so a host-side `df /persist` reports a mount
+    # point that never matches. `eve exec pillar df -k` needs no nested `sh -c`
+    # quoting (which breaks on anything nontrivial) and -k is busybox-safe.
+    local kb gb
+    kb=$(eve_ssh 'eve exec pillar df -k /persist' | tr -d '\r' \
+        | awk '$NF == "/persist" { print $4 }' | tail -1)
+    # A probe that cannot measure must not block the run: warn and continue, so an
+    # instrumentation quirk never masquerades as a provisioning failure. Only a real
+    # measurement that is under the floor is fatal.
+    case "$kb" in
+        ''|*[!0-9]*) note "WARNING: could not measure /persist free space for $TOPOLOGY — floor NOT verified"; return 0 ;;
+    esac
+    gb=$(( kb / 1048576 ))
+    note "/persist free ${gb} GiB (floor ${MIN_PERSIST_FREE_GB} GiB, ~$(( gb * 3 / 4 )) GiB schedulable)"
+    [ "$gb" -ge "$MIN_PERSIST_FREE_GB" ] \
+        || die "/persist has ${gb} GiB free, under the ${MIN_PERSIST_FREE_GB} GiB Longhorn floor for $TOPOLOGY — raise the disk carrying /persist"
+}
+
+base_config() {
+    note "base eden config (TPM + accel + roam-proof + 64 GiB boot, tag $BRINGUP_TAG, root $EDEN_ROOT)"
+    # Self-contained: SET every key the run depends on. `eden config add default`
+    # leaves an already-existing context's keys intact, so any stale value silently
+    # persists across legs (a prior leg's eve.disk=32768 is exactly what shrank the
+    # boot disk to 32 GiB and made the shrink resize2fs fail). This mirrors the
+    # validated bringup-grow.sh config block so prep does not depend on a
+    # pre-configured context.
+    if [ -f "$WSROOT/firmware/OVMF_CODE.fd" ] && [ -f "$WSROOT/firmware/OVMF_VARS.fd" ]; then
+        eden config add default --devmodel ZedVirtual-4G \
+            --eve-firmware "$WSROOT/firmware/OVMF_CODE.fd,$WSROOT/firmware/OVMF_VARS.fd"
+    else
+        eden config add default --devmodel ZedVirtual-4G
+    fi
+    eden config set default --key=eve.devmodel --value=ZedVirtual-4G
+    eden config set default --key=eve.tpm      --value=true
+    eden config set default --key=eve.accel    --value=true
+    eden config set default --key=eve.tag      --value="$BRINGUP_TAG"
+    # Pin the bringup hypervisor to kvm: the SMALL start is always -kvm (12.1.0 has
+    # no -k image); a prior leg's kvm->k conversion leaves eve.hv=k, which makes
+    # `eden setup` try to pull the nonexistent <tag>-k image. The escript's BaseOs
+    # hop -- not eden setup -- is what moves the device to -k.
+    eden config set default --key=eve.hv       --value=kvm
+    # eve.disk sizes the BOOT live.img (via the EVE image's `live <MB>` generator),
+    # not just the extra disks; 64 GiB single boot disk by default. Reset eve.disks
+    # to a single disk (two-disk legs override to 1); without the reset a prior
+    # two-disk leg's eve.disks=1 lingers and eden spuriously creates + write-locks
+    # eve-disk-1.qcow2.
+    eden config set default --key=eve.disk     --value="$BOOT_DISK_MB"
+    eden config set default --key=eve.disks    --value=0
+    # SHORT eden.root so swtpm's control socket path fits its 108-byte AF_UNIX cap.
+    eden config set default --key=eden.root    --value="$EDEN_ROOT"
+    # eden.tests must point at a real tests tree so escripts that run a NESTED
+    # escript (e.g. cross_hv's Step-5 revert) can resolve {{EdenConfig "eden.tests"}}.
+    eden config set default --key=eden.tests   --value="$WSROOT/tests"
+    eden config set default --key=eve.hostfwd  --value='{"2222":"22","2223":"2223"}'
+    # Roam-proof: host CLI -> containers via localhost (every eden container is
+    # published there; adam's cert SAN includes 127.0.0.1), and EVE -> adam via the
+    # QEMU slirp gateway (.2 of net=192.168.0.0/24). A laptop IP/WiFi/location change
+    # then can't break onboarding, the redis-backed pod/volume queries, the eserver
+    # upload, or the EVE-side controller path. See
+    # feedback_eden_bringup_always_roamproof_slirp / feedback_eden_adam_ip_lan_sensitive.
+    eden config set default --key=adam.ip         --value=127.0.0.1
+    eden config set default --key=adam.redis.eden --value=127.0.0.1:6379
+    eden config set default --key=eden.eserver.ip --value=127.0.0.1
+    eden config set default --key=registry.ip     --value=127.0.0.1
+    eden config set default --key=adam.eve-ip     --value=192.168.0.2
+}
+
+eve_ssh() { eden eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+wait_ssh() {
+    note "waiting for EVE ssh (up to $((SSH_TRIES*12))s; a fresh EVE-kvm takes a few minutes to boot sshd)"
+    local i
+    for i in $(seq 1 "$SSH_TRIES"); do
+        # stderr silenced: a not-yet-up sshd makes `eden eve ssh` log a scary
+        # FATA/exit-255 that is NOT a failure of this script -- print our own
+        # heartbeat instead so progress is visible during the boot wait.
+        if timeout 8 eden eve ssh -- "true" >/dev/null 2>&1; then
+            echo "  [wait_ssh] EVE ssh up (attempt $i/$SSH_TRIES)"; verify_console; return 0
+        fi
+        echo "  [wait_ssh] attempt $i/$SSH_TRIES: EVE not ssh-ready yet (still booting); retry in 12s"
+        sleep 12
+    done
+    die "EVE ssh did not come up after $((SSH_TRIES*12))s"
+}
+
+# eden builds the live image by running the EVE image in a throwaway container and
+# discards that container's exit code (RunDockerCommand), so an occasional racy
+# generation surfaces only as a misleading "cannot copy ... live.raw.qcow2: no such
+# file". Retry, wiping the half-built image dir and bumping verbosity, then confirm
+# live.img exists. Extra args pass through to `eden setup` (e.g. --grub-options ...).
+do_setup() {
+    local attempt img="$EDEN_ROOT/default-images/eve/live.img"
+    for attempt in 1 2 3; do
+        if [ "$attempt" -eq 1 ]; then
+            eden setup "$@" && [ -f "$img" ] && return 0
+        else
+            note "eden setup failed (try $((attempt-1))); wiping eve image dir, retrying with debug"
+            rm -rf "$EDEN_ROOT/default-images/eve"
+            eden -v debug setup "$@" && [ -f "$img" ] && return 0
+        fi
+        sleep 5
+    done
+    die "eden setup failed after retries (no $img)"
+}
+
+# swtpm's control socket is an AF_UNIX path capped at 108 bytes; a long eden.root
+# overflows it and swtpm dies while eden boots a dead tpm-tis device anyway -- a
+# silent ~12-min onboard timeout with no hint, and every vault/seal assert then
+# meaningless. Verify swtpm is actually up right after start. See
+# reference_eden_swtpm_enable_and_socket_path.
+verify_swtpm() {
+    local sock="$EDEN_ROOT/default-images/eve/swtpm/swtpm-sock"
+    sleep 3
+    if ! pgrep -x swtpm >/dev/null 2>&1 || [ ! -S "$sock" ]; then
+        sed -n '1,5p' "$(dirname "$sock")/swtpm.log" 2>/dev/null
+        die "swtpm not running / socket missing ($sock, len ${#sock}) — eve.tpm asserts would be meaningless"
+    fi
+    note "swtpm OK (pid $(pgrep -x swtpm | tr '\n' ' '))"
+}
+
+# Console-capture sanity: a mid-conversion stall is diagnosed from the serial log
+# ($EDEN_ROOT/default-eve.log), so confirm the running qemu is writing a fresh log
+# carrying our boot banner. A stale/empty log (content from an orphan qemu that
+# outlived the reset) makes a post-mortem useless -- surface it now, as a WARN.
+verify_console() {
+    local clog="$EDEN_ROOT/default-eve.log" tag="${BRINGUP_TAG}-kvm-amd64"
+    if [ ! -s "$clog" ]; then
+        echo "  WARN: console log $clog missing/empty — a mid-run stall would be undiagnosable" >&2
+    elif ! grep -aq "$tag" "$clog" 2>/dev/null; then
+        echo "  WARN: console log $clog has no '$tag' boot banner (stale from an orphan qemu?)" >&2
+    fi
+}
+
+# Enlarge a qcow2 boot disk by $2 GiB (default GROW_TAIL_GB) and relocate the backup
+# GPT so the free tail is usable (README_kvm_to_k_grow.md recipe). The caller passes
+# an explicit size when its base disk differs, so that base + tail stays at the
+# 64 GiB total. eden must be stopped.
+add_free_tail() {
+    local img="$1" tail_gb="${2:-$GROW_TAIL_GB}" fmt
+    [ -f "$img" ] || die "boot image not found: $img"
+    note "enlarging $img by +${tail_gb}G and relocating backup GPT (sudo-free)"
+    cp -f "$img" "$img.prespare.bak"
+    fmt=$(qemu-img info "$img" | sed -ne 's/^file format: //p')
+    qemu-img resize "$img" "+${tail_gb}G" || die "boot resize failed"
+    # `sgdisk -e` relocates the backup GPT to the new end + extends last-usable-LBA,
+    # exposing the added space as a free tail. Run on a *file* (a qcow2 is round-
+    # tripped through a sparse raw) — no qemu-nbd, no root; same trick as
+    # grow_boot_no_tail.
+    if [ "$fmt" = raw ]; then
+        sgdisk -e "$img" || die "sgdisk -e failed"
+        sgdisk -v "$img" || die "sgdisk -v failed"
+    else
+        local raw="$img.raw.tmp"; rm -f "$raw"
+        qemu-img convert -f qcow2 -O raw "$img" "$raw" || die "qcow2->raw failed"
+        sgdisk -e "$raw" || die "sgdisk -e on raw failed"
+        sgdisk -v "$raw" || die "sgdisk -v on raw failed"
+        qemu-img convert -f raw -O qcow2 "$raw" "$img" || die "raw->qcow2 failed"
+        rm -f "$raw"
+    fi
+}
+
+# Grow the boot disk to an ABSOLUTE size BEFORE first boot and relocate the backup
+# GPT so storage-init's first-boot P3 carve fills the whole disk (NO tail — the
+# ext4-toofull topology). Unlike add_free_tail this is sudo-free: sgdisk on a raw
+# *file* is plain file I/O, and a qcow2 is round-tripped through a sparse raw
+# intermediate (qemu-img convert is sparse-aware, so cheap). Call while eden is
+# stopped, between `eden setup` and the first `eden start`.
+grow_boot_no_tail() {
+    local img="$1" size_gb="$2" fmt
+    [ -f "$img" ] || die "boot image not found: $img"
+    fmt=$(qemu-img info "$img" | sed -ne 's/^file format: //p')
+    note "growing $img to ${size_gb}G (no tail; fmt=$fmt) + relocating backup GPT"
+    qemu-img resize "$img" "${size_gb}G" || die "boot resize failed"
+    if [ "$fmt" = raw ]; then
+        sgdisk -e "$img" || die "sgdisk -e failed"
+        sgdisk -v "$img" || die "sgdisk -v failed"
+    else
+        local raw="$img.raw.tmp"
+        qemu-img convert -f qcow2 -O raw "$img" "$raw" || die "qcow2->raw failed"
+        sgdisk -e "$raw" || die "sgdisk -e on raw failed"
+        sgdisk -v "$raw" || die "sgdisk -v on raw failed"
+        qemu-img convert -f raw -O qcow2 "$raw" "$img" || die "raw->qcow2 failed"
+        rm -f "$raw"
+    fi
+}
+
+# Fill the ext4 /persist to FILL_PCT% used with random-content files so the
+# storage-resizer shrink check (which reads the ext4 filesystem's used blocks
+# directly — NOT volumemgr's RemainingSpace, so no declared volume is needed)
+# can't free 22G within --max-full => decision `insufficient` (reason=too-full).
+# Gauges on `df` used% (what the resizer reads), leaving ~(100-FILL_PCT)% free so
+# the later kvm->kvm hop's rootfs blob still fits.
+fill_persist() {
+    local dir=/persist/resize-fill i usedpct
+    note "filling /persist to ${FILL_PCT}% used (random content)"
+    eve_ssh "eve exec pillar mkdir -p $dir"
+    for i in $(seq 1 400); do
+        usedpct=$(eve_ssh "eve exec pillar sh -c 'df --output=pcent /persist | tail -1 | tr -dc 0-9'" | tr -d '\r' | tail -1)
+        usedpct=${usedpct:-0}
+        echo "  /persist used=${usedpct}% (target ${FILL_PCT}%)"
+        [ "$usedpct" -ge "$FILL_PCT" ] 2>/dev/null && { echo "  reached ${usedpct}%"; break; }
+        eve_ssh "eve exec pillar sh -c 'dd if=/dev/urandom of=$dir/f$i bs=1M count=1024 conv=fsync 2>/dev/null; sync'"
+    done
+    eve_ssh "eve exec pillar sh -c 'df -h /persist'"
+}
+
+# Create the EVE persist zpool on a block device FROM INSIDE the running EVE, so
+# the pool's feature flags match EVE's own zfs and storage-init can import it.
+# Mirrors storage-init.sh's create; `zfs set -u` sets the mountpoint WITHOUT
+# mounting now (avoids clobbering the live ext4 /persist), so the next boot's
+# `zpool import` mounts it at /persist. $1 = device (e.g. /dev/sdb).
+eve_make_persist_pool() {
+    local dev="$1"
+    # Build the pool to MATCH a real EVE-ZFS install — a faithful mirror of
+    # pkg/installer/install prepare_mounts_and_zfs_pool (the installer, not storage-init,
+    # is what lays down a multi-disk ZFS persist): same pool flags, PLUS persist/reserved
+    # (refreservation = available/5), primarycache=metadata, and the non-clustered
+    # persist/snapshots dataset. The bringup base is kvm => non-clustered shape. Child
+    # datasets are created with `-u` (do not mount now) because the live ext4 /persist is
+    # still mounted during this build; they mount on the later storage-init import.
+    note "EVE creating persist zpool on $dev (installer-faithful: +reserved +primarycache +snapshots)"
+    eve_ssh "eve exec pillar sh -c \"zpool labelclear -f $dev 2>/dev/null; \
+        zpool create -f -m none -o feature@encryption=enabled -O atime=off -O overlay=on persist $dev && echo CREATED\"" \
+        | grep -q CREATED || die "zpool create failed on $dev"
+    # refreservation = available/5, computed exactly as the installer does (bytes -> MiB, /5)
+    local avail_bytes resv_mib
+    avail_bytes=$(eve_ssh "eve exec pillar zfs get -o value -Hp available persist" | grep -oE '^[0-9]+$' | head -1)
+    [ -n "$avail_bytes" ] || die "could not read pool available bytes"
+    resv_mib=$(( avail_bytes / 1024 / 1024 / 5 ))
+    note "persist/reserved refreservation = ${resv_mib}m (= available/5)"
+    eve_ssh "eve exec pillar sh -c \"\
+        zfs create -u -o refreservation=${resv_mib}m persist/reserved && \
+        zfs set -u mountpoint=/persist persist && \
+        zfs set primarycache=metadata persist && \
+        zfs create -u -o mountpoint=/persist/containerd/io.containerd.snapshotter.v1.zfs persist/snapshots && \
+        zpool export persist && echo POOL_READY\"" | grep -q POOL_READY \
+        || die "failed to set up/export persist pool on $dev"
+}
+
+# Build an ext4 /persist on a whole SECOND disk (the two-disk-ext4 topology),
+# entirely OFFLINE and sudo-free. sdb is still blank at this point (persist lived
+# on the boot P3), so we rebuild its qcow2: a GPT with one partition named P3 (the
+# EVE persist type GUID) filling the disk, ext4 inside it via `mkfs.ext4 -E offset`
+# on a sparse raw image, then convert back to qcow2. storage-init's
+# `findfs PARTLABEL=P3` then picks it up and mounts it ext4 on the next boot.
+# Contrast with eve_make_persist_pool (ZFS): ext4 has no pool feature-flag
+# constraint, so no in-guest step and no sudo/qemu-nbd are needed — any mkfs.ext4
+# works. eden must be stopped. $1 = sdb qcow2 path (sized EVE_DISK_MB).
+make_sdb_ext4_persist() {
+    local img="$1" raw="$1.raw.tmp" start end off nblk
+    [ -f "$img" ] || die "sdb qcow2 not found: $img"
+    note "building ext4 /persist on sdb ($img): GPT P3 + mkfs.ext4, offline"
+    rm -f "$raw"
+    truncate -s "${EVE_DISK_MB}M" "$raw" || die "truncate sdb raw failed"
+    sgdisk --largest-new=1 --typecode=1:5f24425a-2dfa-11e8-a270-7b663faccc2c \
+        --change-name=1:P3 "$raw" >/dev/null || die "sgdisk sdb P3 failed"
+    start=$(sgdisk -i 1 "$raw" | awk '/First sector:/{print $3}')
+    end=$(sgdisk -i 1 "$raw" | awk '/Last sector:/{print $3}')
+    { [ -n "$start" ] && [ -n "$end" ]; } || die "could not read sdb P3 sectors"
+    off=$((start * 512)); nblk=$((end - start + 1))
+    mkfs.ext4 -F -q -L PERSIST -E offset="$off" "$raw" "$((nblk / 2))k" || die "mkfs.ext4 sdb failed"
+    qemu-img convert -f raw -O qcow2 "$raw" "$img" || die "sdb raw->qcow2 failed"
+    rm -f "$raw"
+}
+
+# Offline-delete the boot disk's P3 (partition 9) so storage-init takes the no-P3
+# -> `zpool import persist` path. eden must be stopped. $1 = boot qcow2.
+delete_boot_p3() {
+    # Superseded by the sudo-free delete_boot_p3_offline (raw round-trip); kept as a
+    # thin alias so no run ever needs root.
+    delete_boot_p3_offline "$@"
+}
+
+# Sudo-free variant of delete_boot_p3: delete the GPT partition named P3 via a
+# qcow2<->raw round-trip (qemu-img convert is sparse-aware) instead of `sudo
+# qemu-nbd`, so the two-disk-ext4 topology needs no root at all. Same GPT result;
+# the freed tail becomes the grow target. eden must be stopped. $1 = boot image.
+delete_boot_p3_offline() {
+    local img="$1" fmt raw
+    [ -f "$img" ] || die "boot image not found: $img"
+    fmt=$(qemu-img info "$img" | sed -ne 's/^file format: //p')
+    note "offline-deleting boot P3 from $img (sudo-free, fmt=$fmt)"
+    _del_p3() {   # delete partition named P3 on block-or-file target $1; die on failure
+        local t="$1" p3
+        p3=$(sgdisk -p "$t" | awk '$NF=="P3"{print $1}')
+        [ -n "$p3" ] || die "no GPT partition named P3 on boot disk"
+        sgdisk -d "$p3" "$t" || die "sgdisk -d $p3 failed"
+        sgdisk -p "$t" | awk '$NF=="P3"{f=1} END{exit !f}' && die "P3 still present after delete"
+        return 0
+    }
+    if [ "$fmt" = raw ]; then
+        _del_p3 "$img"
+    else
+        raw="$img.raw.tmp"; rm -f "$raw"
+        qemu-img convert -f qcow2 -O raw "$img" "$raw" || die "qcow2->raw failed"
+        _del_p3 "$raw"
+        qemu-img convert -f raw -O qcow2 "$raw" "$img" || die "raw->qcow2 failed"
+        rm -f "$raw"
+    fi
+    echo "boot P3 deleted"
+}
+
+wait_settled() {
+    note "onboard + wait for boot (persist is created during boot, before sshd)"
+    eden eve onboard || true
+    wait_ssh
+}
+
+case "$TOPOLOGY" in
+
+    ext4-shrink)
+        # Single 64 GiB ext4 disk (from base_config), P3 fills it (no tail). The
+        # conversion must SHRINK P3 (~63 GiB -> ~41 GiB) to grow ESP/IMGA/IMGB; on a
+        # 64 GiB disk the ~41 GiB post-shrink persist holds the escript's 33 GiB fill,
+        # which a 32 GiB disk (its ~10 GiB post-shrink persist) cannot -- that was the
+        # resize2fs "New size smaller than minimum" failure.
+        guard_no_other_eden
+        base_config
+        force_clean_grub
+        note "eden setup (live.img, single 64 GiB ext4 disk, no tail)"
+        do_setup; eden start; verify_swtpm; eden eve onboard; wait_ssh
+        assert_persist_type ext4
+        echo "READY: ext4-shrink. Run: EXPECT_DECISION=shrink ... kvm_to_k"
+        ;;
+
+    ext4-grow)
+        # Single ext4 disk + >=22G free tail. 32 GiB boot (P3 fills it) + a 32 GiB
+        # tail added after onboarding => 64 GiB total. live.img bringup, then enlarge.
+        guard_no_other_eden
+        base_config
+        force_clean_grub
+        eden config set default --key=eve.disk --value="$EVE_DISK_MB"  # 32 GiB boot; +32 GiB tail = 64
+        note "eden setup (live.img, single ext4 disk)"
+        do_setup; eden start; verify_swtpm
+        wait_settled
+        assert_persist_type ext4
+        note "stopping eden to enlarge the boot disk"
+        eden eve stop; sleep 5
+        add_free_tail "$(image_dir)/live.img"
+        note "resuming (eden start only — do NOT re-run eden setup; --force regenerates live.img)"
+        eden start; verify_console
+        echo "READY: ext4-grow. Run: EXPECT_DECISION=grow ... kvm_to_k"
+        ;;
+
+    twodisk-zfs)
+        # VERIFIED 2026-06-22 (eden sandbox). Two disks: sda boot (P3 deleted =>
+        # free tail), sdb ZFS /persist. EVE builds the pool; we delete boot P3.
+        guard_no_other_eden
+        base_config
+        force_clean_grub
+        eden config set default --key=eve.disks --value=1   # adds sdb
+        # 2x32 GiB is the intended two-disk shape and it clears the Longhorn floor:
+        # a 32 GiB sdb yields a ~25 GiB pool, ~18.7 GiB schedulable after the 25%
+        # reserve, above the 16 GiB minimum. assert_persist_free below enforces it.
+        eden config set default --key=eve.disk  --value="$EVE_DISK_MB"  # sizes sdb
+        note "eden setup + start + onboard (sda boot ext4 P3, sdb blank)"
+        do_setup
+        # eve.disk sizes the boot live.img AND every extra disk together, so sizing
+        # sdb independently means enlarging its qcow2 after setup and before first
+        # boot. The pool is created later by EVE on the raw /dev/sdb, so it picks up
+        # the larger geometry with no partition table to fix up.
+        if [ "$TWODISK_SDB_MB" -ne "$EVE_DISK_MB" ]; then
+            note "enlarging sdb to ${TWODISK_SDB_MB}M (pool disk sized apart from boot)"
+            qemu-img resize "$(image_dir)/eve-disk-1.qcow2" "${TWODISK_SDB_MB}M" \
+                || die "sdb resize failed"
+        fi
+        eden start; verify_swtpm; eden eve onboard
+        wait_ssh
+        # Boot P3 must be ext4 here: a stale ZFS token would put a `persist` pool on
+        # the boot disk and collide with the sdb `zpool create` below.
+        assert_persist_type ext4
+        eve_make_persist_pool /dev/sdb
+        note "stopping eden to delete the boot P3"
+        eden eve stop; sleep 6
+        delete_boot_p3 "$(image_dir)/live.img"
+        note "restart — storage-init no-P3 branch imports persist from sdb"
+        eden start
+        wait_ssh
+        note "verify"
+        eve_ssh "echo persist_type=\$(cat /run/eve.persist_type); eve exec pillar sh -c \"zpool status persist; df -h /persist\""
+        assert_persist_type zfs
+        assert_persist_free
+        echo "READY: twodisk-zfs. Run: EXPECT_DECISION=grow DISK_TOPOLOGY=two-disk ... kvm_to_k"
+        ;;
+
+    twodisk-ext4)
+        # VERIFIED 2026-07-07 (host eden; full kvm->k conversion PASSED via the
+        # ext4mig-host-* scripts, of which this is the portable re-expression).
+        # Two disks: sda boot (P3 deleted => free tail => resizer decides GROW),
+        # sdb = an ext4 /persist on its OWN disk. Simpler than twodisk-zfs: the
+        # persist is built OFFLINE with plain mkfs.ext4 (no in-guest pool, no
+        # reserved/snapshots datasets), and kvm->k needs NO vault fs->zvol migration
+        # (the ext4 vault carries over unchanged). Same grow code path as ZFS: the
+        # resizer's `check --disk <bootdev>` finds no P3 on the boot disk =>
+        # shrink N/A => grow off the free tail (pkg/storage-resizer evaluate/decide;
+        # unit-tested as "multi-disk ext4, boot has free tail -> grow").
+        # Ordering: the FIRST boot must create IMGB+P3 on the boot disk (storage-init
+        # is_first_boot_virt_eve needs BOTH absent), so we boot once with persist on
+        # the boot P3, THEN move persist to sdb + delete boot P3. Pre-seeding sdb's
+        # P3 before first boot would suppress IMGB creation.
+        guard_no_other_eden
+        base_config
+        force_clean_grub
+        eden config set default --key=eve.disks --value=1   # adds sdb
+        eden config set default --key=eve.disk  --value="$EVE_DISK_MB"  # sizes sdb
+        note "eden setup"
+        do_setup
+        # Grow the boot disk before first boot so the P3 (created full) leaves a
+        # >=22G free tail once deleted. grow_boot_no_tail is sudo-free (raw round-trip).
+        grow_boot_no_tail "$(image_dir)/live.img" "$TWODISK_BOOT_GB"
+        note "start + onboard (sda boot ext4 P3, sdb blank)"
+        eden start; verify_swtpm; eden eve onboard
+        wait_ssh
+        note "stop; build sdb ext4 persist (offline) + delete boot P3"
+        eden eve stop; sleep 6
+        make_sdb_ext4_persist "$(image_dir)/eve-disk-1.qcow2"
+        delete_boot_p3_offline "$(image_dir)/live.img"
+        note "restart — storage-init finds P3 on sdb (ext4); boot disk has a free tail"
+        eden start
+        wait_ssh
+        note "verify"
+        eve_ssh "echo persist_type=\$(cat /run/eve.persist_type); eve exec pillar sh -c \"lsblk -o NAME,SIZE,FSTYPE,PARTLABEL /dev/sda /dev/sdb; df -h /persist\""
+        assert_persist_type ext4
+        echo "READY: twodisk-ext4. Run: EXPECT_DECISION=grow DISK_TOPOLOGY=two-disk ... kvm_to_k"
+        ;;
+
+    ext4-toofull)
+        # Single 64 GiB ext4 disk (from base_config) so an EMPTY P3 could shrink to
+        # free 22G; then /persist is filled to FILL_PCT% so the shrink CAN'T free
+        # 22G within --max-full => check `insufficient` (reason=too-full). Refused
+        # case. VERIFIED end-to-end on host eden 2026-07-01 (e2e testplan row C):
+        # check `decision=insufficient persistType=ext4 shrinkApplicable=true
+        # shrink.ok=false`, kvm->k declined with BaseOsStatus.Error
+        # "conversion not possible: persist is too full to free the needed space".
+        guard_no_other_eden
+        base_config
+        force_clean_grub
+        note "eden setup (live.img, single 64 GiB ext4 disk)"
+        do_setup
+        eden start; verify_swtpm; eden eve onboard
+        wait_ssh
+        # A ZFS persist here would be the wrong topology (that is zfs-notail).
+        assert_persist_type ext4
+        fill_persist
+        echo "READY: ext4-toofull. Run: REFUSE_REASON=too-full ... kvm_to_k_refused"
+        ;;
+
+    zfs-grow|zfs-notail)
+        # SINGLE-disk ZFS /persist (persist == the boot disk's P3 as ZFS).
+        # VERIFIED 2026-06-25. The token is delivered via grub.cfg, which eden only
+        # (re)writes when CertsDir has no root-certificate.pem (setupConfigDir gate) —
+        # so we MUST wipe the certs dir (certs_dir(), under eden.root) + adam/redis
+        # volumes before setup,
+        # else `eden setup --grub-options ...` silently skips grub.cfg and the token
+        # never lands. live.img has no pre-baked P3, so storage-init creates it on
+        # first boot and formats it ZFS because the token sets P3_FS_TYPE_DEFAULT=zfs
+        # (storage-init.sh:113). Result: persist_type=zfs, zpool ONLINE on sda9.
+        guard_no_other_eden
+        base_config
+        # zfs-grow needs a free tail AND a pool that clears the /persist floor, both
+        # inside the same 64 GiB total. The tail cannot feed the pool: the ZFS P3 is
+        # created at setup and never grows into space added afterwards. So split
+        # 40 base + 24 tail rather than ext4-grow's 32+32 — the tail only has to cover
+        # the conversion's ~21 GiB of ESP/IMGA/IMGB growth, and the 8 GiB saved goes to
+        # the pool. zfs-notail is a full BOOT_DISK_MB single disk (P3 fills it, no tail).
+        [ "$TOPOLOGY" = zfs-grow ] && eden config set default --key=eve.disk --value="$ZFS_GROW_BASE_MB"
+        note "wipe certs + adam/redis volumes so eden setup regenerates grub.cfg"
+        eden stop || true
+        rm -rf "$(image_dir)/live.img" "$(image_dir)/live.raw.qcow2" "$(certs_dir)"
+        docker volume rm eden_adam_volume eden_redis_volume 2>/dev/null || true
+        note "eden setup with the grub-option (canonical bare token, set_global form)"
+        # $dom0_extra_args is a grub variable expanded at boot; it must reach grub
+        # literally, so keep the single quotes and do not let the shell expand it.
+        # shellcheck disable=SC2016
+        do_setup --grub-options 'set_global dom0_extra_args "$dom0_extra_args eve_install_zfs_with_raid_level "'
+        [ -f "$(certs_dir)/grub.cfg" ] || die "grub.cfg not written — certs were not wiped?"
+        eden start; verify_swtpm; eden eve onboard
+        wait_ssh
+        note "confirm the cmdline took effect"
+        eve_ssh "echo cmdline=\$(cat /proc/cmdline); echo persist_type=\$(cat /run/eve.persist_type)"
+        # Expect: cmdline contains eve_install_zfs_with_raid_level AND persist_type=zfs.
+        assert_persist_type zfs
+        assert_persist_free
+        if [ "$TOPOLOGY" = zfs-grow ]; then
+            note "zfs-grow: add a ${ZFS_GROW_TAIL_GB}G free tail after the ZFS P3"
+            eden eve stop; sleep 5
+            # ZFS partition is not auto-grown -> the added space stays a free tail.
+            add_free_tail "$(image_dir)/live.img" "$ZFS_GROW_TAIL_GB"
+            eden start; verify_console
+            echo "READY(if persist_type=zfs above): zfs-grow. Run: EXPECT_DECISION=grow DISK_TOPOLOGY=zfs ... kvm_to_k"
+        else
+            echo "READY(if persist_type=zfs above): zfs-notail. Run: REFUSE_REASON=zfs ... kvm_to_k_refused"
+        fi
+        ;;
+
+    *)
+        echo "unknown topology: $TOPOLOGY" >&2
+        usage
+        ;;
+esac

--- a/tests/update_eve_image/testdata/prep-kvm-to-k-topology.sh
+++ b/tests/update_eve_image/testdata/prep-kvm-to-k-topology.sh
@@ -27,6 +27,24 @@
 # the ~600 MB of longhornio/* images take from docker.io (186-545 KB/s, 3-4x variance
 # run to run) against the readiness budgets, so treat a single pass as weak evidence.
 #
+# The flakiness is NOT confined to the ZFS legs, and the readiness log now names the
+# condition. A 2026-09-04 sweep on the STRESS line (image
+# lfedge/eve:0.0.0-resize-allprs-stress-833f7358-{kvm,k}, bringup 12.1.0, host also
+# running an unrelated evetest soak) reached PASS=7, but ext4-shrink and twodisk-zfs
+# each needed a second run: both blew the 85m volumemgr-readiness budget the first
+# time, and both passed at the same geometry immediately after. Their reruns reported
+#   UnmetCondition: longhorn not ready: longhorn instance-manager not running on node
+# taking 46 min to clear on twodisk-zfs and ~15 min on ext4-shrink. So the budget is
+# lost to the longhorn instance-manager coming up, not only to image pull rate, and
+# ext4-shrink is as exposed as the ZFS legs. Deliberately NOT recorded in the status
+# column above, which is keyed to the non-stress resize-allprs sweep -- a stress leg
+# ladders through more resizer boots and the two lines must not be pooled.
+#
+# Worth knowing when a first run fails: the two failures presented differently.
+# ext4-shrink sat at Initialized:false with contenttrees=0, while twodisk-zfs never
+# published a VolumeMgrStatus at all (init=<none> for the whole window, no condition
+# ever reported). Only the latter is unexplained; it did not reproduce.
+#
 # Decision logic is from pkg/storage-resizer (decide()/evaluate()): shrink applies
 # ONLY to an ext4 /persist on the boot disk; a ZFS persist or a persist on another
 # disk can only get room from the boot disk's free tail, else `insufficient`.

--- a/tests/update_eve_image/testdata/prep-kvm-to-k-topology.sh
+++ b/tests/update_eve_image/testdata/prep-kvm-to-k-topology.sh
@@ -149,11 +149,15 @@ usage() { sed -n '2,60p' "$0" | sed 's/^# \{0,1\}//'; exit 2; }
 guard_no_other_eden() {
     local busy=0
     docker ps --format '{{.Names}}' 2>/dev/null | grep -qE '^eden_(adam|redis|eserver|registry)$' && busy=1
-    pgrep -f 'qemu-system.*-drive' >/dev/null 2>&1 && busy=1
+    # eden always names its QEMU control socket "<context>-qmp.sock" (pkg/eden/qemu.go),
+    # independent of eden.root/EDEN_HOME. Match that suffix so a leaked eden QEMU is
+    # caught while VMs from other frameworks (e.g. evetest, whose socket is a plain
+    # "qmp.sock") are ignored.
+    pgrep -f '[q]emu-system.*-qmp\.sock' >/dev/null 2>&1 && busy=1
     if [ "$busy" = 1 ]; then
-        echo "An eden instance appears to be running on this host (eden_* containers or qemu)." >&2
-        echo "eden is single-tenant; this script would disturb it. Stop it first or use a" >&2
-        echo "dedicated host / the eden-vm-sandbox skill. Refusing." >&2
+        echo "An eden instance appears to be running on this host (eden_* containers or an" >&2
+        echo "eden-spawned QEMU). eden is single-tenant; this script would disturb it. Stop" >&2
+        echo "it first or use a dedicated host / the eden-vm-sandbox skill. Refusing." >&2
         exit 1
     fi
 }

--- a/tests/update_eve_image/testdata/prep-kvm-to-k-topology.sh
+++ b/tests/update_eve_image/testdata/prep-kvm-to-k-topology.sh
@@ -132,6 +132,7 @@ TWODISK_BOOT_GB="${TWODISK_BOOT_GB:-32}"   # twodisk-ext4 boot-disk size (matche
 EDEN_ROOT="${EDEN_ROOT:-$HOME/.e166o}"     # SHORT eden.root so swtpm's 108-byte AF_UNIX control
                                            # socket path fits (a long path silently dead-TPMs).
 SSH_TRIES="${SSH_TRIES:-40}"               # ssh-up poll attempts (x12s)
+PERSIST_TYPE_TRIES="${PERSIST_TYPE_TRIES:-30}"    # /run/eve.persist_type poll attempts (x10s)
 FILL_PCT="${FILL_PCT:-70}"                 # ext4-toofull: fill /persist to this used% so
                                            # used > maxFull(90%) x (P3-22G) => check insufficient.
 
@@ -202,9 +203,20 @@ force_clean_grub() {
 
 # Fail loudly if the device came up on the wrong /persist filesystem, so a
 # mis-topology is a legible error instead of a silent false pass. $1 = ext4|zfs.
+#
+# sshd answering does not mean storage-init has published /run/eve.persist_type, so
+# an empty read means "not yet", not "wrong topology" -- poll for it. A non-empty
+# value that disagrees IS a mis-topology and fails at once, since it cannot change
+# without another boot.
 assert_persist_type() {
-    local got
-    got=$(eve_ssh 'cat /run/eve.persist_type' | tr -d '\r' | tail -1)
+    local got i
+    for i in $(seq 1 "$PERSIST_TYPE_TRIES"); do
+        got=$(eve_ssh 'cat /run/eve.persist_type' | tr -d '\r' | tail -1)
+        [ -n "$got" ] && break
+        echo "  [persist_type] attempt $i/$PERSIST_TYPE_TRIES: not published yet; retry in 10s"
+        sleep 10
+    done
+    [ -n "$got" ] || die "persist_type never published after $((PERSIST_TYPE_TRIES*10))s (expected $1 for $TOPOLOGY)"
     [ "$got" = "$1" ] || die "persist_type='$got' (expected $1 for $TOPOLOGY)"
 }
 

--- a/tests/update_eve_image/testdata/run-kvm-to-k-tests.sh
+++ b/tests/update_eve_image/testdata/run-kvm-to-k-tests.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# run-kvm-to-k-tests.sh — drive the EVE-kvm -> EVE-k boot-disk repartition test
+# matrix end to end. For each disk topology, prep-kvm-to-k-topology.sh brings eden
+# up in that layout on a SMALL start image, then the mapped escript performs the
+# controller-driven kvm->k conversion and asserts the outcome. Verdicts are
+# collected and the run continues on failure; a summary prints at the end.
+#
+# SCOPE. This drives the repartition + insufficient-space legs, which share the
+# SMALL-start + local-build model whose bringup is the committed
+# prep-kvm-to-k-topology.sh (single source of truth). The remaining kvm->k
+# escripts need a different start image or bringup and are documented, with their
+# exact invocation, under "Other tests" in README_kvm_to_k.md: the app-volume
+# migration (large start), the geometry matrix (per-release starts), the
+# native-EVE-k first-boot test, the persist-wipe / backup-corruption restore
+# tests (plain small start), and the cross-HV family (released images).
+#
+# PREREQUISITES (see README_kvm_to_k.md for the full recipe):
+#   * a local EVE image PAIR built from the conversion branch, tagged
+#     <RESIZE_EVE_REG>:<RESIZE_EVE_VER>-{kvm,k}-<arch> (BOTH flavors present);
+#   * the small bringup release (<BRINGUP_EVE_VER>, default 12.1.0) available;
+#   * swtpm + OVMF on the host and eden configured with eve.tpm=true (the vault /
+#     seal assertions are meaningless without a TPM);
+#   * the host eden slot free — eden is single-tenant and every leg does its own
+#     destructive bringup.
+#
+# ENV:
+#   RESIZE_EVE_VER   (required) version base of the local conversion build, without
+#                    the -<hv>-<arch> suffix, e.g. 0.0.0-resize-allprs-<sha8>.
+#   RESIZE_EVE_REG   (default lfedge/eve) image registry/repo namespace.
+#   BRINGUP_EVE_VER  (default 12.1.0) small-layout start release.
+#   ONLY=a,b,...     run only these leg ids (comma-separated; ids below).
+#   SKIP=a,b,...     skip these leg ids.
+#   EDEN             eden binary (default: <workspace>/dist/bin/eden, else `eden`).
+#
+# LEG ids and their (topology -> escript + knobs) mapping — matches the
+# prep-kvm-to-k-topology.sh header table:
+#   ext4-shrink   ext4 full, 1 disk        -> kvm_to_k  EXPECT_DECISION=shrink
+#   ext4-grow     ext4 +tail, 1 disk       -> kvm_to_k  EXPECT_DECISION=grow
+#   twodisk-ext4  ext4 on sdb, 2 disks     -> kvm_to_k  EXPECT_DECISION=grow DISK_TOPOLOGY=two-disk
+#   twodisk-zfs   zfs on sdb, 2 disks      -> kvm_to_k  EXPECT_DECISION=grow DISK_TOPOLOGY=two-disk
+#   zfs-grow      zfs on boot P3, +tail    -> kvm_to_k  EXPECT_DECISION=grow DISK_TOPOLOGY=zfs
+#   ext4-toofull  ext4 full (fill-driven)  -> kvm_to_k_refused  REFUSE_REASON=too-full
+#   zfs-notail    zfs on boot P3, no tail  -> kvm_to_k_refused  REFUSE_REASON=zfs
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PREP="$HERE/prep-kvm-to-k-topology.sh"
+# testdata/ -> update_eve_image/ -> tests/ -> workspace root
+WS="$(cd "$HERE/../../.." && pwd)"
+EDEN="${EDEN:-$WS/dist/bin/eden}"
+[ -x "$EDEN" ] || EDEN=eden
+# prep-kvm-to-k-topology.sh and the escripts call bare `eden` and use paths
+# relative to the workspace root, so run everything from $WS with dist/bin on PATH.
+export PATH="$WS/dist/bin:$PATH"
+TESTREL="tests/update_eve_image"
+
+: "${RESIZE_EVE_VER:?set RESIZE_EVE_VER to your local conversion build, e.g. 0.0.0-resize-allprs-<sha8>}"
+export RESIZE_EVE_VER
+export RESIZE_EVE_REG="${RESIZE_EVE_REG:-lfedge/eve}"
+export BRINGUP_EVE_VER="${BRINGUP_EVE_VER:-12.1.0}"
+
+[ -f "$PREP" ] || { echo "FATAL: prep script not found: $PREP" >&2; exit 1; }
+
+# id | topology | escript | extra env (space-separated VAR=VAL)
+LEGS=(
+  "ext4-shrink|ext4-shrink|update_eve_image_kvm_to_k|EXPECT_DECISION=shrink"
+  "ext4-grow|ext4-grow|update_eve_image_kvm_to_k|EXPECT_DECISION=grow"
+  "twodisk-ext4|twodisk-ext4|update_eve_image_kvm_to_k|EXPECT_DECISION=grow DISK_TOPOLOGY=two-disk"
+  "twodisk-zfs|twodisk-zfs|update_eve_image_kvm_to_k|EXPECT_DECISION=grow DISK_TOPOLOGY=two-disk"
+  "zfs-grow|zfs-grow|update_eve_image_kvm_to_k|EXPECT_DECISION=grow DISK_TOPOLOGY=zfs"
+  "ext4-toofull|ext4-toofull|update_eve_image_kvm_to_k_refused|REFUSE_REASON=too-full"
+  "zfs-notail|zfs-notail|update_eve_image_kvm_to_k_refused|REFUSE_REASON=zfs"
+)
+
+declare -A WANT NOWANT
+if [ -n "${ONLY:-}" ]; then IFS=',' read -ra a <<<"$ONLY"; for x in "${a[@]}"; do WANT[$x]=1; done; fi
+if [ -n "${SKIP:-}" ]; then IFS=',' read -ra a <<<"$SKIP"; for x in "${a[@]}"; do NOWANT[$x]=1; done; fi
+selected() {
+  [ -n "${NOWANT[$1]:-}" ] && return 1
+  if [ -n "${ONLY:-}" ]; then
+    [ -n "${WANT[$1]:-}" ] && return 0
+    return 1
+  fi
+  return 0
+}
+
+# Reclaim the single-tenant slot before each leg. prep-kvm-to-k-topology.sh guards
+# against a running eden and will NOT reset one, and the escript's final `eden eve
+# reset` leaves the eden_* containers and the qemu/swtpm UP -- a surviving qemu
+# holds a write-lock on the disk image and makes the next `eden setup` fail. So
+# stop eden, drop the eden_* containers + volumes (stale adam certs otherwise
+# reject the new device), kill+verify any qemu/swtpm still bound to eden.root, and
+# drop the prior leg's disk images so `eden setup` regenerates a fresh topology.
+# Mirrors the validated bringup-grow.sh teardown.
+free_slot() {
+  "$EDEN" stop >/dev/null 2>&1 || true
+  docker rm -fv eden_adam eden_redis eden_registry eden_eserver >/dev/null 2>&1 || true
+  docker volume rm -f eden_adam_volume eden_redis_volume eden_eserver_volume eden_registry_volume >/dev/null 2>&1 || true
+  local root
+  root=$("$EDEN" config get default --key eden.root 2>/dev/null | grep -vi 'level=' | tr -d '\r' | tail -1)
+  root="${root:-${EDEN_HOME:-$HOME/.e166o}}"
+  for p in $(pgrep -f "[q]emu-system-x86.*$root" 2>/dev/null) $(pgrep -f "[s]wtpm.*$root" 2>/dev/null); do
+    kill "$p" 2>/dev/null; sleep 1; kill -9 "$p" 2>/dev/null || true
+  done
+  sleep 1
+  pgrep -f "[q]emu-system-x86.*$root" >/dev/null 2>&1 && echo "WARN: qemu on $root survived teardown (next setup may write-lock)" >&2
+  rm -f "$root"/default-images/eve/live.img "$root"/default-images/eve/live.raw* "$root"/default-images/eve/eve-disk-*.qcow2 2>/dev/null || true
+}
+
+now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+declare -A VERDICT
+ORDER=()
+
+for spec in "${LEGS[@]}"; do
+  IFS='|' read -r id topo escript extra <<<"$spec"
+  ORDER+=("$id")
+  if ! selected "$id"; then VERDICT[$id]="SKIP(deselected)"; continue; fi
+  echo
+  echo "########## [$id] $topo -> $escript ($extra) @ $(now) ##########"
+  free_slot
+  if ! ( cd "$WS" && bash "$PREP" "$topo" --yes ); then
+    VERDICT[$id]="FAIL(prep)"
+    echo "########## [$id] FAIL(prep) @ $(now) ##########"
+    continue
+  fi
+  # $extra is intentionally word-split into VAR=VAL args for env
+  # shellcheck disable=SC2086
+  if ( cd "$WS" && env $extra "$EDEN" test "$TESTREL" -e "${escript}\$" -v debug ); then
+    VERDICT[$id]=PASS
+  else
+    VERDICT[$id]="FAIL(escript rc=$?)"
+  fi
+  echo "########## [$id] ${VERDICT[$id]} @ $(now) ##########"
+done
+
+echo
+echo "===================== SUMMARY @ $(now) ====================="
+echo "  image: ${RESIZE_EVE_REG}:${RESIZE_EVE_VER}-{kvm,k}   bringup: ${BRINGUP_EVE_VER}"
+npass=0; nfail=0; nskip=0
+for id in "${ORDER[@]}"; do
+  v="${VERDICT[$id]:-?}"
+  printf '  %-14s %s\n' "$id" "$v"
+  case "$v" in PASS) npass=$((npass+1));; FAIL*) nfail=$((nfail+1));; SKIP*) nskip=$((nskip+1));; esac
+done
+echo "  ----"
+echo "  PASS=$npass  FAIL=$nfail  SKIP=$nskip"
+[ "$nfail" -eq 0 ]

--- a/tests/update_eve_image/testdata/run-kvm-to-k-tests.sh
+++ b/tests/update_eve_image/testdata/run-kvm-to-k-tests.sh
@@ -111,6 +111,49 @@ now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 declare -A VERDICT
 ORDER=()
 
+eden_root() {
+  local root
+  root=$("$EDEN" config get default --key eden.root 2>/dev/null | grep -vi 'level=' | tr -d '\r' | tail -1)
+  echo "${root:-${EDEN_HOME:-$HOME/.e166o}}"
+}
+CONSOLE="$(eden_root)/default-eve.log"
+
+# The emulator and the host kernel are as much a part of a verdict as the EVE image:
+# a QEMU that aborts mid-leg looks exactly like an EVE stall, and the AHCI abort this
+# guards against is host-kernel/guest-kernel dependent. Record them once per run.
+echo "===== run environment @ $(now) ====="
+echo "  image:        ${RESIZE_EVE_REG}:${RESIZE_EVE_VER}-{kvm,k}   bringup: ${BRINGUP_EVE_VER}"
+echo "  host qemu:    $(qemu-system-x86_64 --version 2>/dev/null | head -1)"
+echo "  host kernel:  $(uname -r)"
+echo "  eden:         $(git -C "$WS" rev-parse --short HEAD 2>/dev/null) ($(git -C "$WS" rev-parse --abbrev-ref HEAD 2>/dev/null))"
+echo "  console log:  $CONSOLE"
+
+# A guest-triggered QEMU abort (zero-length-PRDT NCQ command -> ide_dma_cb assertion)
+# kills the VM outright, so whatever step was in flight reports a timeout and the leg
+# gets blamed on EVE. Scan only the console bytes this leg appended, so a previous
+# leg's abort is not re-counted, and keep the disk image when it happens.
+scan_qemu_ahci() {   # $1 = leg id, $2 = console size before the leg
+  local id="$1" from="$2" aborts=0 warns=0
+  [ -f "$CONSOLE" ] || return 0
+  aborts=$(tail -c "+$((from + 1))" "$CONSOLE" 2>/dev/null | grep -ac 'ide_dma_cb: Assertion' || true)
+  warns=$(tail -c "+$((from + 1))" "$CONSOLE" 2>/dev/null | grep -ac 'PRDT length' || true)
+  echo "  [qemu-ahci] leg=$id prdt_warnings=$warns aborts=$aborts"
+  [ "${aborts:-0}" -gt 0 ] || return 0
+  local root img crash
+  root=$(eden_root); img="$root/default-images/eve/live.img"
+  crash="$root/crash-$id-$(date -u +%Y%m%dT%H%M%SZ)"
+  echo "  [qemu-ahci] QEMU ABORTED during this leg -- the verdict below is about the"
+  echo "  [qemu-ahci] emulator, not EVE. Preserving evidence under $crash.*"
+  mkdir -p "$crash"
+  tail -c "+$((from + 1))" "$CONSOLE" > "$crash/console-slice.log" 2>/dev/null || true
+  if [ -f "$img" ]; then
+    # Same filesystem, so this is instant and it also hides the image from free_slot's rm.
+    mv "$img" "$crash/live.img" 2>/dev/null \
+      && qemu-img check "$crash/live.img" > "$crash/qemu-img-check.txt" 2>&1 || true
+  fi
+  return 1
+}
+
 for spec in "${LEGS[@]}"; do
   IFS='|' read -r id topo escript extra <<<"$spec"
   ORDER+=("$id")
@@ -118,9 +161,11 @@ for spec in "${LEGS[@]}"; do
   echo
   echo "########## [$id] $topo -> $escript ($extra) @ $(now) ##########"
   free_slot
+  csize=$(stat -c%s "$CONSOLE" 2>/dev/null || echo 0)
   if ! ( cd "$WS" && bash "$PREP" "$topo" --yes ); then
     VERDICT[$id]="FAIL(prep)"
-    echo "########## [$id] FAIL(prep) @ $(now) ##########"
+    scan_qemu_ahci "$id" "$csize" || VERDICT[$id]="FAIL(emulator-crash in prep)"
+    echo "########## [$id] ${VERDICT[$id]} @ $(now) ##########"
     continue
   fi
   # $extra is intentionally word-split into VAR=VAL args for env
@@ -130,6 +175,9 @@ for spec in "${LEGS[@]}"; do
   else
     VERDICT[$id]="FAIL(escript rc=$?)"
   fi
+  # An abort outranks the escript's own verdict: the device stopped existing, so
+  # whatever the escript concluded is about a corpse.
+  scan_qemu_ahci "$id" "$csize" || VERDICT[$id]="FAIL(emulator-crash)"
   echo "########## [$id] ${VERDICT[$id]} @ $(now) ##########"
 done
 
@@ -141,7 +189,12 @@ for id in "${ORDER[@]}"; do
   v="${VERDICT[$id]:-?}"
   printf '  %-14s %s\n' "$id" "$v"
   case "$v" in PASS) npass=$((npass+1));; FAIL*) nfail=$((nfail+1));; SKIP*) nskip=$((nskip+1));; esac
+  case "$v" in *emulator-crash*) ncrash=$((${ncrash:-0}+1));; esac
 done
 echo "  ----"
 echo "  PASS=$npass  FAIL=$nfail  SKIP=$nskip"
+if [ "${ncrash:-0}" -gt 0 ]; then
+  echo "  NOTE: ${ncrash} leg(s) lost the emulator, not EVE -- see the [qemu-ahci] lines"
+  echo "        and the preserved crash-*/ dirs under $(eden_root)."
+fi
 [ "$nfail" -eq 0 ]

--- a/tests/update_eve_image/testdata/update_eve_image_cross_hv.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_cross_hv.txt
@@ -1,0 +1,212 @@
+# Test: cross-HV-flavor EVE upgrade succeeds when no volumes exist
+#
+# Verifies that EVE accepts a baseos config whose HV flavor differs from
+# the currently running one (e.g. kvm -> k or k -> kvm) when the device
+# has no VolumeConfig / VolumeStatus instances — the happy path enabled
+# by EVE PR #5993 (baseosmgr volume-gate relaxation).
+#
+# Pair: update_eve_image_cross_hv_blocked.txt covers the negative case
+# (volumes present -> upgrade is rejected with "is not supported while
+# volumes exist").
+#
+# Diagnostic enhancement (post-2026-06-07):
+# On kvm -> k, after EVE reboots into IMGB the upgrade may stall at
+# PartitionState:inprogress because baseosmgr (+ volumemgr + domainmgr)
+# block in WaitForUserContainerd waiting for /run/containerd-user/
+# containerd.sock — which k3s creates only once cluster-init.sh succeeds.
+# A kvm /persist may lack state k3s expects, so k3s never comes up and
+# the wait blocks forever. We poll k3s/kube diagnostics during the wait
+# so the failure surfaces with actionable detail instead of a bare timeout.
+#
+# Parameters (env vars; defaults assume both flavors are pullable from
+# lfedge/eve at release tag 12.1.0):
+#  - ALT_HV:        the *other* HV flavor to upgrade to (default: 'k' if
+#                   running kvm, 'kvm' if running k). Auto-derived.
+#  - ALT_EVE_VER:   the EVE release tag for the alternate flavor
+#                   (default: '12.1.0').
+#  - ALT_EVE_REG:   docker registry for the alternate-flavor image
+#                   (default: 'lfedge/eve').
+
+{{$current_hv := EdenConfig "eve.hv"}}
+{{$arch       := EdenConfig "eve.arch"}}
+
+{{$alt_hv_env := EdenGetEnv "ALT_HV"}}
+{{$alt_hv := "k"}}
+{{if eq $current_hv "k"}}{{$alt_hv = "kvm"}}{{end}}
+{{if $alt_hv_env}}{{$alt_hv = $alt_hv_env}}{{end}}
+
+{{$alt_ver_env := EdenGetEnv "ALT_EVE_VER"}}
+{{$alt_ver := "12.1.0"}}
+{{if $alt_ver_env}}{{$alt_ver = $alt_ver_env}}{{end}}
+
+{{$alt_reg_env := EdenGetEnv "ALT_EVE_REG"}}
+{{$alt_reg := "lfedge/eve"}}
+{{if $alt_reg_env}}{{$alt_reg = $alt_reg_env}}{{end}}
+
+{{$alt_short_version := printf "%s-%s-%s" $alt_ver $alt_hv $arch}}
+
+# Step 1: pre-flight — no live volumes on the device.
+message 'pre-flight: assert no live volumes on the device'
+exec -t 1m bash assert-no-volumes.sh
+
+# Shorten baseimage test cooldown so partition flip is quick.
+eden controller edge-node update --config timer.test.baseimage.update=30
+
+# Step 2: download the alternate-flavor EVE rootfs.
+message 'downloading alternate-flavor EVE rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$alt_ver}} --eve-hv={{$alt_hv}} --eve-registry={{$alt_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs'
+
+# Step 3: push the cross-flavor eveimage-update.
+# --os-version explicit so adam's BaseOsConfig.BaseOsVersion carries the
+# cross-flavor tag regardless of any stale eve_version metadata in the
+# squashfs (a known kvm<->k Makefile quirk; see ~/CLAUDE.md memories).
+message 'pushing cross-flavor eveimage-update'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs --os-version={{ $alt_short_version }} -m adam://
+
+! stderr .
+
+# Step 4: wait for the upgrade — and poll k3s / kube diagnostics
+# while we wait. If eve-k boots but k3s never comes up, this is where
+# we'll surface the failure.
+message 'waiting for cross-flavor upgrade to complete (with k3s diagnostics)'
+exec -t 35m bash wait-for-cross-hv-upgrade.sh
+
+# Step 5: roll back via the existing revert_eve_image_update scenario.
+# Skipped if step 4 failed (escript halts on first failure).
+test eden.escript.test -test.run TestEdenScripts/revert_eve_image_update -test.v -testdata {{EdenConfig "eden.tests"}}/update_eve_image/testdata/
+
+# Step 6: clear adam's leftover BaseOsConfig for the alternate version.
+eden -t 1m controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs -m adam://
+eden controller edge-node get-config
+! stdout '{{ $alt_short_version }}'
+
+exec sleep 10
+eden eve reset
+
+-- assert-no-volumes.sh --
+#!/bin/bash
+# Pre-flight: assert no live volumes (IN_CONFIG / DELIVERED) on EVE.
+# Transient delete states (NOT_IN_CONFIG / RESOLVING_TAG) are tolerated.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for i in $(seq 1 12); do
+    out=$("$EDEN" volume ls 2>/dev/null)
+    live=$(echo "$out" | awk 'NR>1 && ($(NF-1) == "IN_CONFIG" || $NF == "DELIVERED")')
+    if [ -z "$live" ]; then
+        echo "OK: no live volumes on the device"
+        echo "$out"
+        exit 0
+    fi
+    echo "Waiting for transient volumes to settle (attempt $i/12):"
+    echo "$live"
+    sleep 5
+done
+echo "FAIL: live volume(s) still present after polling" >&2
+echo "$out" >&2
+exit 1
+
+-- wait-for-cross-hv-upgrade.sh --
+#!/bin/bash
+# Wait for the upgraded EVE to reach PartitionState:active AND running
+# the expected $EXPECT_VERSION, while periodically dumping k3s/kube
+# diagnostics once we've booted into eve-k. Timeout is enforced by the
+# wrapping `exec -t 35m`.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT_VERSION='{{ $alt_short_version }}'
+DEADLINE=$(( $(date +%s) + 1800 ))   # 30 min
+
+# Resilient SSH probe — returns empty (not fatal log line) if SSH fails.
+probe() {
+    local out
+    out=$(timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null)
+    echo "$out" | grep -v 'level=fatal'
+}
+
+dump_k3s_diags() {
+    echo "  --- k3s diagnostics ---"
+    sock=$(probe 'test -S /run/containerd-user/containerd.sock && echo present || echo absent')
+    echo "  /run/containerd-user/containerd.sock: $sock"
+
+    # Container-side runtime view of kube
+    kube_pid=$(probe 'ctr -n services c info kube 2>/dev/null | sed -n "s/.*\"Pid\": *\\([0-9]*\\).*/\\1/p"')
+    echo "  kube container pid: ${kube_pid:-not running}"
+
+    # Cluster-init log — common candidate paths on EVE-k
+    for log in /persist/kubelog/cluster-init.log /persist/k3s/cluster-init.log /persist/log/cluster-init.log /persist/kube/cluster-init.log; do
+        present=$(probe "test -f $log && echo y")
+        if [ "$present" = "y" ]; then
+            echo "  --- tail of $log ---"
+            probe "tail -30 $log" | sed 's/^/    /'
+            break
+        fi
+    done
+
+    # Recent k3s / cluster-init errors anywhere on the device
+    errs=$(probe 'logread 2>/dev/null | grep -iE "k3s|cluster-init|kubelet" | grep -iE "level=error|level=fatal|fail" | tail -10')
+    if [ -n "$errs" ]; then
+        echo "  --- recent k3s/cluster-init errors ---"
+        echo "$errs" | sed 's/^/    /'
+    fi
+
+    # baseosmgr's progress (or stuck spin)
+    baseosmgr_tail=$(probe 'logread 2>/dev/null | grep baseosmgr | tail -3')
+    if [ -n "$baseosmgr_tail" ]; then
+        echo "  --- baseosmgr last 3 log lines ---"
+        echo "$baseosmgr_tail" | sed 's/^/    /'
+    fi
+}
+
+prev_running=""
+diags_dumped_this_state=""
+
+while [ $(date +%s) -lt $DEADLINE ]; do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then
+        echo "$(date +%H:%M:%S): EVE not reachable via SSH (possibly rebooting)"
+        sleep 20
+        continue
+    fi
+
+    imgb_state=$(probe 'eve exec pillar cat /run/baseosmgr/ZbootStatus/IMGB.json' \
+        | grep -oP '"PartitionState":"\K[^"]+' | head -1)
+    [ -z "$imgb_state" ] && imgb_state='unknown'
+
+    echo "$(date +%H:%M:%S): running='$running' IMGB.PartitionState='$imgb_state'"
+
+    # Success: IMGB is now active running the new version.
+    if [ "$running" = "$EXPECT_VERSION" ] && [ "$imgb_state" = "active" ]; then
+        echo "OK: cross-HV upgrade complete (IMGB active, version=$running)"
+        exit 0
+    fi
+
+    # If we've reached the target version but are stuck inprogress,
+    # dump k3s diagnostics every iteration to capture why.
+    if [ "$running" = "$EXPECT_VERSION" ] && [ "$imgb_state" = "inprogress" ]; then
+        dump_k3s_diags
+    fi
+
+    # First time we see the new running version, also dump diags.
+    if [ "$running" = "$EXPECT_VERSION" ] && [ "$prev_running" != "$running" ]; then
+        echo "  (transitioned to $running — booting eve-k)"
+        dump_k3s_diags
+    fi
+
+    prev_running="$running"
+    sleep 30
+done
+
+echo "FAIL: 30m timeout. Last seen: running='$running' IMGB.PartitionState='$imgb_state'"
+dump_k3s_diags
+exit 1
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/update_eve_image/testdata/update_eve_image_cross_hv_with_app_recreate.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_cross_hv_with_app_recreate.txt
@@ -611,8 +611,11 @@ test:
 # that follows can be short, and a failure here clearly says "longhorn", not "app".
 set -uo pipefail
 EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+began=$(date +%s)
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [longhorn-sc] waiting for the StorageClass"
 for _ in $(seq 1 90); do   # ~45m at 30s
     if "$EDEN" eve ssh -- 'eve exec kube kubectl get sc 2>/dev/null' 2>/dev/null | grep -qE '^longhorn'; then
+        echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [longhorn-sc] ready after $(( $(date +%s) - began ))s"
         echo "OK: longhorn StorageClass ready"; exit 0
     fi
     sleep 30

--- a/tests/update_eve_image/testdata/update_eve_image_cross_hv_with_app_recreate.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_cross_hv_with_app_recreate.txt
@@ -141,7 +141,7 @@ eden -t 5m pod deploy -n xhv-app {{template "eclient_image"}} -p 2223:22 --netwo
 #   (c) app RUNNING,
 #   (d) app SSH-reachable.
 message '(a) waiting for volumemgr ready (incl kubeapi.WaitForKubernetes)'
-exec -t 65m bash wait-for-volumemgr-ready.sh
+exec -t 90m bash wait-for-volumemgr-ready.sh
 message '(b) waiting for EVE-k longhorn StorageClass ready (cluster storage up)'
 exec -t 50m bash wait-for-longhorn-sc.sh
 stdout 'OK: longhorn StorageClass ready'
@@ -166,7 +166,7 @@ eden -t 1m controller edge-node -m adam:// reboot -v debug
 message 'waiting for EVE down + back (uptime < 120s)'
 exec -t 15m bash wait-for-reboot-and-back.sh
 message 'post-reboot: waiting for volumemgr Initialized:true'
-exec -t 65m bash wait-for-volumemgr-ready.sh
+exec -t 90m bash wait-for-volumemgr-ready.sh
 message 'post-reboot: waiting for xhv-app to return to RUNNING'
 message 'waiting for EVE-k longhorn StorageClass ready (cluster storage up)'
 exec -t 50m bash wait-for-longhorn-sc.sh
@@ -392,29 +392,43 @@ exit 1
 set -uo pipefail
 EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
 last=""
-# 60m at 10s. This MUST exceed volumemgr's own pre-publish block, which is up to
+# 85m budget. This MUST exceed volumemgr's own pre-publish block, which is up to
 # 20m in WaitForKubernetes (node + kubevirt + longhorn) plus up to 20m more in
 # storageWait before VolumeMgrStatus is published at all. This loop also begins
 # timing before volumemgr begins its own, so a 40m budget could not observe the
-# publish even on a device that converges -- it expired at the very moment volumemgr
-# was released. Initialized is set unconditionally once both waits end
-# (handlediskmetrics.go generateAndPublishVolumeMgrStatus), so reaching it under a
-# longer budget means "the device recovered", not "cluster storage is healthy" --
-# the longhorn and app steps that follow are what establish that.
-for i in $(seq 1 360); do
-    state=$(timeout 8 "$EDEN" eve ssh 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>/dev/null' 2>/dev/null \
-            | tr -d '\r' | grep -oE '"Initialized":[a-z]+')
+# publish even on a device that converges -- it expired at the very moment
+# volumemgr was released.
+#
+# The budget is wall-clock, not an iteration count: each pass also spends up to
+# 8s in an ssh probe that hits its timeout precisely when the device is stalled,
+# so a fixed count can outlive the caller's `exec -t` deadline and get killed
+# before reaching the diagnostics below -- which is when they matter most. Keep
+# it under that deadline with room for the final status dump.
+BUDGET_MIN=85
+deadline=$(( $(date +%s) + BUDGET_MIN * 60 ))
+unmet=""
+while [ "$(date +%s)" -lt "$deadline" ]; do
+    status=$(timeout 8 "$EDEN" eve ssh 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>/dev/null' 2>/dev/null \
+            | tr -d '\r')
+    state=$(echo "$status" | grep -oE '"Initialized":[a-z]+')
+    # UnmetCondition names the readiness gate still outstanding while Initialized
+    # is false. Absent on images predating lf-edge/eve#6240.
+    unmet=$(echo "$status" | grep -oE '"UnmetCondition":"[^"]+"')
     if [ "$state" = '"Initialized":true' ]; then
         echo "OK: volumemgr Initialized:true — populateInitBlobStatus has run"
         exit 0
     fi
-    if [ "$last" != "$state" ]; then
-        echo "$(date +%H:%M:%S) volumemgr state: ${state:-<not-yet-published>}"
-        last="$state"
+    sig="${state:-<not-yet-published>}${unmet:+ $unmet}"
+    if [ "$last" != "$sig" ]; then
+        echo "$(date +%H:%M:%S) volumemgr state: $sig"
+        last="$sig"
     fi
     sleep 10
 done
-echo "FAIL: volumemgr did not reach Initialized:true within 40m" >&2
+echo "FAIL: volumemgr did not reach Initialized:true within ${BUDGET_MIN}m" >&2
+# A reported UnmetCondition distinguishes cluster storage that never converged
+# from a device that published nothing at all.
+echo "FAIL: last reported unmet condition: ${unmet:-<none reported>}" >&2
 echo "--- final state file ---" >&2
 "$EDEN" eve ssh 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>&1' >&2
 exit 1

--- a/tests/update_eve_image/testdata/update_eve_image_cross_hv_with_app_recreate.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_cross_hv_with_app_recreate.txt
@@ -1,0 +1,606 @@
+# Test: end-to-end app-survives-upgrade via delete+recreate around a
+# kvm→k cross-flavor baseos update, with timer.defer.content.delete set
+# to keep the cached blobs alive across the gap.
+#
+# Variant 3 of the app-survives-upgrade family. Variants 1 & 2 attempt
+# to migrate the live AppInstance / Volume through the
+# `RolloutDiskToPVC` path, which currently fails on single-node EVE-k
+# (see lf-edge/eve#6032 — longhorn scratch PVC can't schedule with
+# upstream 3-replica + strict-anti-affinity defaults).
+#
+# This variant is the *operator-facing recipe* that works today AND
+# exercises the blob-reuse code path end-to-end:
+#
+#   1. Deploy xhv-app (eclient) on EVE-kvm; wait RUNNING + functional.
+#   2. Bump timer.defer.content.delete to 24h so deleting the app
+#      below doesn't immediately purge its ContentTree blobs.
+#   3. Delete the app + its network. Volumes/ContentTrees stay in the
+#      CAS (pillar's per-blob GC defers).
+#   4. Push the kvm→k baseos update.
+#   5. After EVE-k boots and volumemgr unblocks from longhorn-wait,
+#      RE-DEPLOY xhv-app with the SAME image.
+#   6. Assert pillar's downloader did NOT pull image bytes for the
+#      redeploy — the cached blobs from step 1 are reused via the
+#      namespace-port (b14391bad) + transitive-label-walk (5fc09f631)
+#      paths. A new longhorn PVC is provisioned natively on EVE-k;
+#      `RolloutDiskToPVC` is NOT exercised (the .img file doesn't
+#      exist for a fresh deploy).
+#   7. Verify the app is RUNNING + functional on EVE-k.
+#   8. Reset timer.defer.content.delete back to 0 so the device's
+#      GC behavior returns to default.
+#
+# Parameters: ALT_HV, ALT_EVE_VER, ALT_EVE_REG — see
+# update_eve_image_cross_hv.txt header for defaults.
+
+{{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+
+{{$current_hv := EdenConfig "eve.hv"}}
+{{$arch       := EdenConfig "eve.arch"}}
+
+{{$alt_hv_env := EdenGetEnv "ALT_HV"}}
+{{$alt_hv := "k"}}
+{{if eq $current_hv "k"}}{{$alt_hv = "kvm"}}{{end}}
+{{if $alt_hv_env}}{{$alt_hv = $alt_hv_env}}{{end}}
+
+{{$alt_ver_env := EdenGetEnv "ALT_EVE_VER"}}
+{{$alt_ver := "12.1.0"}}
+{{if $alt_ver_env}}{{$alt_ver = $alt_ver_env}}{{end}}
+
+{{$alt_reg_env := EdenGetEnv "ALT_EVE_REG"}}
+{{$alt_reg := "lfedge/eve"}}
+{{if $alt_reg_env}}{{$alt_reg = $alt_reg_env}}{{end}}
+
+{{$alt_short_version := printf "%s-%s-%s" $alt_ver $alt_hv $arch}}
+
+# Step 1: pre-flight — clean state.
+message 'pre-flight: clean state'
+exec -t 1m bash assert-no-volumes.sh
+eden -t 1m pod ps
+! stdout 'IN_CONFIG'
+eden controller edge-node update --config timer.test.baseimage.update=30
+
+# Step 2: deploy xhv-app PRE-upgrade on the current EVE (kvm).
+message 'deploying eclient app on EVE-kvm'
+eden -t 1m network create 10.11.12.0/24 -n xhv-app-net
+eden -t 5m pod deploy -n xhv-app {{template "eclient_image"}} -p 2223:22 --networks=xhv-app-net --memory=512MB
+exec -t 10m bash wait-for-app-running.sh
+# Functional check: SSH directly into the app via the host hostfwd
+# (eve.hostfwd: 2223:2223 → zedrouter NAT to app:22 → eclient sshd).
+# eden-bringup.sh extends hostfwd to include 2223:2223 specifically
+# so that ssh root@127.0.0.1 -p 2223 works without `eden sdn fwd`.
+message 'pre-upgrade functional check'
+exec -t 5m bash wait-for-ssh-to-app.sh
+stdout 'OK: app SSH reachable'
+
+# Step 3: set timer.defer.content.delete to 24h. This is the key knob —
+# it tells pillar's volumemgr to retain ContentTree blobs for 24h
+# after the last reference goes away, instead of GC'ing immediately
+# when the app is deleted in Step 4.
+message 'setting timer.defer.content.delete=86400 (24h)'
+eden controller edge-node update --config timer.defer.content.delete=86400
+
+# Wait out one controller config-fetch interval (timer.config.interval=60s)
+# plus margin so volumemgr applies the new deferContentDelete BEFORE the app
+# delete below. Otherwise the device can fetch the timer set and the app delete
+# in one config cycle and volumemgr's select loop may process the delete first,
+# deleting the app's ContentTree with deferContentDelete still 0 and GC-ing its
+# blobs -> the redeploy re-downloads (the FAIL[blob-reuse] mode).
+message 'waiting ~90s for the device to apply deferContentDelete=86400'
+exec sleep 90
+
+# Step 4: delete just the app. The network stays — it has no
+# content-tree association, and keeping it across the upgrade matches
+# what an operator would do in production (a network instance
+# typically outlives many app lifecycles). Volume / ContentTree
+# blobs stay on /persist thanks to the deferred-delete timer.
+message 'deleting app on EVE-kvm (network kept, blobs retained for 24h)'
+eden -t 1m pod delete xhv-app
+# Poll until xhv-app fully disappears from `pod ps` AND volumemgr's
+# VolumeStatus tree empties out. The delete returns as soon as
+# controller config is updated, but EVE-side teardown can take 10+
+# minutes — domainmgr shuts down the VM, volumemgr unrolls the PVC,
+# and (on EVE-k) longhorn detaches and releases the replica. Anything
+# less than a hard wait-for-removal here will start the upgrade on a
+# device with live Volume / DomainStatus and trip the cross-HV gate.
+exec -t 15m bash wait-for-app-gone.sh
+exec -t 1m bash assert-no-volumes.sh
+
+# Step 5: push the cross-flavor eveimage-update.
+message 'downloading alternate-flavor EVE rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$alt_ver}} --eve-hv={{$alt_hv}} --eve-registry={{$alt_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs'
+
+message 'pushing cross-flavor eveimage-update'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs --os-version={{ $alt_short_version }} -m adam://
+! stderr .
+
+# Step 6: wait for the upgrade to complete.
+message 'waiting for cross-flavor upgrade to complete'
+exec -t 35m bash wait-for-cross-hv-upgrade.sh
+
+# Step 7: snapshot eve-k's downloader RecvByteCount baseline NOW, on boot,
+# BEFORE we deploy. /run/downloader/MetricsMap is tmpfs so the counter restarted
+# at the EVE-k reboot; taking the baseline here means the post-assert below
+# measures ALL re-download since boot (volumemgr's blob reconstruction plus the
+# deploy). Blob reuse (commits b14391bad + 5fc09f631) should keep it ~0.
+message 'snapshot eve-k downloader RecvByteCount (baseline, pre-deploy)'
+exec -t 1m bash snapshot-rcv-bytes.sh pre
+
+# Step 8: deploy xhv-app on EVE-k IMMEDIATELY on boot — do NOT wait for volumemgr
+# / cluster readiness first. The network (xhv-app-net) is still present from
+# Step 2. With the defer-delete timer holding the ContentTree blobs on /persist,
+# pillar's CAS finds the manifest by SHA and reuses the existing BlobStatus — no
+# DownloaderConfig for the eden-eclient image. A fresh longhorn PVC is provisioned
+# natively once cluster storage is up.
+message 'deploying eclient app on EVE-k immediately on boot (independent of commit/cluster state)'
+eden -t 5m pod deploy -n xhv-app {{template "eclient_image"}} -p 2223:22 --networks=xhv-app-net --memory=512MB
+
+# Step 9: split the readiness waits for diagnosability, in order:
+#   (a) volumemgr ready (incl kubeapi.WaitForKubernetes),
+#   (b) longhorn StorageClass ready,
+#   (c) app RUNNING,
+#   (d) app SSH-reachable.
+message '(a) waiting for volumemgr ready (incl kubeapi.WaitForKubernetes)'
+exec -t 65m bash wait-for-volumemgr-ready.sh
+message '(b) waiting for EVE-k longhorn StorageClass ready (cluster storage up)'
+exec -t 50m bash wait-for-longhorn-sc.sh
+stdout 'OK: longhorn StorageClass ready'
+message '(c) waiting for the app to reach RUNNING on EVE-k'
+exec -t 45m bash wait-for-app-running.sh
+message '(d) post-upgrade functional check (SSH into the app guest)'
+exec -t 5m bash wait-for-ssh-to-app.sh 2223 30 fresh
+stdout 'OK: app SSH reachable'
+
+# Step 10: assert eve-k's downloader did NOT pull more than ~1 MiB since boot
+# (eden-eclient is ~44 MiB; a real re-download would be unmistakable).
+message 'asserting blob reuse: no image re-download across the conversion'
+exec -t 1m bash snapshot-rcv-bytes.sh post-and-assert
+
+# Step 10a: reboot recovery. Earlier observations on this path showed
+# the longhorn Volume CR could get stuck STATE=detached/ROBUSTNESS=
+# unknown after a routine reboot, with virt-launcher Pending and a
+# misleading "untolerated taint" event. Driving one reboot through
+# this test catches a regression of that mode end-to-end.
+message 'requesting controller-initiated reboot'
+eden -t 1m controller edge-node -m adam:// reboot -v debug
+message 'waiting for EVE down + back (uptime < 120s)'
+exec -t 15m bash wait-for-reboot-and-back.sh
+message 'post-reboot: waiting for volumemgr Initialized:true'
+exec -t 65m bash wait-for-volumemgr-ready.sh
+message 'post-reboot: waiting for xhv-app to return to RUNNING'
+message 'waiting for EVE-k longhorn StorageClass ready (cluster storage up)'
+exec -t 50m bash wait-for-longhorn-sc.sh
+stdout 'OK: longhorn StorageClass ready'
+exec -t 45m bash wait-for-app-running.sh
+message 'post-reboot functional check'
+exec -t 5m bash wait-for-ssh-to-app.sh 2223 30 fresh
+stdout 'OK: app SSH reachable'
+
+# Step 11: reset the defer-delete timer to default (0 → immediate
+# delete on refcount=0). Always runs, even if a later assertion fails
+# in a future revision — make this explicit and unconditional.
+message 'reset timer.defer.content.delete=0 (back to default)'
+eden controller edge-node update --config timer.defer.content.delete=0
+
+# Step 12: cleanup. We skip `eden controller edge-node eveimage-remove`
+# here even though other tests in this family use it — eden's CLI
+# rejects rootfs filenames containing `-k-amd64` (its regex allows
+# only kvm|xen|acrn|rpi|rpi-xen|rpi-kvm; see
+# pkg/openevec/eveImageUpdate.go). adam's record of the staged image
+# is harmless to leave in place and gets wiped on the next bringup.
+eden -t 1m pod delete xhv-app
+eden -t 1m network delete xhv-app-net  # final teardown — release the network too
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs.ver
+exec sleep 10
+eden eve reset
+
+-- assert-no-volumes.sh --
+#!/bin/bash
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for i in $(seq 1 12); do
+    out=$("$EDEN" volume ls 2>/dev/null)
+    live=$(echo "$out" | awk 'NR>1 && ($(NF-1) == "IN_CONFIG" || $NF == "DELIVERED")')
+    if [ -z "$live" ]; then echo "OK: no live volumes"; exit 0; fi
+    sleep 5
+done
+echo "FAIL: live volume(s) present" >&2; "$EDEN" volume ls >&2; exit 1
+
+-- wait-for-app-running.sh --
+#!/bin/bash
+# Poll `eden pod ps` until xhv-app reaches LAST_STATE(EVE)=RUNNING.
+# 25m budget covers both the pre-upgrade kvm case (fast, ~2m) and the
+# post-upgrade eve-k redeploy (slow first boot — longhorn install +
+# VMI start can take 15-20m on a slow rig).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for i in $(seq 1 240); do   # 40m at 10s intervals (deploy-on-boot: app RUNNING is gated on the full post-longhorn volume create + CDI upload + guest boot, ~27m observed)
+    line=$("$EDEN" pod ps 2>/dev/null | grep -E '^xhv-app\s')
+    if echo "$line" | grep -q 'RUNNING'; then
+        echo "OK: xhv-app RUNNING"
+        echo "$line"
+        exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: xhv-app did not reach RUNNING in 40m" >&2
+"$EDEN" pod ps >&2
+exit 1
+
+-- wait-for-app-gone.sh --
+#!/bin/bash
+# Poll until xhv-app fully disappears AND no VolumeStatus files remain
+# under /run/volumemgr/VolumeStatus/. Pillar tears down in this order:
+#   1. controller config drops the app (immediate after `eden pod delete`)
+#   2. domainmgr halts the VM domain (~30-60s)
+#   3. volumemgr unrolls the PVC; on EVE-k longhorn detaches+releases
+#      the replica, which can take 5-10 minutes
+#   4. AppInstanceStatus and VolumeStatus pubsub records get removed
+# We watch (3) + (4) — those are the on-device-state signals.
+# 15m budget covers the slow longhorn case observed in v17.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+last_pod=""
+last_vol=""
+for i in $(seq 1 90); do   # 15m at 10s intervals
+    pod_present=$("$EDEN" pod ps 2>/dev/null | grep -cE '^xhv-app\s')
+    # Count only the per-instance .json files; pillar/pubsub writes a
+    # `restarted` sentinel into this directory at startup and never
+    # removes it, so `ls | wc -l` returns 1 even when no volumes exist.
+    vol_count=$(timeout 12 "$EDEN" eve ssh \
+        'eve exec pillar ls /run/volumemgr/VolumeStatus/*.json 2>/dev/null | wc -l' \
+        2>/dev/null | tr -d '\r' | tail -1)
+    [ -z "$vol_count" ] && vol_count="?"
+    if [ "$pod_present" = "0" ] && [ "$vol_count" = "0" ]; then
+        echo "OK: xhv-app removed and no VolumeStatus files remain"
+        exit 0
+    fi
+    # Progress line — print only when state changes
+    state="pod_rows=$pod_present vol_files=$vol_count"
+    if [ "$last_pod $last_vol" != "$pod_present $vol_count" ]; then
+        echo "$(date +%H:%M:%S) waiting for teardown: $state"
+        last_pod=$pod_present
+        last_vol=$vol_count
+    fi
+    sleep 10
+done
+echo "FAIL: app+volumes did not fully clear in 15m" >&2
+echo "--- final pod ps ---" >&2
+"$EDEN" pod ps >&2
+echo "--- final VolumeStatus listing ---" >&2
+"$EDEN" eve ssh 'eve exec pillar ls -la /run/volumemgr/VolumeStatus/ 2>&1' >&2
+exit 1
+
+-- wait-for-ssh-to-app.sh --
+#!/bin/bash
+# wait-for-ssh-to-app.sh — the REAL guest-readiness / functional gate for the
+# eclient app instance, shared verbatim across the cross-HV / kvm->k tests.
+#
+# `eden pod ps` RUNNING (wait-for-app-running.sh) only reflects
+# AppInstState.EVEState — the ZSwState EVE reports. On EVE-k that is the
+# kubevirt VMI Running phase (qemu launched), NOT the guest kernel booted with
+# sshd accepting connections; on EVE-kvm the gap is smaller but still not
+# guest-ready. So pod-ps RUNNING is a cheap pre-filter only — success is
+# declared HERE, once an AUTHENTICATED ssh command has actually run inside the
+# guest and returned the expected output.
+#
+# Transport: host hostfwd 127.0.0.1:2223 -> EVE-eth0:2223 (eve.hostfwd
+# extension set by eden-bringup.sh) -> zedrouter NAT -> app:22 (eclient sshd).
+# The `eden sdn fwd` wrapper collapses to the same 127.0.0.1:hostport under the
+# non-SDN QEMU user-net these tests run in, so the direct path is used.
+#
+# FRESHNESS: host port 2223 is a static QEMU forward for the whole VM lifetime,
+# so after a delete+redeploy (or a reboot) a *stale* previous eclient could keep
+# answering on it and falsely satisfy a post-conversion check. To guard that,
+# each successful check records the guest's boot_id
+# (/proc/sys/kernel/random/boot_id — a fresh UUID per VM boot) to
+# /tmp/xhv-app-bootid. In "fresh" mode the check requires the connected guest's
+# boot_id to DIFFER from that recorded value; a matching (stale) instance is
+# treated as not-ready-yet and retried until the fresh deploy takes over the
+# port or the budget runs out.
+#
+# Fail-closed: a refused / closed / timed-out ssh, a non-eclient guest, or (in
+# fresh mode) only the stale instance answering, never prints the success
+# marker. On success it prints "OK: app SSH reachable" so the escript pins the
+# framework verdict to a real session:
+#     exec -t 5m bash wait-for-ssh-to-app.sh
+#     stdout 'OK: app SSH reachable'
+#
+# Args (optional): $1 host port (default 2223); $2 attempts, 10s apart
+# (default 30 => 5m); $3 = "fresh" to require a NEW guest instance vs the
+# boot_id the previous successful check recorded (use after a redeploy/reboot).
+#
+# Cert: ssh refuses group-readable keys, so the eclient id_rsa is copied to a
+# 0600 temp file. testscript sets HOME=/no-home, so the real home is resolved
+# from the running UID; dist/tests is only populated by a full `make eden`, so
+# fall back to the master/main reference clones.
+set -uo pipefail
+PORT="${1:-2223}"
+ATTEMPTS="${2:-30}"
+FRESH="${3:-}"
+BOOTID_FILE=/tmp/xhv-app-bootid
+EDEN_TESTS="{{EdenConfig "eden.tests"}}"
+USER_HOME=$(getent passwd "$(id -u)" | cut -d: -f6)
+SRC=""
+for c in "$EDEN_TESTS/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/master/eden/tests/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/main/eden/tests/eclient/image/cert/id_rsa"; do
+    if [ -f "$c" ]; then SRC="$c"; break; fi
+done
+if [ -z "$SRC" ]; then
+    echo "FAIL: could not locate eclient id_rsa cert (EDEN_TESTS=$EDEN_TESTS, USER_HOME=$USER_HOME)" >&2
+    exit 1
+fi
+KEY=$(mktemp); install -m 600 "$SRC" "$KEY"; trap 'rm -f "$KEY"' EXIT
+SSH_OPTS=(-o ConnectTimeout=10 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -i "$KEY")
+prev=""
+[ -f "$BOOTID_FILE" ] && prev=$(cat "$BOOTID_FILE" 2>/dev/null)
+connected=0
+saw_stale=0
+for _ in $(seq 1 "$ATTEMPTS"); do
+    # One round-trip proves auth, the eclient identity, and the guest boot_id.
+    # "AUTHED" is echoed before the identity check, so a connect+auth that fails
+    # only the /etc/issue match is distinguishable from a never-connected ssh.
+    out=$(ssh "${SSH_OPTS[@]}" root@127.0.0.1 -p "$PORT" \
+        'echo AUTHED; grep -q Ubuntu /etc/issue && cat /proc/sys/kernel/random/boot_id' \
+        2>/dev/null)
+    case "$out" in *AUTHED*) connected=1 ;; esac
+    bootid=$(printf '%s\n' "$out" | tr -d '\r' | grep -Ex '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | tail -1)
+    if [ -n "$bootid" ]; then
+        if [ "$FRESH" = "fresh" ] && [ -n "$prev" ] && [ "$bootid" = "$prev" ]; then
+            # Still the previous instance on the static port — wait for the fresh
+            # deploy/boot to take over the NAT before declaring success.
+            saw_stale=1; sleep 10; continue
+        fi
+        echo "$bootid" > "$BOOTID_FILE"
+        echo "OK: app SSH reachable (port=$PORT, boot_id=$bootid, fresh=${FRESH:-no}, cert=$SRC)"
+        exit 0
+    fi
+    sleep 10
+done
+budget=$(( ATTEMPTS * 10 ))
+if [ "$saw_stale" = 1 ]; then
+    echo "FAIL: only the previous app instance (boot_id=$prev) answered within ${budget}s — the fresh deploy never took over the port (stale instance)" >&2
+elif [ "$connected" = 1 ]; then
+    echo "FAIL: ssh connected+authed but the guest never matched the eclient (grep Ubuntu /etc/issue) within ${budget}s (port=$PORT)" >&2
+else
+    echo "FAIL: app never answered an authenticated ssh within ${budget}s (port=$PORT, cert=$SRC)" >&2
+fi
+echo "--- host TCP probe ---" >&2
+( exec 3<>/dev/tcp/127.0.0.1/"$PORT" ) 2>&1 || true
+exit 1
+
+-- wait-for-volumemgr-ready.sh --
+#!/bin/bash
+# After a cross-HV upgrade we need volumemgr on eve-k to have
+# unblocked from its `wait for kubernetes` / longhorn-ready sub-wait
+# and run populateInitBlobStatus(). The signal we watch for is the
+# state file /run/volumemgr/VolumeMgrStatus/volumemgr.json with
+# "Initialized":true — set after kubeapi.WaitForKubernetes returns.
+#
+# Earlier revisions of this helper grepped the volumemgr log for
+# "kubernetes node ready, longhorn ready". That's unreliable: EVE's
+# memlog is a ring buffer; under the load of a fresh longhorn install
+# the buffer rotates within ~20 min, and the marker line scrolls out
+# before we observe it. The state-file approach reads the *persistent
+# fact* on tmpfs, independent of log retention.
+#
+# Print progress every iteration so a stall is visible in the test
+# output (matters because the helper sits silent for up to 20m on
+# first boot, while longhorn pulls + starts its DaemonSets).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+last=""
+# 60m at 10s. This MUST exceed volumemgr's own pre-publish block, which is up to
+# 20m in WaitForKubernetes (node + kubevirt + longhorn) plus up to 20m more in
+# storageWait before VolumeMgrStatus is published at all. This loop also begins
+# timing before volumemgr begins its own, so a 40m budget could not observe the
+# publish even on a device that converges -- it expired at the very moment volumemgr
+# was released. Initialized is set unconditionally once both waits end
+# (handlediskmetrics.go generateAndPublishVolumeMgrStatus), so reaching it under a
+# longer budget means "the device recovered", not "cluster storage is healthy" --
+# the longhorn and app steps that follow are what establish that.
+for i in $(seq 1 360); do
+    state=$(timeout 8 "$EDEN" eve ssh 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>/dev/null' 2>/dev/null \
+            | tr -d '\r' | grep -oE '"Initialized":[a-z]+')
+    if [ "$state" = '"Initialized":true' ]; then
+        echo "OK: volumemgr Initialized:true — populateInitBlobStatus has run"
+        exit 0
+    fi
+    if [ "$last" != "$state" ]; then
+        echo "$(date +%H:%M:%S) volumemgr state: ${state:-<not-yet-published>}"
+        last="$state"
+    fi
+    sleep 10
+done
+echo "FAIL: volumemgr did not reach Initialized:true within 40m" >&2
+echo "--- final state file ---" >&2
+"$EDEN" eve ssh 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>&1' >&2
+exit 1
+
+-- snapshot-rcv-bytes.sh --
+#!/bin/bash
+# Snapshot the cumulative RecvByteCount from /run/downloader/MetricsMap
+# on EVE. The downloader publishes per-interface, per-URL byte
+# counters there; we sum across all URLs and interfaces.
+#
+# With "pre", capture the baseline to /tmp/xhv-rcv-pre.txt. With
+# "post-and-assert", recapture, compute the delta vs the pre-snapshot,
+# and assert the delta is below MAX_DELTA_BYTES (default 1 MiB).
+#
+# Note: /run/ is tmpfs, so the counter is reset on reboot. This
+# script is meant to bracket a single phase (e.g. the post-upgrade
+# redeploy) where pre and post are taken without an intervening
+# reboot.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+MODE=${1:-pre}
+MAX_DELTA_BYTES=${2:-1048576}  # 1 MiB default
+
+capture_recv_bytes() {
+    timeout 15 "$EDEN" eve ssh -- 'eve exec pillar cat /run/downloader/MetricsMap/global.json 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' \
+        | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print(0); sys.exit(0)
+total = 0
+for iface, conn in d.items():
+    for url, m in (conn.get('URLCounters') or {}).items():
+        total += m.get('RecvByteCount', 0)
+print(total)
+"
+}
+
+case "$MODE" in
+    pre)
+        bytes=$(capture_recv_bytes)
+        echo "$bytes" > /tmp/xhv-rcv-pre.txt
+        echo "Pre-snapshot: RecvByteCount total = $bytes bytes"
+        ;;
+    post-and-assert)
+        post=$(capture_recv_bytes)
+        pre=$(cat /tmp/xhv-rcv-pre.txt 2>/dev/null || echo 0)
+        delta=$(( post - pre ))
+        echo "Post-snapshot: RecvByteCount total = $post bytes (pre was $pre, delta = $delta)"
+        if [ "$delta" -lt 0 ]; then
+            echo "FAIL: post < pre — counter went backwards (reboot? not expected on eve-k)" >&2
+            exit 1
+        fi
+        if [ "$delta" -lt "$MAX_DELTA_BYTES" ]; then
+            echo "OK: only $delta bytes received (< ${MAX_DELTA_BYTES} threshold) — no image re-download"
+            exit 0
+        fi
+        echo "FAIL: $delta bytes received exceeds ${MAX_DELTA_BYTES} threshold — image likely re-downloaded" >&2
+        exit 1
+        ;;
+    *)
+        echo "Usage: $0 pre | post-and-assert [max-delta-bytes]" >&2
+        exit 1
+        ;;
+esac
+
+-- wait-for-cross-hv-upgrade.sh --
+#!/bin/bash
+# Wait for the upgraded EVE to reach PartitionState:active running
+# $EXPECT_VERSION, dumping k3s diagnostics if it stalls.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT_VERSION='{{ $alt_short_version }}'
+DEADLINE=$(( $(date +%s) + 1800 ))
+
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+dump_k3s_diags() {
+    sock=$(probe 'test -S /run/containerd-user/containerd.sock && echo present || echo absent')
+    echo "  /run/containerd-user/containerd.sock: $sock"
+    kube_pid=$(probe 'ctr -n services.linuxkit t ls 2>/dev/null | awk "/^kube/{print \$2}"')
+    echo "  kube container pid: ${kube_pid:-not running}"
+}
+
+prev_running=""
+while [ $(date +%s) -lt $DEADLINE ]; do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then
+        echo "$(date +%H:%M:%S): EVE unreachable (rebooting?)"; sleep 20; continue
+    fi
+    imgb_state=$(probe 'eve exec pillar cat /run/baseosmgr/ZbootStatus/IMGB.json' | grep -oP '"PartitionState":"\K[^"]+' | head -1)
+    [ -z "$imgb_state" ] && imgb_state='unknown'
+    echo "$(date +%H:%M:%S): running='$running' IMGB.PartitionState='$imgb_state'"
+    # Proceed as soon as EVE-k is the running rootfs — do NOT also wait for
+    # IMGB to commit 'active' (that's gated on cluster/node readiness ~16m,
+    # which would delay the app deploy and mask the device-side
+    # clusterStorageReady defer + park-and-retry we want to exercise).
+    if [ "$running" = "$EXPECT_VERSION" ]; then
+        echo "OK: booted EVE-k (version=$running, IMGB.PartitionState=$imgb_state) — proceeding now, independent of commit/cluster state"
+        dump_k3s_diags
+        exit 0
+    fi
+    prev_running="$running"
+    sleep 30
+done
+echo "FAIL: 30m timeout. running='$running' IMGB='$imgb_state'" >&2
+dump_k3s_diags >&2
+exit 1
+
+-- wait-for-reboot-and-back.sh --
+#!/bin/bash
+# Wait for EVE to actually reboot. Three phases:
+#   1. Wait up to 2m for SSH to start failing (kernel going down).
+#   2. Wait up to 10m for SSH to succeed AGAIN (kernel up + sshd up).
+#   3. Verify /proc/uptime < 120s (proves an actual reboot happened,
+#      not a transient SSH glitch).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+
+echo "phase 1: waiting for SSH to start failing (reboot underway)"
+went_down=0
+for i in $(seq 1 24); do   # 24 * 5s = 2m
+    if ! timeout 5 "$EDEN" eve ssh 'true' 2>/dev/null; then
+        echo "$(date +%H:%M:%S) SSH unreachable -- reboot in progress"
+        went_down=1
+        break
+    fi
+    sleep 5
+done
+if [ "$went_down" = "0" ]; then
+    echo "FAIL: SSH stayed reachable for 2m -- reboot did not start?" >&2
+    exit 1
+fi
+
+echo "phase 2: waiting for SSH to come back (post-reboot kernel + sshd up)"
+came_up=0
+for i in $(seq 1 60); do   # 60 * 10s = 10m
+    if timeout 8 "$EDEN" eve ssh 'true' 2>/dev/null; then
+        echo "$(date +%H:%M:%S) SSH back online"
+        came_up=1
+        break
+    fi
+    sleep 10
+done
+if [ "$came_up" = "0" ]; then
+    echo "FAIL: SSH did not come back within 10m" >&2
+    exit 1
+fi
+
+echo "phase 3: verifying uptime reset (< 120s)"
+uptime_secs=$(timeout 10 "$EDEN" eve ssh 'cat /proc/uptime' 2>/dev/null | tr -d '\r' | awk '{print int($1)}' | head -1)
+if [ -z "$uptime_secs" ]; then
+    echo "FAIL: could not read /proc/uptime after reboot" >&2
+    exit 1
+fi
+if [ "$uptime_secs" -gt 120 ]; then
+    echo "FAIL: uptime $uptime_secs > 120s -- SSH glitch, not a real reboot" >&2
+    exit 1
+fi
+echo "OK: EVE rebooted, uptime now ${uptime_secs}s"
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- wait-for-longhorn-sc.sh --
+#!/bin/bash
+# Wait until the EVE-k `longhorn` StorageClass exists (longhorn deployed + its CSI
+# provisioner up). On a freshly-converted EVE-k node longhorn can take tens of
+# minutes to deploy -- well after the device reports ONLINE -- so wait for it
+# EXPLICITLY here, before deploying/waiting for an app whose volume needs longhorn.
+# This separates cluster-bringup time from app-bringup time: the wait-for-app-running
+# that follows can be short, and a failure here clearly says "longhorn", not "app".
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 90); do   # ~45m at 30s
+    if "$EDEN" eve ssh -- 'eve exec kube kubectl get sc 2>/dev/null' 2>/dev/null | grep -qE '^longhorn'; then
+        echo "OK: longhorn StorageClass ready"; exit 0
+    fi
+    sleep 30
+done
+echo "FAIL: longhorn StorageClass not ready within budget" >&2; exit 1

--- a/tests/update_eve_image/testdata/update_eve_image_cross_hv_with_contenttree.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_cross_hv_with_contenttree.txt
@@ -1,0 +1,417 @@
+# Test: pre-staged ContentTree (no Volume) survives a cross-HV-flavor EVE
+# upgrade, and an app instance deployed post-upgrade reuses the existing
+# blobs instead of re-downloading.
+#
+# Variant of update_eve_image_cross_hv_with_volume.txt that side-steps
+# the Volume/PVC/CDI machinery entirely:
+#   - Pre-stage a standalone ContentTree on the running EVE (e.g. kvm)
+#     via `eden controller edge-node content-tree-add`. Pillar's
+#     volumemgr downloads ContentTrees eagerly, so the image bits land
+#     on /persist without any Volume being created. No .img file, no
+#     PVC, no CDI involvement on the post-upgrade side.
+#   - Push a cross-flavor baseos update (kvm <-> k).
+#   - After EVE reboots into the other flavor: verify the ContentTree
+#     is still present and LOADED (pubsub-persisted, blobs on /persist).
+#   - Deploy an app instance from the same image. Blob lookup is by
+#     SHA256, so volumemgr finds the pre-staged blobs and reuses them.
+#   - Assert no new ContentSha256 appeared in /run/volumemgr/
+#     ContentTreeStatus — confirms reuse, not re-download.
+#
+# Why this variant exists: the with_volume variant trips on a longhorn
+# scratch-PVC scheduling bug post-upgrade (REPLICATED_STORAGE single-node
+# clusters can't allocate the CDI scratch volume), which is unrelated to
+# the content-tree-survival question. This variant tests the same
+# user-visible property (image bits survive upgrade) without involving
+# the longhorn-backed PVC path at all.
+#
+# Parameters: ALT_HV, ALT_EVE_VER, ALT_EVE_REG — same as the volume variant.
+
+{{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+
+{{$current_hv := EdenConfig "eve.hv"}}
+{{$arch       := EdenConfig "eve.arch"}}
+
+{{$alt_hv_env := EdenGetEnv "ALT_HV"}}
+{{$alt_hv := "k"}}
+{{if eq $current_hv "k"}}{{$alt_hv = "kvm"}}{{end}}
+{{if $alt_hv_env}}{{$alt_hv = $alt_hv_env}}{{end}}
+
+{{$alt_ver_env := EdenGetEnv "ALT_EVE_VER"}}
+{{$alt_ver := "12.1.0"}}
+{{if $alt_ver_env}}{{$alt_ver = $alt_ver_env}}{{end}}
+
+{{$alt_reg_env := EdenGetEnv "ALT_EVE_REG"}}
+{{$alt_reg := "lfedge/eve"}}
+{{if $alt_reg_env}}{{$alt_reg = $alt_reg_env}}{{end}}
+
+{{$alt_short_version := printf "%s-%s-%s" $alt_ver $alt_hv $arch}}
+
+# Step 1: pre-flight — clean state.
+message 'pre-flight: clean state'
+eden -t 1m pod ps
+! stdout 'IN_CONFIG'
+eden controller edge-node update --config timer.test.baseimage.update=30
+
+# Step 2: pre-stage a ContentTree from the eclient image.
+# This kicks off an eager download in pillar's volumemgr; the blobs
+# land on /persist content-addressed storage. No Volume is created.
+message 'pre-staging ContentTree (no Volume)'
+eden -t 1m controller edge-node content-tree-add {{template "eclient_image"}} -n xhv-pre-ct
+
+# Wait for ContentTreeStatus to reach LOADED (state 108) on EVE.
+exec -t 10m bash wait-for-content-tree-loaded.sh
+
+# Step 3: push the cross-flavor eveimage-update.
+# This exercises the ZFS-only gate in baseosmgr that ALLOWS this upgrade
+# on ext3/ext4 /persist (the gate refuses ZFS, see PR baseos-hv-check-volume-gate).
+message 'downloading alternate-flavor EVE rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$alt_ver}} --eve-hv={{$alt_hv}} --eve-registry={{$alt_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs'
+
+message 'pushing cross-flavor eveimage-update with content tree present'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs --os-version={{ $alt_short_version }} -m adam://
+! stderr .
+
+# Step 4: wait for the upgrade to complete.
+message 'waiting for cross-flavor upgrade to complete'
+exec -t 35m bash wait-for-cross-hv-upgrade.sh
+
+# No post-upgrade "wait for ContentTree LOADED on eve-k" gate here, by
+# design. Such a gate would implicitly wait out the ~16m
+# longhorn/kubevirt/CDI install, because volumemgr only republishes
+# ContentTreeStatus after its internal WaitForKubernetes. Deploying the
+# app while the cluster is still coming up is the point: it exercises the
+# device-side volumemgr retry of cluster-storage volume creation
+# (retryFailedClusterVolumeCreate + idempotent CreatePVC) rather than
+# masking the longhorn/CDI-readiness race.
+
+# Step 5b: capture eve-k's RecvByteCount baseline NOW, right after the
+# upgrade completes and before any app deploy. /run/downloader/MetricsMap
+# is tmpfs so the counter restarted at the reboot — what we want is the
+# delta between "just before app deploy" and "after app deploy" on eve-k,
+# which isolates exactly the bytes pulled (if any) to satisfy the new
+# app's image reference.
+message 'snapshot eve-k downloader RecvByteCount (baseline pre-app-deploy)'
+exec -t 1m bash snapshot-rcv-bytes.sh pre
+
+# Step 6: deploy an app instance from the SAME image post-upgrade.
+# Blob lookup is by SHA256, so volumemgr finds the pre-staged blobs
+# and reuses them — no network download.
+message 'deploying app on new flavor using the pre-existing ContentTree'
+eden -t 1m network create 10.11.12.0/24 -n xhv-pre-net
+eden -t 5m pod deploy -n xhv-pre-app {{template "eclient_image"}} -p 2223:22 --networks=xhv-pre-net --memory=512MB
+# The app is deployed as soon as EVE-k's rootfs is running (the cross-hv
+# upgrade wait no longer blocks on IMGB PartitionState=active), so longhorn/CDI
+# are still coming up. Wait for the longhorn StorageClass explicitly with a
+# long timer BEFORE the (short) app-running wait: this separates cluster-bringup
+# time from app-bringup time, so a failure here clearly says "longhorn" rather
+# than an opaque app timeout.
+message 'waiting for EVE-k longhorn StorageClass ready (cluster storage up)'
+exec -t 50m bash wait-for-longhorn-sc.sh
+stdout 'OK: longhorn StorageClass ready'
+exec -t 45m bash wait-for-app-running.sh
+
+# Step 7: assert pillar's downloader on eve-k didn't fetch more than 1 MB
+# of bytes since the baseline taken in Step 5b. The eden-eclient image is
+# ~44 MB, so a re-download would be unmistakable; auth/control traffic
+# rounds to a few KB. The byte-count check is taken straight from
+# /run/downloader/MetricsMap/global.json (pillar's per-URL counter) so it
+# directly measures what we care about: did any image bytes flow.
+message 'asserting pre-staged ContentTree was reused (no re-download): byte-count check'
+exec -t 1m bash snapshot-rcv-bytes.sh post-and-assert
+
+# Step 8: functional check on the post-upgrade app.
+message 'post-upgrade functional check'
+exec -t 5m bash wait-for-ssh-to-app.sh
+stdout 'OK: app SSH reachable'
+
+# Step 9: cleanup. The pod and content-tree are configured at the
+# controller; deleting them is best-effort — `eden eve reset` at the
+# end wipes any residue.
+eden -t 1m pod delete xhv-pre-app
+eden -t 1m network delete xhv-pre-net
+eden controller edge-node eveimage-remove file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs -m adam://
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $alt_short_version }}.squashfs.ver
+
+exec sleep 10
+eden eve reset
+
+-- wait-for-content-tree-loaded.sh --
+#!/bin/bash
+# Poll EVE-side ContentTreeStatus until xhv-pre-ct reaches State=108
+# (LOADED). On kvm pre-upgrade, blob download from Docker Hub can
+# take a few minutes for the eclient image (~44MB).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for i in $(seq 1 120); do   # 10m at 5s intervals
+    out=$(timeout 10 "$EDEN" eve ssh -- \
+        'eve exec pillar sh -c "cat /run/volumemgr/ContentTreeStatus/*.json 2>/dev/null"' \
+        2>/dev/null | grep -v 'level=fatal')
+    if echo "$out" | python3 -c "
+import json, sys, re
+data = sys.stdin.read()
+for m in re.finditer(r'\{[^{}]*?\"DisplayName\":\"[^\"]*xhv-pre-ct[^\"]*\"[^{}]*\}', data):
+    try:
+        obj = json.loads(m.group(0))
+        if obj.get('State') == 108:
+            print('found LOADED ContentTreeStatus for xhv-pre-ct')
+            sys.exit(0)
+    except Exception:
+        pass
+sys.exit(1)
+" 2>/dev/null; then
+        echo "OK: ContentTreeStatus for xhv-pre-ct on EVE is LOADED"
+        exit 0
+    fi
+    sleep 5
+done
+echo "FAIL: ContentTreeStatus for xhv-pre-ct never reached LOADED within 10m" >&2
+timeout 10 "$EDEN" eve ssh -- 'eve exec pillar cat /run/volumemgr/ContentTreeStatus/*.json' 2>/dev/null >&2
+exit 1
+
+-- snapshot-rcv-bytes.sh --
+#!/bin/bash
+# Snapshot the cumulative RecvByteCount from /run/downloader/MetricsMap
+# on EVE. The downloader publishes per-interface, per-URL byte counters
+# there; we sum across all URLs and interfaces.
+#
+# With "pre", capture the baseline to /tmp/xhv-rcv-pre.txt. With
+# "post-and-assert", recapture, compute the delta vs the pre-snapshot,
+# and assert the delta is below MAX_DELTA_BYTES (default 1 MiB). A
+# successful reuse should see only a few KB of control/auth traffic;
+# a re-download would add tens of MB (the eden-eclient image is ~44 MB
+# uncompressed).
+#
+# Note: /run/ is tmpfs, so the counter is reset on reboot. This script
+# is meant to bracket a single phase (e.g. post-upgrade app deploy on
+# eve-k) where pre and post are taken without an intervening reboot.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+MODE=${1:-pre}
+MAX_DELTA_BYTES=${2:-1048576}  # 1 MiB default
+
+capture_recv_bytes() {
+    timeout 15 "$EDEN" eve ssh -- 'eve exec pillar cat /run/downloader/MetricsMap/global.json 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' \
+        | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print(0); sys.exit(0)
+total = 0
+for iface, conn in d.items():
+    for url, m in (conn.get('URLCounters') or {}).items():
+        total += m.get('RecvByteCount', 0)
+print(total)
+"
+}
+
+case "$MODE" in
+    pre)
+        bytes=$(capture_recv_bytes)
+        echo "$bytes" > /tmp/xhv-rcv-pre.txt
+        echo "Pre-snapshot: RecvByteCount total = $bytes bytes"
+        ;;
+    post-and-assert)
+        post=$(capture_recv_bytes)
+        pre=$(cat /tmp/xhv-rcv-pre.txt 2>/dev/null || echo 0)
+        delta=$(( post - pre ))
+        echo "Post-snapshot: RecvByteCount total = $post bytes (pre was $pre, delta = $delta)"
+        if [ "$delta" -lt 0 ]; then
+            echo "FAIL: post < pre — counter went backwards (reboot? not expected on eve-k)" >&2
+            exit 1
+        fi
+        if [ "$delta" -lt "$MAX_DELTA_BYTES" ]; then
+            echo "OK: only $delta bytes received (< ${MAX_DELTA_BYTES} threshold) — no image re-download"
+            exit 0
+        fi
+        echo "FAIL: $delta bytes received exceeds ${MAX_DELTA_BYTES} threshold — image likely re-downloaded" >&2
+        exit 1
+        ;;
+    *)
+        echo "Usage: $0 pre | post-and-assert [max-delta-bytes]" >&2
+        exit 1
+        ;;
+esac
+
+-- wait-for-app-running.sh --
+#!/bin/bash
+# 15m budget (180 x 5s), matching the escript's `exec -t 15m` wrapper.
+# The longhorn StorageClass wait runs first (separate helper), so by the
+# time we get here the cluster storage is up and the app should reach
+# RUNNING quickly; this is just the app-only gate.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for i in $(seq 1 480); do   # 40m at 5s (deploy-on-boot: app RUNNING gated on the full cluster bring-up + volume create + guest boot)
+    line=$("$EDEN" pod ps 2>/dev/null | grep -E '^xhv-pre-app\s')
+    if echo "$line" | grep -q 'RUNNING'; then
+        echo "OK: xhv-pre-app RUNNING"
+        echo "$line"
+        exit 0
+    fi
+    sleep 5
+done
+echo "FAIL: xhv-pre-app did not reach RUNNING in 40m" >&2
+"$EDEN" pod ps >&2
+exit 1
+
+-- wait-for-ssh-to-app.sh --
+#!/bin/bash
+# wait-for-ssh-to-app.sh — the REAL guest-readiness / functional gate for the
+# eclient app instance, shared verbatim across the cross-HV / kvm->k tests.
+#
+# `eden pod ps` RUNNING (wait-for-app-running.sh) only reflects
+# AppInstState.EVEState — the ZSwState EVE reports. On EVE-k that is the
+# kubevirt VMI Running phase (qemu launched), NOT the guest kernel booted with
+# sshd accepting connections; on EVE-kvm the gap is smaller but still not
+# guest-ready. So pod-ps RUNNING is a cheap pre-filter only — success is
+# declared HERE, once an AUTHENTICATED ssh command has actually run inside the
+# guest and returned the expected output.
+#
+# Transport: host hostfwd 127.0.0.1:2223 -> EVE-eth0:2223 (eve.hostfwd
+# extension set by eden-bringup.sh) -> zedrouter NAT -> app:22 (eclient sshd).
+# The `eden sdn fwd` wrapper collapses to the same 127.0.0.1:hostport under the
+# non-SDN QEMU user-net these tests run in, so the direct path is used.
+#
+# FRESHNESS: host port 2223 is a static QEMU forward for the whole VM lifetime,
+# so after a delete+redeploy (or a reboot) a *stale* previous eclient could keep
+# answering on it and falsely satisfy a post-conversion check. To guard that,
+# each successful check records the guest's boot_id
+# (/proc/sys/kernel/random/boot_id — a fresh UUID per VM boot) to
+# /tmp/xhv-app-bootid. In "fresh" mode the check requires the connected guest's
+# boot_id to DIFFER from that recorded value; a matching (stale) instance is
+# treated as not-ready-yet and retried until the fresh deploy takes over the
+# port or the budget runs out.
+#
+# Fail-closed: a refused / closed / timed-out ssh, a non-eclient guest, or (in
+# fresh mode) only the stale instance answering, never prints the success
+# marker. On success it prints "OK: app SSH reachable" so the escript pins the
+# framework verdict to a real session:
+#     exec -t 5m bash wait-for-ssh-to-app.sh
+#     stdout 'OK: app SSH reachable'
+#
+# Args (optional): $1 host port (default 2223); $2 attempts, 10s apart
+# (default 30 => 5m); $3 = "fresh" to require a NEW guest instance vs the
+# boot_id the previous successful check recorded (use after a redeploy/reboot).
+#
+# Cert: ssh refuses group-readable keys, so the eclient id_rsa is copied to a
+# 0600 temp file. testscript sets HOME=/no-home, so the real home is resolved
+# from the running UID; dist/tests is only populated by a full `make eden`, so
+# fall back to the master/main reference clones.
+set -uo pipefail
+PORT="${1:-2223}"
+ATTEMPTS="${2:-30}"
+FRESH="${3:-}"
+BOOTID_FILE=/tmp/xhv-app-bootid
+EDEN_TESTS="{{EdenConfig "eden.tests"}}"
+USER_HOME=$(getent passwd "$(id -u)" | cut -d: -f6)
+SRC=""
+for c in "$EDEN_TESTS/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/master/eden/tests/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/main/eden/tests/eclient/image/cert/id_rsa"; do
+    if [ -f "$c" ]; then SRC="$c"; break; fi
+done
+if [ -z "$SRC" ]; then
+    echo "FAIL: could not locate eclient id_rsa cert (EDEN_TESTS=$EDEN_TESTS, USER_HOME=$USER_HOME)" >&2
+    exit 1
+fi
+KEY=$(mktemp); install -m 600 "$SRC" "$KEY"; trap 'rm -f "$KEY"' EXIT
+SSH_OPTS=(-o ConnectTimeout=10 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -i "$KEY")
+prev=""
+[ -f "$BOOTID_FILE" ] && prev=$(cat "$BOOTID_FILE" 2>/dev/null)
+connected=0
+saw_stale=0
+for _ in $(seq 1 "$ATTEMPTS"); do
+    # One round-trip proves auth, the eclient identity, and the guest boot_id.
+    # "AUTHED" is echoed before the identity check, so a connect+auth that fails
+    # only the /etc/issue match is distinguishable from a never-connected ssh.
+    out=$(ssh "${SSH_OPTS[@]}" root@127.0.0.1 -p "$PORT" \
+        'echo AUTHED; grep -q Ubuntu /etc/issue && cat /proc/sys/kernel/random/boot_id' \
+        2>/dev/null)
+    case "$out" in *AUTHED*) connected=1 ;; esac
+    bootid=$(printf '%s\n' "$out" | tr -d '\r' | grep -Ex '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | tail -1)
+    if [ -n "$bootid" ]; then
+        if [ "$FRESH" = "fresh" ] && [ -n "$prev" ] && [ "$bootid" = "$prev" ]; then
+            # Still the previous instance on the static port — wait for the fresh
+            # deploy/boot to take over the NAT before declaring success.
+            saw_stale=1; sleep 10; continue
+        fi
+        echo "$bootid" > "$BOOTID_FILE"
+        echo "OK: app SSH reachable (port=$PORT, boot_id=$bootid, fresh=${FRESH:-no}, cert=$SRC)"
+        exit 0
+    fi
+    sleep 10
+done
+budget=$(( ATTEMPTS * 10 ))
+if [ "$saw_stale" = 1 ]; then
+    echo "FAIL: only the previous app instance (boot_id=$prev) answered within ${budget}s — the fresh deploy never took over the port (stale instance)" >&2
+elif [ "$connected" = 1 ]; then
+    echo "FAIL: ssh connected+authed but the guest never matched the eclient (grep Ubuntu /etc/issue) within ${budget}s (port=$PORT)" >&2
+else
+    echo "FAIL: app never answered an authenticated ssh within ${budget}s (port=$PORT, cert=$SRC)" >&2
+fi
+echo "--- host TCP probe ---" >&2
+( exec 3<>/dev/tcp/127.0.0.1/"$PORT" ) 2>&1 || true
+exit 1
+
+-- wait-for-cross-hv-upgrade.sh --
+#!/bin/bash
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT_VERSION='{{ $alt_short_version }}'
+DEADLINE=$(( $(date +%s) + 1800 ))
+
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+prev_running=""
+while [ $(date +%s) -lt $DEADLINE ]; do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then
+        echo "$(date +%H:%M:%S): EVE unreachable (rebooting?)"; sleep 20; continue
+    fi
+    imgb_state=$(probe 'eve exec pillar cat /run/baseosmgr/ZbootStatus/IMGB.json' | grep -oP '"PartitionState":"\K[^"]+' | head -1)
+    [ -z "$imgb_state" ] && imgb_state='unknown'
+    echo "$(date +%H:%M:%S): running='$running' IMGB.PartitionState='$imgb_state'"
+    # Proceed as soon as EVE-k is the running rootfs — do NOT also wait for
+    # IMGB to commit 'active'. On EVE-k the commit is gated on cluster/node
+    # readiness (~16m), so requiring 'active' here would delay the app deploy
+    # until longhorn/CDI are up, defeating the device-side clusterStorageReady
+    # defer + park-and-retry we want to exercise.
+    if [ "$running" = "$EXPECT_VERSION" ]; then
+        echo "OK: booted EVE-k (version=$running, IMGB.PartitionState=$imgb_state) — deploying app now, independent of commit/cluster state"
+        exit 0
+    fi
+    prev_running="$running"
+    sleep 30
+done
+echo "FAIL: 30m timeout. running='$running' IMGB='$imgb_state'" >&2
+exit 1
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- wait-for-longhorn-sc.sh --
+#!/bin/bash
+# Wait until the EVE-k `longhorn` StorageClass exists (longhorn deployed + its CSI
+# provisioner up). On a freshly-converted EVE-k node longhorn can take tens of
+# minutes to deploy -- well after the device reports ONLINE -- so wait for it
+# EXPLICITLY here, before deploying/waiting for an app whose volume needs longhorn.
+# This separates cluster-bringup time from app-bringup time: the wait-for-app-running
+# that follows can be short, and a failure here clearly says "longhorn", not "app".
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 90); do   # ~45m at 30s
+    if "$EDEN" eve ssh -- 'eve exec kube kubectl get sc 2>/dev/null' 2>/dev/null | grep -qE '^longhorn'; then
+        echo "OK: longhorn StorageClass ready"; exit 0
+    fi
+    sleep 30
+done
+echo "FAIL: longhorn StorageClass not ready within budget" >&2; exit 1

--- a/tests/update_eve_image/testdata/update_eve_image_cross_hv_with_contenttree.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_cross_hv_with_contenttree.txt
@@ -408,8 +408,11 @@ test:
 # that follows can be short, and a failure here clearly says "longhorn", not "app".
 set -uo pipefail
 EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+began=$(date +%s)
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [longhorn-sc] waiting for the StorageClass"
 for _ in $(seq 1 90); do   # ~45m at 30s
     if "$EDEN" eve ssh -- 'eve exec kube kubectl get sc 2>/dev/null' 2>/dev/null | grep -qE '^longhorn'; then
+        echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [longhorn-sc] ready after $(( $(date +%s) - began ))s"
         echo "OK: longhorn StorageClass ready"; exit 0
     fi
     sleep 30

--- a/tests/update_eve_image/testdata/update_eve_image_cross_hv_with_contenttree.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_cross_hv_with_contenttree.txt
@@ -9,7 +9,7 @@
 #     volumemgr downloads ContentTrees eagerly, so the image bits land
 #     on /persist without any Volume being created. No .img file, no
 #     PVC, no CDI involvement on the post-upgrade side.
-#   - Push a cross-flavor baseos update (kvm <-> k).
+#   - Push a cross-flavor baseos update (kvm -> k).
 #   - After EVE reboots into the other flavor: verify the ContentTree
 #     is still present and LOADED (pubsub-persisted, blobs on /persist).
 #   - Deploy an app instance from the same image. Blob lookup is by

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k.txt
@@ -235,7 +235,7 @@ message 'waiting ~90s for the device to apply deferContentDelete=86400'
 exec sleep 90
 
 # Step 6: delete the app (keep the network), then wait for full EVE-side teardown.
-# The cross-HV gate refuses kvm<->k while any Volume exists, so we must reach zero
+# The cross-HV gate refuses kvm->k while any Volume exists, so we must reach zero
 # volumes before pushing the -k update.
 message 'deleting app on EVE-kvm (network kept, blobs retained for 24h)'
 eden -t 1m pod delete xhv-app
@@ -1170,7 +1170,7 @@ exit 1
 #!/bin/bash
 # Poll until xhv-app fully disappears AND no per-instance VolumeStatus files
 # remain under /run/volumemgr/VolumeStatus/. Pillar tears down VM -> PVC ->
-# pubsub records; the cross-HV gate refuses kvm<->k while any Volume exists, so
+# pubsub records; the cross-HV gate refuses kvm->k while any Volume exists, so
 # we must reach zero before pushing the -k update.
 set -uo pipefail
 EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k.txt
@@ -53,7 +53,7 @@
 #       offline resize2fs SHRINK has real blocks to relocate (a stress watchdog can
 #       then interrupt the shrink, not only the grow). 0 disables. Ignored unless
 #       EXPECT_DECISION=shrink.
-#   RELOCATE_CRITICAL_HIGH (default 0) also rewrite the identity/connectivity-
+#   RELOCATE_CRITICAL_HIGH (default 0) also rewrite the identity- and vault-
 #       critical files into high blocks during the fill, so the shrink must relocate
 #       them and a watchdog-interrupted move exercises the /config restore fail-safe.
 #       Opt-in (soak).
@@ -107,7 +107,7 @@
 {{$fill_gib := "33"}}
 {{if $fill_gib_env}}{{$fill_gib = $fill_gib_env}}{{end}}
 
-# RELOCATE_CRITICAL_HIGH=1 rewrites the identity/connectivity-critical files into
+# RELOCATE_CRITICAL_HIGH=1 rewrites the identity- and vault-critical files into
 # high blocks during the fill, so the offline shrink must relocate them and a
 # watchdog-interrupted move can exercise the /config backup+restore fail-safe
 # end-to-end. Off (0) by default so a single run stays deterministic; the soak
@@ -1561,7 +1561,8 @@ if [ "$RELOCATE" = "1" ]; then
     for pat in "checkpoint/lastconfig"* "checkpoint/controllercerts"* \
                certs/ecdh.*.pem certs/attest.*.pem certs/ek.*.pem \
                "status/nim/DevicePortConfigList" "status/zedclient/OnboardingStatus"* \
-               "status/vaultmgr/VaultConfig"; do
+               "status/vaultmgr/VaultConfig" \
+               ".fscrypt/policies" ".fscrypt/protectors"; do
       [ -e "$pat" ] || continue
       if [ -f "$pat" ]; then targets="$targets $pat"
       elif [ -d "$pat" ]; then targets="$targets $(find "$pat" -type f 2>/dev/null)"; fi
@@ -1681,7 +1682,7 @@ cap_one() {
 for pat in checkpoint/lastconfig* checkpoint/controllercerts* \
            certs/ecdh.*.pem certs/attest.*.pem certs/ek.*.pem \
            status/nim/DevicePortConfigList status/zedclient/OnboardingStatus* \
-           status/vaultmgr/VaultConfig; do
+           status/vaultmgr/VaultConfig .fscrypt/policies .fscrypt/protectors; do
   [ -e "$pat" ] || continue
   if [ -f "$pat" ]; then cap_one "$pat"
   elif [ -d "$pat" ]; then find "$pat" -type f 2>/dev/null | while IFS= read -r ff; do cap_one "$ff"; done

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k.txt
@@ -304,7 +304,7 @@ exec -t 2m bash capture-critical-blocks.sh after-shrink
 # and only THEN assert blob reuse (downloader byte count did not increase since
 # the deploy — proving the early deploy reused the retained ContentTree).
 message '(a) waiting for volumemgr ready (incl kubeapi.WaitForKubernetes)'
-exec -t 65m bash wait-for-volumemgr-ready.sh
+exec -t 90m bash wait-for-volumemgr-ready.sh
 message '(b) waiting for EVE-k longhorn StorageClass ready (cluster storage up)'
 exec -t 50m bash wait-for-longhorn-sc.sh
 stdout 'OK: longhorn StorageClass ready'
@@ -326,7 +326,7 @@ eden -t 1m controller edge-node -m adam:// reboot -v debug
 message 'waiting for EVE down + back (uptime < 120s)'
 exec -t 15m bash wait-for-reboot-and-back.sh
 message 'post-reboot: volumemgr Initialized:true'
-exec -t 65m bash wait-for-volumemgr-ready.sh
+exec -t 90m bash wait-for-volumemgr-ready.sh
 message 'post-reboot: app back to RUNNING + functional'
 message 'waiting for EVE-k longhorn StorageClass ready (cluster storage up)'
 exec -t 50m bash wait-for-longhorn-sc.sh
@@ -1039,20 +1039,30 @@ ct_count() {
         | tr -d '\r' | grep -E '^[0-9]+$' | tail -1
 }
 last=""
-# 60m at 10s. This MUST exceed volumemgr's own pre-publish block, which is up to
+# 85m budget. This MUST exceed volumemgr's own pre-publish block, which is up to
 # 20m in WaitForKubernetes (node + kubevirt + longhorn) plus up to 20m more in
 # storageWait before VolumeMgrStatus is published at all. This loop also begins
 # timing before volumemgr begins its own, so a 40m budget could not observe the
-# publish even on a device that converges -- it expired at the very moment volumemgr
-# was released. Initialized is set unconditionally once both waits end
-# (handlediskmetrics.go generateAndPublishVolumeMgrStatus), so reaching it under a
-# longer budget means "the device recovered", not "cluster storage is healthy" --
-# the longhorn and app steps that follow are what establish that.
-for _ in $(seq 1 360); do
-    init=$(probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>/dev/null' \
-            | tr -d '\r' | grep -oE '"Initialized":[a-z]+')
+# publish even on a device that converges -- it expired at the very moment
+# volumemgr was released.
+#
+# The budget is wall-clock, not an iteration count: each pass also spends up to
+# 16s in two ssh probes that hit their timeout precisely when the device is
+# stalled, so a fixed count can outlive the caller's `exec -t` deadline and get
+# killed before reaching the diagnostics below -- which is when they matter most.
+# Keep it under that deadline with room for the final status dump.
+BUDGET_MIN=85
+deadline=$(( $(date +%s) + BUDGET_MIN * 60 ))
+unmet=""
+while [ "$(date +%s)" -lt "$deadline" ]; do
+    status=$(probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>/dev/null' \
+            | tr -d '\r')
+    init=$(echo "$status" | grep -oE '"Initialized":[a-z]+')
+    # UnmetCondition names the readiness gate still outstanding while Initialized
+    # is false. Absent on images predating lf-edge/eve#6240.
+    unmet=$(echo "$status" | grep -oE '"UnmetCondition":"[^"]+"')
     ct=$(ct_count); [ -z "$ct" ] && ct='?'
-    sig="init=${init:-<none>} contenttrees=$ct"
+    sig="init=${init:-<none>} contenttrees=$ct${unmet:+ $unmet}"
     if [ "$sig" != "$last" ]; then
         echo "$(date +%H:%M:%S) [readiness] $sig"; last="$sig"
     fi
@@ -1061,7 +1071,10 @@ for _ in $(seq 1 360); do
     fi
     sleep 10
 done
-echo "FAIL: volumemgr did not reach Initialized:true within 40m" >&2
+echo "FAIL: volumemgr did not reach Initialized:true within ${BUDGET_MIN}m" >&2
+# A reported UnmetCondition distinguishes cluster storage that never converged
+# from a device that published nothing at all.
+echo "FAIL: last reported unmet condition: ${unmet:-<none reported>}" >&2
 probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>&1' >&2
 exit 1
 

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k.txt
@@ -1423,8 +1423,11 @@ test:
 # that follows can be short, and a failure here clearly says "longhorn", not "app".
 set -uo pipefail
 EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+began=$(date +%s)
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [longhorn-sc] waiting for the StorageClass"
 for _ in $(seq 1 90); do   # ~45m at 30s
     if "$EDEN" eve ssh -- 'eve exec kube kubectl get sc 2>/dev/null' 2>/dev/null | grep -qE '^longhorn'; then
+        echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [longhorn-sc] ready after $(( $(date +%s) - began ))s"
         echo "OK: longhorn StorageClass ready"; exit 0
     fi
     sleep 30

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k.txt
@@ -1,0 +1,1704 @@
+# Test: EVE-kvm -> EVE-k in-field boot-disk repartition (small -> large GPT
+# geometry conversion), driven end-to-end through the controller, with a
+# deferred-content-delete app so a post-conversion redeploy needs no download.
+#
+# One parameterized escript for the REPARTITIONING successful-conversion cases of
+# the kvm-to-k e2e test plan. It is the single repartitioning escript: the shrink
+# and grow variants differ only in a Step-1 precondition and the final geometry
+# assertion, so they are selected by env knobs rather than duplicated.
+#
+# These cases ALWAYS start on a SMALL (old, released) image that lacks the
+# conversion code; a kvm->kvm hop to the conversion-capable build lands the code
+# without changing geometry, and the kvm->k hop is the cross-flavor seam that
+# triggers the repartition.
+#
+# Image sequence (exact — see README_kvm_to_k.md for how to build/bring up):
+#   1. SMALL start: EVE up on a stock 12.1.0-kvm install (small: 36 MiB ESP,
+#                   512 MiB IMGA/IMGB). For EXPECT_DECISION=grow the disk is also
+#                   enlarged host-side so >= 22 GB is unallocated after P3.
+#   2. kvm conversion-capable: BaseOs-update kvm->kvm to the local kvm-to-k build.
+#                   Same geometry; lands the conversion code. Then settle the
+#                   vault to a local TPM unlock.
+#   3. k image    : BaseOs-update kvm->k. The cross-flavor seam arms the offline
+#                   repartition; storage-init resizes ESP/IMGA/IMGB (shrinking P3
+#                   first if there is no free tail), then boots EVE-k on the
+#                   now-large geometry. The grow/shrink runs offline because the
+#                   boot disk's GPT can't be re-read live while its rootfs is mounted.
+#
+# Knobs (env):
+#   EXPECT_DECISION  shrink|grow  (default shrink)
+#       shrink: the boot disk is full; ext4 P3 is shrunk to make room, then
+#               ESP/IMGA/IMGB grow. (the field layout)
+#       grow:   the boot disk has a >= 22 GB free tail; ESP/IMGA/IMGB grow into
+#               it and P3 is untouched.
+#       Drives the Step-1 precondition and the post-conversion geometry assert.
+#       ('proceed' is not a repartition; 'insufficient' is the declined sibling —
+#        both are separate escripts, out of scope here.)
+#   DISK_TOPOLOGY  single|two-disk|zfs  (default single)
+#       Drives the data-preservation invariant. two-disk/zfs setup is NOT done by
+#       this escript (installer / host-side; see the test plan's Format D/G); the
+#       escript only asserts the result, and the persist-disk assertion for those
+#       layouts is still a TODO.
+#   POST_REBOOT_CHECK  non-empty => after the conversion, reboot EVE-k once and
+#       re-verify the app recovers (longhorn re-attach regression).
+#   RESIZE_EVE_VER  (required) version base of the local kvm-to-k images, without
+#       the -<hv>-<arch> suffix, e.g. "0.0.0-kvm-to-k-resize-<sha>". No default
+#       for a local build; the test fails fast if unset.
+#   RESIZE_EVE_REG  (default lfedge/eve) image registry/repo namespace; the full
+#       docker tag is <RESIZE_EVE_REG>:<RESIZE_EVE_VER>-<hv>-<arch>.
+#   BRINGUP_EVE_VER (default 12.1.0) substring the running base release must
+#       contain at Step 1; this escript does NOT install the base image (bringup
+#       is manual — see README_kvm_to_k.md).
+#   FILL_PERSIST_GIB (default 33, shrink only) GiB to pre-fill into /persist so the
+#       offline resize2fs SHRINK has real blocks to relocate (a stress watchdog can
+#       then interrupt the shrink, not only the grow). 0 disables. Ignored unless
+#       EXPECT_DECISION=shrink.
+#   RELOCATE_CRITICAL_HIGH (default 0) also rewrite the identity/connectivity-
+#       critical files into high blocks during the fill, so the shrink must relocate
+#       them and a watchdog-interrupted move exercises the /config restore fail-safe.
+#       Opt-in (soak).
+#   RELOCATE_STRICT (default 0) hard-fail unless every critical file landed high.
+#
+# What it asserts:
+#   - the boot disk started SMALL and ended LARGE: ESP/IMGA/IMGB grew, the reserved
+#     ESP-B (GPT #7, GUID …30056) was created at ~2 GiB (the full 2+2+10+10 EVE-k
+#     layout), and P3 is unchanged (grow) or shrank (shrink);
+#   - the conversion was observed (device state/sub-state transitions logged);
+#   - the repartition preserved the TPM seal (post-hoc from /persist/newlog: the
+#     last boot on the conversion-capable kvm image unsealed locally, no PCR5
+#     re-seal; the EVE-k boot's controller-key is the expected new-rootfs behavior);
+#   - the redeploy reused cached blobs (downloader received < 1 MiB).
+
+{{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+
+{{$arch := EdenConfig "eve.arch"}}
+
+{{$resize_ver_env := EdenGetEnv "RESIZE_EVE_VER"}}
+{{$resize_ver := "REPLACE-WITH-RESIZE-VERSION"}}
+{{if $resize_ver_env}}{{$resize_ver = $resize_ver_env}}{{end}}
+
+{{$resize_reg_env := EdenGetEnv "RESIZE_EVE_REG"}}
+{{$resize_reg := "lfedge/eve"}}
+{{if $resize_reg_env}}{{$resize_reg = $resize_reg_env}}{{end}}
+
+{{$bringup_ver_env := EdenGetEnv "BRINGUP_EVE_VER"}}
+{{$bringup_ver := "12.1.0"}}
+{{if $bringup_ver_env}}{{$bringup_ver = $bringup_ver_env}}{{end}}
+
+# --- knob: expected resizer decision ---
+{{$decision_env := EdenGetEnv "EXPECT_DECISION"}}
+{{$decision := "shrink"}}
+{{if $decision_env}}{{$decision = $decision_env}}{{end}}
+
+# --- knob: disk topology ---
+{{$topology_env := EdenGetEnv "DISK_TOPOLOGY"}}
+{{$topology := "single"}}
+{{if $topology_env}}{{$topology = $topology_env}}{{end}}
+
+{{$post_reboot := EdenGetEnv "POST_REBOOT_CHECK"}}
+
+# --- knob: stress the offline SHRINK (shrink variant only) ---
+# GiB to pre-fill into /persist before the convert so the offline resize2fs SHRINK
+# has real blocks to relocate and runs long enough for a stress watchdog to
+# interrupt it (not only the GROW). Keep it BELOW the post-shrink P3 size (~41 GiB
+# on a 64 GiB boot disk) or the shrink can't fit. Applied only when
+# EXPECT_DECISION=shrink (grow/two-disk/zfs have no shrink to slow). 0 disables.
+{{$fill_gib_env := EdenGetEnv "FILL_PERSIST_GIB"}}
+{{$fill_gib := "33"}}
+{{if $fill_gib_env}}{{$fill_gib = $fill_gib_env}}{{end}}
+
+# RELOCATE_CRITICAL_HIGH=1 rewrites the identity/connectivity-critical files into
+# high blocks during the fill, so the offline shrink must relocate them and a
+# watchdog-interrupted move can exercise the /config backup+restore fail-safe
+# end-to-end. Off (0) by default so a single run stays deterministic; the soak
+# turns it on. (Deterministic full-wipe / partial-corruption coverage is the
+# separate persist-wipe / backup-corrupt restore escripts.)
+{{$reloc_env := EdenGetEnv "RELOCATE_CRITICAL_HIGH"}}
+{{$reloc := "0"}}
+{{if $reloc_env}}{{$reloc = $reloc_env}}{{end}}
+
+# RELOCATE_STRICT=1 hard-fails the run unless fill-persist staged EVERY critical
+# file above the post-shrink boundary (reloc-high ASSERT: PASS). Off by default:
+# reloc-to-high is best-effort, so the soak stays observational. Turn on only to
+# prove the relocation path is exercised on every iteration.
+{{$reloc_strict_env := EdenGetEnv "RELOCATE_STRICT"}}
+{{$reloc_strict := "0"}}
+{{if $reloc_strict_env}}{{$reloc_strict = $reloc_strict_env}}{{end}}
+
+# Derive the post-conversion geometry assert mode from (decision, topology).
+#   shrink/single         -> assert-grown            (ESP/IMGA/IMGB grew, P3 shrank)
+#   grow/single, grow/zfs -> assert-grown-no-shrink  (grew, P3 untouched)
+#   grow/two-disk         -> assert-grown-no-p3       (grew, no P3 on boot disk)  [TODO: format D]
+{{$geomMode := "assert-grown"}}
+{{if eq $decision "grow"}}{{$geomMode = "assert-grown-no-shrink"}}{{end}}
+{{if and (eq $decision "grow") (eq $topology "two-disk")}}{{$geomMode = "assert-grown-no-p3"}}{{end}}
+
+{{$kvm_short := printf "%s-kvm-%s" $resize_ver $arch}}
+{{$k_short   := printf "%s-k-%s" $resize_ver $arch}}
+
+# Step 0: pre-flight. Fail fast if the version param wasn't supplied, confirm a
+# clean device, and shorten the baseimage commit timer so updates apply fast.
+message 'pre-flight: parameters + clean state'
+exec -t 1m bash require-resize-ver.sh
+exec -t 1m bash assert-no-volumes.sh
+eden -t 1m pod ps
+! stdout 'IN_CONFIG'
+eden controller edge-node update --config timer.test.baseimage.update=30
+
+# Step 1: baseline — always SMALL/old start. The conversion code isn't on a
+# released small image; the kvm hop below lands it. The disk must be SMALL
+# (load-bearing: if it is already large the conversion is a no-op and the test
+# proves nothing). For EXPECT_DECISION=grow, also require the >= 22 GB free tail
+# so the resizer's check returns `grow`; without it the test would silently
+# degrade into the shrink path, so the precondition is fail-fast.
+message 'baseline: confirm we are on the expected SMALL bringup release'
+exec -t 3m bash assert-running-version.sh {{ $bringup_ver }}
+message 'baseline: confirm SMALL boot-disk geometry'
+exec -t 2m bash capture-partitions.sh save small
+exec -t 1m bash capture-partitions.sh assert-small
+{{if eq $decision "grow"}}
+message 'precondition: boot disk has a >= 22G free tail (lsblk; resizer not on bringup image yet)'
+exec -t 2m bash assert-free-tail.sh
+{{end}}
+
+# Step 2: kvm->kvm hop — lands the conversion code, geometry unchanged.
+message 'downloading conversion-capable kvm rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$resize_ver}} --eve-hv=kvm --eve-registry={{$resize_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs'
+message 'pushing kvm->kvm BaseOs update (lands conversion code)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs --os-version={{ $kvm_short }} -m adam://
+! stderr .
+message 'waiting for kvm->kvm upgrade to complete'
+exec -t 25m bash wait-for-upgrade.sh {{ $kvm_short }}
+
+# A same-flavor upgrade must not repartition: re-confirm geometry is still SMALL,
+# then confirm the resizer's check returns the decision THIS scenario requires. A
+# regression that repartitions on a same-flavor upgrade, or that consumes the
+# free tail (grow) / frees space (shrink), is caught here.
+message 'post-kvm-upgrade: geometry must still be SMALL'
+exec -t 1m bash capture-partitions.sh assert-small
+message 'post-kvm-upgrade: assert storage-resizer check decision == {{ $decision }}'
+exec -t 2m bash assert-check-decision.sh {{ $decision }}
+
+# Step 3: settle the vault to a LOCAL TPM unlock. A new rootfs moves PCRs 8,13,
+# so the first post-upgrade boot unlocks via the controller key; one or more
+# controller-driven reboots return it to a local seal. UnlockMethod==0 means
+# "not decided yet this boot" — wait, don't treat it as a value.
+message 'settling vault to local TPM unlock (reboot loop)'
+exec -t 40m bash settle-vault-local.sh
+
+# Step 3b (shrink variant only): pre-fill /persist so the offline resize2fs SHRINK
+# has real blocks to relocate. On the near-empty eden /persist the shrink finishes
+# in ~1s and a stress watchdog only ever interrupts the GROW; filling makes the
+# shrink slow enough to be cut too, exercising shrink-resume + the P3-recreate
+# (FAIL[recreate-induced]) path. Skipped for grow/two-disk/zfs (no shrink to slow).
+{{if eq $decision "shrink"}}
+message 'pre-filling /persist (target ~{{ $fill_gib }} GiB in high blocks) so the shrink must relocate'
+{{if eq $reloc "1"}}
+message 'recording critical-file blocks (baseline, before relocate-to-high)'
+exec -t 2m bash capture-critical-blocks.sh before-relocate
+{{end}}
+exec -t 30m bash fill-persist.sh {{ $fill_gib }} {{ $reloc }}
+{{if eq $reloc "1"}}
+message 'recording critical-file blocks (after relocate-to-high)'
+exec -t 2m bash capture-critical-blocks.sh after-relocate
+{{if eq $reloc_strict "1"}}
+# RELOCATE_STRICT: refuse to continue unless every critical file landed high, so
+# the shrink is guaranteed to exercise critical-file relocation this iteration.
+stdout 'reloc-high ASSERT: PASS'
+{{end}}
+{{end}}
+{{end}}
+
+# Step 4: deploy the eclient app on EVE-kvm; wait RUNNING + functional.
+message 'deploying eclient app on EVE-kvm'
+eden -t 1m network create 10.11.12.0/24 -n xhv-app-net
+eden -t 5m pod deploy -n xhv-app {{template "eclient_image"}} -p 2223:22 --networks=xhv-app-net --memory=512MB
+exec -t 10m bash wait-for-app-running.sh
+message 'pre-conversion functional check'
+exec -t 5m bash wait-for-ssh-to-app.sh
+stdout 'OK: app SSH reachable'
+
+# Step 5: set timer.defer.content.delete=24h so deleting the app below does NOT
+# immediately GC its ContentTree blobs — they must survive the conversion so the
+# post-conversion redeploy reuses them (asserted at Step 11).
+message 'setting timer.defer.content.delete=86400 (24h)'
+eden controller edge-node update --config timer.defer.content.delete=86400
+
+# Wait out one controller config-fetch interval (timer.config.interval=60s)
+# plus margin so volumemgr applies the new deferContentDelete BEFORE the app
+# delete below. Otherwise the device can fetch the timer set and the app delete
+# in one config cycle and volumemgr's select loop may process the delete first,
+# deleting the app's ContentTree with deferContentDelete still 0 and GC-ing its
+# blobs -> the redeploy re-downloads (the FAIL[blob-reuse] mode).
+message 'waiting ~90s for the device to apply deferContentDelete=86400'
+exec sleep 90
+
+# Step 6: delete the app (keep the network), then wait for full EVE-side teardown.
+# The cross-HV gate refuses kvm<->k while any Volume exists, so we must reach zero
+# volumes before pushing the -k update.
+message 'deleting app on EVE-kvm (network kept, blobs retained for 24h)'
+eden -t 1m pod delete xhv-app
+exec -t 15m bash wait-for-app-gone.sh
+exec -t 1m bash assert-no-volumes.sh
+
+# Step 7: BaseOs-update kvm->k. This is the cross-flavor seam that triggers the
+# boot-disk repartition.
+message 'downloading k rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$resize_ver}} --eve-hv=k --eve-registry={{$resize_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs'
+message 'pushing kvm->k BaseOs update (triggers boot-disk repartition)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs --os-version={{ $k_short }} -m adam://
+! stderr .
+
+# Step 8: drive AND watch the conversion. The repartition runs OFFLINE in
+# storage-init, so this logs device state/sub-state TRANSITIONS as it polls to
+# completion and tolerates the reboots the offline resize needs. It returns once
+# EVE-k is running; the seal is checked post-hoc (Step 10).
+message 'waiting for + watching the kvm->k conversion (logging state transitions)'
+exec -t 45m bash watch-conversion.sh {{ $k_short }}
+
+# Step 9: deploy the app on EVE-k IMMEDIATELY after boot — do NOT wait for
+# volumemgr / cluster readiness first. Blob reuse (no image re-download) is still
+# required, but it is asserted at the END of Step 11 (downloader byte count
+# unchanged): with the app deployed early, volumemgr re-establishes the retained
+# ContentTree store while the app volume is deferred until cluster storage is up.
+# Snapshot the downloader baseline (RecvByteCount resets on the EVE-k reboot) just
+# before deploying so the post-assert measures only re-download after the deploy.
+message 'snapshot eve-k downloader RecvByteCount (baseline, pre-deploy)'
+exec -t 1m bash snapshot-rcv-bytes.sh pre
+message 'deploying eclient app on EVE-k immediately on boot (independent of commit/cluster state)'
+eden -t 5m pod deploy -n xhv-app {{template "eclient_image"}} -p 2223:22 --networks=xhv-app-net --memory=512MB
+
+# Step 10: while the app installs, run the static post-conversion checks: the boot
+# disk grew to LARGE (P3 unchanged on grow, shrank on shrink), and the repartition
+# preserved the local TPM seal (post-hoc from /persist/newlog: the LAST boot on
+# the conversion-capable kvm image unsealed locally — keyed on the specific
+# version so a future baseline that logs a local unlock can't satisfy it — plus no
+# PCR5-driven re-seal; the EVE-k boot's controller-key is expected and not asserted).
+message 'asserting boot-disk repartition outcome ({{ $decision }} / {{ $topology }})'
+exec -t 2m bash capture-partitions.sh save large
+exec -t 1m bash capture-partitions.sh {{ $geomMode }}
+{{if or (eq $topology "two-disk") (eq $topology "zfs")}}
+# TODO(two-disk/zfs — formats D/G): assert the persist partition/disk is
+# byte-unchanged after the grow. Needs the format-D/G setup (installer or
+# host-side hand-construction) the e2e test plan describes; the persist device
+# is NOT /dev/sda P3 in those layouts. Wire a capture-partitions mode that
+# reads the persist disk (or P3 fs-type for zfs) once that setup exists.
+{{end}}
+message 'asserting repartition preserved the TPM seal (post-hoc from /persist/newlog)'
+exec -t 3m bash assert-seal-from-newlog.sh {{ $k_short }} {{ $kvm_short }}
+message 'detecting whether the offline resize recreated /persist (for the blob-reuse verdict)'
+exec -t 2m bash assert-persist-not-recreated.sh
+{{if and (eq $decision "shrink") (eq $reloc "1")}}
+message 'recording critical-file blocks (after offline shrink; compare vs before/after-relocate)'
+exec -t 2m bash capture-critical-blocks.sh after-shrink
+{{end}}
+
+# Step 11: split the readiness waits into SEPARATE steps for diagnosability, in
+# order, so a failure localizes to one stage:
+#   (a) volumemgr ready (incl kubeapi.WaitForKubernetes),
+#   (b) longhorn StorageClass ready (cluster storage up),
+#   (c) app RUNNING,
+#   (d) app SSH-reachable,
+# and only THEN assert blob reuse (downloader byte count did not increase since
+# the deploy — proving the early deploy reused the retained ContentTree).
+message '(a) waiting for volumemgr ready (incl kubeapi.WaitForKubernetes)'
+exec -t 65m bash wait-for-volumemgr-ready.sh
+message '(b) waiting for EVE-k longhorn StorageClass ready (cluster storage up)'
+exec -t 50m bash wait-for-longhorn-sc.sh
+stdout 'OK: longhorn StorageClass ready'
+message '(c) waiting for the app to reach RUNNING on EVE-k'
+exec -t 65m bash wait-for-app-running.sh
+message '(d) post-conversion functional check (SSH into the app guest)'
+exec -t 5m bash wait-for-ssh-to-app.sh 2223 30 fresh
+stdout 'OK: app SSH reachable'
+message 'capturing blob-reuse diagnostics (downloader / contenttree / verifier)'
+exec -t 3m bash capture-blob-diagnostics.sh
+message 'asserting blob reuse across the conversion: no image re-download after deploy'
+exec -t 1m bash snapshot-rcv-bytes.sh post-and-assert
+
+# Step 11b (optional): EVE-k app survives a plain reboot (longhorn re-attach
+# regression — see update_eve_image_cross_hv_with_app_recreate.txt Step 10a).
+{{if $post_reboot}}
+message 'post-conversion reboot-recovery: requesting controller-initiated reboot'
+eden -t 1m controller edge-node -m adam:// reboot -v debug
+message 'waiting for EVE down + back (uptime < 120s)'
+exec -t 15m bash wait-for-reboot-and-back.sh
+message 'post-reboot: volumemgr Initialized:true'
+exec -t 65m bash wait-for-volumemgr-ready.sh
+message 'post-reboot: app back to RUNNING + functional'
+message 'waiting for EVE-k longhorn StorageClass ready (cluster storage up)'
+exec -t 50m bash wait-for-longhorn-sc.sh
+stdout 'OK: longhorn StorageClass ready'
+exec -t 65m bash wait-for-app-running.sh
+exec -t 5m bash wait-for-ssh-to-app.sh 2223 30 fresh
+stdout 'OK: app SSH reachable'
+{{end}}
+
+# Step 12: reset the defer-delete timer to default and clean up.
+message 'reset timer.defer.content.delete=0 (back to default)'
+eden controller edge-node update --config timer.defer.content.delete=0
+eden -t 1m pod delete xhv-app
+eden -t 1m network delete xhv-app-net
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs.ver
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs.ver
+exec sleep 10
+eden eve reset
+
+-- require-resize-ver.sh --
+#!/bin/bash
+# Fail fast if RESIZE_EVE_VER wasn't supplied (the escript default is a
+# placeholder). Without it, the eveimage-update steps would silently try to
+# download a bogus version.
+set -uo pipefail
+VER='{{ $resize_ver }}'
+if [ -z "$VER" ] || [ "$VER" = "REPLACE-WITH-RESIZE-VERSION" ]; then
+    echo "FAIL: RESIZE_EVE_VER not set." >&2
+    echo "      Export it to the version base of your local kvm-to-k" >&2
+    echo "      build, e.g. RESIZE_EVE_VER=0.0.0-kvm-to-k-resize-1a2b3c4d" >&2
+    echo "      (the part before -kvm-amd64 / -k-amd64 in the docker tag)." >&2
+    exit 1
+fi
+echo "OK: RESIZE_EVE_VER=$VER"
+
+-- assert-running-version.sh --
+#!/bin/bash
+# Sanity-check that EVE is running the expected SMALL bringup release before the
+# conversion starts. This escript does not install the base image — bringup
+# happens manually before the test (see README_kvm_to_k.md). This guards against
+# running the test against the wrong base image or an already-upgraded device.
+#
+# Matches the expected version as a substring of /run/eve-release (which is the
+# full "<ver>-<hv>-<arch>" form, e.g. "12.1.0-kvm-amd64"), so passing "12.1.0"
+# accepts the kvm bringup image without pinning the hv/arch suffix.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT="${1:?expected bringup version substring}"
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+for _ in $(seq 1 18); do   # ~3m at 10s; tolerate ssh not up yet
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -n "$running" ]; then
+        case "$running" in
+            *"$EXPECT"*)
+                echo "OK: running the expected bringup release ('$running' contains '$EXPECT')"
+                exit 0 ;;
+            *)
+                echo "FAIL: running version '$running' does not match expected bringup '$EXPECT'." >&2
+                echo "      Bring eve up on the small '$EXPECT' image before this test, or set" >&2
+                echo "      BRINGUP_EVE_VER to the release you brought up on." >&2
+                echo "      See README_kvm_to_k.md." >&2
+                exit 1 ;;
+        esac
+    fi
+    sleep 10
+done
+echo "FAIL: could not read /run/eve-release (ssh down / device not up?)" >&2
+exit 1
+
+-- capture-partitions.sh --
+#!/bin/bash
+# Read the boot-disk GPT geometry from EVE via lsblk and either save it, assert
+# it is the SMALL layout, or assert it grew to the LARGE layout. The grow asserts
+# also require the reserved ESP-B (GPT #7, fresh-install GUID …30056) to have been
+# created at ~2 GiB, i.e. the full 2+2+10+10 EVE-k layout. Three grow asserts:
+# assert-grown requires P3 SHRUNK (shrink/single); assert-grown-no-shrink requires
+# P3 UNCHANGED (grow/single, grow/zfs); assert-grown-no-p3 requires NO P3 (grow/
+# two-disk). The escript derives which from (EXPECT_DECISION, DISK_TOPOLOGY).
+#
+# Usage:
+#   capture-partitions.sh save  <tag>          # snapshot sizes to /tmp/xhv-parts-<tag>.env
+#   capture-partitions.sh assert-small         # ESP/IMGA/IMGB small; no ESP-B yet
+#   capture-partitions.sh assert-grown         # ESP/IMGA/IMGB grew; ESP-B #7; P3 shrank
+#   capture-partitions.sh assert-grown-no-shrink  # ESP/IMGA/IMGB grew; ESP-B #7; P3 unchanged
+#   capture-partitions.sh assert-grown-no-p3      # ESP/IMGA/IMGB grew; ESP-B #7; NO P3 (two-disk)
+#
+# Sizes come straight from `lsblk -b -P -o NAME,PARTLABEL,SIZE /dev/sda` — the
+# same lsblk pillar's diskmetrics uses, so it is present in the pillar ns. The
+# disk is /dev/sda under eden (qemu SATA/IDE).
+#
+# SMALL layout (12.1.0 make-raw): ESP 36 MiB, IMGA/IMGB 512 MiB, big P3, no ESP-B.
+# LARGE layout (EVE-k target):    ESP 2 GiB,  IMGA/IMGB 10 GiB, ESP-B 2 GiB (#7);
+# P3 shrinks (shrink variant) or is unchanged with the grow taken from a free tail.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+MODE=${1:-}
+TAG=${2:-}
+
+GiB=$(( 1024 * 1024 * 1024 ))
+MiB=$(( 1024 * 1024 ))
+
+# Read sizes into env-file form: ESP=<bytes> IMGA=<bytes> IMGB=<bytes> P3=<bytes>
+read_sizes() {
+    timeout 20 "$EDEN" eve ssh -- \
+        'eve exec pillar lsblk -b -P -o NAME,PARTLABEL,PARTUUID,SIZE /dev/sda 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c '
+import sys, re
+out = {}
+espb_name = ""
+for line in sys.stdin:
+    m = dict(re.findall(r"(\w+)=\"([^\"]*)\"", line))
+    label = m.get("PARTLABEL", "")
+    size = m.get("SIZE", "")
+    if not size:
+        continue
+    if label == "EFI System":
+        # Once ESP-B exists there are two "EFI System" partitions; tell them
+        # apart by the fixed fresh-install GUIDs (ESP-A …30051, ESP-B …30056).
+        if m.get("PARTUUID", "").lower().endswith("30056"):
+            out["ESPB"] = size
+            espb_name = m.get("NAME", "")
+        else:
+            out["ESP"] = size
+    elif label in ("IMGA", "IMGB", "P3"):
+        out[label] = size
+for k in ("ESP", "ESPB", "IMGA", "IMGB", "P3"):
+    print("%s=%s" % (k, out.get(k, "0")))
+print("ESPB_NAME=%s" % espb_name)
+'
+}
+
+load_current() {
+    local env
+    env=$(read_sizes)
+    eval "$env"
+    if [ "${ESP:-0}" = "0" ] || [ "${IMGA:-0}" = "0" ] || [ "${IMGB:-0}" = "0" ]; then
+        echo "FAIL: could not read partition sizes from /dev/sda" >&2
+        echo "      raw lsblk:" >&2
+        timeout 20 "$EDEN" eve ssh -- 'eve exec pillar lsblk -b -o NAME,PARTLABEL,PARTUUID,SIZE /dev/sda' >&2 2>/dev/null
+        exit 1
+    fi
+}
+
+print_table() {
+    printf '  %-10s %12s  (%s)\n' EFI   "$ESP"       "$(( ESP  / MiB )) MiB"
+    printf '  %-10s %12s  (%s)\n' IMGA  "$IMGA"      "$(( IMGA / MiB )) MiB"
+    printf '  %-10s %12s  (%s)\n' IMGB  "$IMGB"      "$(( IMGB / MiB )) MiB"
+    printf '  %-10s %12s  (%s)\n' ESP-B "${ESPB:-0}" "$(( ${ESPB:-0} / MiB )) MiB"
+    printf '  %-10s %12s  (%s)\n' P3    "$P3"        "$(( P3   / MiB )) MiB"
+}
+
+case "$MODE" in
+    save)
+        [ -n "$TAG" ] || { echo "Usage: $0 save <tag>" >&2; exit 1; }
+        load_current
+        printf 'ESP=%s\nIMGA=%s\nIMGB=%s\nP3=%s\n' "$ESP" "$IMGA" "$IMGB" "$P3" > "/tmp/xhv-parts-$TAG.env"
+        echo "Saved $TAG partition sizes:"
+        print_table
+        ;;
+    assert-small)
+        load_current
+        echo "Current partition sizes:"
+        print_table
+        # Small ESP is 36 MiB, IMGA/IMGB 512 MiB; allow generous headroom but
+        # stay far below the large floors so this is unambiguous.
+        if [ "$ESP"  -ge $(( 256 * MiB )) ] || \
+           [ "$IMGA" -ge "$GiB" ] || \
+           [ "$IMGB" -ge "$GiB" ]; then
+            echo "FAIL: geometry is not SMALL (ESP/IMGA/IMGB too big)" >&2
+            exit 1
+        fi
+        # ESP-B is only created by the conversion; a SMALL device must not have one
+        # yet, so its later presence proves the grow created it rather than it
+        # pre-existing.
+        if [ "${ESPB:-0}" != "0" ]; then
+            echo "FAIL: SMALL geometry already has an ESP-B (GUID …30056)" >&2
+            exit 1
+        fi
+        echo "OK: boot disk is on the SMALL geometry (no ESP-B yet)"
+        ;;
+    assert-grown|assert-grown-no-shrink|assert-grown-no-p3)
+        load_current
+        # shellcheck disable=SC1091
+        if [ ! -f /tmp/xhv-parts-small.env ]; then
+            echo "FAIL: no small baseline (/tmp/xhv-parts-small.env) to compare against" >&2
+            exit 1
+        fi
+        S_ESP=$(grep '^ESP='  /tmp/xhv-parts-small.env | cut -d= -f2)
+        S_IMGA=$(grep '^IMGA=' /tmp/xhv-parts-small.env | cut -d= -f2)
+        S_IMGB=$(grep '^IMGB=' /tmp/xhv-parts-small.env | cut -d= -f2)
+        S_P3=$(grep '^P3='   /tmp/xhv-parts-small.env | cut -d= -f2)
+        echo "Partition sizes before -> after conversion (bytes):"
+        printf '  %-10s %14s -> %14s\n' EFI   "$S_ESP"  "$ESP"
+        printf '  %-10s %14s -> %14s\n' IMGA  "$S_IMGA" "$IMGA"
+        printf '  %-10s %14s -> %14s\n' IMGB  "$S_IMGB" "$IMGB"
+        printf '  %-10s %14s -> %14s\n' ESP-B "(none)"  "${ESPB:-0}"
+        printf '  %-10s %14s -> %14s\n' P3    "$S_P3"   "$P3"
+        rc=0
+        # ESP/IMGA/IMGB must have grown vs baseline AND reached the large floor.
+        # Large targets are ESP 2 GiB, IMGA/IMGB 10 GiB; floors are set below the
+        # target to tolerate GPT alignment while still being unambiguously large.
+        [ "$ESP"  -gt "$S_ESP"  ] || { echo "FAIL: ESP did not grow"  >&2; rc=1; }
+        [ "$IMGA" -gt "$S_IMGA" ] || { echo "FAIL: IMGA did not grow" >&2; rc=1; }
+        [ "$IMGB" -gt "$S_IMGB" ] || { echo "FAIL: IMGB did not grow" >&2; rc=1; }
+        [ "$ESP"  -ge $(( 1 * GiB )) ] || { echo "FAIL: ESP < 1 GiB floor (target 2 GiB)"  >&2; rc=1; }
+        [ "$IMGA" -ge $(( 8 * GiB )) ] || { echo "FAIL: IMGA < 8 GiB floor (target 10 GiB)" >&2; rc=1; }
+        [ "$IMGB" -ge $(( 8 * GiB )) ] || { echo "FAIL: IMGB < 8 GiB floor (target 10 GiB)" >&2; rc=1; }
+        # ESP-B: the grow must have created the reserved second EFI System
+        # partition at #7 with the fresh-install GUID (…30056) at ~2 GiB, so the
+        # converted device reaches the same 2+2+10+10 layout as a fresh EVE-k
+        # install. read_sizes keys ESPB off the …30056 GUID, so a missing or
+        # wrong-GUID ESP-B reads as absent here.
+        [ "${ESPB:-0}" != "0" ] || { echo "FAIL: ESP-B (GUID …30056) was not created" >&2; rc=1; }
+        [ "${ESPB:-0}" -ge $(( 1 * GiB )) ] 2>/dev/null || { echo "FAIL: ESP-B < 1 GiB floor (target 2 GiB): ${ESPB:-0}" >&2; rc=1; }
+        [ "${ESPB_NAME:-}" = "sda7" ] || { echo "FAIL: ESP-B at ${ESPB_NAME:-<none>}, expected sda7 (partition #7)" >&2; rc=1; }
+        case "$MODE" in
+            assert-grown)
+                # Shrink variant: P3 must have shrunk to make room.
+                [ "$P3" -lt "$S_P3" ] || { echo "FAIL: P3 did not shrink" >&2; rc=1; }
+                ok="OK: boot disk repartitioned SMALL -> LARGE (ESP/IMGA/IMGB grew, ESP-B #7 created, P3 shrank)" ;;
+            assert-grown-no-shrink)
+                # Grow-only variant: P3 must NOT have shrunk (the grow took the free
+                # tail). Allow 1 MiB tolerance for GPT alignment jitter.
+                [ "$P3" -ge $(( S_P3 - MiB )) ] || { echo "FAIL: P3 shrank ($S_P3 -> $P3) — expected unchanged on the grow-only path" >&2; rc=1; }
+                ok="OK: ESP/IMGA/IMGB grew to LARGE, ESP-B #7 created, P3 not shrunk (grow-only path)" ;;
+            assert-grown-no-p3)
+                # Two-disk variant: persist is on another disk, so the boot disk has
+                # NO P3 at all after the grow.
+                [ "$P3" = "0" ] || { echo "FAIL: boot disk has a P3 ($P3) — expected none (two-disk persist)" >&2; rc=1; }
+                ok="OK: ESP/IMGA/IMGB grew to LARGE, ESP-B #7 created, no P3 on boot disk (two-disk path)" ;;
+        esac
+        [ "$rc" = "0" ] && echo "$ok"
+        exit "$rc"
+        ;;
+    *)
+        echo "Usage: $0 save <tag> | assert-small | assert-grown | assert-grown-no-shrink | assert-grown-no-p3" >&2
+        exit 1
+        ;;
+esac
+
+-- assert-free-tail.sh --
+#!/bin/bash
+# Step-1 fail-fast (grow variant only) that the boot disk has >= ~22 GB free after
+# its partitions, using only lsblk. The small bringup image (e.g. 12.1.0) does NOT
+# ship the storage-resizer binary, so the authoritative `storage-resizer check`
+# cannot run yet — that runs after the kvm->kvm hop (assert-check-decision.sh).
+# This geometric check just confirms the host-side enlarge created the tail before
+# we proceed.
+#
+# free tail ~= disk total - sum(partition sizes). Alignment gaps and the GPT
+# reservation make this a slight over-estimate (< 1 MiB), negligible against the
+# 22 GB threshold and the ~24 GB tail the recipe adds.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+GiB=$(( 1024 * 1024 * 1024 ))
+NEED=$(( 22 * GiB ))
+
+read_disk_and_parts() {
+    timeout 20 "$EDEN" eve ssh -- \
+        'eve exec pillar lsblk -b -P -o NAME,TYPE,SIZE /dev/sda 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c '
+import sys, re
+disk = 0; parts = 0
+for line in sys.stdin:
+    m = dict(re.findall(r"(\w+)=\"([^\"]*)\"", line))
+    t = m.get("TYPE", ""); s = int(m.get("SIZE", "0") or 0)
+    if t == "disk":
+        disk = max(disk, s)
+    elif t == "part":
+        parts += s
+print("%d %d" % (disk, parts))
+'
+}
+
+pair=$(read_disk_and_parts)
+disk=${pair%% *}; parts=${pair##* }
+if [ "${disk:-0}" = "0" ] || [ "${parts:-0}" = "0" ]; then
+    echo "FAIL: could not read disk/partition sizes from /dev/sda" >&2
+    exit 1
+fi
+free=$(( disk - parts ))
+echo "disk=$disk parts=$parts free_tail~=$free ($(( free / GiB )) GiB); need $(( NEED / GiB )) GiB"
+if [ "$free" -ge "$NEED" ]; then
+    echo "OK: free tail ~$(( free / GiB )) GiB present (>= 22 GiB) — grow precondition met"
+    exit 0
+fi
+echo "FAIL: free tail ~$(( free / GiB )) GiB < 22 GiB. Enlarge the disk before this test" >&2
+echo "      (qemu-img resize + sgdisk -e); see README_kvm_to_k.md." >&2
+exit 1
+
+-- assert-check-decision.sh --
+#!/bin/bash
+# Assert storage-resizer's pre-flight `check` returns the EXPECTED decision on the
+# live boot disk. Generalizes the former assert-check-grow.sh: the expected
+# decision is arg 1, so one helper serves every format in the matrix. This is the
+# load-bearing precondition guard — if the bringup/topology was not set up for the
+# requested EXPECT_DECISION, the test would silently exercise a different path.
+#
+# decision meanings (pkg/storage-resizer/README.md check table):
+#   grow         free tail >= --need; ESP/IMGA/IMGB grow into it, P3 untouched
+#   shrink       no free tail; ext4 P3 shrunk to make room, then grow
+#   proceed      already EVE-k geometry; no-op
+#   insufficient can't free --need within --max-full (or zfs P3 with no free tail)
+#
+# Usage: assert-check-decision.sh <grow|shrink|proceed|insufficient> [disk=/dev/sda]
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT="${1:?expected decision: grow|shrink|proceed|insufficient}"
+DISK="${2:-/dev/sda}"
+
+run_check() {
+    timeout 30 "$EDEN" eve ssh -- \
+        "eve exec pillar /usr/bin/storage-resizer check --disk $DISK --json 2>/dev/null" \
+        2>/dev/null | grep -v 'level=fatal'
+}
+
+for _ in $(seq 1 12); do   # ~2m at 10s — tolerate ssh/pillar not up yet
+    js=$(run_check)
+    dec=$(echo "$js" | python3 -c '
+import sys, json
+try:
+    o = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+sp = o.get("spaceForLargePartitions", {}) or {}
+print("%s|%s|%s" % (o.get("decision",""), sp.get("ok"), sp.get("freeTailBytes",0)))
+' 2>/dev/null)
+    if [ -n "$dec" ] && [ "${dec%%|*}" != "" ]; then
+        decision=${dec%%|*}; rest=${dec#*|}; ok=${rest%%|*}; tail=${rest##*|}
+        echo "storage-resizer check: decision=$decision freeTailOK=$ok freeTailBytes=$tail (expected=$EXPECT)"
+        if [ "$decision" = "$EXPECT" ]; then
+            echo "OK: check decided '$EXPECT' as this scenario requires"
+            exit 0
+        fi
+        echo "FAIL: check decided '$decision' but EXPECT_DECISION='$EXPECT'." >&2
+        echo "      The disk was not set up for the '$EXPECT' path — check the bringup/topology." >&2
+        echo "$js" >&2
+        exit 1
+    fi
+    sleep 10
+done
+echo "FAIL: no decision from storage-resizer check (binary missing or ssh down?)" >&2
+echo "      tried: eve exec pillar /usr/bin/storage-resizer check --disk $DISK --json" >&2
+exit 1
+
+-- settle-vault-local.sh --
+#!/bin/bash
+# Settle the TPM-sealed vault to a LOCAL unlock by rebooting through the
+# controller until VaultStatus.UnlockMethod is 1 (tpm-local-sealed).
+#
+# UnlockMethod values (pkg/pillar/types/vaultmgrtypes.go):
+#   0 none (not decided yet this boot)   1 tpm-local-sealed
+#   2 controller-key                     3 no-tpm
+# Per the conversion test design, 0 means "wait until it is set" — never treat
+# an unpublished/0 value as a result. The expected path after a new rootfs is
+# one controller-key boot (PCRs 8,13 moved) then a local seal.
+#
+# Reboots go through the controller (eden ... reboot), never `eve ssh reboot`:
+# the controller path is update-aware and recorded in reboot-reason.log. By the
+# time this runs the kvm->kvm update is already active, so the reboot is safe.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+
+# Read the highest UnlockMethod seen across all VaultStatus files (there is
+# normally one). Prints 0 if not yet published / ssh down.
+read_unlock() {
+    _u=$(timeout 15 "$EDEN" eve ssh -- \
+        'eve exec pillar sh -c "cat /run/vaultmgr/VaultStatus/*.json 2>/dev/null"' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c '
+import sys, json, re
+best = 0
+data = sys.stdin.read()
+_d = data
+_dec = json.JSONDecoder(); _p = 0
+while _p < len(_d):
+    _s = _d[_p:].lstrip()
+    if not _s: break
+    _p = len(_d) - len(_s)
+    try:
+        o, _p = _dec.raw_decode(_d, _p)
+    except Exception:
+        break
+    v = o.get("UnlockMethod", 0)
+    if isinstance(v, int) and v > best:
+        best = v
+print(best)
+' 2>/dev/null)
+    # Emit only a validated 0-3. A transient/garbled read (e.g. pillar still
+    # starting right after a reboot, when eve ssh answers but eve exec pillar
+    # does not yet) becomes 0 so the caller keeps polling rather than treating
+    # the stray value as a settled decision and aborting.
+    case "$_u" in 0|1|2|3) echo "$_u" ;; *) echo 0 ;; esac
+}
+
+# Wait (up to ~12m) for UnlockMethod to become non-zero this boot, then echo it.
+wait_decided() {
+    local m
+    for _ in $(seq 1 72); do   # 12m at 10s
+        m=$(read_unlock)
+        if [ "${m:-0}" != "0" ]; then echo "$m"; return 0; fi
+        sleep 10
+    done
+    echo 0
+}
+
+reboot_and_wait_back() {
+    echo "$(date +%H:%M:%S) rebooting via controller to re-seal..."
+    timeout 60 "$EDEN" controller edge-node -m adam:// reboot -v debug || true
+    # Wait for SSH to drop then return.
+    for _ in $(seq 1 24); do timeout 5 "$EDEN" eve ssh 'true' 2>/dev/null || break; sleep 5; done
+    for _ in $(seq 1 90); do timeout 8 "$EDEN" eve ssh 'true' 2>/dev/null && return 0; sleep 10; done
+    echo "WARN: SSH did not return within 15m after reboot" >&2
+    return 0
+}
+
+for attempt in $(seq 1 4); do
+    echo "$(date +%H:%M:%S) settle attempt $attempt: waiting for vault unlock decision"
+    m=$(wait_decided)
+    case "$m" in
+        1) echo "OK: vault unlocked locally (tpm-local-sealed) — settled"; exit 0 ;;
+        2) echo "  unlock=controller-key (2): rebooting to re-seal to the settled state" ;;
+        3) echo "FAIL: unlock=no-tpm (3) — this test requires eve.tpm=true" >&2; exit 1 ;;
+        *) echo "FAIL: vault never reported an unlock method (stuck at 0/none)" >&2; exit 1 ;;
+    esac
+    reboot_and_wait_back
+done
+echo "FAIL: vault did not settle to a local unlock after 4 reboots" >&2
+exit 1
+
+-- watch-conversion.sh --
+#!/bin/bash
+# Drive AND watch the kvm->k conversion (shrink+grow, or grow) to completion,
+# state/sub-state TRANSITION. The post-grow vault seal check is done POST-HOC
+# from /persist/newlog (assert-seal-from-newlog.sh): the live post-grow EVE-kvm
+# window is only ~1-2 min and an ssh poll loop misses it.
+#
+# The repartition runs OFFLINE in storage-init (the boot disk's GPT can't be re-read
+# live while its rootfs is mounted): baseosmgr arms the shrink/grow flag and
+# reboots, storage-init grows ESP/IMGA/IMGB (possibly with a busy-disk
+# reboot-to-apply), the device re-checks (proceed) and does the cross-flavor A/B
+# install, then reboots into EVE-k.
+#
+# Logs, only when it changes, the tuple of: running version, IMGA/IMGB active
+# partition+version, controller-reported device state + sub-state (from adam),
+# and on-device Converting + ConvertSubState. Completion is slot-agnostic (the
+# grow can relocate the active slot).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+K_VERSION="${1:?expected -k version}"
+SERIAL_LOG='{{EdenConfig "eve.log"}}'
+DEADLINE=$(( $(date +%s) + 2700 ))   # 45m
+
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+substate_name() {
+    case "$1" in
+        1) echo preflight ;;
+        2) echo rebooting-to-resize ;;
+        3) echo making-space ;;
+        4) echo creating-partitions ;;
+        5) echo renaming-partitions ;;
+        6) echo installing ;;
+        7) echo rebooting-to-target ;;
+        *) echo "sub_$1" ;;
+    esac
+}
+
+# Controller's view from adam: the latest ZiDevice report's state + sub_state.
+# (eden info -o/--format json panics on this build, so grep the text-proto.)
+ctrl_state() {
+    local c st sub
+    c=$(timeout 20 "$EDEN" info --tail 8 2>/dev/null | grep -a '^content: ztype:ZiDevice' | tail -1)
+    st=$(echo "$c" | grep -oE 'state:ZDEVICE_STATE_[A-Z_]+' | head -1 | cut -d: -f2)
+    sub=$(echo "$c" | grep -oE 'sub_state:ZDEVICE_SUBSTATE_[A-Z_]+' | head -1 | cut -d: -f2)
+    echo "${st:-?}/${sub:-NONE}"
+}
+
+# Which partition (IMGA/IMGB) is active, and the version on it.
+active_part() {
+    probe 'eve exec pillar sh -c "cat /run/baseosmgr/ZbootStatus/IMGA.json /run/baseosmgr/ZbootStatus/IMGB.json 2>/dev/null"' | python3 -c '
+import sys, json, re
+act = "?"; ver = "?"
+_d = sys.stdin.read()
+_dec = json.JSONDecoder(); _p = 0
+while _p < len(_d):
+    _s = _d[_p:].lstrip()
+    if not _s: break
+    _p = len(_d) - len(_s)
+    try:
+        o, _p = _dec.raw_decode(_d, _p)
+    except Exception:
+        break
+    if o.get("PartitionState") == "active":
+        act = o.get("PartitionLabel", "?"); ver = o.get("ShortVersion", "?")
+print("%s:%s" % (act, ver))' 2>/dev/null || echo "?:?"
+}
+
+serial_off=0
+report_serial() {
+    [ -f "$SERIAL_LOG" ] || return 0
+    local size new
+    size=$(stat -c%s "$SERIAL_LOG" 2>/dev/null || echo 0)
+    if [ "$size" -gt "$serial_off" ]; then
+        new=$(tail -c +$(( serial_off + 1 )) "$SERIAL_LOG" 2>/dev/null)
+        serial_off=$size
+        echo "$new" | grep -aE 'storage-resizer:|repartition|grow|reboot to apply|convert' | while IFS= read -r l; do
+            echo "  serial> $l"
+        done
+    fi
+}
+
+last_sig=""
+reboots=0
+unreachable_run=0
+seen_converting=0
+was_unreachable=0   # rising edge (unreachable->reachable) marks a controller reconnect
+
+# Parallel stress-fill cleanup. The boot-disk RESIZE (shrink+grow) runs offline
+# in storage-init with pillar down (device unreachable); when it finishes the
+# device boots back into eve-kvm for a ~1-2 min window before rebooting into
+# EVE-k. We must free /persist/tmp/stressfill in THAT window — once EVE-k starts
+# installing its cluster a full /persist hits the ephemeral-storage eviction
+# threshold and wedges longhorn. The main watch loop's 15s cadence can miss the
+# window, so run a dedicated tight ssh loop here in the background. It is
+# SELF-GATING on the grown layout (IMGA >= 1 GiB): that is only true AFTER the
+# resize, so it never wipes the fill on the pre-resize eve-kvm boot (where the
+# fill must still be present to slow the shrink). Gate logic is base64'd so no
+# quoting has to survive ssh -> eve exec pillar sh.
+read -r -d '' _GATE <<'GATE_EOF' || true
+imga=$(lsblk -b -P -o PARTLABEL,SIZE /dev/sda 2>/dev/null | grep 'PARTLABEL="IMGA"' | grep -oE 'SIZE="[0-9]+"' | grep -oE '[0-9]+' | head -1)
+[ -n "$imga" ] || exit 0
+[ "$imga" -ge 1073741824 ] || exit 0      # grown => resize already done (post-grow eve-kvm)
+[ -d /persist/tmp/stressfill ] || exit 0
+rm -rf /persist/tmp/stressfill && sync && echo FILL-CLEANED
+GATE_EOF
+_GATE_B64=$(printf '%s' "$_GATE" | base64 | tr -d '\n')
+# The bg subshell writes its success to a marker FILE (its stdout is racy — it is
+# killed by the EXIT trap when this script returns, losing any late writes). The
+# main loop below echoes the marker, so the confirmation lands reliably in the
+# captured stdout.
+_fill_marker=$(mktemp)
+_fill_reported=0
+(
+    while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+        if timeout 10 "$EDEN" eve ssh "eve exec pillar sh -c 'echo $_GATE_B64 | base64 -d | sh'" 2>/dev/null | grep -q FILL-CLEANED; then
+            echo "$(date +%H:%M:%S) [fill-cleanup] freed /persist/tmp/stressfill on the post-resize grown layout (before EVE-k cluster install)" > "$_fill_marker"
+            break
+        fi
+        sleep 3
+    done
+) &
+_fill_pid=$!
+trap '[ -n "${_fill_pid:-}" ] && kill "$_fill_pid" 2>/dev/null; rm -f "$_fill_marker"' EXIT
+
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    if [ "$_fill_reported" = 0 ] && [ -s "$_fill_marker" ]; then
+        cat "$_fill_marker"; _fill_reported=1
+    fi
+    report_serial
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then
+        unreachable_run=$(( unreachable_run + 1 ))
+        was_unreachable=1
+        if [ "$last_sig" != "UNREACHABLE" ]; then
+            echo "$(date +%H:%M:%S) [transition] EVE unreachable (rebooting?)"
+            last_sig="UNREACHABLE"
+        fi
+        sleep 15
+        continue
+    fi
+    if [ "$unreachable_run" -ge 2 ]; then
+        reboots=$(( reboots + 1 ))
+        echo "$(date +%H:%M:%S) observed a reboot (count=$reboots)"
+    fi
+    unreachable_run=0
+
+    actver=$(active_part)
+    bos=$(probe 'eve exec pillar sh -c "cat /run/baseosmgr/BaseOsStatus/*.json 2>/dev/null"')
+    conv=$(echo "$bos" | grep -o '"Converting":[a-z]*' | head -1 | cut -d: -f2); [ -z "$conv" ] && conv=false
+    csub=$(echo "$bos" | grep -o '"ConvertSubState":[0-9]*' | head -1 | cut -d: -f2); [ -z "$csub" ] && csub=0
+    [ "$conv" = "true" ] && seen_converting=1
+    dev=$(ctrl_state)
+    if [ "$was_unreachable" = 1 ]; then
+        echo "MILESTONE: EVE reconnected @ $(date -u +%Y-%m-%dT%H:%M:%SZ) running=$running ctrl_state=$dev (reboot #$reboots)"
+        was_unreachable=0
+    fi
+
+    sig="run=$running active=$actver dev=$dev converting=$conv csub=$csub($(substate_name "$csub"))"
+    if [ "$sig" != "$last_sig" ]; then
+        echo "$(date +%H:%M:%S) [transition] $sig"
+        last_sig="$sig"
+    fi
+
+    # Done: the device has BOOTED the -k version. We deliberately do NOT wait for
+    # the A/B commit to 'active' or for the cluster to be online here — the app is
+    # deployed immediately after this, and readiness is verified in the split steps
+    # of Step 11. PartitionState is typically still 'updating'/'inprogress' now.
+    if [ "$running" = "$K_VERSION" ]; then
+        report_serial
+        echo "OK: EVE-k booted (running=$running, active=$actver, converting=$conv)"
+        echo "    observed: CONVERTING=$seen_converting reboots=$reboots"
+        exit 0
+    fi
+    sleep 15
+done
+echo "FAIL: 45m timeout. running='${running:-?}' active='${actver:-?}' dev='${dev:-?}'" >&2
+echo "      observed: CONVERTING=$seen_converting reboots=$reboots" >&2
+exit 1
+
+-- assert-seal-from-newlog.sh --
+#!/bin/bash
+# Post-hoc, VERSION-MAPPED TPM-seal check from /persist/newlog (durable across the
+# conversion's reboots; survives the repartition since /persist is on P3). Robust
+# and future-proof vs racing the ~1-2 min live post-grow window.
+#
+# Args: <k-version> <kvm-version>  (the -k target, and the conversion-capable kvm
+# image whose post-grow boot must unseal locally).
+#
+# Each unlock line is mapped to the EXACT eve version of its boot using the
+# per-boot "EVE version: <ver>" marker that device-steps.sh logs on pillar.out
+# (NOT baseosmgr's embedded "to EVE version X", which is source pillar). Then:
+#   (1) the LAST boot on the conversion-capable kvm version must have unsealed
+#       LOCALLY (tpm-local-sealed) — that is the post-grow / pre-EVE-k boot, on
+#       which only PCR5 (the repartition, excluded from the seal) changed. Keying
+#       on the specific kvm version (not "any kvm boot") keeps the test correct
+#       even if a future baseline OS also logs a local unlock; and
+#   (2) no controller-key / unseal-FAILED boot lists PCR5 in its mismatch set
+#       (an independent gate: a PCR5-driven re-seal means the repartition broke
+#       the seal). The -k boot is legitimately controller-key (PCRs 8/9/13).
+#
+# Retrieval per the eve-device-logs skill: /persist/newlog has no top-level
+# dev.log; logs are in collect/ (plaintext) + keepSentQueue/ (gz); busybox find
+# has no -exec {} +, so use -exec ... \; per-file (zcat -f handles both).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+K_VERSION="${1:?expected -k version}"
+KVM_VERSION="${2:?expected kvm (conversion-capable) version}"
+
+raw=$(timeout 120 "$EDEN" eve ssh 'eve exec pillar sh -c "find /persist/newlog -name \"dev.log.*\" -exec zcat -f {} \; 2>/dev/null | grep -aE \"EVE version: |unlocked: method=|local TPM unseal FAILED\""' 2>/dev/null | grep -v 'level=fatal')
+
+echo "$raw" | KVM="$KVM_VERSION" K="$K_VERSION" python3 -c '
+import sys, os, re
+kvm = os.environ["KVM"]
+ev = []
+for line in sys.stdin:
+    sm = re.search(r"\"seconds\":(\d+)", line); nm = re.search(r"\"nanos\":(\d+)", line)
+    sec = int(sm.group(1)) if sm else 0; ns = int(nm.group(1)) if nm else 0
+    # per-boot version marker: device-steps echo on pillar.out, "<date> EVE version: <ver>".
+    # Exclude baseosmgr "to EVE version X" (source pillar, embedded) by requiring pillar.out.
+    if "pillar.out" in line and "EVE version:" in line:
+        mv = re.search(r"EVE version: ([0-9][A-Za-z0-9._+-]*)", line)
+        if mv:
+            ev.append((sec, ns, "VER", mv.group(1), []))
+        continue
+    if "unlocked: method=tpm-local-sealed" in line:
+        ev.append((sec, ns, "UNLOCK", "local", []))
+    elif "method=controller-key" in line:
+        pc = re.search(r"mismatching ?PCRs=\[([0-9 ]*)\]", line)
+        ev.append((sec, ns, "UNLOCK", "controller", pc.group(1).split() if pc else []))
+    elif "unseal FAILED" in line:
+        pc = re.search(r"mismatching ?PCRs=\[([0-9 ]*)\]", line)
+        ev.append((sec, ns, "FAILED", "failed", pc.group(1).split() if pc else []))
+ev.sort(key=lambda x: (x[0], x[1]))
+cur = None; unlocks = []; pcr5 = []
+for e in ev:
+    if e[2] == "VER":
+        cur = e[3]
+    else:
+        unlocks.append((cur, e[3], e[4]))
+        if "5" in e[4]:
+            pcr5.append((cur, e[3], e[4]))
+for u in unlocks:
+    print("  unlock> version=%s method=%s pcrs=%s" % (u[0], u[1], u[2] or "-"))
+kvmu = [u for u in unlocks if u[0] == kvm]
+print("SUMMARY: kvm_version=%s kvm_unlocks=%d pcr5_reseals=%d" % (kvm, len(kvmu), len(pcr5)))
+rc = 0
+if pcr5:
+    print("FAIL: PCR5 in a re-seal/unseal-FAILED set %s -> the repartition broke the TPM seal" % pcr5); rc = 1
+if not kvmu:
+    print("FAIL: no unlock recorded on the conversion-capable kvm version %s (post-grow boot not observed)" % kvm); rc = 1
+elif kvmu[-1][1] != "local":
+    print("FAIL: the LAST %s boot (post-grow) unlocked %s, not local -> repartition broke the seal" % (kvm, kvmu[-1][1])); rc = 1
+else:
+    print("OK: post-grow %s boot unlocked LOCALLY (%d kvm local unseal(s); no PCR5 re-seal)" % (kvm, sum(1 for u in kvmu if u[1] == "local")))
+sys.exit(rc)
+'
+
+-- wait-for-volumemgr-ready.sh --
+#!/bin/bash
+# Gate before the post-conversion redeploy. On EVE-k, volumemgr must finish its
+# "wait for kubernetes" / longhorn-ready init and RE-ESTABLISH the retained
+# ContentTree blobs in the EVE-k content store before a redeploy can REUSE them.
+# Deploying earlier causes the image to be re-downloaded (verified: ~44 MiB vs 0
+# with this gate). Wait for /run/volumemgr/VolumeMgrStatus/volumemgr.json
+# "Initialized":true (set after kubeapi.WaitForKubernetes returns).
+#
+# Instrumented: logs a timeline of (volumemgr Initialized, number of
+# ContentTreeStatus objects volumemgr currently tracks) so we can see WHEN the
+# store becomes ready and whether the retained ContentTree is recognized before
+# full Initialized — i.e. whether a narrower "blobs recognized" signal would let
+# the deploy fire sooner than waiting for the whole longhorn bring-up.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+probe() { timeout 8 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+ct_count() {
+    probe 'eve exec pillar sh -c "ls /run/volumemgr/ContentTreeStatus/*.json 2>/dev/null | wc -l"' \
+        | tr -d '\r' | grep -E '^[0-9]+$' | tail -1
+}
+last=""
+# 60m at 10s. This MUST exceed volumemgr's own pre-publish block, which is up to
+# 20m in WaitForKubernetes (node + kubevirt + longhorn) plus up to 20m more in
+# storageWait before VolumeMgrStatus is published at all. This loop also begins
+# timing before volumemgr begins its own, so a 40m budget could not observe the
+# publish even on a device that converges -- it expired at the very moment volumemgr
+# was released. Initialized is set unconditionally once both waits end
+# (handlediskmetrics.go generateAndPublishVolumeMgrStatus), so reaching it under a
+# longer budget means "the device recovered", not "cluster storage is healthy" --
+# the longhorn and app steps that follow are what establish that.
+for _ in $(seq 1 360); do
+    init=$(probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>/dev/null' \
+            | tr -d '\r' | grep -oE '"Initialized":[a-z]+')
+    ct=$(ct_count); [ -z "$ct" ] && ct='?'
+    sig="init=${init:-<none>} contenttrees=$ct"
+    if [ "$sig" != "$last" ]; then
+        echo "$(date +%H:%M:%S) [readiness] $sig"; last="$sig"
+    fi
+    if [ "$init" = '"Initialized":true' ]; then
+        echo "OK: volumemgr Initialized:true (contenttrees=$ct)"; exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: volumemgr did not reach Initialized:true within 40m" >&2
+probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>&1' >&2
+exit 1
+
+-- capture-blob-diagnostics.sh --
+#!/bin/bash
+# Observational diagnostics for the post-conversion blob-reuse question (does the
+# redeploy reuse the retained ContentTree, or re-download?). Runs after the app
+# reaches RUNNING, before the byte-count assertion, so it captures regardless of
+# pass/fail. Pulls the downloader / ContentTree / verifier lines from the EVE-k
+# boot out of /persist/newlog (see the eve-device-logs skill for the retrieval
+# form: logs live in collect/+keepSentQueue/, busybox find has no -exec {} +).
+# Never fails the test — purely informational.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+echo "--- live downloader RecvByteCount (per-URL) ---"
+timeout 15 "$EDEN" eve ssh -- 'eve exec pillar cat /run/downloader/MetricsMap/global.json 2>/dev/null' 2>/dev/null \
+    | grep -v 'level=fatal' | python3 -c '
+import sys, json
+try: d=json.load(sys.stdin)
+except Exception: sys.exit(0)
+for iface,conn in d.items():
+    for url,m in (conn.get("URLCounters") or {}).items():
+        rb=m.get("RecvByteCount",0)
+        if rb: print("  %d bytes  %s" % (rb, url))
+' 2>/dev/null || true
+echo "--- newlog: downloader/contenttree/verifier on the EVE-k boot (cache hit vs fetch) ---"
+timeout 90 "$EDEN" eve ssh 'eve exec pillar sh -c "find /persist/newlog -name \"dev.log.*\" -exec zcat -f {} \; 2>/dev/null | grep -aE \"already (in cache|verified|downloaded)|reusing|RecvByteCount|starting download|download done|ContentTree.*(DOWNLOAD|DELIVERED|LOADED)\""' 2>/dev/null \
+    | grep -v 'level=fatal' | grep -aoE 'msg\\":\\"[^"]*' | sed 's/^msg.":."/  newlog> /' | tail -30 || true
+echo "OK: blob diagnostics captured (informational)"
+
+-- wait-for-upgrade.sh --
+#!/bin/bash
+# Generic "wait for a same- or cross-flavor BaseOs upgrade to land": poll until
+# /run/eve-release equals the expected version AND IMGB is the active partition.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT_VERSION="${1:?expected version}"
+DEADLINE=$(( $(date +%s) + 1500 ))   # 25m
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then echo "$(date +%H:%M:%S): EVE unreachable (rebooting?)"; sleep 20; continue; fi
+    imgb_state=$(probe 'eve exec pillar cat /run/baseosmgr/ZbootStatus/IMGB.json' | grep -oP '"PartitionState":"\K[^"]+' | head -1)
+    [ -z "$imgb_state" ] && imgb_state='unknown'
+    echo "$(date +%H:%M:%S): running='$running' IMGB.PartitionState='$imgb_state'"
+    if [ "$running" = "$EXPECT_VERSION" ] && [ "$imgb_state" = "active" ]; then
+        echo "OK: upgrade to $running complete (IMGB active)"; exit 0
+    fi
+    sleep 20
+done
+echo "FAIL: upgrade to $EXPECT_VERSION did not complete in 25m (running='$running')" >&2
+exit 1
+
+-- assert-no-volumes.sh --
+#!/bin/bash
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 12); do
+    out=$("$EDEN" volume ls 2>/dev/null)
+    live=$(echo "$out" | awk 'NR>1 && ($(NF-1) == "IN_CONFIG" || $NF == "DELIVERED")')
+    if [ -z "$live" ]; then echo "OK: no live volumes"; exit 0; fi
+    sleep 5
+done
+echo "FAIL: live volume(s) present" >&2; "$EDEN" volume ls >&2; exit 1
+
+-- wait-for-app-running.sh --
+#!/bin/bash
+# Poll `eden pod ps` until xhv-app reaches LAST_STATE(EVE)=RUNNING. 60m budget
+# covers the fast pre-conversion kvm case (bounded by the caller's shorter -t)
+# and the slow post-conversion eve-k redeploy (longhorn install + CDI upload +
+# VMI start; ~27m observed on healthy runs). Logs each LAST_STATE(EVE) change
+# with a UTC timestamp and stamps the RUNNING milestone so the leg is measurable.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+last_st=""
+for _ in $(seq 1 360); do   # 60m at 10s (bumped 40m->60m: 40m fully consumed on stalled runs while healthy runs finish in minutes; give a genuine platform-readiness margin)
+    line=$("$EDEN" pod ps 2>/dev/null | grep -E '^xhv-app\s')
+    st=$(echo "$line" | awk '{print $NF}')
+    if [ "$st" != "$last_st" ]; then
+        echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [app] LAST_STATE(EVE)=${st:-<absent>}"; last_st="$st"
+    fi
+    if echo "$line" | grep -q 'RUNNING'; then
+        echo "MILESTONE: app RUNNING @ $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        echo "OK: xhv-app RUNNING"; echo "$line"; exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: xhv-app did not reach RUNNING in 60m" >&2
+"$EDEN" pod ps >&2
+exit 1
+
+-- wait-for-app-gone.sh --
+#!/bin/bash
+# Poll until xhv-app fully disappears AND no per-instance VolumeStatus files
+# remain under /run/volumemgr/VolumeStatus/. Pillar tears down VM -> PVC ->
+# pubsub records; the cross-HV gate refuses kvm<->k while any Volume exists, so
+# we must reach zero before pushing the -k update.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+last_pod=""; last_vol=""
+for _ in $(seq 1 90); do   # 15m at 10s
+    pod_present=$("$EDEN" pod ps 2>/dev/null | grep -cE '^xhv-app\s')
+    # Count only per-instance .json; pubsub writes a never-removed `restarted`
+    # sentinel into this dir, so `ls | wc -l` is 1 even with no volumes.
+    vol_count=$(timeout 12 "$EDEN" eve ssh \
+        'eve exec pillar ls /run/volumemgr/VolumeStatus/*.json 2>/dev/null | wc -l' \
+        2>/dev/null | tr -d '\r' | tail -1)
+    [ -z "$vol_count" ] && vol_count="?"
+    if [ "$pod_present" = "0" ] && [ "$vol_count" = "0" ]; then
+        echo "OK: xhv-app removed and no VolumeStatus files remain"; exit 0
+    fi
+    if [ "$last_pod $last_vol" != "$pod_present $vol_count" ]; then
+        echo "$(date +%H:%M:%S) waiting for teardown: pod_rows=$pod_present vol_files=$vol_count"
+        last_pod=$pod_present; last_vol=$vol_count
+    fi
+    sleep 10
+done
+echo "FAIL: app+volumes did not fully clear in 15m" >&2
+"$EDEN" pod ps >&2
+"$EDEN" eve ssh 'eve exec pillar ls -la /run/volumemgr/VolumeStatus/ 2>&1' >&2
+exit 1
+
+-- snapshot-rcv-bytes.sh --
+#!/bin/bash
+# Snapshot cumulative RecvByteCount from /run/downloader/MetricsMap on EVE.
+# "pre" saves the baseline; "post-and-assert" recomputes the delta and asserts
+# it is below MAX_DELTA_BYTES (default 1 MiB). /run is tmpfs (reset on reboot),
+# so pre/post must bracket a single phase with no intervening reboot.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+MODE=${1:-pre}
+MAX_DELTA_BYTES=${2:-1048576}
+
+capture_recv_bytes() {
+    timeout 15 "$EDEN" eve ssh -- 'eve exec pillar cat /run/downloader/MetricsMap/global.json 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print(0); sys.exit(0)
+total = 0
+for iface, conn in d.items():
+    for url, m in (conn.get('URLCounters') or {}).items():
+        total += m.get('RecvByteCount', 0)
+print(total)
+"
+}
+
+case "$MODE" in
+    pre)
+        bytes=$(capture_recv_bytes)
+        echo "$bytes" > /tmp/xhv-rcv-pre.txt
+        echo "Pre-snapshot: RecvByteCount total = $bytes bytes"
+        ;;
+    post-and-assert)
+        post=$(capture_recv_bytes)
+        pre=$(cat /tmp/xhv-rcv-pre.txt 2>/dev/null || echo 0)
+        delta=$(( post - pre ))
+        echo "Post-snapshot: RecvByteCount total = $post bytes (pre was $pre, delta = $delta)"
+        if [ "$delta" -lt 0 ]; then
+            echo "FAIL: post < pre — counter went backwards (unexpected reboot?)" >&2; exit 1
+        fi
+        if [ "$delta" -lt "$MAX_DELTA_BYTES" ]; then
+            echo "OK: only $delta bytes received (< ${MAX_DELTA_BYTES}) — no image re-download"; exit 0
+        fi
+        info=$(cat /tmp/xhv-persist-recreate.info 2>/dev/null || echo clean)
+        if [ "${info%%|*}" = "recreated" ]; then
+            rts=$(printf '%s' "$info" | cut -d'|' -f2); rstep=$(printf '%s' "$info" | cut -d'|' -f3)
+            echo "FAIL[recreate-induced]: $delta bytes re-downloaded, BUT /persist was recreated during the resize -- storage-init mount-fsck found P3 corrupt at $rts, after the watchdog interrupted: $rstep. The re-download is the expected consequence; the conversion otherwise completed (this is the ONLY failure)." >&2
+            exit 1
+        fi
+        echo "FAIL[blob-reuse]: $delta bytes re-downloaded with NO /persist recreate -- real blob-reuse regression (image not reused across the conversion)." >&2
+        exit 1
+        ;;
+    *) echo "Usage: $0 pre | post-and-assert [max-delta-bytes]" >&2; exit 1 ;;
+esac
+
+-- wait-for-ssh-to-app.sh --
+#!/bin/bash
+# wait-for-ssh-to-app.sh — the REAL guest-readiness / functional gate for the
+# eclient app instance, shared verbatim across the cross-HV / kvm->k tests.
+#
+# `eden pod ps` RUNNING (wait-for-app-running.sh) only reflects
+# AppInstState.EVEState — the ZSwState EVE reports. On EVE-k that is the
+# kubevirt VMI Running phase (qemu launched), NOT the guest kernel booted with
+# sshd accepting connections; on EVE-kvm the gap is smaller but still not
+# guest-ready. So pod-ps RUNNING is a cheap pre-filter only — success is
+# declared HERE, once an AUTHENTICATED ssh command has actually run inside the
+# guest and returned the expected output.
+#
+# Transport: host hostfwd 127.0.0.1:2223 -> EVE-eth0:2223 (eve.hostfwd
+# extension set by eden-bringup.sh) -> zedrouter NAT -> app:22 (eclient sshd).
+# The `eden sdn fwd` wrapper collapses to the same 127.0.0.1:hostport under the
+# non-SDN QEMU user-net these tests run in, so the direct path is used.
+#
+# FRESHNESS: host port 2223 is a static QEMU forward for the whole VM lifetime,
+# so after a delete+redeploy (or a reboot) a *stale* previous eclient could keep
+# answering on it and falsely satisfy a post-conversion check. To guard that,
+# each successful check records the guest's boot_id
+# (/proc/sys/kernel/random/boot_id — a fresh UUID per VM boot) to
+# /tmp/xhv-app-bootid. In "fresh" mode the check requires the connected guest's
+# boot_id to DIFFER from that recorded value; a matching (stale) instance is
+# treated as not-ready-yet and retried until the fresh deploy takes over the
+# port or the budget runs out.
+#
+# Fail-closed: a refused / closed / timed-out ssh, a non-eclient guest, or (in
+# fresh mode) only the stale instance answering, never prints the success
+# marker. On success it prints "OK: app SSH reachable" so the escript pins the
+# framework verdict to a real session:
+#     exec -t 5m bash wait-for-ssh-to-app.sh
+#     stdout 'OK: app SSH reachable'
+#
+# Args (optional): $1 host port (default 2223); $2 attempts, 10s apart
+# (default 30 => 5m); $3 = "fresh" to require a NEW guest instance vs the
+# boot_id the previous successful check recorded (use after a redeploy/reboot).
+#
+# Cert: ssh refuses group-readable keys, so the eclient id_rsa is copied to a
+# 0600 temp file. testscript sets HOME=/no-home, so the real home is resolved
+# from the running UID; dist/tests is only populated by a full `make eden`, so
+# fall back to the master/main reference clones.
+set -uo pipefail
+PORT="${1:-2223}"
+ATTEMPTS="${2:-30}"
+FRESH="${3:-}"
+BOOTID_FILE=/tmp/xhv-app-bootid
+EDEN_TESTS="{{EdenConfig "eden.tests"}}"
+USER_HOME=$(getent passwd "$(id -u)" | cut -d: -f6)
+SRC=""
+for c in "$EDEN_TESTS/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/master/eden/tests/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/main/eden/tests/eclient/image/cert/id_rsa"; do
+    if [ -f "$c" ]; then SRC="$c"; break; fi
+done
+if [ -z "$SRC" ]; then
+    echo "FAIL: could not locate eclient id_rsa cert (EDEN_TESTS=$EDEN_TESTS, USER_HOME=$USER_HOME)" >&2
+    exit 1
+fi
+KEY=$(mktemp); install -m 600 "$SRC" "$KEY"; trap 'rm -f "$KEY"' EXIT
+SSH_OPTS=(-o ConnectTimeout=10 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -i "$KEY")
+prev=""
+[ -f "$BOOTID_FILE" ] && prev=$(cat "$BOOTID_FILE" 2>/dev/null)
+connected=0
+saw_stale=0
+for _ in $(seq 1 "$ATTEMPTS"); do
+    # One round-trip proves auth, the eclient identity, and the guest boot_id.
+    # "AUTHED" is echoed before the identity check, so a connect+auth that fails
+    # only the /etc/issue match is distinguishable from a never-connected ssh.
+    out=$(ssh "${SSH_OPTS[@]}" root@127.0.0.1 -p "$PORT" \
+        'echo AUTHED; grep -q Ubuntu /etc/issue && cat /proc/sys/kernel/random/boot_id' \
+        2>/dev/null)
+    case "$out" in *AUTHED*) connected=1 ;; esac
+    bootid=$(printf '%s\n' "$out" | tr -d '\r' | grep -Ex '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | tail -1)
+    if [ -n "$bootid" ]; then
+        if [ "$FRESH" = "fresh" ] && [ -n "$prev" ] && [ "$bootid" = "$prev" ]; then
+            # Still the previous instance on the static port — wait for the fresh
+            # deploy/boot to take over the NAT before declaring success.
+            saw_stale=1; sleep 10; continue
+        fi
+        echo "$bootid" > "$BOOTID_FILE"
+        echo "OK: app SSH reachable (port=$PORT, boot_id=$bootid, fresh=${FRESH:-no}, cert=$SRC)"
+        exit 0
+    fi
+    sleep 10
+done
+budget=$(( ATTEMPTS * 10 ))
+if [ "$saw_stale" = 1 ]; then
+    echo "FAIL: only the previous app instance (boot_id=$prev) answered within ${budget}s — the fresh deploy never took over the port (stale instance)" >&2
+elif [ "$connected" = 1 ]; then
+    echo "FAIL: ssh connected+authed but the guest never matched the eclient (grep Ubuntu /etc/issue) within ${budget}s (port=$PORT)" >&2
+else
+    echo "FAIL: app never answered an authenticated ssh within ${budget}s (port=$PORT, cert=$SRC)" >&2
+fi
+echo "--- host TCP probe ---" >&2
+( exec 3<>/dev/tcp/127.0.0.1/"$PORT" ) 2>&1 || true
+exit 1
+
+-- wait-for-reboot-and-back.sh --
+#!/bin/bash
+# Wait for EVE to actually reboot. Three phases:
+#   1. Wait up to 2m for SSH to start failing (kernel going down).
+#   2. Wait up to 10m for SSH to succeed AGAIN (kernel up + sshd up).
+#   3. Verify /proc/uptime < 120s (proves an actual reboot happened,
+#      not a transient SSH glitch).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+
+echo "phase 1: waiting for SSH to start failing (reboot underway)"
+went_down=0
+for i in $(seq 1 24); do   # 24 * 5s = 2m
+    if ! timeout 5 "$EDEN" eve ssh 'true' 2>/dev/null; then
+        echo "$(date +%H:%M:%S) SSH unreachable -- reboot in progress"
+        went_down=1
+        break
+    fi
+    sleep 5
+done
+if [ "$went_down" = "0" ]; then
+    echo "FAIL: SSH stayed reachable for 2m -- reboot did not start?" >&2
+    exit 1
+fi
+
+echo "phase 2: waiting for SSH to come back (post-reboot kernel + sshd up)"
+came_up=0
+for i in $(seq 1 60); do   # 60 * 10s = 10m
+    if timeout 8 "$EDEN" eve ssh 'true' 2>/dev/null; then
+        echo "$(date +%H:%M:%S) SSH back online"
+        came_up=1
+        break
+    fi
+    sleep 10
+done
+if [ "$came_up" = "0" ]; then
+    echo "FAIL: SSH did not come back within 10m" >&2
+    exit 1
+fi
+
+echo "phase 3: verifying uptime reset (< 120s)"
+uptime_secs=$(timeout 10 "$EDEN" eve ssh 'cat /proc/uptime' 2>/dev/null | tr -d '\r' | awk '{print int($1)}' | head -1)
+if [ -z "$uptime_secs" ]; then
+    echo "FAIL: could not read /proc/uptime after reboot" >&2
+    exit 1
+fi
+if [ "$uptime_secs" -gt 120 ]; then
+    echo "FAIL: uptime $uptime_secs > 120s -- SSH glitch, not a real reboot" >&2
+    exit 1
+fi
+echo "OK: EVE rebooted, uptime now ${uptime_secs}s"
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+-- wait-for-longhorn-sc.sh --
+#!/bin/bash
+# Wait until the EVE-k `longhorn` StorageClass exists (longhorn deployed + its CSI
+# provisioner up). On a freshly-converted EVE-k node longhorn can take tens of
+# minutes to deploy -- well after the device reports ONLINE -- so wait for it
+# EXPLICITLY here, before deploying/waiting for an app whose volume needs longhorn.
+# This separates cluster-bringup time from app-bringup time: the wait-for-app-running
+# that follows can be short, and a failure here clearly says "longhorn", not "app".
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 90); do   # ~45m at 30s
+    if "$EDEN" eve ssh -- 'eve exec kube kubectl get sc 2>/dev/null' 2>/dev/null | grep -qE '^longhorn'; then
+        echo "OK: longhorn StorageClass ready"; exit 0
+    fi
+    sleep 30
+done
+echo "FAIL: longhorn StorageClass not ready within budget" >&2; exit 1
+-- fill-persist.sh --
+#!/bin/bash
+# fill-persist.sh — leave /persist holding data that sits ABOVE the post-shrink
+# boundary, so the offline resize2fs SHRINK must relocate it (real work) and runs
+# long enough for the stress watchdog (run-watchdog --no-pet, escalating from
+# ~1s) to interrupt the SHRINK, not only the GROW. On the near-empty eden
+# /persist the shrink finishes in ~1s, so without this the shrink-resume /
+# P3-recreate (FAIL[recreate-induced]) paths are never tested.
+#
+# Method (fill-high-then-trim-low): a freshly-formatted ext4 allocates
+# sequentially-created files roughly low-block to high-block. So:
+#   1. fill /persist to ~90% of its ORIGINAL size with equal-size numbered files
+#      (urandom — real, non-zero, INCOMPRESSIBLE bytes), pushing data all the way
+#      into the high block groups;
+#   2. delete the EARLIEST (lowest-block) files until usage drops to the target,
+#      leaving the survivors concentrated in the high blocks — ABOVE where the
+#      shrink boundary will fall.
+# resize2fs then has to move those high blocks down into the freed low space =
+# slow shrink. (A plain `dd if=/dev/zero` of the target size just packs low,
+# below the boundary, so nothing is relocated and the shrink stays fast — which
+# is why that approach does not work.)
+#
+# Args: $1 = TARGET used GiB to leave after the trim (0 = skip). Keep it BELOW the
+#            post-shrink P3 size (~41 GiB on a 64 GiB boot disk) or the shrink
+#            can't fit and storage-resizer aborts. Default 33 (~80% of ~41 GiB).
+#       $2 = RELOCATE (0/1): 1 also rewrites the identity/connectivity-critical
+#            files into high blocks at peak fill so the shrink must relocate them
+#            (opt-in, soak-only). Default 0.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+TARGET_GIB="${1:-33}"
+RELOCATE="${2:-0}"
+if [ "$TARGET_GIB" = "0" ]; then echo "fill-persist: target=0, skipping"; exit 0; fi
+if [ "$TARGET_GIB" = "clean" ]; then
+    echo "fill-persist: removing /persist/tmp/stressfill (free space for EVE-k longhorn/CDI)"
+    "$EDEN" eve ssh 'eve exec pillar sh -c "rm -rf /persist/tmp/stressfill; sync; df -h /persist | tail -1"' 2>/dev/null | grep -v 'level=fatal'
+    echo "OK: stress-fill removed"; exit 0
+fi
+HIGH_PCT=90        # fill to this % of the original /persist size before trimming
+CHUNK_MIB=256      # file size = delete granularity
+echo "fill-persist: fill /persist to ${HIGH_PCT}% then trim to ~${TARGET_GIB} GiB used (high blocks survive)"
+
+# The device-side logic is base64-encoded so nothing has to survive the
+# ssh -> `eve exec pillar sh -c` quoting layers. It runs as busybox sh with
+# args: $1=TARGET_GIB $2=HIGH_PCT $3=CHUNK_MIB $4=RELOCATE(0/1).
+read -r -d '' RUNNER <<'RUNNER_EOF' || true
+set -u
+TARGET_GIB=$1; HIGH_PCT=$2; CHUNK_MIB=$3; RELOCATE=$4
+DIR=/persist/tmp/stressfill
+rm -rf "$DIR"; mkdir -p "$DIR"
+used_kb() { df -k /persist | tail -1 | awk '{print $3}'; }
+usedpct() { df -h /persist | tail -1 | awk '{print $5}'; }
+cap_kb=$(df -k /persist | tail -1 | awk '{print $2}')
+hi_kb=$(( cap_kb * HIGH_PCT / 100 ))
+tgt_kb=$(( TARGET_GIB * 1024 * 1024 ))
+# 1. Bulk fill to HIGH_PCT with numbered, incompressible files. A fresh ext4 packs
+#    sequentially-created files low-block to high-block, so file 000000 is the lowest
+#    and the highest-numbered file is the highest blocks.
+n=0
+while [ "$(used_kb)" -lt "$hi_kb" ]; do
+  dd if=/dev/urandom of="$DIR/$(printf %06d "$n")" bs=1M count="$CHUNK_MIB" 2>/dev/null || break
+  n=$((n+1))
+done
+echo "  filled: $n files, used $(df -h /persist | tail -1 | awk '{print $3" ("$5")"}')"
+if [ "$RELOCATE" = "1" ]; then
+  # Deterministic high placement. A tiny file lands ABOVE the shrink boundary only if
+  # there is NO free extent below it: ext4 mballoc searches from the file's low parent-
+  # dir block group and takes the first low hole. So:
+  #   (a) top the fs off to ~ENOSPC — numbered chunks until they fail, then a tail file
+  #       per block size — leaving no free block anywhere (needs root for reserved
+  #       blocks; pillar is root);
+  #   (b) free a hole ONLY in the high region by deleting chunk files whose ACTUAL
+  #       first physical block is >= HIBLK (filefrag), not by filename order: after an
+  #       ENOSPC top-off the highest-numbered file is not reliably the highest block,
+  #       so a name-order delete can free low space and the copy then lands low again;
+  #   (c) copy each target into that hole; since low is full the copy must allocate high.
+  # filefrag verifies; if a target still lands low, grow the hole with more high chunks
+  # and retry the survivors. mv is DEFERRED to the end — replacing a target frees its
+  # low original, which the next target would otherwise grab.
+  FF=/usr/sbin/filefrag; [ -x "$FF" ] || FF=$(command -v filefrag 2>/dev/null || echo "")
+  tot4k=$(( cap_kb / 4 )); HIBLK=$(( tot4k * 70 / 100 ))
+  while dd if=/dev/urandom of="$DIR/$(printf %06d "$n")" bs=1M count="$CHUNK_MIB" 2>/dev/null; do n=$((n+1)); done
+  for bs in 1M 64k 4k; do dd if=/dev/urandom of="$DIR/tail.$bs" bs="$bs" 2>/dev/null || true; done
+  sync
+  echo "  topped off to ~ENOSPC (used $(usedpct)); require start-blk >= ${HIBLK} of ~${tot4k}"
+  firstblk() { [ -n "$FF" ] || { echo ""; return; }
+    "$FF" -b4096 -v "$1" 2>/dev/null | awk -F: '/^ *[0-9]+:/{split($3,a,".");gsub(/ /,"",a[1]);print a[1];exit}'; }
+  hole_top=$(( n - 1 ))
+  # Pool of chunk files that physically start in HIGH blocks (first block >= HIBLK).
+  # Deleting from it frees a hole guaranteed above the boundary regardless of creation
+  # order. Needs filefrag; without it grow_hole falls back to filename order (the copy
+  # can only be checked, not placed, so placement is unverified anyway).
+  hi_pool=""
+  if [ -n "$FF" ]; then
+    for cf in "$DIR"/[0-9]*; do
+      [ -f "$cf" ] || continue
+      cfb=$(firstblk "$cf")
+      [ -n "$cfb" ] && [ "$cfb" -ge "$HIBLK" ] 2>/dev/null && hi_pool="$hi_pool $cf"
+    done
+  fi
+  grow_hole() {   # free $1 chunk files, preferring ones known to start at HIGH blocks
+    k=0
+    if [ -n "$hi_pool" ]; then
+      new_pool=""
+      for cf in $hi_pool; do
+        if [ "$k" -lt "$1" ] && [ -f "$cf" ]; then
+          rm -f "$cf" 2>/dev/null && k=$(( k + 1 ))
+        else
+          new_pool="$new_pool $cf"
+        fi
+      done
+      hi_pool="$new_pool"
+    fi
+    while [ "$k" -lt "$1" ] && [ "$hole_top" -ge 0 ]; do   # fallback: filename order
+      rm -f "$DIR/$(printf %06d "$hole_top")" 2>/dev/null
+      hole_top=$(( hole_top - 1 )); k=$(( k + 1 ))
+    done
+    sync
+  }
+  grow_hole 8   # ~2 GiB initial high hole
+  ( cd /persist 2>/dev/null || exit 0
+    targets=""
+    for pat in "checkpoint/lastconfig"* "checkpoint/controllercerts"* \
+               certs/ecdh.*.pem certs/attest.*.pem certs/ek.*.pem \
+               "status/nim/DevicePortConfigList" "status/zedclient/OnboardingStatus"*; do
+      [ -e "$pat" ] || continue
+      if [ -f "$pat" ]; then targets="$targets $pat"
+      elif [ -d "$pat" ]; then targets="$targets $(find "$pat" -type f 2>/dev/null)"; fi
+    done
+    reloc_tot=0; for ff in $targets; do reloc_tot=$(( reloc_tot + 1 )); done
+    pending="$targets"; staged=""; round=0
+    while [ -n "$pending" ] && [ "$round" -lt 6 ]; do
+      round=$(( round + 1 )); failed=""
+      for ff in $pending; do   # paths are fixed and space-free
+        [ -f "$ff" ] || continue
+        dd if="$ff" of="$ff.reloc.$$" bs=1M 2>/dev/null; sync
+        sb=$(firstblk "$ff.reloc.$$")
+        if [ -z "$FF" ] || { [ -n "$sb" ] && [ "$sb" -ge "$HIBLK" ] 2>/dev/null && cmp -s "$ff" "$ff.reloc.$$" 2>/dev/null; }; then
+          staged="$staged $ff"
+        else
+          rm -f "$ff.reloc.$$"; failed="$failed $ff"
+        fi
+      done
+      pending="$failed"
+      [ -n "$pending" ] && grow_hole 8   # not all high yet: enlarge the hole, retry survivors
+    done
+    reloc_ok=0
+    for ff in $staged; do   # commit staged high copies at once (frees low originals)
+      if mv "$ff.reloc.$$" "$ff" 2>/dev/null; then
+        reloc_ok=$(( reloc_ok + 1 )); sz=$(wc -c < "$ff" 2>/dev/null)
+        echo "    relocated-high: $ff ($sz bytes)"
+      fi
+    done
+    sync
+    if [ -z "$FF" ]; then
+      echo "  reloc-high verify: ${reloc_ok}/${reloc_tot} critical files (filefrag absent — unverified)"
+      echo "  reloc-high ASSERT: SKIP — filefrag absent, placement unverified"
+    else
+      # What the shrink acts on is FINAL placement, so re-read every critical's
+      # current first block and count those >= HIBLK — including ones already high
+      # before the copy loop, which "pending" alone would misreport as failed.
+      high_final=0
+      for ff in $targets; do
+        [ -f "$ff" ] || continue
+        fb=$(firstblk "$ff")
+        if [ -n "$fb" ] && [ "$fb" -ge "$HIBLK" ] 2>/dev/null; then
+          high_final=$(( high_final + 1 ))
+          case " $staged " in *" $ff "*) : ;; *) echo "    already-high: $ff (no move needed, blk $fb)" ;; esac
+        else
+          echo "    reloc-FAILED-low: $ff (blk ${fb:-?}, below ${HIBLK})"
+        fi
+      done
+      echo "  reloc-high verify: ${high_final}/${reloc_tot} critical files above block ${HIBLK} (final placement)"
+      if [ "$high_final" -lt "$reloc_tot" ]; then
+        echo "  reloc-high ASSERT: FAIL — $(( reloc_tot - high_final )) critical file(s) not above boundary; shrink will not relocate them this iteration"
+      else
+        echo "  reloc-high ASSERT: PASS — all ${reloc_tot} critical files above boundary"
+      fi
+    fi )
+fi
+i=0
+while [ "$(used_kb)" -gt "$tgt_kb" ] && [ "$i" -lt "$n" ]; do
+  rm -f "$DIR/$(printf %06d "$i")"; i=$((i+1))
+done
+sync
+echo "  trimmed: deleted $i earliest files, used $(df -h /persist | tail -1 | awk '{print $3" ("$5")"}')"
+RUNNER_EOF
+B64=$(printf '%s' "$RUNNER" | base64 | tr -d '\n')
+"$EDEN" eve ssh "eve exec pillar sh -c 'echo $B64 | base64 -d > /tmp/fillrunner.sh; sh /tmp/fillrunner.sh ${TARGET_GIB} ${HIGH_PCT} ${CHUNK_MIB} ${RELOCATE}; rm -f /tmp/fillrunner.sh'" 2>/dev/null | grep -v 'level=fatal'
+echo "OK: /persist filled-high-then-trimmed to ~${TARGET_GIB} GiB (survivors in high blocks)"
+
+-- capture-critical-blocks.sh --
+#!/bin/bash
+# capture-critical-blocks.sh <label> — record the physical block placement (via
+# filefrag/FIEMAP) of the identity/connectivity-critical files that fill-persist.sh
+# relocates into high blocks. Called at three points so the movement is visible:
+#   before-relocate : original placement (freshly-created, low block groups)
+#   after-relocate  : after fill-persist rewrote them into the high (to-be-shrunk) tail
+#   after-shrink    : after the offline resize2fs SHRINK, which must move the high
+#                     survivors down into the freed low space (EVE-k, post-conversion)
+# Output only — this never asserts, so it can't fail the run. filefrag ships in the
+# pillar image's e2fsprogs-extra; if absent the file is noted and skipped.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+LABEL="${1:-unlabeled}"
+# base64 the device-side logic so nothing has to survive the ssh -> `eve exec
+# pillar sh -c` quoting layers (same technique as fill-persist.sh). Arg: $1=LABEL.
+read -r -d '' RUNNER <<'RUNNER_EOF' || true
+set -u
+LABEL=$1
+FF=/usr/sbin/filefrag
+[ -x "$FF" ] || FF=$(command -v filefrag 2>/dev/null || echo filefrag)
+cd /persist 2>/dev/null || { echo "critical-blocks[$LABEL]: no /persist"; exit 0; }
+tot4k=$(( $(df -k /persist | tail -1 | awk '{print $2}') / 4 ))
+PDEV=$(stat -c '%d' /persist 2>/dev/null)
+echo "critical-blocks[$LABEL]: /persist ~${tot4k} fs-blocks (4KiB) dev=${PDEV:-?}; phys4k = physical block range per extent"
+cap_one() {
+  f=$1; [ -f "$f" ] || return 0
+  out=$("$FF" -b4096 -v "$f" 2>/dev/null) || { echo "    $f  (filefrag failed)"; return 0; }
+  phys=$(printf '%s\n' "$out" | awk -F: '/^[[:space:]]*[0-9]+:/{r=$3; gsub(/[^0-9.]/,"",r); printf "%s ", r}')
+  ext=$(printf '%s\n' "$out" | awk '/extent[s]? found/{print $(NF-2)}')
+  sz=$(wc -c < "$f" 2>/dev/null)
+  # filefrag's phys block is relative to the fs the file actually lives on, so a
+  # file NOT on the /persist device would not be a valid witness for the /persist
+  # shrink relocation. Flag any device mismatch with the real path + mountpoint so
+  # the report can exclude it rather than mistaking it for an unmoved survivor.
+  # (Soak confirms all criticals are on /persist; this stays as an invariant guard.)
+  fdev=$(stat -c '%d' "$f" 2>/dev/null)
+  loc=""
+  [ -n "$fdev" ] && [ -n "$PDEV" ] && [ "$fdev" != "$PDEV" ] && \
+    loc="  OFF-PERSIST(dev=${fdev} real=$(readlink -f "$f" 2>/dev/null) mnt=$(df "$f" 2>/dev/null | tail -1 | awk '{print $NF}'))"
+  echo "    $f  size=${sz}B  extents=${ext:-?}  phys4k=[${phys% }]${loc}"
+}
+for pat in checkpoint/lastconfig* checkpoint/controllercerts* \
+           certs/ecdh.*.pem certs/attest.*.pem certs/ek.*.pem \
+           status/nim/DevicePortConfigList status/zedclient/OnboardingStatus*; do
+  [ -e "$pat" ] || continue
+  if [ -f "$pat" ]; then cap_one "$pat"
+  elif [ -d "$pat" ]; then find "$pat" -type f 2>/dev/null | while IFS= read -r ff; do cap_one "$ff"; done
+  fi
+done
+RUNNER_EOF
+B64=$(printf '%s' "$RUNNER" | base64 | tr -d '\n')
+# Diagnostic only: a transient ssh blip leaves grep with no non-fatal stdout,
+# which returns 1 under pipefail. Swallow it so a capture can never fail the run.
+"$EDEN" eve ssh "eve exec pillar sh -c 'echo $B64 | base64 -d > /tmp/capblocks.sh; sh /tmp/capblocks.sh \"${LABEL}\"; rm -f /tmp/capblocks.sh'" 2>/dev/null | grep -v 'level=fatal' || true
+exit 0
+
+-- assert-persist-not-recreated.sh --
+#!/bin/bash
+# Detect whether the offline resize recreated (wiped) /persist, and RECORD it for
+# the final blob-reuse verdict (this step does not itself fail). storage-init
+# mkfs's P3 when its filesystem fails identification/fsck -- a watchdog-interrupted
+# shrink can corrupt it -- which destroys /persist (newlog, the retained
+# ContentTree, restored identity), so the post-conversion app redeploy must then
+# re-download. A recreate during INITIAL bringup (a blank, freshly-partitioned P3)
+# is expected and excluded; we flag only a recreate at/after the resize began
+# (storage-init's "shrink+grow requested"/"grow-only requested" marker), and note
+# WHICH resize step the watchdog interrupted (the last step logged before the
+# recreate) so the blob-reuse check can report FAIL[recreate-induced]. Markers in
+# storage-init.sh; retrieval per the eve-device-logs skill; ISO8601 sorts lexically.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+INFO=/tmp/xhv-persist-recreate.info
+echo "clean" > "$INFO"
+
+logs=$(timeout 90 "$EDEN" eve ssh 'eve exec pillar sh -c "find /persist/newlog -name \"dev.log.*\" -exec zcat -f {} \; 2>/dev/null | grep -aoE \"2026[^\\\"]*(recreating it as|shrink\+grow requested|grow-only requested|shrink P3 to|shrink complete|Resizing the filesystem|grow EFI|grow complete)[^\\\"]*\""' 2>/dev/null | grep -v 'level=fatal' | sort -u)
+
+tsof() { grep -aoE '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}'; }
+resize_ts=$(printf '%s\n' "$logs" | grep -aE 'shrink\+grow requested|grow-only requested' | tsof | sort | head -1)
+if [ -z "$resize_ts" ]; then
+    echo "WARNING: no resize marker in newlog; persist-recreate detection inconclusive"
+    echo "OK: /persist preserved (recorded clean)"; exit 0
+fi
+recreate_ts=$(printf '%s\n' "$logs" | grep -a 'recreating it as' | tsof | sort -u | awk -v r="$resize_ts" '$0>=r' | head -1)
+if [ -z "$recreate_ts" ]; then
+    echo "OK: /persist preserved across the resize (no P3 recreate at/after $resize_ts; bringup format excluded)"; exit 0
+fi
+# A recreate happened at/after the resize. The last resize step logged before it is
+# (best effort) what the watchdog interrupted.
+step=$(printf '%s\n' "$logs" | grep -aE 'shrink P3 to|shrink complete|Resizing the filesystem|grow EFI|grow complete' | tail -1)
+[ -n "$step" ] || step="(no resize step logged before the recreate)"
+printf 'recreated|%s|%s\n' "$recreate_ts" "$step" > "$INFO"
+echo "NOTE: /persist was recreated at $recreate_ts (at/after the resize); last step before it: $step"
+echo "(recorded -- the blob-reuse check reports FAIL[recreate-induced] if the app re-downloads)"

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k.txt
@@ -1513,6 +1513,9 @@ if [ "$RELOCATE" = "1" ]; then
   # and retry the survivors. mv is DEFERRED to the end — replacing a target frees its
   # low original, which the next target would otherwise grab.
   FF=/usr/sbin/filefrag; [ -x "$FF" ] || FF=$(command -v filefrag 2>/dev/null || echo "")
+  # HIBLK must stay ABOVE the post-shrink boundary (~63% of this figure), so anything
+  # staged here is genuinely in the tail the shrink evacuates. cap_kb is df's, which
+  # runs low by ext4's metadata overhead — keep the 70% margin if that ever changes.
   tot4k=$(( cap_kb / 4 )); HIBLK=$(( tot4k * 70 / 100 ))
   while dd if=/dev/urandom of="$DIR/$(printf %06d "$n")" bs=1M count="$CHUNK_MIB" 2>/dev/null; do n=$((n+1)); done
   for bs in 1M 64k 4k; do dd if=/dev/urandom of="$DIR/tail.$bs" bs="$bs" 2>/dev/null || true; done
@@ -1646,9 +1649,17 @@ LABEL=$1
 FF=/usr/sbin/filefrag
 [ -x "$FF" ] || FF=$(command -v filefrag 2>/dev/null || echo filefrag)
 cd /persist 2>/dev/null || { echo "critical-blocks[$LABEL]: no /persist"; exit 0; }
-tot4k=$(( $(df -k /persist | tail -1 | awk '{print $2}') / 4 ))
+# The shrink boundary is dumpe2fs' "Block count". df/statvfs reports f_blocks NET of
+# ext4 metadata overhead (~2.4%: 238,264 of 10,213,376 blocks on the post-shrink
+# /persist), so a file between the two figures is INSIDE the filesystem and the shrink
+# correctly leaves it alone — reading the df figure as the boundary calls that stranded.
+DE=/usr/sbin/dumpe2fs
+[ -x "$DE" ] || DE=$(command -v dumpe2fs 2>/dev/null || echo dumpe2fs)
+dfb4k=$(( $(df -k /persist | tail -1 | awk '{print $2}') / 4 ))
+SRC=$(df /persist | tail -1 | awk '{print $1}')
+tot4k=$("$DE" -h "$SRC" 2>/dev/null | awk -F: '/^Block count/{gsub(/[^0-9]/,"",$2); print $2}')
 PDEV=$(stat -c '%d' /persist 2>/dev/null)
-echo "critical-blocks[$LABEL]: /persist ~${tot4k} fs-blocks (4KiB) dev=${PDEV:-?}; phys4k = physical block range per extent"
+echo "critical-blocks[$LABEL]: /persist ${tot4k:-?} fs-blocks (4KiB, dumpe2fs Block count on ${SRC:-?} = shrink boundary; df-derived ${dfb4k} excludes metadata) dev=${PDEV:-?}; phys4k = physical block range per extent"
 cap_one() {
   f=$1; [ -f "$f" ] || return 0
   out=$("$FF" -b4096 -v "$f" 2>/dev/null) || { echo "    $f  (filefrag failed)"; return 0; }

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k.txt
@@ -1560,7 +1560,8 @@ if [ "$RELOCATE" = "1" ]; then
     targets=""
     for pat in "checkpoint/lastconfig"* "checkpoint/controllercerts"* \
                certs/ecdh.*.pem certs/attest.*.pem certs/ek.*.pem \
-               "status/nim/DevicePortConfigList" "status/zedclient/OnboardingStatus"*; do
+               "status/nim/DevicePortConfigList" "status/zedclient/OnboardingStatus"* \
+               "status/vaultmgr/VaultConfig"; do
       [ -e "$pat" ] || continue
       if [ -f "$pat" ]; then targets="$targets $pat"
       elif [ -d "$pat" ]; then targets="$targets $(find "$pat" -type f 2>/dev/null)"; fi
@@ -1679,7 +1680,8 @@ cap_one() {
 }
 for pat in checkpoint/lastconfig* checkpoint/controllercerts* \
            certs/ecdh.*.pem certs/attest.*.pem certs/ek.*.pem \
-           status/nim/DevicePortConfigList status/zedclient/OnboardingStatus*; do
+           status/nim/DevicePortConfigList status/zedclient/OnboardingStatus* \
+           status/vaultmgr/VaultConfig; do
   [ -e "$pat" ] || continue
   if [ -f "$pat" ]; then cap_one "$pat"
   elif [ -d "$pat" ]; then find "$pat" -type f 2>/dev/null | while IFS= read -r ff; do cap_one "$ff"; done

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k.txt
@@ -842,10 +842,33 @@ report_serial() {
 }
 
 last_sig=""
+last_boserr=""
 reboots=0
 unreachable_run=0
 seen_converting=0
 was_unreachable=0   # rising edge (unreachable->reachable) marks a controller reconnect
+
+# First non-empty BaseOsStatus.Error across the published status files, on one
+# line. Reads the same JSON the loop already fetches for Converting; the field is
+# flat because BaseOsStatus embeds ErrorAndTime anonymously.
+bos_error() {
+    printf '%s' "$1" | python3 -c '
+import sys, json
+d = sys.stdin.read(); dec = json.JSONDecoder(); p = 0
+while p < len(d):
+    s = d[p:].lstrip()
+    if not s:
+        break
+    p = len(d) - len(s)
+    try:
+        o, p = dec.raw_decode(d, p)
+    except Exception:
+        break
+    e = (o.get("Error") or "").strip()
+    if e:
+        print(" ".join(e.split()))
+        break' 2>/dev/null
+}
 
 # Parallel stress-fill cleanup. The boot-disk RESIZE (shrink+grow) runs offline
 # in storage-init with pillar down (device unreachable); when it finishes the
@@ -922,6 +945,26 @@ while [ "$(date +%s)" -lt "$DEADLINE" ]; do
         echo "$(date +%H:%M:%S) [transition] $sig"
         last_sig="$sig"
     fi
+
+    # baseosmgr reports a refused conversion on BaseOsStatus.Error — the same text
+    # the controller surfaces as the base-OS update error. Log any error as it
+    # appears, and stop on the one that names the retry gate: storage-init's
+    # resize-failed.json marker survives the reboot and nothing re-arms until the
+    # EVE version changes or the update is withdrawn, so the device can never reach
+    # the -k version and waiting out the deadline only hides the reason.
+    boserr=$(bos_error "$bos")
+    if [ -n "$boserr" ] && [ "$boserr" != "$last_boserr" ]; then
+        echo "$(date +%H:%M:%S) [BaseOsStatus.Error] $boserr"
+        last_boserr="$boserr"
+    fi
+    case "$boserr" in
+        *"not retrying until the EVE version changes"*)
+            report_serial
+            echo "FAIL: conversion DECLINED — the resizer aborted and will not retry" >&2
+            echo "      $boserr" >&2
+            echo "      observed: CONVERTING=$seen_converting reboots=$reboots" >&2
+            exit 1 ;;
+    esac
 
     # Done: the device has BOOTED the -k version. We deliberately do NOT wait for
     # the A/B commit to 'active' or for the cluster to be online here — the app is

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_backup_corrupt_restore.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_backup_corrupt_restore.txt
@@ -1,0 +1,565 @@
+# Test: kvm-to-k conversion fault case F11 — PARTIAL CORRUPTION of the backed-up
+# critical files in /persist (truncate each to ~half), and verify the device still
+# recovers WITH NO CONTROLLER REACHABLE via restore's per-type validity gate plus
+# pillar's .bak fallback. Sibling of the F9 (full-wipe) test.
+#
+# This does NOT run a real shrink/grow and does NOT wipe /persist. It exercises the
+# backup->corrupt->restore fail-safe against PARTIAL corruption: an online
+# `storage-resizer backup` copies the critical files to the CONFIG partition; we
+# then truncate each backed-up file to about half its bytes ON THE RUNNING DEVICE
+# (via eve exec pillar; the offline qemu-nbd mount does not reliably see a fresh
+# device's recent /persist writes) -- EXCEPT the .bak fallback files
+# (checkpoint/lastconfig.bak and checkpoint/controllercerts.bak), left intact so
+# pillar's .bak fallback can recover the no-validator checkpoint files. On the next
+# boot `maybe_restore_after_persist` runs restore (flag present), whose needsRestore
+# gate restores files that are invalid FOR THEIR TYPE: certs/*.pem lose their
+# -----END and .json files (incl. DevicePortConfigList/global.json and
+# OnboardingStatus/global.json) fail json.Valid -> restored from the /config backup.
+# The no-validator checkpoint files (lastconfig, controllercerts) keep the truncated
+# live copy and instead recover via their intact .bak copies -- which now exist from
+# first save thanks to lf-edge/eve #6122. The real shrink is skipped with a
+# resize-failed.json marker matched to the running EVE version.
+#
+# The load-bearing proof is that a controller-ENCRYPTED credential is decrypted
+# OFFLINE from the RESTORED ecdh cert. We inject an encrypted WiFi device port
+# BEFORE the backup so it rides through checkpoint/lastconfig into the backup;
+# after the wipe+restore, pillar applies the restored checkpoint offline and nim
+# re-decrypts the WiFi creds. One CipherBlockStatus.Error=="" after an offline
+# boot proves identity restore + config restore + decrypt-from-restored-key.
+# (App userdata is the wrong vehicle — it decrypts only at domain instantiation,
+# which needs the wiped image; device-network creds decrypt during nim's DPC
+# reconcile, independent of the app pipeline and of radio presence.)
+#
+# DEPENDENCY: the `eden controller edge-node add-wireless` CLI is eden PR #1202
+# (branch openevec-add-wireless), a SIBLING of add-cross-hv-eve-tests. This
+# escript lives with the other kvm-to-k escripts; to run it, have #1202 present in
+# the eden binary (merge/cherry-pick it into the branch you build eden from).
+#
+# IMAGE REQUIREMENT: the EVE image must back up the persistent OnboardingStatus
+# topic, i.e. `status/zedclient/OnboardingStatus` must be in storage-resizer's
+# defaultBackupPatterns (pkg/storage-resizer/backup.go, lf-edge/eve PR #6063).
+# Without it the truncated OnboardingStatus/global.json is not restored, the device
+# can't take cmd/client's offline UUID shortcut, and it stays stuck at onboarding
+# -- see the disabled FIX-SIM block in backup-and-arm.sh, which you can uncomment
+# to run against an UNPATCHED image.
+#
+# Sibling of the F9 (full-wipe) test; it reuses F9's setup and assertions with the
+# wipe replaced by the on-device truncation below. Run it against an image carrying
+# both the #6063 OnboardingStatus backup and the #6122 .bak-on-first-save fixes
+# (e.g. resize-allprs). What it proves: the no-validator checkpoint files
+# (lastconfig, controllercerts) recover offline via their .bak copies, and the
+# .pem/.json files via the restore-gate -- so a partial /persist corruption stays
+# recoverable with no controller.
+#
+# Bringup is MANUAL (like the other kvm-to-k escripts): bring an onboarded device
+# up on the SMALL bringup release (default 12.1.0); this test hops it to the
+# resize-capable kvm build so the storage-resizer binary + storage-init restore
+# hooks are present. TPM must be on (ecdh private key is TPM-resident; only files
+# in /persist are truncated, the fs and swtpm state are preserved).
+#
+# Knobs (env):
+#   RESIZE_EVE_VER  (required) version base of the local kvm-to-k build, e.g.
+#                   "0.0.0-kvm-to-k-resize-<sha>". Fails fast if unset.
+#   RESIZE_EVE_REG  (default lfedge/eve) image registry/repo namespace.
+#   BRINGUP_EVE_VER (default 12.1.0) substring the running base release must
+#                   contain at Step 1 (bringup is manual — see README_kvm_to_k.md).
+
+{{$arch := EdenConfig "eve.arch"}}
+
+{{$resize_ver_env := EdenGetEnv "RESIZE_EVE_VER"}}
+{{$resize_ver := "REPLACE-WITH-RESIZE-VERSION"}}
+{{if $resize_ver_env}}{{$resize_ver = $resize_ver_env}}{{end}}
+
+{{$resize_reg_env := EdenGetEnv "RESIZE_EVE_REG"}}
+{{$resize_reg := "lfedge/eve"}}
+{{if $resize_reg_env}}{{$resize_reg = $resize_reg_env}}{{end}}
+
+{{$bringup_ver_env := EdenGetEnv "BRINGUP_EVE_VER"}}
+{{$bringup_ver := "12.1.0"}}
+{{if $bringup_ver_env}}{{$bringup_ver = $bringup_ver_env}}{{end}}
+
+# SKIP_KVM_HOP=1 when the device was brought up DIRECTLY on the resize kvm image
+# (no 12.1.0 base to upgrade from) — skips Step 1's kvm->kvm upgrade.
+{{$skip_hop_env := EdenGetEnv "SKIP_KVM_HOP"}}
+{{$skip_hop := ""}}
+{{if $skip_hop_env}}{{$skip_hop = $skip_hop_env}}{{end}}
+
+{{$kvm_short := printf "%s-kvm-%s" $resize_ver $arch}}
+{{$ssid := "eden-f9"}}
+
+# Step 0: pre-flight. Fail fast if the version param wasn't supplied, confirm a
+# clean device, and shorten the baseimage commit timer so the kvm hop applies fast.
+message 'pre-flight: parameters + clean state'
+exec -t 1m bash require-resize-ver.sh
+eden -t 1m pod ps
+! stdout 'IN_CONFIG'
+eden controller edge-node update --config timer.test.baseimage.update=30
+
+# Step 1: get the device onto the resize-capable kvm build so /usr/bin/storage-resizer
+# + the storage-init restore hooks exist. (Geometry is irrelevant to F9 — no
+# conversion happens.) Two paths:
+#   SKIP_KVM_HOP unset: bring up on the SMALL bringup release, then kvm->kvm
+#                       upgrade to the resize image (matches the sibling escripts).
+#   SKIP_KVM_HOP set:   the device was brought up DIRECTLY on the resize kvm image;
+#                       just assert it and skip the upgrade (faster; avoids the
+#                       small->large IMGB-fit question).
+{{if $skip_hop}}
+message 'baseline: device already on the resize-capable kvm build (SKIP_KVM_HOP)'
+exec -t 3m bash assert-running-version.sh {{ $kvm_short }}
+{{else}}
+message 'baseline: confirm we are on the expected SMALL bringup release'
+exec -t 3m bash assert-running-version.sh {{ $bringup_ver }}
+message 'downloading conversion-capable kvm rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$resize_ver}} --eve-hv=kvm --eve-registry={{$resize_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs'
+message 'pushing kvm->kvm BaseOs update (lands resize/restore code)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs --os-version={{ $kvm_short }} -m adam://
+! stderr .
+message 'waiting for kvm->kvm upgrade to complete'
+exec -t 25m bash wait-for-upgrade.sh {{ $kvm_short }}
+{{end}}
+
+# Step 2: inject an ENCRYPTED WiFi device port (eden PR #1202), wait for the
+# BASELINE decrypt (proves the port was ingested + decrypted pre-wipe), then
+# snapshot identity + the DPCL for the post-restore comparison.
+message 'injecting encrypted WiFi port (eden PR #1202 add-wireless)'
+eden -t 2m controller edge-node add-wireless --port wlan0 --ssid {{ $ssid }} --password eden-f9-psk
+! stderr 'level=fatal'
+message 'waiting for BASELINE decrypt (pre-wipe) of the WiFi creds'
+exec -t 5m bash assert-decrypt.sh {{ $ssid }} 240
+message 'snapshotting identity (UUID, certs) + DPCL before the wipe'
+exec -t 2m bash snapshot-identity.sh
+
+# Step 3: online backup of the critical files to the CONFIG partition + arm the
+# skip-shrink marker. GATED on a content check: the backed-up checkpoint must
+# already carry the encrypted WiFi port (SSID) and the ecdh cert before we stop.
+message 'backup identity to CONFIG + arm skip-shrink (gated on artifact content)'
+exec -t 6m bash backup-and-arm.sh {{ $ssid }}
+
+# Step 4: PARTIALLY CORRUPT /persist ON THE RUNNING DEVICE. Truncate each backed-up
+# critical file to ~half in the live /persist (via eve exec pillar), EXCEPT the
+# .bak files, then sync. On-device (not an offline qemu-nbd mount) because the
+# offline mount does not reliably reflect a fresh device's recent /persist writes.
+message 'partial corruption: truncate critical /persist files to half on-device (keep .bak)'
+exec -t 3m bash corrupt-persist-ondevice.sh
+
+# Step 5: go OFFLINE (stop the controller), reboot into the offline restore path,
+# and wait for the device to come back up. eve stop/start reboots on the same
+# live.img so the truncated /persist (P3) survives into storage-init's restore.
+message 'going offline: stopping the controller (adam)'
+exec docker stop eden_adam
+message 'rebooting into restore with partially-corrupted /persist'
+eden -t 2m eve stop
+eden -t 2m eve start
+exec -t 12m bash wait-ssh-up.sh
+
+# Step 6: assertions — all while the controller is DOWN.
+message 'asserting device identity was restored offline (UUID + certs)'
+exec -t 3m bash assert-identity-restored.sh
+message 'asserting DPC landed + WiFi creds decrypted from the RESTORED ecdh (offline)'
+exec -t 5m bash assert-decrypt.sh {{ $ssid }} 240
+message 'asserting the DPCL config round-tripped (status-stripped compare)'
+exec -t 2m bash assert-dpcl-stable.sh
+message 'asserting conversion bookkeeping was cleaned up (flag gone, persist NOT recreated)'
+exec -t 2m bash assert-cleanup.sh
+message 'recording the full /persist inventory after restore (+ critical-file sizes vs pre-corruption)'
+exec -t 2m bash record-persist-after.sh
+
+# Step 7: bring the controller back and reset.
+message 'restarting controller + reset'
+exec docker start eden_adam
+exec sleep 10
+eden eve reset
+
+-- require-resize-ver.sh --
+#!/bin/bash
+# Fail fast if RESIZE_EVE_VER wasn't supplied (the escript default is a placeholder).
+set -uo pipefail
+VER='{{ $resize_ver }}'
+if [ -z "$VER" ] || [ "$VER" = "REPLACE-WITH-RESIZE-VERSION" ]; then
+    echo "FAIL: RESIZE_EVE_VER not set." >&2
+    echo "      Export it to the version base of your local kvm-to-k build," >&2
+    echo "      e.g. RESIZE_EVE_VER=0.0.0-kvm-to-k-resize-1a2b3c4d" >&2
+    echo "      (the part before -kvm-amd64 in the docker tag)." >&2
+    exit 1
+fi
+echo "OK: RESIZE_EVE_VER=$VER"
+
+-- assert-running-version.sh --
+#!/bin/bash
+# Sanity-check EVE is on the expected SMALL bringup release before the test.
+# Matches the arg as a substring of /run/eve-release (full "<ver>-<hv>-<arch>").
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT="${1:?expected bringup version substring}"
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+for _ in $(seq 1 18); do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -n "$running" ]; then
+        case "$running" in
+            *"$EXPECT"*) echo "OK: running '$running' contains '$EXPECT'"; exit 0 ;;
+            *) echo "FAIL: running '$running' != expected bringup '$EXPECT'." >&2
+               echo "      Bring eve up on the small '$EXPECT' image, or set BRINGUP_EVE_VER." >&2
+               exit 1 ;;
+        esac
+    fi
+    sleep 10
+done
+echo "FAIL: could not read /run/eve-release (ssh down / device not up?)" >&2
+exit 1
+
+-- wait-for-upgrade.sh --
+#!/bin/bash
+# Wait for a same-flavor BaseOs upgrade to land: /run/eve-release == expected AND
+# IMGB is the active partition.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT_VERSION="${1:?expected version}"
+DEADLINE=$(( $(date +%s) + 1500 ))
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then echo "$(date +%H:%M:%S): EVE unreachable (rebooting?)"; sleep 20; continue; fi
+    imgb_state=$(probe 'eve exec pillar cat /run/baseosmgr/ZbootStatus/IMGB.json' | grep -oP '"PartitionState":"\K[^"]+' | head -1)
+    [ -z "$imgb_state" ] && imgb_state='unknown'
+    echo "$(date +%H:%M:%S): running='$running' IMGB.PartitionState='$imgb_state'"
+    if [ "$running" = "$EXPECT_VERSION" ] && [ "$imgb_state" = "active" ]; then
+        echo "OK: upgrade to $running complete (IMGB active)"; exit 0
+    fi
+    sleep 20
+done
+echo "FAIL: upgrade to $EXPECT_VERSION did not complete in 25m (running='$running')" >&2
+exit 1
+
+-- assert-decrypt.sh --
+#!/bin/bash
+# Assert the encrypted WiFi creds are DECRYPTED. Two on-disk proofs (both under
+# /run, which is tmpfs and cleared each boot -> presence == THIS boot):
+#   1. zedagent published the controller DPC carrying our SSID
+#      (/run/zedagent/DevicePortConfig/zedagent.json) -> the config was applied.
+#   2. nim published a CipherBlockStatus with Error=="" & IsCipher:true
+#      (/run/nim/CipherBlockStatus/*.json) -> a cipher block decrypted OK.
+# Plus a log guard: the always-logged Error-level "decryption was unsuccessful"
+# line for our SSID must be ABSENT. Used pre-wipe (baseline) and post-wipe/offline
+# (the load-bearing decrypt-from-restored-ecdh proof) — identical device checks.
+# Usage: assert-decrypt.sh <ssid> <deadline_secs>
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+SSID="${1:?ssid}"
+BUDGET="${2:-240}"
+probe() { timeout 20 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+DEADLINE=$(( $(date +%s) + BUDGET ))
+dpc_ok=0; cbs_ok=0
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    # 1. controller DPC (ephemeral, JSON on disk) carries the SSID.
+    dpc=$(probe 'eve exec pillar sh -c "cat /run/zedagent/DevicePortConfig/*.json 2>/dev/null"')
+    echo "$dpc" | grep -q "$SSID" && dpc_ok=1 || dpc_ok=0
+    # 2. a CipherBlockStatus with Error empty and IsCipher true. cat may
+    #    concatenate several JSON objects with or without separators, so parse
+    #    them with a raw_decode loop rather than splitting on a delimiter.
+    cbs=$(probe 'eve exec pillar sh -c "cat /run/nim/CipherBlockStatus/*.json 2>/dev/null"')
+    if echo "$cbs" | python3 -c '
+import sys,json
+buf=sys.stdin.read()
+dec=json.JSONDecoder(); i=0; n=len(buf); ok=False
+while i<n:
+    while i<n and buf[i] in " \t\r\n": i+=1
+    if i>=n: break
+    try: o,end=dec.raw_decode(buf,i)
+    except ValueError: i+=1; continue
+    i=end
+    if isinstance(o,dict) and o.get("IsCipher") and o.get("Error","")=="": ok=True
+sys.exit(0 if ok else 1)
+' 2>/dev/null; then cbs_ok=1; else cbs_ok=0; fi
+    echo "$(date +%H:%M:%S): dpc_has_ssid=$dpc_ok cipher_decrypted_ok=$cbs_ok"
+    if [ "$dpc_ok" = 1 ] && [ "$cbs_ok" = 1 ]; then
+        # log guard: the Error-level failure line for our SSID must be absent.
+        fail=$(probe "eve exec pillar sh -c \"find /persist/newlog -name 'dev.log.*' -exec zcat -f {} \\; 2>/dev/null | grep -a '$SSID, wifi config cipherblock decryption was unsuccessful' | head -1\"")
+        if [ -n "$fail" ]; then
+            echo "FAIL: found a decryption-unsuccessful log line for $SSID:" >&2
+            echo "  $fail" >&2
+            exit 1
+        fi
+        echo "OK: WiFi creds decrypted (DPC carries $SSID, CipherBlockStatus Error=='', no failure log)"
+        exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: did not observe a successful decrypt of $SSID within ${BUDGET}s" >&2
+echo "  last CipherBlockStatus:" >&2; echo "$cbs" >&2
+exit 1
+
+-- snapshot-identity.sh --
+#!/bin/bash
+# Snapshot pre-wipe identity + DPCL for the post-restore comparison:
+#   /tmp/f9-uuid            device UUID (/persist/status/uuid)
+#   /tmp/f9-certs           sorted list of /persist/certs/*.pem basenames
+#   /tmp/f9-dpcl-before.json  DevicePortConfigList global.json (raw)
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+probe() { timeout 20 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+uuid=$(probe 'eve exec pillar cat /persist/status/uuid' | tr -d '\r' | grep -E '^[0-9a-fA-F-]{36}$' | head -1)
+if [ -z "$uuid" ]; then echo "FAIL: could not read device UUID (/persist/status/uuid)" >&2; exit 1; fi
+echo "$uuid" > /tmp/f9-uuid
+probe 'eve exec pillar sh -c "ls /persist/certs/*.pem 2>/dev/null | xargs -n1 basename"' | tr -d '\r' | sort > /tmp/f9-certs
+probe 'eve exec pillar sh -c "cat /persist/status/nim/DevicePortConfigList/*.json 2>/dev/null"' > /tmp/f9-dpcl-before.json
+# Full pre-corruption /persist inventory (names + numeric owners + sizes) so the
+# post-restore state can be diffed to show what each corrupted file recovered to.
+probe 'eve exec pillar ls -laRn /persist' > /tmp/f11-persist-before.txt 2>/dev/null
+if [ ! -s /tmp/f9-certs ] || [ ! -s /tmp/f9-dpcl-before.json ]; then
+    echo "FAIL: empty certs list or DPCL snapshot" >&2; exit 1
+fi
+echo "OK: snapshot UUID=$uuid certs=$(wc -l </tmp/f9-certs) dpcl_bytes=$(wc -c </tmp/f9-dpcl-before.json) persist_before=$(wc -l </tmp/f11-persist-before.txt 2>/dev/null || echo 0)lines"
+
+-- backup-and-arm.sh --
+#!/bin/bash
+# Online backup of the critical files to the CONFIG PARTITION (runtime /config is
+# a ro tmpfs, so we mount PARTLABEL=CONFIG rw from the pillar ns, as baseosmgr's
+# withConfigPartitionRW does), then arm the skip-shrink marker. Ships a single
+# device-side script via base64 to avoid nested-quoting hell. The backup LOOPS
+# until the backed-up checkpoint carries the encrypted WiFi port (SSID) + the
+# ecdh cert — that content check is the gate that makes it safe to stop+wipe.
+# Usage: backup-and-arm.sh <ssid>
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+SSID="${1:?ssid}"
+
+read -r -d '' DEV_SCRIPT <<EOF
+#!/bin/sh
+set -u
+SSID="$SSID"
+TARGET="78G"
+CFGP=\$(findfs PARTLABEL=CONFIG) || { echo "FAIL: no CONFIG partition"; exit 1; }
+# Wait for the .bak fallbacks to be created before we stop+truncate. eve #6122
+# creates lastconfig.bak/controllercerts.bak on the first save, but a beat after
+# onboard -- and F11 keeps them intact to test the .bak fallback for the
+# no-validator checkpoint files (lastconfig, controllercerts). Bounded wait; the
+# device is still running here so pillar can create them.
+w=0
+while [ \$w -lt 36 ]; do
+    w=\$((w+1))
+    [ -f /persist/checkpoint/lastconfig.bak ] && [ -f /persist/checkpoint/controllercerts.bak ] && break
+    sleep 5
+done
+[ -f /persist/checkpoint/lastconfig.bak ] && [ -f /persist/checkpoint/controllercerts.bak ] \
+    && echo "both .bak fallbacks present after \${w} check(s)" \
+    || echo "WARN: .bak fallback(s) still absent after wait -- needs eve #6122 in the image"
+mkdir -p /tmp/f9cfg
+mountpoint -q /tmp/f9cfg || mount -t vfat -o rw,iocharset=iso8859-1 "\$CFGP" /tmp/f9cfg || { echo "FAIL: mount CONFIG rw"; exit 1; }
+ok=0; i=0
+while [ \$i -lt 18 ]; do
+    i=\$((i+1))
+    /usr/bin/storage-resizer backup --persist /persist --backup-dir /tmp/f9cfg/backup-persist --flag-file /tmp/f9cfg/repartition-inprogress --target "\$TARGET" >/dev/null 2>&1
+    if cat /tmp/f9cfg/backup-persist/checkpoint/lastconfig* 2>/dev/null | tr -d '\\0' | grep -q "\$SSID" && ls /tmp/f9cfg/backup-persist/certs/ecdh.*.pem >/dev/null 2>&1; then
+        ok=1; break
+    fi
+    sync; sleep 10
+done
+if [ "\$ok" != 1 ]; then
+    echo "FAIL: backup did not capture SSID \$SSID + ecdh cert in the checkpoint"
+    ls -la /tmp/f9cfg/backup-persist/checkpoint /tmp/f9cfg/backup-persist/certs 2>/dev/null
+    umount /tmp/f9cfg 2>/dev/null
+    exit 1
+fi
+# --- FIX-SIM (STAGE_ONBOARDINGSTATUS) -- disabled; re-enable for UNPATCHED images -
+# storage-resizer's defaultBackupPatterns must include the persistent OnboardingStatus
+# topic (the UUID that cmd/client's offline shortcut reads); without it the device
+# stays stuck at onboarding offline after a /persist wipe. Once the EVE image is
+# rebuilt with "status/zedclient/OnboardingStatus" added to defaultBackupPatterns
+# (pkg/storage-resizer/backup.go), the real backup covers it and this test passes as
+# is. To run against an UNPATCHED image, UNCOMMENT the two lines below to stage it
+# manually (validated: doing so makes the full test pass). /persist/status/uuid is
+# intentionally NOT staged -- cmd/client regenerates it from the restored
+# OnboardingStatus (os.Stat-missing forces the write).
+#mkdir -p /tmp/f9cfg/backup-persist/status/zedclient
+#cp -a /persist/status/zedclient/OnboardingStatus /tmp/f9cfg/backup-persist/status/zedclient/ 2>/dev/null || true
+# ---------------------------------------------------------------------------------
+REL=\$(tr -d '\\r\\n' < /hostfs/etc/eve-release 2>/dev/null); [ -n "\$REL" ] || REL=\$(tr -d '\\r\\n' < /run/eve-release 2>/dev/null)
+if [ -z "\$REL" ]; then echo "FAIL: could not read running eve-release for the marker"; umount /tmp/f9cfg 2>/dev/null; exit 1; fi
+printf '{"eve_release":"%s","step":"f9-test","rc":"0","ts":"f9"}' "\$REL" > /tmp/f9cfg/resize-failed.json
+sync
+umount /tmp/f9cfg
+echo "OK: backed up identity+checkpoint (SSID \$SSID present) and armed skip-shrink for \$REL"
+EOF
+
+B64=$(printf '%s' "$DEV_SCRIPT" | base64 -w0)
+out=$(timeout 300 "$EDEN" eve ssh -- "eve exec pillar sh -c 'echo $B64 | base64 -d > /tmp/f9-backup.sh; sh /tmp/f9-backup.sh'" 2>/dev/null | grep -v 'level=fatal')
+echo "$out"
+echo "$out" | grep -q '^OK:' || { echo "FAIL: backup-and-arm did not succeed on device" >&2; exit 1; }
+
+-- corrupt-persist-ondevice.sh --
+#!/bin/bash
+# ON-DEVICE partial corruption: truncate each backed-up critical file in the RUNNING
+# /persist to ~half its bytes, EXCEPT the .bak fallbacks (lastconfig.bak,
+# controllercerts.bak), then sync. On-device rather than an offline qemu-nbd mount:
+# that mount does NOT reliably reflect a fresh device's recent /persist writes (it
+# showed an empty checkpoint even after a guest sync + eve stop). The no-validator
+# files (lastconfig, controllercerts) recover via their .bak; the .pem/.json via the
+# restore-gate. The .bak were already waited-for in backup-and-arm; here we verify +
+# keep them. Ships a device-side script via base64.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+read -r -d '' DEV_SCRIPT <<'EOF'
+#!/bin/sh
+set -u
+FAIL=0; TRUNC=0
+for f in checkpoint/lastconfig checkpoint/controllercerts \
+         certs/ecdh.cert.pem certs/attest.cert.pem certs/ek.cert.pem \
+         status/nim/DevicePortConfigList/global.json status/zedclient/OnboardingStatus/global.json; do
+    p=/persist/$f
+    if [ ! -f "$p" ]; then echo "note: $f absent, skipping"; continue; fi
+    sz=$(stat -c%s "$p"); half=$((sz/2))
+    if truncate -s "$half" "$p"; then echo "truncated $f: $sz -> $half bytes"; TRUNC=$((TRUNC+1)); else echo "FAIL: truncate $f"; FAIL=1; fi
+done
+for b in checkpoint/lastconfig.bak checkpoint/controllercerts.bak; do
+    [ -f /persist/$b ] && echo "kept intact: $b ($(stat -c%s /persist/$b) bytes)" || echo "WARN: expected .bak missing: $b"
+done
+sync
+[ "$TRUNC" -ge 1 ] || { echo "FAIL: nothing truncated (target files absent on device?)"; FAIL=1; }
+[ "$FAIL" = 0 ] && echo "OK: on-device truncation done ($TRUNC files, .bak kept)" || echo "FAIL: on-device truncation errors"
+exit $FAIL
+EOF
+B64=$(printf '%s' "$DEV_SCRIPT" | base64 -w0)
+out=$(timeout 120 "$EDEN" eve ssh -- "eve exec pillar sh -c 'echo $B64 | base64 -d > /tmp/f11-corrupt.sh; sh /tmp/f11-corrupt.sh'" 2>/dev/null | grep -v 'level=fatal')
+echo "$out"
+echo "$out" | grep -q '^OK: on-device truncation done' || { echo "FAIL: on-device corruption did not complete" >&2; exit 1; }
+echo "$out" | grep -q 'truncated checkpoint/lastconfig:' || { echo "FAIL: lastconfig was not truncated (absent on device?)" >&2; exit 1; }
+
+-- wait-ssh-up.sh --
+#!/bin/bash
+# After a cold start (eve stop -> wipe -> eve start), wait for SSH to come up and
+# confirm a fresh boot (uptime < 300s). Not a reboot, so no "went down" phase.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+came_up=0
+for i in $(seq 1 66); do   # 66 * 10s = 11m
+    if timeout 8 "$EDEN" eve ssh 'true' 2>/dev/null; then
+        echo "$(date +%H:%M:%S) SSH online"; came_up=1; break
+    fi
+    sleep 10
+done
+if [ "$came_up" = "0" ]; then echo "FAIL: SSH did not come up within 11m of eve start" >&2; exit 1; fi
+uptime_secs=$(timeout 10 "$EDEN" eve ssh 'cat /proc/uptime' 2>/dev/null | tr -d '\r' | awk '{print int($1)}' | head -1)
+[ -n "$uptime_secs" ] || { echo "FAIL: could not read /proc/uptime" >&2; exit 1; }
+if [ "$uptime_secs" -gt 300 ]; then echo "FAIL: uptime $uptime_secs > 300s -- not a fresh boot?" >&2; exit 1; fi
+echo "OK: EVE up after corruption+restore, uptime ${uptime_secs}s"
+
+-- assert-identity-restored.sh --
+#!/bin/bash
+# Assert device identity survived the /persist wipe (restored from /config):
+#   - UUID unchanged vs the pre-wipe snapshot;
+#   - the same /persist/certs/*.pem basenames are present again.
+# Runs while the controller is DOWN, so success means offline recovery.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+probe() { timeout 20 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+before_uuid=$(cat /tmp/f9-uuid 2>/dev/null)
+[ -n "$before_uuid" ] || { echo "FAIL: no pre-wipe UUID snapshot" >&2; exit 1; }
+after_uuid=""
+for _ in $(seq 1 18); do
+    after_uuid=$(probe 'eve exec pillar cat /persist/status/uuid' | tr -d '\r' | grep -E '^[0-9a-fA-F-]{36}$' | head -1)
+    [ -n "$after_uuid" ] && break
+    sleep 10
+done
+if [ "$after_uuid" != "$before_uuid" ]; then
+    echo "FAIL: UUID changed across the corruption: before='$before_uuid' after='$after_uuid'" >&2
+    exit 1
+fi
+probe 'eve exec pillar sh -c "ls /persist/certs/*.pem 2>/dev/null | xargs -n1 basename"' | tr -d '\r' | sort > /tmp/f9-certs-after
+missing=$(comm -23 /tmp/f9-certs /tmp/f9-certs-after)
+if [ -n "$missing" ]; then
+    echo "FAIL: certs missing after restore:" >&2; echo "$missing" >&2
+    exit 1
+fi
+echo "OK: UUID preserved ($after_uuid) and all $(wc -l </tmp/f9-certs) certs restored (offline)"
+
+-- assert-dpcl-stable.sh --
+#!/bin/bash
+# Assert the restored DevicePortConfigList carries the SAME config as before the
+# wipe. global.json mixes config with runtime status, so strip the volatile
+# status/timestamp fields (types/dpc.go, types/conntest.go) and compare the rest:
+#   DPCL:            drop CurrentIndex
+#   per DevicePortConfig:   drop State, LastFailed, LastSucceeded, LastError,
+#                           LastWarning, LastIPAndDNS
+#   per NetworkPortConfig:  drop LastFailed, LastSucceeded, LastError, LastWarning
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+probe() { timeout 20 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+# Take the "after" snapshot once nim has settled a little.
+sleep 20
+probe 'eve exec pillar sh -c "cat /persist/status/nim/DevicePortConfigList/*.json 2>/dev/null"' > /tmp/f9-dpcl-after.json
+[ -s /tmp/f9-dpcl-after.json ] || { echo "FAIL: empty DPCL after restore" >&2; exit 1; }
+python3 - /tmp/f9-dpcl-before.json /tmp/f9-dpcl-after.json <<'PY'
+import sys, json
+# Volatile per-DPC fields. TimePriority is the config-submission timestamp; zedagent
+# re-stamps it when it re-applies the checkpointed config offline, so it changes
+# even though the port config content is identical.
+VOL_DPC  = {"State","LastFailed","LastSucceeded","LastError","LastWarning","LastIPAndDNS","TimePriority"}
+# Volatile per-port fields. ConfigSource is provenance (Origin + SubmittedAt) that
+# legitimately differs on an offline re-apply, not port config content.
+VOL_PORT = {"LastFailed","LastSucceeded","LastError","LastWarning","ConfigSource"}
+def norm(path):
+    with open(path) as f:
+        d = json.load(f)
+    d.pop("CurrentIndex", None)
+    for dpc in d.get("PortConfigList", []) or []:
+        for k in VOL_DPC: dpc.pop(k, None)
+        for p in dpc.get("Ports", []) or []:
+            for k in VOL_PORT: p.pop(k, None)
+    return json.dumps(d, sort_keys=True)
+b, a = norm(sys.argv[1]), norm(sys.argv[2])
+if b != a:
+    print("FAIL: DPCL config differs across wipe/restore (status-stripped)", file=sys.stderr)
+    print("BEFORE:", b[:800], file=sys.stderr)
+    print("AFTER :", a[:800], file=sys.stderr)
+    sys.exit(1)
+print("OK: DPCL config round-tripped unchanged (status-stripped)")
+PY
+
+-- assert-cleanup.sh --
+#!/bin/bash
+# Assert restore/cleanup ran: the repartition flag + backup dir are gone from the
+# CONFIG partition. Unlike F9, /persist was NOT reformatted (only files truncated;
+# the fs stayed intact), so restore does NOT stamp persist_recreated -- it must be
+# absent/false. Mounts CONFIG ro to read.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+read -r -d '' DEV_SCRIPT <<'EOF'
+#!/bin/sh
+set -u
+CFGP=$(findfs PARTLABEL=CONFIG) || { echo "FAIL: no CONFIG partition"; exit 1; }
+mkdir -p /tmp/f11chk
+mountpoint -q /tmp/f11chk || mount -t vfat -o ro,iocharset=iso8859-1 "$CFGP" /tmp/f11chk || { echo "FAIL: mount CONFIG ro"; exit 1; }
+rc=0
+if [ -e /tmp/f11chk/repartition-inprogress ]; then echo "FAIL: repartition-inprogress still present (restore/cleanup did not run)"; rc=1; fi
+if [ -d /tmp/f11chk/backup-persist ]; then echo "FAIL: backup-persist dir not cleaned up"; rc=1; fi
+# /persist was truncated in place, NOT reformatted: persist_recreated must NOT be true.
+if [ -f /tmp/f11chk/resize-failed.json ] && grep -q '"persist_recreated":true' /tmp/f11chk/resize-failed.json; then
+    echo "FAIL: persist_recreated:true set, but /persist was only truncated (not reformatted):"; cat /tmp/f11chk/resize-failed.json
+    rc=1
+fi
+umount /tmp/f11chk 2>/dev/null
+[ $rc = 0 ] && echo "OK: conversion bookkeeping cleaned up (persist not recreated)"
+exit $rc
+EOF
+B64=$(printf '%s' "$DEV_SCRIPT" | base64 -w0)
+out=$(timeout 60 "$EDEN" eve ssh -- "eve exec pillar sh -c 'echo $B64 | base64 -d > /tmp/f11-chk.sh; sh /tmp/f11-chk.sh'" 2>/dev/null | grep -v 'level=fatal')
+echo "$out"
+echo "$out" | grep -q 'bookkeeping cleaned up' || { echo "FAIL: cleanup assertions failed" >&2; exit 1; }
+
+-- record-persist-after.sh --
+#!/bin/bash
+# Record the full /persist inventory AFTER storage-init restore ran, and print the
+# recovery-relevant subtrees (checkpoint/certs/status) with sizes so the run shows
+# exactly what each corrupted file recovered to. Full before/after inventories are
+# saved to /tmp/f11-persist-{before,after}.txt for diffing (before is captured in
+# snapshot-identity.sh, pre-corruption).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+probe() { timeout 30 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+probe 'eve exec pillar ls -laRn /persist' > /tmp/f11-persist-after.txt 2>/dev/null
+echo "=== /persist checkpoint + certs + status after restore (size time name) ==="
+probe 'eve exec pillar ls -la --time-style=+%H:%M:%S /persist/checkpoint /persist/certs /persist/status/nim/DevicePortConfigList /persist/status/zedclient/OnboardingStatus 2>/dev/null'
+after_lines=$(wc -l < /tmp/f11-persist-after.txt 2>/dev/null || echo 0)
+before_lines=$(wc -l < /tmp/f11-persist-before.txt 2>/dev/null || echo 0)
+echo "OK: recorded /persist after restore (${after_lines} lines -> /tmp/f11-persist-after.txt; pre-corruption ${before_lines} lines -> /tmp/f11-persist-before.txt)"

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_backup_corrupt_restore.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_backup_corrupt_restore.txt
@@ -1,7 +1,7 @@
-# Test: kvm-to-k conversion fault case F11 — PARTIAL CORRUPTION of the backed-up
+# Test: kvm-to-k conversion fault case: backup-corruption restore — PARTIAL CORRUPTION of the backed-up
 # critical files in /persist (truncate each to ~half), and verify the device still
 # recovers WITH NO CONTROLLER REACHABLE via restore's per-type validity gate plus
-# pillar's .bak fallback. Sibling of the F9 (full-wipe) test.
+# pillar's .bak fallback. Sibling of the persist-wipe test.
 #
 # This does NOT run a real shrink/grow and does NOT wipe /persist. It exercises the
 # backup->corrupt->restore fail-safe against PARTIAL corruption: an online
@@ -43,7 +43,7 @@
 # -- see the disabled FIX-SIM block in backup-and-arm.sh, which you can uncomment
 # to run against an UNPATCHED image.
 #
-# Sibling of the F9 (full-wipe) test; it reuses F9's setup and assertions with the
+# Sibling of the persist-wipe test; it reuses the persist-wipe test's setup and assertions with the
 # wipe replaced by the on-device truncation below. Run it against an image carrying
 # both the #6063 OnboardingStatus backup and the #6122 .bak-on-first-save fixes
 # (e.g. resize-allprs). What it proves: the no-validator checkpoint files
@@ -85,7 +85,7 @@
 {{if $skip_hop_env}}{{$skip_hop = $skip_hop_env}}{{end}}
 
 {{$kvm_short := printf "%s-kvm-%s" $resize_ver $arch}}
-{{$ssid := "eden-f9"}}
+{{$ssid := "eden-restore"}}
 
 # Step 0: pre-flight. Fail fast if the version param wasn't supplied, confirm a
 # clean device, and shorten the baseimage commit timer so the kvm hop applies fast.
@@ -96,7 +96,7 @@ eden -t 1m pod ps
 eden controller edge-node update --config timer.test.baseimage.update=30
 
 # Step 1: get the device onto the resize-capable kvm build so /usr/bin/storage-resizer
-# + the storage-init restore hooks exist. (Geometry is irrelevant to F9 — no
+# + the storage-init restore hooks exist. (Geometry is irrelevant to this test — no
 # conversion happens.) Two paths:
 #   SKIP_KVM_HOP unset: bring up on the SMALL bringup release, then kvm->kvm
 #                       upgrade to the resize image (matches the sibling escripts).
@@ -123,7 +123,7 @@ exec -t 25m bash wait-for-upgrade.sh {{ $kvm_short }}
 # BASELINE decrypt (proves the port was ingested + decrypted pre-wipe), then
 # snapshot identity + the DPCL for the post-restore comparison.
 message 'injecting encrypted WiFi port (eden PR #1202 add-wireless)'
-eden -t 2m controller edge-node add-wireless --port wlan0 --ssid {{ $ssid }} --password eden-f9-psk
+eden -t 2m controller edge-node add-wireless --port wlan0 --ssid {{ $ssid }} --password eden-restore-psk
 ! stderr 'level=fatal'
 message 'waiting for BASELINE decrypt (pre-wipe) of the WiFi creds'
 exec -t 5m bash assert-decrypt.sh {{ $ssid }} 240
@@ -292,24 +292,24 @@ exit 1
 -- snapshot-identity.sh --
 #!/bin/bash
 # Snapshot pre-wipe identity + DPCL for the post-restore comparison:
-#   /tmp/f9-uuid            device UUID (/persist/status/uuid)
-#   /tmp/f9-certs           sorted list of /persist/certs/*.pem basenames
-#   /tmp/f9-dpcl-before.json  DevicePortConfigList global.json (raw)
+#   /tmp/restore-uuid            device UUID (/persist/status/uuid)
+#   /tmp/restore-certs           sorted list of /persist/certs/*.pem basenames
+#   /tmp/restore-dpcl-before.json  DevicePortConfigList global.json (raw)
 set -uo pipefail
 EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
 probe() { timeout 20 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
 uuid=$(probe 'eve exec pillar cat /persist/status/uuid' | tr -d '\r' | grep -E '^[0-9a-fA-F-]{36}$' | head -1)
 if [ -z "$uuid" ]; then echo "FAIL: could not read device UUID (/persist/status/uuid)" >&2; exit 1; fi
-echo "$uuid" > /tmp/f9-uuid
-probe 'eve exec pillar sh -c "ls /persist/certs/*.pem 2>/dev/null | xargs -n1 basename"' | tr -d '\r' | sort > /tmp/f9-certs
-probe 'eve exec pillar sh -c "cat /persist/status/nim/DevicePortConfigList/*.json 2>/dev/null"' > /tmp/f9-dpcl-before.json
+echo "$uuid" > /tmp/restore-uuid
+probe 'eve exec pillar sh -c "ls /persist/certs/*.pem 2>/dev/null | xargs -n1 basename"' | tr -d '\r' | sort > /tmp/restore-certs
+probe 'eve exec pillar sh -c "cat /persist/status/nim/DevicePortConfigList/*.json 2>/dev/null"' > /tmp/restore-dpcl-before.json
 # Full pre-corruption /persist inventory (names + numeric owners + sizes) so the
 # post-restore state can be diffed to show what each corrupted file recovered to.
-probe 'eve exec pillar ls -laRn /persist' > /tmp/f11-persist-before.txt 2>/dev/null
-if [ ! -s /tmp/f9-certs ] || [ ! -s /tmp/f9-dpcl-before.json ]; then
+probe 'eve exec pillar ls -laRn /persist' > /tmp/restore-persist-before.txt 2>/dev/null
+if [ ! -s /tmp/restore-certs ] || [ ! -s /tmp/restore-dpcl-before.json ]; then
     echo "FAIL: empty certs list or DPCL snapshot" >&2; exit 1
 fi
-echo "OK: snapshot UUID=$uuid certs=$(wc -l </tmp/f9-certs) dpcl_bytes=$(wc -c </tmp/f9-dpcl-before.json) persist_before=$(wc -l </tmp/f11-persist-before.txt 2>/dev/null || echo 0)lines"
+echo "OK: snapshot UUID=$uuid certs=$(wc -l </tmp/restore-certs) dpcl_bytes=$(wc -c </tmp/restore-dpcl-before.json) persist_before=$(wc -l </tmp/restore-persist-before.txt 2>/dev/null || echo 0)lines"
 
 -- backup-and-arm.sh --
 #!/bin/bash
@@ -332,7 +332,7 @@ TARGET="78G"
 CFGP=\$(findfs PARTLABEL=CONFIG) || { echo "FAIL: no CONFIG partition"; exit 1; }
 # Wait for the .bak fallbacks to be created before we stop+truncate. eve #6122
 # creates lastconfig.bak/controllercerts.bak on the first save, but a beat after
-# onboard -- and F11 keeps them intact to test the .bak fallback for the
+# onboard -- and this test keeps them intact to test the .bak fallback for the
 # no-validator checkpoint files (lastconfig, controllercerts). Bounded wait; the
 # device is still running here so pillar can create them.
 w=0
@@ -344,21 +344,21 @@ done
 [ -f /persist/checkpoint/lastconfig.bak ] && [ -f /persist/checkpoint/controllercerts.bak ] \
     && echo "both .bak fallbacks present after \${w} check(s)" \
     || echo "WARN: .bak fallback(s) still absent after wait -- needs eve #6122 in the image"
-mkdir -p /tmp/f9cfg
-mountpoint -q /tmp/f9cfg || mount -t vfat -o rw,iocharset=iso8859-1 "\$CFGP" /tmp/f9cfg || { echo "FAIL: mount CONFIG rw"; exit 1; }
+mkdir -p /tmp/restore-cfg
+mountpoint -q /tmp/restore-cfg || mount -t vfat -o rw,iocharset=iso8859-1 "\$CFGP" /tmp/restore-cfg || { echo "FAIL: mount CONFIG rw"; exit 1; }
 ok=0; i=0
 while [ \$i -lt 18 ]; do
     i=\$((i+1))
-    /usr/bin/storage-resizer backup --persist /persist --backup-dir /tmp/f9cfg/backup-persist --flag-file /tmp/f9cfg/repartition-inprogress --target "\$TARGET" >/dev/null 2>&1
-    if cat /tmp/f9cfg/backup-persist/checkpoint/lastconfig* 2>/dev/null | tr -d '\\0' | grep -q "\$SSID" && ls /tmp/f9cfg/backup-persist/certs/ecdh.*.pem >/dev/null 2>&1; then
+    /usr/bin/storage-resizer backup --persist /persist --backup-dir /tmp/restore-cfg/backup-persist --flag-file /tmp/restore-cfg/repartition-inprogress --target "\$TARGET" >/dev/null 2>&1
+    if cat /tmp/restore-cfg/backup-persist/checkpoint/lastconfig* 2>/dev/null | tr -d '\\0' | grep -q "\$SSID" && ls /tmp/restore-cfg/backup-persist/certs/ecdh.*.pem >/dev/null 2>&1; then
         ok=1; break
     fi
     sync; sleep 10
 done
 if [ "\$ok" != 1 ]; then
     echo "FAIL: backup did not capture SSID \$SSID + ecdh cert in the checkpoint"
-    ls -la /tmp/f9cfg/backup-persist/checkpoint /tmp/f9cfg/backup-persist/certs 2>/dev/null
-    umount /tmp/f9cfg 2>/dev/null
+    ls -la /tmp/restore-cfg/backup-persist/checkpoint /tmp/restore-cfg/backup-persist/certs 2>/dev/null
+    umount /tmp/restore-cfg 2>/dev/null
     exit 1
 fi
 # --- FIX-SIM (STAGE_ONBOARDINGSTATUS) -- disabled; re-enable for UNPATCHED images -
@@ -371,19 +371,19 @@ fi
 # manually (validated: doing so makes the full test pass). /persist/status/uuid is
 # intentionally NOT staged -- cmd/client regenerates it from the restored
 # OnboardingStatus (os.Stat-missing forces the write).
-#mkdir -p /tmp/f9cfg/backup-persist/status/zedclient
-#cp -a /persist/status/zedclient/OnboardingStatus /tmp/f9cfg/backup-persist/status/zedclient/ 2>/dev/null || true
+#mkdir -p /tmp/restore-cfg/backup-persist/status/zedclient
+#cp -a /persist/status/zedclient/OnboardingStatus /tmp/restore-cfg/backup-persist/status/zedclient/ 2>/dev/null || true
 # ---------------------------------------------------------------------------------
 REL=\$(tr -d '\\r\\n' < /hostfs/etc/eve-release 2>/dev/null); [ -n "\$REL" ] || REL=\$(tr -d '\\r\\n' < /run/eve-release 2>/dev/null)
-if [ -z "\$REL" ]; then echo "FAIL: could not read running eve-release for the marker"; umount /tmp/f9cfg 2>/dev/null; exit 1; fi
-printf '{"eve_release":"%s","step":"f9-test","rc":"0","ts":"f9"}' "\$REL" > /tmp/f9cfg/resize-failed.json
+if [ -z "\$REL" ]; then echo "FAIL: could not read running eve-release for the marker"; umount /tmp/restore-cfg 2>/dev/null; exit 1; fi
+printf '{"eve_release":"%s","step":"restore-test","rc":"0","ts":"restore"}' "\$REL" > /tmp/restore-cfg/resize-failed.json
 sync
-umount /tmp/f9cfg
+umount /tmp/restore-cfg
 echo "OK: backed up identity+checkpoint (SSID \$SSID present) and armed skip-shrink for \$REL"
 EOF
 
 B64=$(printf '%s' "$DEV_SCRIPT" | base64 -w0)
-out=$(timeout 300 "$EDEN" eve ssh -- "eve exec pillar sh -c 'echo $B64 | base64 -d > /tmp/f9-backup.sh; sh /tmp/f9-backup.sh'" 2>/dev/null | grep -v 'level=fatal')
+out=$(timeout 300 "$EDEN" eve ssh -- "eve exec pillar sh -c 'echo $B64 | base64 -d > /tmp/restore-backup.sh; sh /tmp/restore-backup.sh'" 2>/dev/null | grep -v 'level=fatal')
 echo "$out"
 echo "$out" | grep -q '^OK:' || { echo "FAIL: backup-and-arm did not succeed on device" >&2; exit 1; }
 
@@ -420,7 +420,7 @@ sync
 exit $FAIL
 EOF
 B64=$(printf '%s' "$DEV_SCRIPT" | base64 -w0)
-out=$(timeout 120 "$EDEN" eve ssh -- "eve exec pillar sh -c 'echo $B64 | base64 -d > /tmp/f11-corrupt.sh; sh /tmp/f11-corrupt.sh'" 2>/dev/null | grep -v 'level=fatal')
+out=$(timeout 120 "$EDEN" eve ssh -- "eve exec pillar sh -c 'echo $B64 | base64 -d > /tmp/restore-corrupt.sh; sh /tmp/restore-corrupt.sh'" 2>/dev/null | grep -v 'level=fatal')
 echo "$out"
 echo "$out" | grep -q '^OK: on-device truncation done' || { echo "FAIL: on-device corruption did not complete" >&2; exit 1; }
 echo "$out" | grep -q 'truncated checkpoint/lastconfig:' || { echo "FAIL: lastconfig was not truncated (absent on device?)" >&2; exit 1; }
@@ -453,7 +453,7 @@ echo "OK: EVE up after corruption+restore, uptime ${uptime_secs}s"
 set -uo pipefail
 EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
 probe() { timeout 20 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
-before_uuid=$(cat /tmp/f9-uuid 2>/dev/null)
+before_uuid=$(cat /tmp/restore-uuid 2>/dev/null)
 [ -n "$before_uuid" ] || { echo "FAIL: no pre-wipe UUID snapshot" >&2; exit 1; }
 after_uuid=""
 for _ in $(seq 1 18); do
@@ -465,13 +465,13 @@ if [ "$after_uuid" != "$before_uuid" ]; then
     echo "FAIL: UUID changed across the corruption: before='$before_uuid' after='$after_uuid'" >&2
     exit 1
 fi
-probe 'eve exec pillar sh -c "ls /persist/certs/*.pem 2>/dev/null | xargs -n1 basename"' | tr -d '\r' | sort > /tmp/f9-certs-after
-missing=$(comm -23 /tmp/f9-certs /tmp/f9-certs-after)
+probe 'eve exec pillar sh -c "ls /persist/certs/*.pem 2>/dev/null | xargs -n1 basename"' | tr -d '\r' | sort > /tmp/restore-certs-after
+missing=$(comm -23 /tmp/restore-certs /tmp/restore-certs-after)
 if [ -n "$missing" ]; then
     echo "FAIL: certs missing after restore:" >&2; echo "$missing" >&2
     exit 1
 fi
-echo "OK: UUID preserved ($after_uuid) and all $(wc -l </tmp/f9-certs) certs restored (offline)"
+echo "OK: UUID preserved ($after_uuid) and all $(wc -l </tmp/restore-certs) certs restored (offline)"
 
 -- assert-dpcl-stable.sh --
 #!/bin/bash
@@ -487,9 +487,9 @@ EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "ed
 probe() { timeout 20 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
 # Take the "after" snapshot once nim has settled a little.
 sleep 20
-probe 'eve exec pillar sh -c "cat /persist/status/nim/DevicePortConfigList/*.json 2>/dev/null"' > /tmp/f9-dpcl-after.json
-[ -s /tmp/f9-dpcl-after.json ] || { echo "FAIL: empty DPCL after restore" >&2; exit 1; }
-python3 - /tmp/f9-dpcl-before.json /tmp/f9-dpcl-after.json <<'PY'
+probe 'eve exec pillar sh -c "cat /persist/status/nim/DevicePortConfigList/*.json 2>/dev/null"' > /tmp/restore-dpcl-after.json
+[ -s /tmp/restore-dpcl-after.json ] || { echo "FAIL: empty DPCL after restore" >&2; exit 1; }
+python3 - /tmp/restore-dpcl-before.json /tmp/restore-dpcl-after.json <<'PY'
 import sys, json
 # Volatile per-DPC fields. TimePriority is the config-submission timestamp; zedagent
 # re-stamps it when it re-applies the checkpointed config offline, so it changes
@@ -519,7 +519,7 @@ PY
 -- assert-cleanup.sh --
 #!/bin/bash
 # Assert restore/cleanup ran: the repartition flag + backup dir are gone from the
-# CONFIG partition. Unlike F9, /persist was NOT reformatted (only files truncated;
+# CONFIG partition. Unlike the persist-wipe test, /persist was NOT reformatted (only files truncated;
 # the fs stayed intact), so restore does NOT stamp persist_recreated -- it must be
 # absent/false. Mounts CONFIG ro to read.
 set -uo pipefail
@@ -528,22 +528,22 @@ read -r -d '' DEV_SCRIPT <<'EOF'
 #!/bin/sh
 set -u
 CFGP=$(findfs PARTLABEL=CONFIG) || { echo "FAIL: no CONFIG partition"; exit 1; }
-mkdir -p /tmp/f11chk
-mountpoint -q /tmp/f11chk || mount -t vfat -o ro,iocharset=iso8859-1 "$CFGP" /tmp/f11chk || { echo "FAIL: mount CONFIG ro"; exit 1; }
+mkdir -p /tmp/restore-chk
+mountpoint -q /tmp/restore-chk || mount -t vfat -o ro,iocharset=iso8859-1 "$CFGP" /tmp/restore-chk || { echo "FAIL: mount CONFIG ro"; exit 1; }
 rc=0
-if [ -e /tmp/f11chk/repartition-inprogress ]; then echo "FAIL: repartition-inprogress still present (restore/cleanup did not run)"; rc=1; fi
-if [ -d /tmp/f11chk/backup-persist ]; then echo "FAIL: backup-persist dir not cleaned up"; rc=1; fi
+if [ -e /tmp/restore-chk/repartition-inprogress ]; then echo "FAIL: repartition-inprogress still present (restore/cleanup did not run)"; rc=1; fi
+if [ -d /tmp/restore-chk/backup-persist ]; then echo "FAIL: backup-persist dir not cleaned up"; rc=1; fi
 # /persist was truncated in place, NOT reformatted: persist_recreated must NOT be true.
-if [ -f /tmp/f11chk/resize-failed.json ] && grep -q '"persist_recreated":true' /tmp/f11chk/resize-failed.json; then
-    echo "FAIL: persist_recreated:true set, but /persist was only truncated (not reformatted):"; cat /tmp/f11chk/resize-failed.json
+if [ -f /tmp/restore-chk/resize-failed.json ] && grep -q '"persist_recreated":true' /tmp/restore-chk/resize-failed.json; then
+    echo "FAIL: persist_recreated:true set, but /persist was only truncated (not reformatted):"; cat /tmp/restore-chk/resize-failed.json
     rc=1
 fi
-umount /tmp/f11chk 2>/dev/null
+umount /tmp/restore-chk 2>/dev/null
 [ $rc = 0 ] && echo "OK: conversion bookkeeping cleaned up (persist not recreated)"
 exit $rc
 EOF
 B64=$(printf '%s' "$DEV_SCRIPT" | base64 -w0)
-out=$(timeout 60 "$EDEN" eve ssh -- "eve exec pillar sh -c 'echo $B64 | base64 -d > /tmp/f11-chk.sh; sh /tmp/f11-chk.sh'" 2>/dev/null | grep -v 'level=fatal')
+out=$(timeout 60 "$EDEN" eve ssh -- "eve exec pillar sh -c 'echo $B64 | base64 -d > /tmp/restore-chk.sh; sh /tmp/restore-chk.sh'" 2>/dev/null | grep -v 'level=fatal')
 echo "$out"
 echo "$out" | grep -q 'bookkeeping cleaned up' || { echo "FAIL: cleanup assertions failed" >&2; exit 1; }
 
@@ -552,14 +552,14 @@ echo "$out" | grep -q 'bookkeeping cleaned up' || { echo "FAIL: cleanup assertio
 # Record the full /persist inventory AFTER storage-init restore ran, and print the
 # recovery-relevant subtrees (checkpoint/certs/status) with sizes so the run shows
 # exactly what each corrupted file recovered to. Full before/after inventories are
-# saved to /tmp/f11-persist-{before,after}.txt for diffing (before is captured in
+# saved to /tmp/restore-persist-{before,after}.txt for diffing (before is captured in
 # snapshot-identity.sh, pre-corruption).
 set -uo pipefail
 EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
 probe() { timeout 30 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
-probe 'eve exec pillar ls -laRn /persist' > /tmp/f11-persist-after.txt 2>/dev/null
+probe 'eve exec pillar ls -laRn /persist' > /tmp/restore-persist-after.txt 2>/dev/null
 echo "=== /persist checkpoint + certs + status after restore (size time name) ==="
 probe 'eve exec pillar ls -la --time-style=+%H:%M:%S /persist/checkpoint /persist/certs /persist/status/nim/DevicePortConfigList /persist/status/zedclient/OnboardingStatus 2>/dev/null'
-after_lines=$(wc -l < /tmp/f11-persist-after.txt 2>/dev/null || echo 0)
-before_lines=$(wc -l < /tmp/f11-persist-before.txt 2>/dev/null || echo 0)
-echo "OK: recorded /persist after restore (${after_lines} lines -> /tmp/f11-persist-after.txt; pre-corruption ${before_lines} lines -> /tmp/f11-persist-before.txt)"
+after_lines=$(wc -l < /tmp/restore-persist-after.txt 2>/dev/null || echo 0)
+before_lines=$(wc -l < /tmp/restore-persist-before.txt 2>/dev/null || echo 0)
+echo "OK: recorded /persist after restore (${after_lines} lines -> /tmp/restore-persist-after.txt; pre-corruption ${before_lines} lines -> /tmp/restore-persist-before.txt)"

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_backup_corrupt_restore.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_backup_corrupt_restore.txt
@@ -140,6 +140,8 @@ exec -t 6m bash backup-and-arm.sh {{ $ssid }}
 # critical file to ~half in the live /persist (via eve exec pillar), EXCEPT the
 # .bak files, then sync. On-device (not an offline qemu-nbd mount) because the
 # offline mount does not reliably reflect a fresh device's recent /persist writes.
+# The kept .bak must be no older than the config being truncated — step 3 refreshes
+# it, and this step fails if it is older.
 message 'partial corruption: truncate critical /persist files to half on-device (keep .bak)'
 exec -t 3m bash corrupt-persist-ondevice.sh
 
@@ -350,7 +352,7 @@ ok=0; i=0
 while [ \$i -lt 18 ]; do
     i=\$((i+1))
     /usr/bin/storage-resizer backup --persist /persist --backup-dir /tmp/restore-cfg/backup-persist --flag-file /tmp/restore-cfg/repartition-inprogress --target "\$TARGET" >/dev/null 2>&1
-    if cat /tmp/restore-cfg/backup-persist/checkpoint/lastconfig* 2>/dev/null | tr -d '\\0' | grep -q "\$SSID" && ls /tmp/restore-cfg/backup-persist/certs/ecdh.*.pem >/dev/null 2>&1; then
+    if tr -d '\\0' < /tmp/restore-cfg/backup-persist/checkpoint/lastconfig 2>/dev/null | grep -q "\$SSID" && ls /tmp/restore-cfg/backup-persist/certs/ecdh.*.pem >/dev/null 2>&1; then
         ok=1; break
     fi
     sync; sleep 10
@@ -361,6 +363,23 @@ if [ "\$ok" != 1 ]; then
     umount /tmp/restore-cfg 2>/dev/null
     exit 1
 fi
+# The corruption step truncates checkpoint/lastconfig and keeps lastconfig.bak, and
+# storage-resizer's needsRestore has a validator only for .pem and .json, so it keeps
+# the truncated live copy and pillar falls back to the .bak. Pillar's rotation moves
+# the OLD primary into .bak, so the .bak predates the add-wireless injection until a
+# further config save happens; a stale one leaves zedagent republishing a DPC without
+# wlan0, which no amount of polling in assert-decrypt.sh can fix. Refresh the
+# fallback from the primary this loop just gated on.
+cp /persist/checkpoint/lastconfig /persist/checkpoint/lastconfig.bak || {
+    echo "FAIL: could not refresh lastconfig.bak from the gated primary"
+    umount /tmp/restore-cfg 2>/dev/null
+    exit 1; }
+sync
+tr -d '\\0' < /persist/checkpoint/lastconfig.bak | grep -q "\$SSID" || {
+    echo "FAIL: lastconfig.bak does not carry SSID \$SSID after the refresh"
+    umount /tmp/restore-cfg 2>/dev/null
+    exit 1; }
+echo "lastconfig.bak refreshed from the primary (\$(stat -c%s /persist/checkpoint/lastconfig.bak) bytes, carries \$SSID)"
 # --- FIX-SIM (STAGE_ONBOARDINGSTATUS) -- disabled; re-enable for UNPATCHED images -
 # storage-resizer's defaultBackupPatterns must include the persistent OnboardingStatus
 # topic (the UUID that cmd/client's offline shortcut reads); without it the device
@@ -395,8 +414,9 @@ echo "$out" | grep -q '^OK:' || { echo "FAIL: backup-and-arm did not succeed on 
 # that mount does NOT reliably reflect a fresh device's recent /persist writes (it
 # showed an empty checkpoint even after a guest sync + eve stop). The no-validator
 # files (lastconfig, controllercerts) recover via their .bak; the .pem/.json via the
-# restore-gate. The .bak were already waited-for in backup-and-arm; here we verify +
-# keep them. Ships a device-side script via base64.
+# restore-gate. The .bak were waited for and refreshed in backup-and-arm; here we
+# keep them and verify they are no older than what we truncate. Ships a device-side
+# script via base64.
 set -uo pipefail
 EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
 read -r -d '' DEV_SCRIPT <<'EOF'
@@ -409,11 +429,20 @@ for f in checkpoint/lastconfig checkpoint/controllercerts \
     p=/persist/$f
     if [ ! -f "$p" ]; then echo "note: $f absent, skipping"; continue; fi
     sz=$(stat -c%s "$p"); half=$((sz/2))
+    [ "$f" = checkpoint/lastconfig ] && LC_SZ=$sz
     if truncate -s "$half" "$p"; then echo "truncated $f: $sz -> $half bytes"; TRUNC=$((TRUNC+1)); else echo "FAIL: truncate $f"; FAIL=1; fi
 done
 for b in checkpoint/lastconfig.bak checkpoint/controllercerts.bak; do
     [ -f /persist/$b ] && echo "kept intact: $b ($(stat -c%s /persist/$b) bytes)" || echo "WARN: expected .bak missing: $b"
 done
+# pillar reads this .bak for the config it republishes, so a fallback older than the
+# config just truncated fails the post-restore DPC assert 240s later, at a step that
+# looks unrelated. Fail here instead.
+BAK_SZ=$(stat -c%s /persist/checkpoint/lastconfig.bak 2>/dev/null || echo 0)
+if [ "${LC_SZ:-0}" -gt 0 ] && [ "$BAK_SZ" -lt "$LC_SZ" ]; then
+    echo "FAIL: lastconfig.bak ($BAK_SZ B) is older than the pre-truncation lastconfig ($LC_SZ B)"
+    FAIL=1
+fi
 sync
 [ "$TRUNC" -ge 1 ] || { echo "FAIL: nothing truncated (target files absent on device?)"; FAIL=1; }
 [ "$FAIL" = 0 ] && echo "OK: on-device truncation done ($TRUNC files, .bak kept)" || echo "FAIL: on-device truncation errors"

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_geom.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_geom.txt
@@ -1,0 +1,458 @@
+# Test: EVE-kvm -> EVE-k boot-disk repartition, GEOMETRY ONLY, parameterized by
+# the STARTING release. One escript, many starts: the matrix runner
+# (run-kvm-to-k-geom-matrix.sh) brings EVE up on each release in turn and runs
+# this with BRINGUP_EVE_VER + the expected start sizes.
+#
+# Unlike update_eve_image_kvm_to_k_resize.txt this deliberately does NOT deploy an
+# app, defer content-tree deletes, or check blob reuse or the TPM seal. It proves
+# exactly one thing: whatever the starting geometry, driving kvm->k ends with the
+# full EVE-k target layout of 2+2+10+10 GiB, i.e. ESP-A 2G, the reserved ESP-B 2G,
+# IMGA 10G, IMGB 10G.
+#
+# Image sequence (same three-hop shape as the resize test):
+#   1. START     : EVE up on the parameterized BRINGUP_EVE_VER (a stock release
+#                  whose geometry is asserted against START_* below). Does NOT carry
+#                  the conversion code.
+#   2. kvm hop   : BaseOs-update kvm->kvm to the conversion-capable RESIZE_EVE_VER
+#                  build. Same geometry; lands the conversion code.
+#   3. k image   : BaseOs-update kvm->k. The cross-flavor seam arms the offline
+#                  repartition; storage-init grows the disk to the EVE-k target.
+#
+# NOTE (TDD): as of this writing the in-field resizer (pkg/storage-resizer,
+# sizecheck.go: espTargetBytes=2G, imgTargetBytes=10G, spaceNeededBytes=2+10+10)
+# grows only ESP/IMGA/IMGB and does NOT create the reserved ESP-B. So the final
+# assertion FAILS until the conversion is taught to carve ESP-B. This escript is
+# the spec for that work.
+#
+# Parameters (env):
+#   RESIZE_EVE_VER  (required) version base of the local conversion-capable images,
+#                   without the -<hv>-<arch> suffix, e.g. "0.0.0-kvm-to-k-resize-<sha>".
+#   RESIZE_EVE_REG  (default lfedge/eve) image registry/repo namespace.
+#   BRINGUP_EVE_VER (required) the starting release EVE was brought up on; asserted
+#                   as a substring of /run/eve-release. No default — the runner
+#                   sets it per release.
+#   START_ESP_MIB   (default 0) expected starting ESP-A size in MiB; 0 skips the
+#   START_IMGA_MIB  (default 0)  size band check for that partition (presence and
+#   START_IMGB_MIB  (default 0)  the ESP-B flag are always checked).
+#   START_HAS_ESPB  (default 0) 1 if the starting image already has the reserved
+#                   ESP-B (only the TBD post-ESP-B releases do).
+
+{{$arch := EdenConfig "eve.arch"}}
+
+{{$resize_ver_env := EdenGetEnv "RESIZE_EVE_VER"}}
+{{$resize_ver := "REPLACE-WITH-RESIZE-VERSION"}}
+{{if $resize_ver_env}}{{$resize_ver = $resize_ver_env}}{{end}}
+
+{{$resize_reg_env := EdenGetEnv "RESIZE_EVE_REG"}}
+{{$resize_reg := "lfedge/eve"}}
+{{if $resize_reg_env}}{{$resize_reg = $resize_reg_env}}{{end}}
+
+{{$bringup_ver_env := EdenGetEnv "BRINGUP_EVE_VER"}}
+{{$bringup_ver := ""}}
+{{if $bringup_ver_env}}{{$bringup_ver = $bringup_ver_env}}{{end}}
+
+{{$start_esp := EdenGetEnv "START_ESP_MIB"}}{{if not $start_esp}}{{$start_esp = "0"}}{{end}}
+{{$start_imga := EdenGetEnv "START_IMGA_MIB"}}{{if not $start_imga}}{{$start_imga = "0"}}{{end}}
+{{$start_imgb := EdenGetEnv "START_IMGB_MIB"}}{{if not $start_imgb}}{{$start_imgb = "0"}}{{end}}
+{{$start_espb := EdenGetEnv "START_HAS_ESPB"}}{{if not $start_espb}}{{$start_espb = "0"}}{{end}}
+
+{{$kvm_short := printf "%s-kvm-%s" $resize_ver $arch}}
+{{$k_short   := printf "%s-k-%s" $resize_ver $arch}}
+
+# Step 0: pre-flight. Fail fast on missing params and a dirty device; shorten the
+# baseimage commit timer so updates apply fast.
+message 'pre-flight: parameters + clean state'
+exec -t 1m bash require-resize-ver.sh
+exec -t 1m bash require-bringup-ver.sh
+exec -t 1m bash assert-no-volumes.sh
+eden -t 1m pod ps
+! stdout 'IN_CONFIG'
+eden controller edge-node update --config timer.test.baseimage.update=30
+
+# Step 1: confirm the starting release and its geometry (parameterized per release).
+message 'baseline: confirm we are on the expected START release'
+exec -t 3m bash assert-running-version.sh {{ $bringup_ver }}
+message 'baseline: confirm the expected START boot-disk geometry'
+exec -t 2m bash capture-geom.sh assert-start {{ $start_esp }} {{ $start_imga }} {{ $start_imgb }} {{ $start_espb }}
+
+# Step 2: BaseOs-update kvm->kvm to the conversion-capable build. Same geometry;
+# this only lands the conversion code.
+message 'downloading conversion-capable kvm rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$resize_ver}} --eve-hv=kvm --eve-registry={{$resize_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs'
+
+message 'pushing kvm->kvm BaseOs update (lands conversion code, geometry unchanged)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs --os-version={{ $kvm_short }} -m adam://
+! stderr .
+
+message 'waiting for kvm->kvm upgrade to complete'
+exec -t 25m bash wait-for-upgrade.sh {{ $kvm_short }}
+
+# A same-flavor upgrade must NOT repartition — re-assert the START geometry so a
+# regression that resizes on a kvm->kvm hop is caught here.
+message 'post-kvm-upgrade: geometry must be UNCHANGED'
+exec -t 2m bash capture-geom.sh assert-start {{ $start_esp }} {{ $start_imga }} {{ $start_imgb }} {{ $start_espb }}
+
+# Step 3: BaseOs-update kvm->k. The cross-flavor seam triggers the offline
+# repartition; watch it to completion (state/sub-state transitions), tolerating the
+# reboots the offline resize needs.
+message 'downloading conversion-capable k rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$resize_ver}} --eve-hv=k --eve-registry={{$resize_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs'
+
+message 'pushing kvm->k BaseOs update (triggers boot-disk repartition)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs --os-version={{ $k_short }} -m adam://
+! stderr .
+
+message 'waiting for + watching the kvm->k repartition (logging state transitions)'
+# 90m budget: a start whose IMGA/IMGB must GROW (e.g. 16.13.0's 4->10 GiB) copies
+# several GiB during the online grow, which on constrained I/O can take ~30m before
+# the offline shrink + EVE-k boot even begin. Starts that only create ESP-B (17.0.0)
+# or copy tiny partitions (10.1.0/12.1.0) finish far sooner.
+exec -t 90m bash watch-conversion-geom.sh {{ $k_short }}
+
+# Step 4: the one assertion — the boot disk ended on the full EVE-k target of
+# 2+2+10+10 (ESP-A 2G, reserved ESP-B 2G, IMGA 10G, IMGB 10G).
+message 'asserting final boot-disk geometry: 2+2+10+10 (ESP-A, ESP-B, IMGA, IMGB)'
+exec -t 2m bash capture-geom.sh assert-final
+
+# Cleanup.
+message 'cleanup'
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs.ver
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs.ver
+exec sleep 10
+eden eve reset
+
+-- require-resize-ver.sh --
+#!/bin/bash
+# Fail fast if RESIZE_EVE_VER wasn't supplied (the escript default is a
+# placeholder). Without it the eveimage-update steps would try a bogus version.
+set -uo pipefail
+VER='{{ $resize_ver }}'
+if [ -z "$VER" ] || [ "$VER" = "REPLACE-WITH-RESIZE-VERSION" ]; then
+    echo "FAIL: RESIZE_EVE_VER not set." >&2
+    echo "      Export the version base of your conversion-capable build, e.g." >&2
+    echo "      RESIZE_EVE_VER=0.0.0-kvm-to-k-resize-1a2b3c4d (the part before" >&2
+    echo "      -kvm-amd64 / -k-amd64 in the docker tag)." >&2
+    exit 1
+fi
+echo "OK: RESIZE_EVE_VER=$VER"
+
+-- require-bringup-ver.sh --
+#!/bin/bash
+# Fail fast if BRINGUP_EVE_VER wasn't supplied. This escript does not install the
+# base image — the runner brings EVE up on the release under test and passes its
+# version here so Step 1 can confirm we are on the intended start.
+set -uo pipefail
+VER='{{ $bringup_ver }}'
+if [ -z "$VER" ]; then
+    echo "FAIL: BRINGUP_EVE_VER not set." >&2
+    echo "      Set it to the release EVE was brought up on (e.g. 10.1.0, 16.13.0," >&2
+    echo "      17.0.0-rc1). The matrix runner sets it per release." >&2
+    exit 1
+fi
+echo "OK: BRINGUP_EVE_VER=$VER"
+
+-- assert-no-volumes.sh --
+#!/bin/bash
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 12); do
+    out=$("$EDEN" volume ls 2>/dev/null)
+    live=$(echo "$out" | awk 'NR>1 && ($(NF-1) == "IN_CONFIG" || $NF == "DELIVERED")')
+    if [ -z "$live" ]; then echo "OK: no live volumes"; exit 0; fi
+    sleep 5
+done
+echo "FAIL: live volume(s) present" >&2; "$EDEN" volume ls >&2; exit 1
+
+-- assert-running-version.sh --
+#!/bin/bash
+# Sanity-check that EVE is running the expected START release before the conversion
+# starts. Matches the expected version as a substring of /run/eve-release (the full
+# "<ver>-<hv>-<arch>" form), so "10.1.0" accepts the kvm bringup image without
+# pinning the hv/arch suffix.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT="${1:?expected bringup version substring}"
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+for _ in $(seq 1 18); do   # ~3m at 10s; tolerate ssh not up yet
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -n "$running" ]; then
+        case "$running" in
+            *"$EXPECT"*)
+                echo "OK: running the expected START release ('$running' contains '$EXPECT')"
+                exit 0 ;;
+            *)
+                echo "FAIL: running version '$running' does not match expected START '$EXPECT'." >&2
+                echo "      Bring eve up on '$EXPECT' before this test, or set BRINGUP_EVE_VER" >&2
+                echo "      to the release you brought up on." >&2
+                exit 1 ;;
+        esac
+    fi
+    sleep 10
+done
+echo "FAIL: could not read /run/eve-release (ssh down / device not up?)" >&2
+exit 1
+
+-- capture-geom.sh --
+#!/bin/bash
+# Read the boot-disk GPT geometry from EVE (lsblk over ssh) and either assert the
+# expected STARTING geometry for this release, or assert the FINAL EVE-k target.
+#
+# The two ESPs (ESP-A and the reserved ESP-B) share the GPT PARTLABEL "EFI System"
+# and type ef00; they are distinguished ONLY by PARTUUID (pkg/mkimage-raw-efi/
+# make-raw: ESP-A = ...30051, ESP-B = ...30056). So this reads PARTUUID too and
+# COUNTS the "EFI System" partitions rather than matching on the (shared) label.
+#
+# Usage:
+#   capture-geom.sh report
+#   capture-geom.sh assert-start <esp_mib> <imga_mib> <imgb_mib> <has_espb 0|1>
+#   capture-geom.sh assert-final
+#
+# assert-final target (EVE-k, WITH the reserved ESP-B):
+#   ESP-A 2 GiB, ESP-B 2 GiB, IMGA 10 GiB, IMGB 10 GiB  ==  "2+2+10+10".
+# The in-field resizer does not yet create ESP-B (see the escript header), so
+# assert-final is expected to FAIL until that lands — this is the spec for it.
+#
+# Sizes/uuids come from `lsblk -b -P -o NAME,PARTLABEL,PARTUUID,SIZE /dev/sda` — the
+# same lsblk pillar's diskmetrics uses. Disk is /dev/sda under eden (qemu SATA/IDE).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+MODE=${1:-report}
+GiB=$(( 1024 * 1024 * 1024 ))
+MiB=$(( 1024 * 1024 ))
+
+read_geom() {
+    timeout 20 "$EDEN" eve ssh -- \
+        'eve exec pillar lsblk -b -P -o NAME,PARTLABEL,PARTUUID,SIZE /dev/sda 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c '
+import sys, re
+esp = []; img = {}
+for line in sys.stdin:
+    m = dict(re.findall(r"(\w+)=\"([^\"]*)\"", line))
+    lbl = m.get("PARTLABEL", ""); sz = m.get("SIZE", ""); uu = m.get("PARTUUID", "")
+    if not sz:
+        continue
+    if lbl == "EFI System":
+        esp.append((int(sz), uu))
+    elif lbl in ("IMGA", "IMGB"):
+        img[lbl] = int(sz)
+esp.sort()
+hasb = 1 if any(u.endswith("30056") for _, u in esp) else 0
+print("ESP_COUNT=%d" % len(esp))
+print("ESP_MIN=%d" % (esp[0][0] if esp else 0))
+print("ESP_MAX=%d" % (esp[-1][0] if esp else 0))
+print("ESP_HAS_B=%d" % hasb)
+print("ESP_UUIDS=%s" % ",".join(u for _, u in esp))
+print("IMGA=%d" % img.get("IMGA", 0))
+print("IMGB=%d" % img.get("IMGB", 0))
+'
+}
+
+load() {
+    eval "$(read_geom)"
+    if [ "${ESP_COUNT:-0}" = "0" ] || [ "${IMGA:-0}" = "0" ] || [ "${IMGB:-0}" = "0" ]; then
+        echo "FAIL: could not read partition geometry from /dev/sda" >&2
+        timeout 20 "$EDEN" eve ssh -- 'eve exec pillar lsblk -o NAME,PARTLABEL,PARTUUID,SIZE /dev/sda' >&2 2>/dev/null
+        exit 1
+    fi
+}
+
+report() {
+    printf '  ESPs : count=%s  sizes=[%s..%s] MiB  reserved_ESP_B=%s  uuids=[%s]\n' \
+        "$ESP_COUNT" "$(( ESP_MIN / MiB ))" "$(( ESP_MAX / MiB ))" "$ESP_HAS_B" "$ESP_UUIDS"
+    printf '  IMGA : %s MiB\n' "$(( IMGA / MiB ))"
+    printf '  IMGB : %s MiB\n' "$(( IMGB / MiB ))"
+}
+
+# in_band <actual_bytes> <expected_mib> <name>: expected 0 => skip. Otherwise accept
+# actual within [0.5x, 2x] of expected — loose enough for GPT alignment jitter, tight
+# enough to tell each release's start size apart from the 2G/10G targets.
+in_band() {
+    local actual=$1 exp_mib=$2 name=$3 lo hi
+    [ "$exp_mib" = "0" ] && return 0
+    lo=$(( exp_mib * MiB / 2 )); hi=$(( exp_mib * MiB * 2 ))
+    if [ "$actual" -lt "$lo" ] || [ "$actual" -gt "$hi" ]; then
+        echo "FAIL: $name = $(( actual / MiB )) MiB, expected ~${exp_mib} MiB (band $(( lo / MiB ))..$(( hi / MiB )) MiB)" >&2
+        return 1
+    fi
+    return 0
+}
+
+case "$MODE" in
+    report)
+        load; echo "Current boot-disk geometry:"; report
+        ;;
+    assert-start)
+        E_ESP=${2:?esp_mib}; E_IMGA=${3:?imga_mib}; E_IMGB=${4:?imgb_mib}; E_ESPB=${5:?has_espb}
+        load
+        echo "START geometry:"; report
+        rc=0
+        in_band "$ESP_MIN" "$E_ESP"  "ESP"  || rc=1
+        in_band "$IMGA"    "$E_IMGA" "IMGA" || rc=1
+        in_band "$IMGB"    "$E_IMGB" "IMGB" || rc=1
+        if [ "$ESP_HAS_B" != "$E_ESPB" ]; then
+            if [ "$E_ESPB" = "1" ]; then
+                echo "FAIL: expected the reserved ESP-B on this START release, none found (ESP_COUNT=$ESP_COUNT)" >&2
+            else
+                echo "FAIL: START release already has the reserved ESP-B (already converted?) ESP_COUNT=$ESP_COUNT" >&2
+            fi
+            rc=1
+        fi
+        [ "$rc" = "0" ] && echo "OK: START geometry matches the expected layout for this release"
+        exit "$rc"
+        ;;
+    assert-final)
+        load
+        echo "FINAL geometry:"; report
+        rc=0
+        # Target: two ESPs each ~2 GiB (ESP-A + reserved ESP-B), IMGA/IMGB ~10 GiB.
+        # Floors sit below target to tolerate alignment while staying unambiguous.
+        [ "$ESP_COUNT" -ge 2 ] || { echo "FAIL: expected 2 ESPs (ESP-A + reserved ESP-B); found $ESP_COUNT — the conversion did not create ESP-B" >&2; rc=1; }
+        [ "$ESP_HAS_B" = "1" ] || { echo "FAIL: no partition carries the reserved ESP-B PARTUUID (...30056)" >&2; rc=1; }
+        [ "$ESP_MIN" -ge $(( 3 * GiB / 2 )) ] || { echo "FAIL: an ESP is < 1.5 GiB (target 2 GiB): min=$(( ESP_MIN / MiB )) MiB" >&2; rc=1; }
+        [ "$IMGA" -ge $(( 9 * GiB )) ] || { echo "FAIL: IMGA < 9 GiB floor (target 10 GiB): $(( IMGA / MiB )) MiB" >&2; rc=1; }
+        [ "$IMGB" -ge $(( 9 * GiB )) ] || { echo "FAIL: IMGB < 9 GiB floor (target 10 GiB): $(( IMGB / MiB )) MiB" >&2; rc=1; }
+        [ "$rc" = "0" ] && echo "OK: final boot-disk geometry is 2+2+10+10 (ESP-A + reserved ESP-B 2G each, IMGA/IMGB 10G)"
+        exit "$rc"
+        ;;
+    *)
+        echo "Usage: $0 report | assert-start <esp_mib> <imga_mib> <imgb_mib> <has_espb> | assert-final" >&2
+        exit 1
+        ;;
+esac
+
+-- wait-for-upgrade.sh --
+#!/bin/bash
+# Wait for a same- or cross-flavor BaseOs upgrade to land: poll until
+# /run/eve-release equals the expected version AND IMGB is the active partition.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT_VERSION="${1:?expected version}"
+DEADLINE=$(( $(date +%s) + 1500 ))   # 25m
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then echo "$(date +%H:%M:%S): EVE unreachable (rebooting?)"; sleep 20; continue; fi
+    imgb_state=$(probe 'eve exec pillar cat /run/baseosmgr/ZbootStatus/IMGB.json' | grep -oP '"PartitionState":"\K[^"]+' | head -1)
+    [ -z "$imgb_state" ] && imgb_state='unknown'
+    echo "$(date +%H:%M:%S): running='$running' IMGB.PartitionState='$imgb_state'"
+    if [ "$running" = "$EXPECT_VERSION" ] && [ "$imgb_state" = "active" ]; then
+        echo "OK: upgrade to $running complete (IMGB active)"; exit 0
+    fi
+    sleep 20
+done
+echo "FAIL: upgrade to $EXPECT_VERSION did not complete in 25m (running='$running')" >&2
+exit 1
+
+-- watch-conversion-geom.sh --
+#!/bin/bash
+# Drive AND watch the kvm->k conversion to completion, logging state/sub-state
+# TRANSITIONS. The repartition runs OFFLINE in storage-init (the boot disk's GPT
+# can't be re-read live while its rootfs is mounted): baseosmgr arms the resize flag
+# and reboots, storage-init grows the partitions (possibly with a busy-disk
+# reboot-to-apply), the device re-checks and does the cross-flavor A/B install, then
+# boots EVE-k. Completion is slot-agnostic (the grow can relocate the active slot).
+#
+# Unlike the resize test's watch-conversion.sh this does NO /persist stress-fill
+# cleanup — this escript deploys no app and pre-fills nothing, so /persist stays
+# near-empty and there is nothing to free before the EVE-k cluster installs.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+K_VERSION="${1:?expected -k version}"
+DEADLINE=$(( $(date +%s) + 5400 ))   # 90m (matches the escript exec -t; see the budget note there)
+
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+substate_name() {
+    case "$1" in
+        1) echo preflight ;;
+        2) echo rebooting-to-resize ;;
+        3) echo making-space ;;
+        4) echo creating-partitions ;;
+        5) echo renaming-partitions ;;
+        6) echo installing ;;
+        7) echo rebooting-to-target ;;
+        *) echo "sub_$1" ;;
+    esac
+}
+
+# Controller's view from adam: the latest ZiDevice report's state + sub_state.
+ctrl_state() {
+    local c st sub
+    c=$(timeout 20 "$EDEN" info --tail 8 2>/dev/null | grep -a '^content: ztype:ZiDevice' | tail -1)
+    st=$(echo "$c" | grep -oE 'state:ZDEVICE_STATE_[A-Z_]+' | head -1 | cut -d: -f2)
+    sub=$(echo "$c" | grep -oE 'sub_state:ZDEVICE_SUBSTATE_[A-Z_]+' | head -1 | cut -d: -f2)
+    echo "${st:-?}/${sub:-NONE}"
+}
+
+# Which partition (IMGA/IMGB) is active, and the version on it.
+active_part() {
+    probe 'eve exec pillar sh -c "cat /run/baseosmgr/ZbootStatus/IMGA.json /run/baseosmgr/ZbootStatus/IMGB.json 2>/dev/null"' | python3 -c '
+import sys, json, re
+act = "?"; ver = "?"
+_d = sys.stdin.read()
+_dec = json.JSONDecoder(); _p = 0
+while _p < len(_d):
+    _s = _d[_p:].lstrip()
+    if not _s: break
+    _p = len(_d) - len(_s)
+    try:
+        o, _p = _dec.raw_decode(_d, _p)
+    except Exception:
+        break
+    if o.get("PartitionState") == "active":
+        act = o.get("PartitionLabel", "?"); ver = o.get("ShortVersion", "?")
+print("%s:%s" % (act, ver))' 2>/dev/null || echo "?:?"
+}
+
+last_sig=""
+reboots=0
+unreachable_run=0
+seen_converting=0
+
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then
+        unreachable_run=$(( unreachable_run + 1 ))
+        if [ "$last_sig" != "UNREACHABLE" ]; then
+            echo "$(date +%H:%M:%S) [transition] EVE unreachable (rebooting?)"
+            last_sig="UNREACHABLE"
+        fi
+        sleep 15
+        continue
+    fi
+    if [ "$unreachable_run" -ge 2 ]; then
+        reboots=$(( reboots + 1 ))
+        echo "$(date +%H:%M:%S) observed a reboot (count=$reboots)"
+    fi
+    unreachable_run=0
+
+    actver=$(active_part)
+    bos=$(probe 'eve exec pillar sh -c "cat /run/baseosmgr/BaseOsStatus/*.json 2>/dev/null"')
+    conv=$(echo "$bos" | grep -o '"Converting":[a-z]*' | head -1 | cut -d: -f2); [ -z "$conv" ] && conv=false
+    csub=$(echo "$bos" | grep -o '"ConvertSubState":[0-9]*' | head -1 | cut -d: -f2); [ -z "$csub" ] && csub=0
+    [ "$conv" = "true" ] && seen_converting=1
+    dev=$(ctrl_state)
+
+    sig="run=$running active=$actver dev=$dev converting=$conv csub=$csub($(substate_name "$csub"))"
+    if [ "$sig" != "$last_sig" ]; then
+        echo "$(date +%H:%M:%S) [transition] $sig"
+        last_sig="$sig"
+    fi
+
+    # Done: booted the -k version and the conversion cleared. Slot-agnostic.
+    if [ "$running" = "$K_VERSION" ] && [ "$conv" = "false" ] && \
+       printf '%s' "$actver" | grep -q ":$K_VERSION$"; then
+        echo "OK: conversion+upgrade complete (active=$actver, running=$running)"
+        echo "    observed: CONVERTING=$seen_converting reboots=$reboots"
+        exit 0
+    fi
+    sleep 15
+done
+echo "FAIL: watch timeout (90m). running='${running:-?}' active='${actver:-?}' dev='${dev:-?}'" >&2
+echo "      observed: CONVERTING=$seen_converting reboots=$reboots" >&2
+exit 1

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_persist_wipe_restore.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_persist_wipe_restore.txt
@@ -1,0 +1,507 @@
+# Test: kvm-to-k conversion fault case F9 — FORCE /persist LOSS and verify the
+# device-identity / connectivity-critical files SURVIVE via the /config backup +
+# early-boot restore, recovering the device fully WITH NO CONTROLLER REACHABLE.
+#
+# This does NOT run a real shrink/grow. It exercises only the backup->wipe->restore
+# fail-safe: an online `storage-resizer backup` copies the critical files to the
+# CONFIG partition; we then destroy P3's ext4 so storage-init reformats /persist
+# empty on the next boot; `maybe_restore_after_persist` repopulates identity from
+# the backup. The real shrink is skipped with a resize-failed.json marker matched
+# to the running EVE version (storage-resize.sh maybe_offline_disk_resize).
+#
+# The load-bearing proof is that a controller-ENCRYPTED credential is decrypted
+# OFFLINE from the RESTORED ecdh cert. We inject an encrypted WiFi device port
+# BEFORE the backup so it rides through checkpoint/lastconfig into the backup;
+# after the wipe+restore, pillar applies the restored checkpoint offline and nim
+# re-decrypts the WiFi creds. One CipherBlockStatus.Error=="" after an offline
+# boot proves identity restore + config restore + decrypt-from-restored-key.
+# (App userdata is the wrong vehicle — it decrypts only at domain instantiation,
+# which needs the wiped image; device-network creds decrypt during nim's DPC
+# reconcile, independent of the app pipeline and of radio presence.)
+#
+# DEPENDENCY: the `eden controller edge-node add-wireless` CLI is eden PR #1202
+# (branch openevec-add-wireless), a SIBLING of add-cross-hv-eve-tests. This
+# escript lives with the other kvm-to-k escripts; to run it, have #1202 present in
+# the eden binary (merge/cherry-pick it into the branch you build eden from).
+#
+# IMAGE REQUIREMENT: the EVE image must back up the persistent OnboardingStatus
+# topic, i.e. `status/zedclient/OnboardingStatus` must be in storage-resizer's
+# defaultBackupPatterns (pkg/storage-resizer/backup.go, lf-edge/eve #6063).
+# Without it the device can't take cmd/client's offline UUID shortcut after the
+# wipe and stays stuck at onboarding.
+#
+# VALIDATED end-to-end in an eden sandbox (resize-allprs kvm image, TPM on): full
+# PASS -- wipe -> restore -> offline boot -> identity restored -> last config
+# re-applied offline -> WiFi creds decrypted from the RESTORED ecdh cert -> DPCL
+# config round-trips -> cleanup. Confirmed storage-init reformats P3 after the wipe
+# (the fsck backup-superblock concern did not bite with wipefs -a + head/tail zero).
+#
+# Bringup is MANUAL (like the other kvm-to-k escripts): bring an onboarded device
+# up on the SMALL bringup release (default 12.1.0); this test hops it to the
+# resize-capable kvm build so the storage-resizer binary + storage-init restore
+# hooks are present. TPM must be on (ecdh private key is TPM-resident; the wipe
+# must NOT lose it — only P3 is wiped, swtpm state is preserved).
+#
+# Knobs (env):
+#   RESIZE_EVE_VER  (required) version base of the local kvm-to-k build, e.g.
+#                   "0.0.0-kvm-to-k-resize-<sha>". Fails fast if unset.
+#   RESIZE_EVE_REG  (default lfedge/eve) image registry/repo namespace.
+#   BRINGUP_EVE_VER (default 12.1.0) substring the running base release must
+#                   contain at Step 1 (bringup is manual — see README_kvm_to_k.md).
+
+{{$arch := EdenConfig "eve.arch"}}
+
+{{$resize_ver_env := EdenGetEnv "RESIZE_EVE_VER"}}
+{{$resize_ver := "REPLACE-WITH-RESIZE-VERSION"}}
+{{if $resize_ver_env}}{{$resize_ver = $resize_ver_env}}{{end}}
+
+{{$resize_reg_env := EdenGetEnv "RESIZE_EVE_REG"}}
+{{$resize_reg := "lfedge/eve"}}
+{{if $resize_reg_env}}{{$resize_reg = $resize_reg_env}}{{end}}
+
+{{$bringup_ver_env := EdenGetEnv "BRINGUP_EVE_VER"}}
+{{$bringup_ver := "12.1.0"}}
+{{if $bringup_ver_env}}{{$bringup_ver = $bringup_ver_env}}{{end}}
+
+# SKIP_KVM_HOP=1 when the device was brought up DIRECTLY on the resize kvm image
+# (no 12.1.0 base to upgrade from) — skips Step 1's kvm->kvm upgrade.
+{{$skip_hop_env := EdenGetEnv "SKIP_KVM_HOP"}}
+{{$skip_hop := ""}}
+{{if $skip_hop_env}}{{$skip_hop = $skip_hop_env}}{{end}}
+
+{{$kvm_short := printf "%s-kvm-%s" $resize_ver $arch}}
+{{$ssid := "eden-f9"}}
+
+# Step 0: pre-flight. Fail fast if the version param wasn't supplied, confirm a
+# clean device, and shorten the baseimage commit timer so the kvm hop applies fast.
+message 'pre-flight: parameters + clean state'
+exec -t 1m bash require-resize-ver.sh
+eden -t 1m pod ps
+! stdout 'IN_CONFIG'
+eden controller edge-node update --config timer.test.baseimage.update=30
+
+# Step 1: get the device onto the resize-capable kvm build so /usr/bin/storage-resizer
+# + the storage-init restore hooks exist. (Geometry is irrelevant to F9 — no
+# conversion happens.) Two paths:
+#   SKIP_KVM_HOP unset: bring up on the SMALL bringup release, then kvm->kvm
+#                       upgrade to the resize image (matches the sibling escripts).
+#   SKIP_KVM_HOP set:   the device was brought up DIRECTLY on the resize kvm image;
+#                       just assert it and skip the upgrade (faster; avoids the
+#                       small->large IMGB-fit question).
+{{if $skip_hop}}
+message 'baseline: device already on the resize-capable kvm build (SKIP_KVM_HOP)'
+exec -t 3m bash assert-running-version.sh {{ $kvm_short }}
+{{else}}
+message 'baseline: confirm we are on the expected SMALL bringup release'
+exec -t 3m bash assert-running-version.sh {{ $bringup_ver }}
+message 'downloading conversion-capable kvm rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$resize_ver}} --eve-hv=kvm --eve-registry={{$resize_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs'
+message 'pushing kvm->kvm BaseOs update (lands resize/restore code)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs --os-version={{ $kvm_short }} -m adam://
+! stderr .
+message 'waiting for kvm->kvm upgrade to complete'
+exec -t 25m bash wait-for-upgrade.sh {{ $kvm_short }}
+{{end}}
+
+# Step 2: inject an ENCRYPTED WiFi device port (eden PR #1202), wait for the
+# BASELINE decrypt (proves the port was ingested + decrypted pre-wipe), then
+# snapshot identity + the DPCL for the post-restore comparison.
+message 'injecting encrypted WiFi port (eden PR #1202 add-wireless)'
+eden -t 2m controller edge-node add-wireless --port wlan0 --ssid {{ $ssid }} --password eden-f9-psk
+! stderr 'level=fatal'
+message 'waiting for BASELINE decrypt (pre-wipe) of the WiFi creds'
+exec -t 5m bash assert-decrypt.sh {{ $ssid }} 240
+message 'snapshotting identity (UUID, certs) + DPCL before the wipe'
+exec -t 2m bash snapshot-identity.sh
+
+# Step 3: online backup of the critical files to the CONFIG partition + arm the
+# skip-shrink marker. GATED on a content check: the backed-up checkpoint must
+# already carry the encrypted WiFi port (SSID) and the ecdh cert before we stop.
+message 'backup identity to CONFIG + arm skip-shrink (gated on artifact content)'
+exec -t 6m bash backup-and-arm.sh {{ $ssid }}
+
+# Step 4: FORCE /persist loss. Stop the VM (clean flush), then destroy P3's ext4
+# on the boot qcow2 so storage-init's fsck fails and reformats /persist empty.
+message 'forcing /persist loss: stop VM, wipe P3 superblocks'
+eden -t 2m eve stop
+exec -t 6m bash wipe-persist.sh
+
+# Step 5: go OFFLINE (stop the controller) to prove recovery without a controller,
+# boot the wiped device, and wait for it to come back up.
+message 'going offline: stopping the controller (adam)'
+exec docker stop eden_adam
+message 'booting with wiped /persist'
+eden -t 2m eve start
+exec -t 12m bash wait-ssh-up.sh
+
+# Step 6: assertions — all while the controller is DOWN.
+message 'asserting device identity was restored offline (UUID + certs)'
+exec -t 3m bash assert-identity-restored.sh
+message 'asserting DPC landed + WiFi creds decrypted from the RESTORED ecdh (offline)'
+exec -t 5m bash assert-decrypt.sh {{ $ssid }} 240
+message 'asserting the DPCL config round-tripped (status-stripped compare)'
+exec -t 2m bash assert-dpcl-stable.sh
+message 'asserting conversion bookkeeping was cleaned up (flag gone, marker recreated)'
+exec -t 2m bash assert-cleanup.sh
+
+# Step 7: bring the controller back and reset.
+message 'restarting controller + reset'
+exec docker start eden_adam
+exec sleep 10
+eden eve reset
+
+-- require-resize-ver.sh --
+#!/bin/bash
+# Fail fast if RESIZE_EVE_VER wasn't supplied (the escript default is a placeholder).
+set -uo pipefail
+VER='{{ $resize_ver }}'
+if [ -z "$VER" ] || [ "$VER" = "REPLACE-WITH-RESIZE-VERSION" ]; then
+    echo "FAIL: RESIZE_EVE_VER not set." >&2
+    echo "      Export it to the version base of your local kvm-to-k build," >&2
+    echo "      e.g. RESIZE_EVE_VER=0.0.0-kvm-to-k-resize-1a2b3c4d" >&2
+    echo "      (the part before -kvm-amd64 in the docker tag)." >&2
+    exit 1
+fi
+echo "OK: RESIZE_EVE_VER=$VER"
+
+-- assert-running-version.sh --
+#!/bin/bash
+# Sanity-check EVE is on the expected SMALL bringup release before the test.
+# Matches the arg as a substring of /run/eve-release (full "<ver>-<hv>-<arch>").
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT="${1:?expected bringup version substring}"
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+for _ in $(seq 1 18); do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -n "$running" ]; then
+        case "$running" in
+            *"$EXPECT"*) echo "OK: running '$running' contains '$EXPECT'"; exit 0 ;;
+            *) echo "FAIL: running '$running' != expected bringup '$EXPECT'." >&2
+               echo "      Bring eve up on the small '$EXPECT' image, or set BRINGUP_EVE_VER." >&2
+               exit 1 ;;
+        esac
+    fi
+    sleep 10
+done
+echo "FAIL: could not read /run/eve-release (ssh down / device not up?)" >&2
+exit 1
+
+-- wait-for-upgrade.sh --
+#!/bin/bash
+# Wait for a same-flavor BaseOs upgrade to land: /run/eve-release == expected AND
+# IMGB is the active partition.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT_VERSION="${1:?expected version}"
+DEADLINE=$(( $(date +%s) + 1500 ))
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then echo "$(date +%H:%M:%S): EVE unreachable (rebooting?)"; sleep 20; continue; fi
+    imgb_state=$(probe 'eve exec pillar cat /run/baseosmgr/ZbootStatus/IMGB.json' | grep -oP '"PartitionState":"\K[^"]+' | head -1)
+    [ -z "$imgb_state" ] && imgb_state='unknown'
+    echo "$(date +%H:%M:%S): running='$running' IMGB.PartitionState='$imgb_state'"
+    if [ "$running" = "$EXPECT_VERSION" ] && [ "$imgb_state" = "active" ]; then
+        echo "OK: upgrade to $running complete (IMGB active)"; exit 0
+    fi
+    sleep 20
+done
+echo "FAIL: upgrade to $EXPECT_VERSION did not complete in 25m (running='$running')" >&2
+exit 1
+
+-- assert-decrypt.sh --
+#!/bin/bash
+# Assert the encrypted WiFi creds are DECRYPTED. Two on-disk proofs (both under
+# /run, which is tmpfs and cleared each boot -> presence == THIS boot):
+#   1. zedagent published the controller DPC carrying our SSID
+#      (/run/zedagent/DevicePortConfig/zedagent.json) -> the config was applied.
+#   2. nim published a CipherBlockStatus with Error=="" & IsCipher:true
+#      (/run/nim/CipherBlockStatus/*.json) -> a cipher block decrypted OK.
+# Plus a log guard: the always-logged Error-level "decryption was unsuccessful"
+# line for our SSID must be ABSENT. Used pre-wipe (baseline) and post-wipe/offline
+# (the load-bearing decrypt-from-restored-ecdh proof) — identical device checks.
+# Usage: assert-decrypt.sh <ssid> <deadline_secs>
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+SSID="${1:?ssid}"
+BUDGET="${2:-240}"
+probe() { timeout 20 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+DEADLINE=$(( $(date +%s) + BUDGET ))
+dpc_ok=0; cbs_ok=0
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    # 1. controller DPC (ephemeral, JSON on disk) carries the SSID.
+    dpc=$(probe 'eve exec pillar sh -c "cat /run/zedagent/DevicePortConfig/*.json 2>/dev/null"')
+    echo "$dpc" | grep -q "$SSID" && dpc_ok=1 || dpc_ok=0
+    # 2. a CipherBlockStatus with Error empty and IsCipher true. cat may
+    #    concatenate several JSON objects with or without separators, so parse
+    #    them with a raw_decode loop rather than splitting on a delimiter.
+    cbs=$(probe 'eve exec pillar sh -c "cat /run/nim/CipherBlockStatus/*.json 2>/dev/null"')
+    if echo "$cbs" | python3 -c '
+import sys,json
+buf=sys.stdin.read()
+dec=json.JSONDecoder(); i=0; n=len(buf); ok=False
+while i<n:
+    while i<n and buf[i] in " \t\r\n": i+=1
+    if i>=n: break
+    try: o,end=dec.raw_decode(buf,i)
+    except ValueError: i+=1; continue
+    i=end
+    if isinstance(o,dict) and o.get("IsCipher") and o.get("Error","")=="": ok=True
+sys.exit(0 if ok else 1)
+' 2>/dev/null; then cbs_ok=1; else cbs_ok=0; fi
+    echo "$(date +%H:%M:%S): dpc_has_ssid=$dpc_ok cipher_decrypted_ok=$cbs_ok"
+    if [ "$dpc_ok" = 1 ] && [ "$cbs_ok" = 1 ]; then
+        # log guard: the Error-level failure line for our SSID must be absent.
+        fail=$(probe "eve exec pillar sh -c \"find /persist/newlog -name 'dev.log.*' -exec zcat -f {} \\; 2>/dev/null | grep -a '$SSID, wifi config cipherblock decryption was unsuccessful' | head -1\"")
+        if [ -n "$fail" ]; then
+            echo "FAIL: found a decryption-unsuccessful log line for $SSID:" >&2
+            echo "  $fail" >&2
+            exit 1
+        fi
+        echo "OK: WiFi creds decrypted (DPC carries $SSID, CipherBlockStatus Error=='', no failure log)"
+        exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: did not observe a successful decrypt of $SSID within ${BUDGET}s" >&2
+echo "  last CipherBlockStatus:" >&2; echo "$cbs" >&2
+exit 1
+
+-- snapshot-identity.sh --
+#!/bin/bash
+# Snapshot pre-wipe identity + DPCL for the post-restore comparison:
+#   /tmp/f9-uuid            device UUID (/persist/status/uuid)
+#   /tmp/f9-certs           sorted list of /persist/certs/*.pem basenames
+#   /tmp/f9-dpcl-before.json  DevicePortConfigList global.json (raw)
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+probe() { timeout 20 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+uuid=$(probe 'eve exec pillar cat /persist/status/uuid' | tr -d '\r' | grep -E '^[0-9a-fA-F-]{36}$' | head -1)
+if [ -z "$uuid" ]; then echo "FAIL: could not read device UUID (/persist/status/uuid)" >&2; exit 1; fi
+echo "$uuid" > /tmp/f9-uuid
+probe 'eve exec pillar sh -c "ls /persist/certs/*.pem 2>/dev/null | xargs -n1 basename"' | tr -d '\r' | sort > /tmp/f9-certs
+probe 'eve exec pillar sh -c "cat /persist/status/nim/DevicePortConfigList/*.json 2>/dev/null"' > /tmp/f9-dpcl-before.json
+if [ ! -s /tmp/f9-certs ] || [ ! -s /tmp/f9-dpcl-before.json ]; then
+    echo "FAIL: empty certs list or DPCL snapshot" >&2; exit 1
+fi
+echo "OK: snapshot UUID=$uuid certs=$(wc -l </tmp/f9-certs) dpcl_bytes=$(wc -c </tmp/f9-dpcl-before.json)"
+
+-- backup-and-arm.sh --
+#!/bin/bash
+# Online backup of the critical files to the CONFIG PARTITION (runtime /config is
+# a ro tmpfs, so we mount PARTLABEL=CONFIG rw from the pillar ns, as baseosmgr's
+# withConfigPartitionRW does), then arm the skip-shrink marker. Ships a single
+# device-side script via base64 to avoid nested-quoting hell. The backup LOOPS
+# until the backed-up checkpoint carries the encrypted WiFi port (SSID) + the
+# ecdh cert — that content check is the gate that makes it safe to stop+wipe.
+# Usage: backup-and-arm.sh <ssid>
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+SSID="${1:?ssid}"
+
+read -r -d '' DEV_SCRIPT <<EOF
+#!/bin/sh
+set -u
+SSID="$SSID"
+TARGET="78G"
+CFGP=\$(findfs PARTLABEL=CONFIG) || { echo "FAIL: no CONFIG partition"; exit 1; }
+mkdir -p /tmp/f9cfg
+mountpoint -q /tmp/f9cfg || mount -t vfat -o rw,iocharset=iso8859-1 "\$CFGP" /tmp/f9cfg || { echo "FAIL: mount CONFIG rw"; exit 1; }
+ok=0; i=0
+while [ \$i -lt 18 ]; do
+    i=\$((i+1))
+    /usr/bin/storage-resizer backup --persist /persist --backup-dir /tmp/f9cfg/backup-persist --flag-file /tmp/f9cfg/repartition-inprogress --target "\$TARGET" >/dev/null 2>&1
+    if cat /tmp/f9cfg/backup-persist/checkpoint/lastconfig* 2>/dev/null | tr -d '\\0' | grep -q "\$SSID" && ls /tmp/f9cfg/backup-persist/certs/ecdh.*.pem >/dev/null 2>&1; then
+        ok=1; break
+    fi
+    sync; sleep 10
+done
+if [ "\$ok" != 1 ]; then
+    echo "FAIL: backup did not capture SSID \$SSID + ecdh cert in the checkpoint"
+    ls -la /tmp/f9cfg/backup-persist/checkpoint /tmp/f9cfg/backup-persist/certs 2>/dev/null
+    umount /tmp/f9cfg 2>/dev/null
+    exit 1
+fi
+REL=\$(tr -d '\\r\\n' < /hostfs/etc/eve-release 2>/dev/null); [ -n "\$REL" ] || REL=\$(tr -d '\\r\\n' < /run/eve-release 2>/dev/null)
+if [ -z "\$REL" ]; then echo "FAIL: could not read running eve-release for the marker"; umount /tmp/f9cfg 2>/dev/null; exit 1; fi
+printf '{"eve_release":"%s","step":"f9-test","rc":"0","ts":"f9"}' "\$REL" > /tmp/f9cfg/resize-failed.json
+sync
+umount /tmp/f9cfg
+echo "OK: backed up identity+checkpoint (SSID \$SSID present) and armed skip-shrink for \$REL"
+EOF
+
+B64=$(printf '%s' "$DEV_SCRIPT" | base64 -w0)
+out=$(timeout 300 "$EDEN" eve ssh -- "eve exec pillar sh -c 'echo $B64 | base64 -d > /tmp/f9-backup.sh; sh /tmp/f9-backup.sh'" 2>/dev/null | grep -v 'level=fatal')
+echo "$out"
+echo "$out" | grep -q '^OK:' || { echo "FAIL: backup-and-arm did not succeed on device" >&2; exit 1; }
+
+-- wipe-persist.sh --
+#!/bin/bash
+# HOST-SIDE, SUDO-FREE: with the VM stopped, destroy P3's ext4 on the boot qcow2 so
+# storage-init's fsck fails and reformats /persist empty on the next boot. Zeroing
+# the first 5 MiB of P3 obliterates the ext4 primary superblock + group descriptors
+# (what `wipefs -a` dropped) and the last 5 MiB mirrors the installer scrub. Done via
+# a qcow2<->raw round-trip (qemu-img/sgdisk/dd operate on the file), so no
+# `sudo qemu-nbd`/root is needed. FIRST-RUN CHECK: confirm the boot log shows
+# storage-init RECREATING P3 (if fsck -y recovers from a backup superblock, zero more).
+set -uo pipefail
+IMG='{{EdenConfigPath "eve.image-file"}}'
+[ -f "$IMG" ] || { echo "FAIL: live image not found: $IMG" >&2; exit 1; }
+RAW="${IMG%.img}.wipe.raw"
+# Ensure qemu has released the image (eden eve stop already ran). Match the comm
+# (pgrep -x): a `-f "file=$IMG"` regex can miss a shutting-down qemu and let the
+# convert hit the qcow2 write lock.
+for _ in $(seq 1 90); do pgrep -x qemu-system-x86 >/dev/null 2>&1 || break; sleep 2; done
+pgrep -x qemu-system-x86 >/dev/null 2>&1 && { echo "FAIL: qemu still running; refusing to edit a locked image" >&2; exit 1; }
+qemu-img convert -O raw "$IMG" "$RAW" || { echo "FAIL: convert to raw" >&2; rm -f "$RAW"; exit 1; }
+# Resolve the P3 partition NUMBER straight from the GPT (sgdisk reads the file
+# directly; do NOT use `lsblk -d`, whose --nodeps hides partition rows).
+PARTNUM=$(sgdisk -p "$RAW" 2>/dev/null | awk '$NF=="P3"{print $1; exit}')
+if [ -z "$PARTNUM" ]; then
+    echo "FAIL: no P3 partition on $IMG (device never created it?)" >&2
+    sgdisk -p "$RAW" >&2 2>/dev/null || true
+    rm -f "$RAW"; exit 1
+fi
+FIRST=$(sgdisk -i "$PARTNUM" "$RAW" | sed -n 's/.*First sector: \([0-9]*\).*/\1/p')
+LAST=$(sgdisk -i "$PARTNUM" "$RAW" | sed -n 's/.*Last sector: \([0-9]*\).*/\1/p')
+[ -n "$FIRST" ] && [ -n "$LAST" ] || { echo "FAIL: could not read P3 sector range" >&2; rm -f "$RAW"; exit 1; }
+echo "wiping P3 #$PARTNUM (sectors $FIRST..$LAST) in $RAW"
+dd if=/dev/zero of="$RAW" bs=512 seek="$FIRST" count=10240 conv=notrunc 2>/dev/null                    # first 5 MiB (ext4 primary SB + GDT)
+dd if=/dev/zero of="$RAW" bs=512 seek="$(( LAST - 10240 + 1 ))" count=10240 conv=notrunc 2>/dev/null   # last 5 MiB
+sync
+qemu-img convert -O qcow2 "$RAW" "$IMG.new" && mv -f "$IMG.new" "$IMG" && rm -f "$RAW" \
+    || { echo "FAIL: convert back to qcow2" >&2; rm -f "$RAW" "$IMG.new"; exit 1; }
+echo "OK: P3 wiped (sudo-free round-trip)"
+
+-- wait-ssh-up.sh --
+#!/bin/bash
+# After a cold start (eve stop -> wipe -> eve start), wait for SSH to come up and
+# confirm a fresh boot (uptime < 300s). Not a reboot, so no "went down" phase.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+came_up=0
+for i in $(seq 1 66); do   # 66 * 10s = 11m
+    if timeout 8 "$EDEN" eve ssh 'true' 2>/dev/null; then
+        echo "$(date +%H:%M:%S) SSH online"; came_up=1; break
+    fi
+    sleep 10
+done
+if [ "$came_up" = "0" ]; then echo "FAIL: SSH did not come up within 11m of eve start" >&2; exit 1; fi
+uptime_secs=$(timeout 10 "$EDEN" eve ssh 'cat /proc/uptime' 2>/dev/null | tr -d '\r' | awk '{print int($1)}' | head -1)
+[ -n "$uptime_secs" ] || { echo "FAIL: could not read /proc/uptime" >&2; exit 1; }
+if [ "$uptime_secs" -gt 300 ]; then echo "FAIL: uptime $uptime_secs > 300s -- not a fresh boot?" >&2; exit 1; fi
+echo "OK: EVE up after wipe, uptime ${uptime_secs}s"
+
+-- assert-identity-restored.sh --
+#!/bin/bash
+# Assert device identity survived the /persist wipe (restored from /config):
+#   - UUID unchanged vs the pre-wipe snapshot;
+#   - the same /persist/certs/*.pem basenames are present again.
+# Runs while the controller is DOWN, so success means offline recovery.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+probe() { timeout 20 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+before_uuid=$(cat /tmp/f9-uuid 2>/dev/null)
+[ -n "$before_uuid" ] || { echo "FAIL: no pre-wipe UUID snapshot" >&2; exit 1; }
+after_uuid=""
+for _ in $(seq 1 18); do
+    after_uuid=$(probe 'eve exec pillar cat /persist/status/uuid' | tr -d '\r' | grep -E '^[0-9a-fA-F-]{36}$' | head -1)
+    [ -n "$after_uuid" ] && break
+    sleep 10
+done
+if [ "$after_uuid" != "$before_uuid" ]; then
+    echo "FAIL: UUID changed across the wipe: before='$before_uuid' after='$after_uuid'" >&2
+    exit 1
+fi
+probe 'eve exec pillar sh -c "ls /persist/certs/*.pem 2>/dev/null | xargs -n1 basename"' | tr -d '\r' | sort > /tmp/f9-certs-after
+# Gate only on the device-IDENTITY certs, which are what storage-resizer's /config
+# backup set preserves (certs/{ecdh,attest,ek}.*.pem). Controller-fetched certs such
+# as server-signing-cert.pem are re-fetched from the controller on reconnect, NOT
+# restored offline, so they are legitimately absent after an offline wipe+restore --
+# requiring them here produced a false FAIL on a settled image.
+missing=$(comm -23 <(grep -E '^(ecdh|attest|ek)\.' /tmp/f9-certs) /tmp/f9-certs-after)
+if [ -n "$missing" ]; then
+    echo "FAIL: backed-up identity certs missing after restore:" >&2; echo "$missing" >&2
+    exit 1
+fi
+echo "OK: UUID preserved ($after_uuid) and all $(grep -cE '^(ecdh|attest|ek)\.' /tmp/f9-certs) identity certs (ecdh/attest/ek) restored (offline)"
+
+-- assert-dpcl-stable.sh --
+#!/bin/bash
+# Assert the restored DevicePortConfigList carries the SAME config as before the
+# wipe. global.json mixes config with runtime status, so strip the volatile
+# status/timestamp fields (types/dpc.go, types/conntest.go) and compare the rest:
+#   DPCL:            drop CurrentIndex
+#   per DevicePortConfig:   drop State, LastFailed, LastSucceeded, LastError,
+#                           LastWarning, LastIPAndDNS
+#   per NetworkPortConfig:  drop LastFailed, LastSucceeded, LastError, LastWarning
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+probe() { timeout 20 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+# Take the "after" snapshot once nim has settled a little.
+sleep 20
+probe 'eve exec pillar sh -c "cat /persist/status/nim/DevicePortConfigList/*.json 2>/dev/null"' > /tmp/f9-dpcl-after.json
+[ -s /tmp/f9-dpcl-after.json ] || { echo "FAIL: empty DPCL after restore" >&2; exit 1; }
+python3 - /tmp/f9-dpcl-before.json /tmp/f9-dpcl-after.json <<'PY'
+import sys, json
+# Volatile per-DPC fields. TimePriority is the config-submission timestamp; zedagent
+# re-stamps it when it re-applies the checkpointed config offline, so it changes
+# even though the port config content is identical.
+VOL_DPC  = {"State","LastFailed","LastSucceeded","LastError","LastWarning","LastIPAndDNS","TimePriority"}
+# Volatile per-port fields. ConfigSource is provenance (Origin + SubmittedAt) that
+# legitimately differs on an offline re-apply, not port config content.
+VOL_PORT = {"LastFailed","LastSucceeded","LastError","LastWarning","ConfigSource"}
+def norm(path):
+    with open(path) as f:
+        d = json.load(f)
+    d.pop("CurrentIndex", None)
+    for dpc in d.get("PortConfigList", []) or []:
+        for k in VOL_DPC: dpc.pop(k, None)
+        for p in dpc.get("Ports", []) or []:
+            for k in VOL_PORT: p.pop(k, None)
+    return json.dumps(d, sort_keys=True)
+b, a = norm(sys.argv[1]), norm(sys.argv[2])
+if b != a:
+    print("FAIL: DPCL config differs across wipe/restore (status-stripped)", file=sys.stderr)
+    print("BEFORE:", b[:800], file=sys.stderr)
+    print("AFTER :", a[:800], file=sys.stderr)
+    sys.exit(1)
+print("OK: DPCL config round-tripped unchanged (status-stripped)")
+PY
+
+-- assert-cleanup.sh --
+#!/bin/bash
+# Assert restore/cleanup ran: the repartition flag is gone from the CONFIG
+# partition and resize-failed.json records persist_recreated (a destructive
+# reformat happened this boot, so restore stamps it). Mounts CONFIG ro to read.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+read -r -d '' DEV_SCRIPT <<'EOF'
+#!/bin/sh
+set -u
+CFGP=$(findfs PARTLABEL=CONFIG) || { echo "FAIL: no CONFIG partition"; exit 1; }
+mkdir -p /tmp/f9chk
+mountpoint -q /tmp/f9chk || mount -t vfat -o ro,iocharset=iso8859-1 "$CFGP" /tmp/f9chk || { echo "FAIL: mount CONFIG ro"; exit 1; }
+rc=0
+if [ -e /tmp/f9chk/repartition-inprogress ]; then echo "FAIL: repartition-inprogress still present (restore/cleanup did not run)"; rc=1; fi
+if [ -d /tmp/f9chk/backup-persist ]; then echo "FAIL: backup-persist dir not cleaned up"; rc=1; fi
+if [ -f /tmp/f9chk/resize-failed.json ]; then
+    if grep -q '"persist_recreated":true' /tmp/f9chk/resize-failed.json; then
+        echo "OK: resize-failed.json records persist_recreated:true"
+    else
+        echo "FAIL: resize-failed.json present but persist_recreated not set:"; cat /tmp/f9chk/resize-failed.json
+        rc=1
+    fi
+else
+    echo "FAIL: resize-failed.json missing (baseosmgr should still see the decline marker)"; rc=1
+fi
+umount /tmp/f9chk 2>/dev/null
+[ $rc = 0 ] && echo "OK: conversion bookkeeping cleaned up"
+exit $rc
+EOF
+B64=$(printf '%s' "$DEV_SCRIPT" | base64 -w0)
+out=$(timeout 60 "$EDEN" eve ssh -- "eve exec pillar sh -c 'echo $B64 | base64 -d > /tmp/f9-chk.sh; sh /tmp/f9-chk.sh'" 2>/dev/null | grep -v 'level=fatal')
+echo "$out"
+echo "$out" | grep -q 'bookkeeping cleaned up' || { echo "FAIL: cleanup assertions failed" >&2; exit 1; }

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_persist_wipe_restore.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_persist_wipe_restore.txt
@@ -350,11 +350,16 @@ set -uo pipefail
 IMG='{{EdenConfigPath "eve.image-file"}}'
 [ -f "$IMG" ] || { echo "FAIL: live image not found: $IMG" >&2; exit 1; }
 RAW="${IMG%.img}.wipe.raw"
-# Ensure qemu has released the image (eden eve stop already ran). Match the comm
-# (pgrep -x): a `-f "file=$IMG"` regex can miss a shutting-down qemu and let the
-# convert hit the qcow2 write lock.
-for _ in $(seq 1 90); do pgrep -x qemu-system-x86 >/dev/null 2>&1 || break; sleep 2; done
-pgrep -x qemu-system-x86 >/dev/null 2>&1 && { echo "FAIL: qemu still running; refusing to edit a locked image" >&2; exit 1; }
+# Ensure qemu has released the image. Scope the match to this eden.root, the same
+# way run-kvm-to-k-tests.sh free_slot() does: a bare `pgrep -x qemu-system-x86`
+# matches ANY VM on the host, so an unrelated evetest/ztest run makes this refuse
+# forever. Matching the root rather than `file=$IMG` still catches a
+# shutting-down qemu, since its argv carries the root in the drive, console-log
+# and swtpm-socket paths.
+EDENROOT="$(cd "$(dirname "$IMG")/../.." && pwd)"
+qemu_on_root() { pgrep -f "[q]emu-system-x86.*$EDENROOT" >/dev/null 2>&1; }
+for _ in $(seq 1 90); do qemu_on_root || break; sleep 2; done
+qemu_on_root && { echo "FAIL: qemu still running on $EDENROOT; refusing to edit a locked image" >&2; exit 1; }
 qemu-img convert -O raw "$IMG" "$RAW" || { echo "FAIL: convert to raw" >&2; rm -f "$RAW"; exit 1; }
 # Resolve the P3 partition NUMBER straight from the GPT (sgdisk reads the file
 # directly; do NOT use `lsblk -d`, whose --nodeps hides partition rows).

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_persist_wipe_restore.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_persist_wipe_restore.txt
@@ -1,4 +1,4 @@
-# Test: kvm-to-k conversion fault case F9 — FORCE /persist LOSS and verify the
+# Test: kvm-to-k conversion fault case: persist-wipe restore — FORCE /persist LOSS and verify the
 # device-identity / connectivity-critical files SURVIVE via the /config backup +
 # early-boot restore, recovering the device fully WITH NO CONTROLLER REACHABLE.
 #
@@ -70,7 +70,7 @@
 {{if $skip_hop_env}}{{$skip_hop = $skip_hop_env}}{{end}}
 
 {{$kvm_short := printf "%s-kvm-%s" $resize_ver $arch}}
-{{$ssid := "eden-f9"}}
+{{$ssid := "eden-restore"}}
 
 # Step 0: pre-flight. Fail fast if the version param wasn't supplied, confirm a
 # clean device, and shorten the baseimage commit timer so the kvm hop applies fast.
@@ -81,7 +81,7 @@ eden -t 1m pod ps
 eden controller edge-node update --config timer.test.baseimage.update=30
 
 # Step 1: get the device onto the resize-capable kvm build so /usr/bin/storage-resizer
-# + the storage-init restore hooks exist. (Geometry is irrelevant to F9 — no
+# + the storage-init restore hooks exist. (Geometry is irrelevant to this test — no
 # conversion happens.) Two paths:
 #   SKIP_KVM_HOP unset: bring up on the SMALL bringup release, then kvm->kvm
 #                       upgrade to the resize image (matches the sibling escripts).
@@ -108,7 +108,7 @@ exec -t 25m bash wait-for-upgrade.sh {{ $kvm_short }}
 # BASELINE decrypt (proves the port was ingested + decrypted pre-wipe), then
 # snapshot identity + the DPCL for the post-restore comparison.
 message 'injecting encrypted WiFi port (eden PR #1202 add-wireless)'
-eden -t 2m controller edge-node add-wireless --port wlan0 --ssid {{ $ssid }} --password eden-f9-psk
+eden -t 2m controller edge-node add-wireless --port wlan0 --ssid {{ $ssid }} --password eden-restore-psk
 ! stderr 'level=fatal'
 message 'waiting for BASELINE decrypt (pre-wipe) of the WiFi creds'
 exec -t 5m bash assert-decrypt.sh {{ $ssid }} 240
@@ -272,21 +272,21 @@ exit 1
 -- snapshot-identity.sh --
 #!/bin/bash
 # Snapshot pre-wipe identity + DPCL for the post-restore comparison:
-#   /tmp/f9-uuid            device UUID (/persist/status/uuid)
-#   /tmp/f9-certs           sorted list of /persist/certs/*.pem basenames
-#   /tmp/f9-dpcl-before.json  DevicePortConfigList global.json (raw)
+#   /tmp/restore-uuid            device UUID (/persist/status/uuid)
+#   /tmp/restore-certs           sorted list of /persist/certs/*.pem basenames
+#   /tmp/restore-dpcl-before.json  DevicePortConfigList global.json (raw)
 set -uo pipefail
 EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
 probe() { timeout 20 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
 uuid=$(probe 'eve exec pillar cat /persist/status/uuid' | tr -d '\r' | grep -E '^[0-9a-fA-F-]{36}$' | head -1)
 if [ -z "$uuid" ]; then echo "FAIL: could not read device UUID (/persist/status/uuid)" >&2; exit 1; fi
-echo "$uuid" > /tmp/f9-uuid
-probe 'eve exec pillar sh -c "ls /persist/certs/*.pem 2>/dev/null | xargs -n1 basename"' | tr -d '\r' | sort > /tmp/f9-certs
-probe 'eve exec pillar sh -c "cat /persist/status/nim/DevicePortConfigList/*.json 2>/dev/null"' > /tmp/f9-dpcl-before.json
-if [ ! -s /tmp/f9-certs ] || [ ! -s /tmp/f9-dpcl-before.json ]; then
+echo "$uuid" > /tmp/restore-uuid
+probe 'eve exec pillar sh -c "ls /persist/certs/*.pem 2>/dev/null | xargs -n1 basename"' | tr -d '\r' | sort > /tmp/restore-certs
+probe 'eve exec pillar sh -c "cat /persist/status/nim/DevicePortConfigList/*.json 2>/dev/null"' > /tmp/restore-dpcl-before.json
+if [ ! -s /tmp/restore-certs ] || [ ! -s /tmp/restore-dpcl-before.json ]; then
     echo "FAIL: empty certs list or DPCL snapshot" >&2; exit 1
 fi
-echo "OK: snapshot UUID=$uuid certs=$(wc -l </tmp/f9-certs) dpcl_bytes=$(wc -c </tmp/f9-dpcl-before.json)"
+echo "OK: snapshot UUID=$uuid certs=$(wc -l </tmp/restore-certs) dpcl_bytes=$(wc -c </tmp/restore-dpcl-before.json)"
 
 -- backup-and-arm.sh --
 #!/bin/bash
@@ -307,33 +307,33 @@ set -u
 SSID="$SSID"
 TARGET="78G"
 CFGP=\$(findfs PARTLABEL=CONFIG) || { echo "FAIL: no CONFIG partition"; exit 1; }
-mkdir -p /tmp/f9cfg
-mountpoint -q /tmp/f9cfg || mount -t vfat -o rw,iocharset=iso8859-1 "\$CFGP" /tmp/f9cfg || { echo "FAIL: mount CONFIG rw"; exit 1; }
+mkdir -p /tmp/restore-cfg
+mountpoint -q /tmp/restore-cfg || mount -t vfat -o rw,iocharset=iso8859-1 "\$CFGP" /tmp/restore-cfg || { echo "FAIL: mount CONFIG rw"; exit 1; }
 ok=0; i=0
 while [ \$i -lt 18 ]; do
     i=\$((i+1))
-    /usr/bin/storage-resizer backup --persist /persist --backup-dir /tmp/f9cfg/backup-persist --flag-file /tmp/f9cfg/repartition-inprogress --target "\$TARGET" >/dev/null 2>&1
-    if cat /tmp/f9cfg/backup-persist/checkpoint/lastconfig* 2>/dev/null | tr -d '\\0' | grep -q "\$SSID" && ls /tmp/f9cfg/backup-persist/certs/ecdh.*.pem >/dev/null 2>&1; then
+    /usr/bin/storage-resizer backup --persist /persist --backup-dir /tmp/restore-cfg/backup-persist --flag-file /tmp/restore-cfg/repartition-inprogress --target "\$TARGET" >/dev/null 2>&1
+    if cat /tmp/restore-cfg/backup-persist/checkpoint/lastconfig* 2>/dev/null | tr -d '\\0' | grep -q "\$SSID" && ls /tmp/restore-cfg/backup-persist/certs/ecdh.*.pem >/dev/null 2>&1; then
         ok=1; break
     fi
     sync; sleep 10
 done
 if [ "\$ok" != 1 ]; then
     echo "FAIL: backup did not capture SSID \$SSID + ecdh cert in the checkpoint"
-    ls -la /tmp/f9cfg/backup-persist/checkpoint /tmp/f9cfg/backup-persist/certs 2>/dev/null
-    umount /tmp/f9cfg 2>/dev/null
+    ls -la /tmp/restore-cfg/backup-persist/checkpoint /tmp/restore-cfg/backup-persist/certs 2>/dev/null
+    umount /tmp/restore-cfg 2>/dev/null
     exit 1
 fi
 REL=\$(tr -d '\\r\\n' < /hostfs/etc/eve-release 2>/dev/null); [ -n "\$REL" ] || REL=\$(tr -d '\\r\\n' < /run/eve-release 2>/dev/null)
-if [ -z "\$REL" ]; then echo "FAIL: could not read running eve-release for the marker"; umount /tmp/f9cfg 2>/dev/null; exit 1; fi
-printf '{"eve_release":"%s","step":"f9-test","rc":"0","ts":"f9"}' "\$REL" > /tmp/f9cfg/resize-failed.json
+if [ -z "\$REL" ]; then echo "FAIL: could not read running eve-release for the marker"; umount /tmp/restore-cfg 2>/dev/null; exit 1; fi
+printf '{"eve_release":"%s","step":"restore-test","rc":"0","ts":"restore"}' "\$REL" > /tmp/restore-cfg/resize-failed.json
 sync
-umount /tmp/f9cfg
+umount /tmp/restore-cfg
 echo "OK: backed up identity+checkpoint (SSID \$SSID present) and armed skip-shrink for \$REL"
 EOF
 
 B64=$(printf '%s' "$DEV_SCRIPT" | base64 -w0)
-out=$(timeout 300 "$EDEN" eve ssh -- "eve exec pillar sh -c 'echo $B64 | base64 -d > /tmp/f9-backup.sh; sh /tmp/f9-backup.sh'" 2>/dev/null | grep -v 'level=fatal')
+out=$(timeout 300 "$EDEN" eve ssh -- "eve exec pillar sh -c 'echo $B64 | base64 -d > /tmp/restore-backup.sh; sh /tmp/restore-backup.sh'" 2>/dev/null | grep -v 'level=fatal')
 echo "$out"
 echo "$out" | grep -q '^OK:' || { echo "FAIL: backup-and-arm did not succeed on device" >&2; exit 1; }
 
@@ -403,7 +403,7 @@ echo "OK: EVE up after wipe, uptime ${uptime_secs}s"
 set -uo pipefail
 EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
 probe() { timeout 20 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
-before_uuid=$(cat /tmp/f9-uuid 2>/dev/null)
+before_uuid=$(cat /tmp/restore-uuid 2>/dev/null)
 [ -n "$before_uuid" ] || { echo "FAIL: no pre-wipe UUID snapshot" >&2; exit 1; }
 after_uuid=""
 for _ in $(seq 1 18); do
@@ -415,18 +415,18 @@ if [ "$after_uuid" != "$before_uuid" ]; then
     echo "FAIL: UUID changed across the wipe: before='$before_uuid' after='$after_uuid'" >&2
     exit 1
 fi
-probe 'eve exec pillar sh -c "ls /persist/certs/*.pem 2>/dev/null | xargs -n1 basename"' | tr -d '\r' | sort > /tmp/f9-certs-after
+probe 'eve exec pillar sh -c "ls /persist/certs/*.pem 2>/dev/null | xargs -n1 basename"' | tr -d '\r' | sort > /tmp/restore-certs-after
 # Gate only on the device-IDENTITY certs, which are what storage-resizer's /config
 # backup set preserves (certs/{ecdh,attest,ek}.*.pem). Controller-fetched certs such
 # as server-signing-cert.pem are re-fetched from the controller on reconnect, NOT
 # restored offline, so they are legitimately absent after an offline wipe+restore --
 # requiring them here produced a false FAIL on a settled image.
-missing=$(comm -23 <(grep -E '^(ecdh|attest|ek)\.' /tmp/f9-certs) /tmp/f9-certs-after)
+missing=$(comm -23 <(grep -E '^(ecdh|attest|ek)\.' /tmp/restore-certs) /tmp/restore-certs-after)
 if [ -n "$missing" ]; then
     echo "FAIL: backed-up identity certs missing after restore:" >&2; echo "$missing" >&2
     exit 1
 fi
-echo "OK: UUID preserved ($after_uuid) and all $(grep -cE '^(ecdh|attest|ek)\.' /tmp/f9-certs) identity certs (ecdh/attest/ek) restored (offline)"
+echo "OK: UUID preserved ($after_uuid) and all $(grep -cE '^(ecdh|attest|ek)\.' /tmp/restore-certs) identity certs (ecdh/attest/ek) restored (offline)"
 
 -- assert-dpcl-stable.sh --
 #!/bin/bash
@@ -442,9 +442,9 @@ EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "ed
 probe() { timeout 20 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
 # Take the "after" snapshot once nim has settled a little.
 sleep 20
-probe 'eve exec pillar sh -c "cat /persist/status/nim/DevicePortConfigList/*.json 2>/dev/null"' > /tmp/f9-dpcl-after.json
-[ -s /tmp/f9-dpcl-after.json ] || { echo "FAIL: empty DPCL after restore" >&2; exit 1; }
-python3 - /tmp/f9-dpcl-before.json /tmp/f9-dpcl-after.json <<'PY'
+probe 'eve exec pillar sh -c "cat /persist/status/nim/DevicePortConfigList/*.json 2>/dev/null"' > /tmp/restore-dpcl-after.json
+[ -s /tmp/restore-dpcl-after.json ] || { echo "FAIL: empty DPCL after restore" >&2; exit 1; }
+python3 - /tmp/restore-dpcl-before.json /tmp/restore-dpcl-after.json <<'PY'
 import sys, json
 # Volatile per-DPC fields. TimePriority is the config-submission timestamp; zedagent
 # re-stamps it when it re-applies the checkpointed config offline, so it changes
@@ -482,26 +482,26 @@ read -r -d '' DEV_SCRIPT <<'EOF'
 #!/bin/sh
 set -u
 CFGP=$(findfs PARTLABEL=CONFIG) || { echo "FAIL: no CONFIG partition"; exit 1; }
-mkdir -p /tmp/f9chk
-mountpoint -q /tmp/f9chk || mount -t vfat -o ro,iocharset=iso8859-1 "$CFGP" /tmp/f9chk || { echo "FAIL: mount CONFIG ro"; exit 1; }
+mkdir -p /tmp/restore-chk
+mountpoint -q /tmp/restore-chk || mount -t vfat -o ro,iocharset=iso8859-1 "$CFGP" /tmp/restore-chk || { echo "FAIL: mount CONFIG ro"; exit 1; }
 rc=0
-if [ -e /tmp/f9chk/repartition-inprogress ]; then echo "FAIL: repartition-inprogress still present (restore/cleanup did not run)"; rc=1; fi
-if [ -d /tmp/f9chk/backup-persist ]; then echo "FAIL: backup-persist dir not cleaned up"; rc=1; fi
-if [ -f /tmp/f9chk/resize-failed.json ]; then
-    if grep -q '"persist_recreated":true' /tmp/f9chk/resize-failed.json; then
+if [ -e /tmp/restore-chk/repartition-inprogress ]; then echo "FAIL: repartition-inprogress still present (restore/cleanup did not run)"; rc=1; fi
+if [ -d /tmp/restore-chk/backup-persist ]; then echo "FAIL: backup-persist dir not cleaned up"; rc=1; fi
+if [ -f /tmp/restore-chk/resize-failed.json ]; then
+    if grep -q '"persist_recreated":true' /tmp/restore-chk/resize-failed.json; then
         echo "OK: resize-failed.json records persist_recreated:true"
     else
-        echo "FAIL: resize-failed.json present but persist_recreated not set:"; cat /tmp/f9chk/resize-failed.json
+        echo "FAIL: resize-failed.json present but persist_recreated not set:"; cat /tmp/restore-chk/resize-failed.json
         rc=1
     fi
 else
     echo "FAIL: resize-failed.json missing (baseosmgr should still see the decline marker)"; rc=1
 fi
-umount /tmp/f9chk 2>/dev/null
+umount /tmp/restore-chk 2>/dev/null
 [ $rc = 0 ] && echo "OK: conversion bookkeeping cleaned up"
 exit $rc
 EOF
 B64=$(printf '%s' "$DEV_SCRIPT" | base64 -w0)
-out=$(timeout 60 "$EDEN" eve ssh -- "eve exec pillar sh -c 'echo $B64 | base64 -d > /tmp/f9-chk.sh; sh /tmp/f9-chk.sh'" 2>/dev/null | grep -v 'level=fatal')
+out=$(timeout 60 "$EDEN" eve ssh -- "eve exec pillar sh -c 'echo $B64 | base64 -d > /tmp/restore-chk.sh; sh /tmp/restore-chk.sh'" 2>/dev/null | grep -v 'level=fatal')
 echo "$out"
 echo "$out" | grep -q 'bookkeeping cleaned up' || { echo "FAIL: cleanup assertions failed" >&2; exit 1; }

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_refused.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_refused.txt
@@ -1,0 +1,425 @@
+# Test: EVE-kvm -> EVE-k conversion is DECLINED when the boot disk cannot be
+# repartitioned, and the device stays on the kvm image, reports the reason, and
+# remains controller-manageable. This is the "refused" sibling of the successful
+# update_eve_image_kvm_to_k.txt; it covers the e2e test plan's `insufficient`
+# cases, parameterized over the REASON for refusal.
+#
+# Per pkg/storage-resizer decide()/evaluate() (and baseosmgr/diskconvert, which
+# always calls `check --disk <boot> --json` with NO --persist flags), the
+# conversion is refused (decision=insufficient) when no room can be freed:
+#   REFUSE_REASON=zfs       /persist is ZFS (shrinking ZFS is unsupported) and the
+#                           boot disk has no >=22G free tail.   (persistType=zfs)
+#   REFUSE_REASON=too-full  /persist is ext4 on the boot disk but too full to free
+#                           22G within --max-full.   (shrinkApplicable, !shrink.ok)
+# (A ZFS or other-disk persist WITH a boot free tail is a `grow` success and lives
+# in update_eve_image_kvm_to_k.txt, not here.)
+#
+# Set up the matching topology first (see prep-kvm-to-k-topology.sh):
+#   REFUSE_REASON=zfs       -> prep zfs-notail     (1-disk ZFS persist, no tail)
+#   REFUSE_REASON=too-full  -> prep ext4-toofull   (1-disk ext4 persist, filled)
+#
+# What it asserts:
+#   - after the kvm->kvm hop, `storage-resizer check` decides `insufficient` for
+#     the expected reason (the topology was set up correctly);
+#   - the kvm->k BaseOs update is DECLINED: the device stays on the kvm image,
+#     baseosmgr publishes a BaseOsStatus.Error (the decline is reported, not a
+#     silent stall), and EVE->adam stays reachable (device still manageable);
+#   - the boot-disk geometry is UNCHANGED (no repartition happened).
+#
+# Knobs (env):
+#   REFUSE_REASON   zfs|too-full   (default zfs). Drives the check-reason assert.
+#   RESIZE_EVE_VER  (required) version base of the local kvm-to-k build, e.g.
+#                   "0.0.0-kvm-to-k-resize-<sha>". Fails fast if unset.
+#   RESIZE_EVE_REG  (default lfedge/eve) image registry/repo namespace.
+#   BRINGUP_EVE_VER (default 12.1.0) substring the running base release must
+#                   contain at Step 1 (bringup is manual — see README_kvm_to_k.md).
+
+{{$arch := EdenConfig "eve.arch"}}
+
+{{$resize_ver_env := EdenGetEnv "RESIZE_EVE_VER"}}
+{{$resize_ver := "REPLACE-WITH-RESIZE-VERSION"}}
+{{if $resize_ver_env}}{{$resize_ver = $resize_ver_env}}{{end}}
+
+{{$resize_reg_env := EdenGetEnv "RESIZE_EVE_REG"}}
+{{$resize_reg := "lfedge/eve"}}
+{{if $resize_reg_env}}{{$resize_reg = $resize_reg_env}}{{end}}
+
+{{$bringup_ver_env := EdenGetEnv "BRINGUP_EVE_VER"}}
+{{$bringup_ver := "12.1.0"}}
+{{if $bringup_ver_env}}{{$bringup_ver = $bringup_ver_env}}{{end}}
+
+# --- knob: expected refusal reason ---
+{{$reason_env := EdenGetEnv "REFUSE_REASON"}}
+{{$reason := "zfs"}}
+{{if $reason_env}}{{$reason = $reason_env}}{{end}}
+
+{{$kvm_short := printf "%s-kvm-%s" $resize_ver $arch}}
+{{$k_short   := printf "%s-k-%s" $resize_ver $arch}}
+
+# Step 0: pre-flight. Fail fast if the version param wasn't supplied, confirm a
+# clean device, and shorten the baseimage commit timer so the update applies fast.
+message 'pre-flight: parameters + clean state'
+exec -t 1m bash require-resize-ver.sh
+exec -t 1m bash assert-no-volumes.sh
+eden -t 1m pod ps
+! stdout 'IN_CONFIG'
+eden controller edge-node update --config timer.test.baseimage.update=30
+
+# Step 1: baseline — SMALL/old start, and (by construction) a disk that cannot be
+# repartitioned: a full ZFS persist, or a too-full ext4 persist. There is NO free
+# tail; the refusal is the point of the test.
+message 'baseline: confirm we are on the expected SMALL bringup release'
+exec -t 3m bash assert-running-version.sh {{ $bringup_ver }}
+message 'baseline: confirm SMALL boot-disk geometry'
+exec -t 2m bash capture-partitions.sh save small
+exec -t 1m bash capture-partitions.sh assert-small
+
+# Step 2: kvm->kvm hop — lands the conversion code + the storage-resizer binary,
+# geometry unchanged. (No vault settle / no app: the refusal is independent of
+# both, and nothing repartitions, so there is no seal to preserve.)
+message 'downloading conversion-capable kvm rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$resize_ver}} --eve-hv=kvm --eve-registry={{$resize_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs'
+message 'pushing kvm->kvm BaseOs update (lands conversion code)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs --os-version={{ $kvm_short }} -m adam://
+! stderr .
+message 'waiting for kvm->kvm upgrade to complete'
+exec -t 25m bash wait-for-upgrade.sh {{ $kvm_short }}
+
+# Step 3: assert the resizer's pre-flight check REFUSES for the expected reason.
+# This is the load-bearing precondition: if the disk was not set up for the
+# requested REFUSE_REASON, the conversion might actually succeed (or refuse for a
+# different reason) and the test would prove nothing.
+message 'post-kvm-upgrade: geometry must still be SMALL'
+exec -t 1m bash capture-partitions.sh assert-small
+message 'post-kvm-upgrade: assert storage-resizer check refuses ({{ $reason }})'
+exec -t 2m bash assert-refused-check.sh {{ $reason }}
+
+# Step 4: push the kvm->k BaseOs update. baseosmgr runs the cross-flavor check,
+# gets `insufficient`, and must decline rather than repartition.
+message 'downloading k rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$resize_ver}} --eve-hv=k --eve-registry={{$resize_reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs'
+message 'pushing kvm->k BaseOs update (must be DECLINED)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs --os-version={{ $k_short }} -m adam://
+! stderr .
+
+# Step 5: assert the convert was declined cleanly — still on the kvm image,
+# BaseOsStatus carries the decline Error (baseosmgr SetErrorNow on
+# OutcomeInsufficient), and EVE->adam is still reachable. Polls for the decline
+# to be published (baseosmgr processes the -k config first).
+message 'asserting the conversion was DECLINED (still kvm, error reported, manageable)'
+exec -t 10m bash assert-declined.sh {{ $kvm_short }}
+
+# Step 6: the boot disk must NOT have been repartitioned — geometry still SMALL.
+message 'asserting the boot disk was NOT repartitioned (geometry still SMALL)'
+exec -t 1m bash capture-partitions.sh assert-small
+
+# Step 7: clean up.
+message 'reset timer.test.baseimage.update + clean up'
+eden controller edge-node update --config timer.defer.content.delete=0
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $kvm_short }}.squashfs.ver
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs.ver
+exec sleep 10
+eden eve reset
+
+-- require-resize-ver.sh --
+#!/bin/bash
+# Fail fast if RESIZE_EVE_VER wasn't supplied (the escript default is a
+# placeholder). Without it, the eveimage-update steps would silently try to
+# download a bogus version.
+set -uo pipefail
+VER='{{ $resize_ver }}'
+if [ -z "$VER" ] || [ "$VER" = "REPLACE-WITH-RESIZE-VERSION" ]; then
+    echo "FAIL: RESIZE_EVE_VER not set." >&2
+    echo "      Export it to the version base of your local kvm-to-k" >&2
+    echo "      build, e.g. RESIZE_EVE_VER=0.0.0-kvm-to-k-resize-1a2b3c4d" >&2
+    echo "      (the part before -kvm-amd64 / -k-amd64 in the docker tag)." >&2
+    exit 1
+fi
+echo "OK: RESIZE_EVE_VER=$VER"
+
+-- assert-running-version.sh --
+#!/bin/bash
+# Sanity-check that EVE is running the expected SMALL bringup release before the
+# test. This escript does not install the base image — bringup happens manually
+# (see README_kvm_to_k.md + prep-kvm-to-k-topology.sh). Matches as a substring of
+# /run/eve-release (the full "<ver>-<hv>-<arch>" form).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT="${1:?expected bringup version substring}"
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+for _ in $(seq 1 18); do   # ~3m at 10s; tolerate ssh not up yet
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -n "$running" ]; then
+        case "$running" in
+            *"$EXPECT"*)
+                echo "OK: running the expected bringup release ('$running' contains '$EXPECT')"
+                exit 0 ;;
+            *)
+                echo "FAIL: running version '$running' does not match expected bringup '$EXPECT'." >&2
+                echo "      Bring eve up on the small '$EXPECT' image before this test, or set" >&2
+                echo "      BRINGUP_EVE_VER to the release you brought up on." >&2
+                exit 1 ;;
+        esac
+    fi
+    sleep 10
+done
+echo "FAIL: could not read /run/eve-release (ssh down / device not up?)" >&2
+exit 1
+
+-- capture-partitions.sh --
+#!/bin/bash
+# Trimmed boot-disk geometry helper for the refused test: only `save` and
+# `assert-small` are needed (the refused case never grows). Sizes from
+# `lsblk -b -P -o NAME,PARTLABEL,PARTUUID,SIZE /dev/sda`. P3 may be 0 (ZFS-on-
+# another-disk), so only ESP/IMGA/IMGB are required non-zero. assert-small also
+# checks the reserved ESP-B (GPT #7, fresh-install GUID …30056) is absent: a
+# refused conversion must never create it.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+MODE=${1:-}
+TAG=${2:-}
+GiB=$(( 1024 * 1024 * 1024 ))
+MiB=$(( 1024 * 1024 ))
+
+read_sizes() {
+    timeout 20 "$EDEN" eve ssh -- \
+        'eve exec pillar lsblk -b -P -o NAME,PARTLABEL,PARTUUID,SIZE /dev/sda 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c '
+import sys, re
+out = {}
+for line in sys.stdin:
+    m = dict(re.findall(r"(\w+)=\"([^\"]*)\"", line))
+    label = m.get("PARTLABEL", "")
+    size = m.get("SIZE", "")
+    if not size:
+        continue
+    if label == "EFI System":
+        # ESP-B (reserved #7) has the fresh-install GUID …30056; a refused
+        # conversion must never create it, so track it separately from ESP-A.
+        if m.get("PARTUUID", "").lower().endswith("30056"):
+            out["ESPB"] = size
+        else:
+            out["ESP"] = size
+    elif label in ("IMGA", "IMGB", "P3"):
+        out[label] = size
+for k in ("ESP", "ESPB", "IMGA", "IMGB", "P3"):
+    print("%s=%s" % (k, out.get(k, "0")))
+'
+}
+
+load_current() {
+    eval "$(read_sizes)"
+    if [ "${ESP:-0}" = "0" ] || [ "${IMGA:-0}" = "0" ] || [ "${IMGB:-0}" = "0" ]; then
+        echo "FAIL: could not read ESP/IMGA/IMGB sizes from /dev/sda" >&2
+        timeout 20 "$EDEN" eve ssh -- 'eve exec pillar lsblk -b -o NAME,PARTLABEL,PARTUUID,SIZE /dev/sda' >&2 2>/dev/null
+        exit 1
+    fi
+}
+
+print_table() {
+    for p in ESP IMGA IMGB P3; do
+        v=$(eval echo "\$$p")
+        printf '  %-10s %12s  (%s MiB)\n' "$p" "$v" "$(( v / MiB ))"
+    done
+}
+
+case "$MODE" in
+    save)
+        [ -n "$TAG" ] || { echo "Usage: $0 save <tag>" >&2; exit 1; }
+        load_current
+        printf 'ESP=%s\nIMGA=%s\nIMGB=%s\nP3=%s\n' "$ESP" "$IMGA" "$IMGB" "$P3" > "/tmp/xhv-parts-$TAG.env"
+        echo "Saved $TAG partition sizes:"; print_table
+        ;;
+    assert-small)
+        load_current; echo "Current partition sizes:"; print_table
+        if [ "$ESP" -ge $(( 256 * MiB )) ] || [ "$IMGA" -ge "$GiB" ] || [ "$IMGB" -ge "$GiB" ]; then
+            echo "FAIL: geometry is not SMALL (ESP/IMGA/IMGB too big)" >&2; exit 1
+        fi
+        if [ "${ESPB:-0}" != "0" ]; then
+            echo "FAIL: refused conversion created an ESP-B (GUID …30056)" >&2; exit 1
+        fi
+        echo "OK: boot disk is on the SMALL geometry (no ESP-B)"
+        ;;
+    *)
+        echo "Usage: $0 save <tag> | assert-small" >&2
+        exit 1
+        ;;
+esac
+
+-- assert-refused-check.sh --
+#!/bin/bash
+# Assert storage-resizer's pre-flight `check` REFUSES the conversion for the
+# expected reason. Mirrors how baseosmgr/diskconvert invokes it — `check --disk
+# <boot> --json` with NO --persist flags, so persistType comes from
+# /run/eve.persist_type and persist is assumed on the boot disk.
+#
+# Verifies decision==insufficient AND the reason-specific fields of the report
+# (pkg/storage-resizer evaluate()/decide(), JSON tags from sizecheck.go):
+#   zfs:      persistType=="zfs"  (shrink not applicable; ZFS can't be shrunk)
+#   too-full: shrinkApplicable==true AND spaceToShrinkExt.ok==false (ext4 too full)
+#
+# Usage: assert-refused-check.sh <zfs|too-full> [disk=/dev/sda]
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT="${1:?expected reason: zfs|too-full}"
+DISK="${2:-/dev/sda}"
+
+run_check() {
+    timeout 30 "$EDEN" eve ssh -- \
+        "eve exec pillar /usr/bin/storage-resizer check --disk $DISK --json 2>/dev/null" \
+        2>/dev/null | grep -v 'level=fatal'
+}
+
+for _ in $(seq 1 12); do   # ~2m at 10s — tolerate ssh/pillar not up yet
+    js=$(run_check)
+    parsed=$(echo "$js" | EXPECT="$EXPECT" python3 -c '
+import sys, os, json
+try:
+    o = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+expect = os.environ["EXPECT"]
+dec = o.get("decision", "")
+ptype = o.get("persistType", "")
+sapp = o.get("shrinkApplicable", False)
+sh = o.get("spaceToShrinkExt", {}) or {}
+shok = sh.get("ok", None)
+reason = o.get("decisionReason", "")
+print("decision=%s persistType=%s shrinkApplicable=%s shrink.ok=%s reason=%r"
+      % (dec, ptype, sapp, shok, reason))
+ok = (dec == "insufficient")
+if expect == "zfs":
+    ok = ok and (ptype == "zfs")
+elif expect == "too-full":
+    ok = ok and bool(sapp) and (shok is False)
+else:
+    print("UNKNOWN_EXPECT"); sys.exit(3)
+sys.exit(0 if ok else 1)
+' 2>/dev/null)
+    rc=$?
+    if [ -n "$parsed" ] && echo "$parsed" | grep -q '^decision='; then
+        echo "storage-resizer check: $parsed (expected refusal=$EXPECT)"
+        if [ "$rc" = "0" ]; then
+            echo "OK: check refuses ('insufficient') for the '$EXPECT' reason as required"
+            exit 0
+        fi
+        echo "FAIL: check did not refuse for '$EXPECT'." >&2
+        echo "      The disk was not set up for the '$EXPECT' refusal — check the topology" >&2
+        echo "      (prep-kvm-to-k-topology.sh zfs-notail / ext4-toofull)." >&2
+        echo "$js" >&2
+        exit 1
+    fi
+    sleep 10
+done
+echo "FAIL: no decision from storage-resizer check (binary missing or ssh down?)" >&2
+echo "      tried: eve exec pillar /usr/bin/storage-resizer check --disk $DISK --json" >&2
+exit 1
+
+-- assert-declined.sh --
+#!/bin/bash
+# Assert a cross-flavor update was DECLINED (insufficient): the device did NOT
+# repartition, is still running the kvm image, reports the decline via a non-empty
+# BaseOsStatus.Error (baseosmgr SetErrorNow on OutcomeInsufficient), and remains
+# controller-reachable. Polls for the decline Error to be published.
+# Arg: <kvm-version> (the conversion-capable kvm image the device must stay on).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+KVM_VERSION="${1:?expected kvm (conversion-capable) version}"
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+bos_error() {
+    probe 'eve exec pillar sh -c "cat /run/baseosmgr/BaseOsStatus/*.json 2>/dev/null"' \
+        | python3 -c 'import sys,re,json
+errs=[]
+_d = sys.stdin.read()
+_dec = json.JSONDecoder(); _p = 0
+while _p < len(_d):
+    _s = _d[_p:].lstrip()
+    if not _s: break
+    _p = len(_d) - len(_s)
+    try:
+        o, _p = _dec.raw_decode(_d, _p)
+    except Exception:
+        break
+    e=o.get("Error","")
+    if e: errs.append(e)
+print(" | ".join(errs))' 2>/dev/null
+}
+
+# 1. Wait (up to ~8m) for baseosmgr to publish the decline Error, while the device
+#    stays on the kvm image (a transition to -k would mean it was NOT declined).
+err=""
+for _ in $(seq 1 48); do   # 8m at 10s
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -n "$running" ] && [ "$running" != "$KVM_VERSION" ]; then
+        echo "FAIL: device left the kvm image ('$running' != '$KVM_VERSION') — convert was NOT declined" >&2
+        exit 1
+    fi
+    err=$(bos_error)
+    if [ -n "$err" ]; then
+        echo "BaseOsStatus.Error: $err"
+        break
+    fi
+    sleep 10
+done
+[ -n "$err" ] || { echo "FAIL: no BaseOsStatus.Error within 8m — decline must be reported, not a silent stall" >&2; exit 1; }
+
+# 2. Re-confirm still on the kvm image.
+running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+echo "running=$running (expected kvm=$KVM_VERSION)"
+[ "$running" = "$KVM_VERSION" ] || { echo "FAIL: not on the kvm image after decline ('$running')" >&2; exit 1; }
+
+# 3. EVE -> adam still reachable (device manageable).
+code=$(probe 'eve exec pillar curl -sk --max-time 5 https://$(tr -d "\r\n" < /config/server)/api/v2/edgedevice/ping -o /dev/null -w "%{http_code}"' | tr -d '\r' | tail -1)
+echo "EVE->adam ping http_code=$code"
+[ "$code" = "200" ] || { echo "FAIL: EVE->adam not reachable ($code) — device not manageable after decline" >&2; exit 1; }
+echo "OK: convert declined cleanly — still kvm, Error reported, controller-reachable"
+
+-- wait-for-upgrade.sh --
+#!/bin/bash
+# Wait for a same- or cross-flavor BaseOs upgrade to land: poll until
+# /run/eve-release equals the expected version AND IMGB is the active partition.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT_VERSION="${1:?expected version}"
+DEADLINE=$(( $(date +%s) + 1500 ))   # 25m
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then echo "$(date +%H:%M:%S): EVE unreachable (rebooting?)"; sleep 20; continue; fi
+    imgb_state=$(probe 'eve exec pillar cat /run/baseosmgr/ZbootStatus/IMGB.json' | grep -oP '"PartitionState":"\K[^"]+' | head -1)
+    [ -z "$imgb_state" ] && imgb_state='unknown'
+    echo "$(date +%H:%M:%S): running='$running' IMGB.PartitionState='$imgb_state'"
+    if [ "$running" = "$EXPECT_VERSION" ] && [ "$imgb_state" = "active" ]; then
+        echo "OK: upgrade to $running complete (IMGB active)"; exit 0
+    fi
+    sleep 20
+done
+echo "FAIL: upgrade to $EXPECT_VERSION did not complete in 25m (running='$running')" >&2
+exit 1
+
+-- assert-no-volumes.sh --
+#!/bin/bash
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 12); do
+    out=$("$EDEN" volume ls 2>/dev/null)
+    live=$(echo "$out" | awk 'NR>1 && ($(NF-1) == "IN_CONFIG" || $NF == "DELIVERED")')
+    if [ -z "$live" ]; then echo "OK: no live volumes"; exit 0; fi
+    sleep 5
+done
+echo "FAIL: live volume(s) present" >&2; "$EDEN" volume ls >&2; exit 1
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_volmig.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_volmig.txt
@@ -102,7 +102,7 @@ stdout 'OK: ESP-B present'
 # Step 4: on EVE-k, wait for the cluster + app, then the load-bearing assertion:
 # the data marker survived (the volume was migrated, not recreated).
 message 'waiting for EVE-k content store (volumemgr) ready'
-exec -t 65m bash wait-for-volumemgr-ready.sh
+exec -t 90m bash wait-for-volumemgr-ready.sh
 message 'snapshot downloader RecvByteCount baseline on EVE-k'
 exec -t 1m bash snapshot-rcv-bytes.sh pre
 message 'waiting for EVE-k longhorn StorageClass ready (cluster storage up)'
@@ -560,20 +560,30 @@ ct_count() {
         | tr -d '\r' | grep -E '^[0-9]+$' | tail -1
 }
 last=""
-# 60m at 10s. This MUST exceed volumemgr's own pre-publish block, which is up to
+# 85m budget. This MUST exceed volumemgr's own pre-publish block, which is up to
 # 20m in WaitForKubernetes (node + kubevirt + longhorn) plus up to 20m more in
 # storageWait before VolumeMgrStatus is published at all. This loop also begins
 # timing before volumemgr begins its own, so a 40m budget could not observe the
-# publish even on a device that converges -- it expired at the very moment volumemgr
-# was released. Initialized is set unconditionally once both waits end
-# (handlediskmetrics.go generateAndPublishVolumeMgrStatus), so reaching it under a
-# longer budget means "the device recovered", not "cluster storage is healthy" --
-# the longhorn and app steps that follow are what establish that.
-for _ in $(seq 1 360); do
-    init=$(probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>/dev/null' \
-            | tr -d '\r' | grep -oE '"Initialized":[a-z]+')
+# publish even on a device that converges -- it expired at the very moment
+# volumemgr was released.
+#
+# The budget is wall-clock, not an iteration count: each pass also spends up to
+# 16s in two ssh probes that hit their timeout precisely when the device is
+# stalled, so a fixed count can outlive the caller's `exec -t` deadline and get
+# killed before reaching the diagnostics below -- which is when they matter most.
+# Keep it under that deadline with room for the final status dump.
+BUDGET_MIN=85
+deadline=$(( $(date +%s) + BUDGET_MIN * 60 ))
+unmet=""
+while [ "$(date +%s)" -lt "$deadline" ]; do
+    status=$(probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>/dev/null' \
+            | tr -d '\r')
+    init=$(echo "$status" | grep -oE '"Initialized":[a-z]+')
+    # UnmetCondition names the readiness gate still outstanding while Initialized
+    # is false. Absent on images predating lf-edge/eve#6240.
+    unmet=$(echo "$status" | grep -oE '"UnmetCondition":"[^"]+"')
     ct=$(ct_count); [ -z "$ct" ] && ct='?'
-    sig="init=${init:-<none>} contenttrees=$ct"
+    sig="init=${init:-<none>} contenttrees=$ct${unmet:+ $unmet}"
     if [ "$sig" != "$last" ]; then
         echo "$(date +%H:%M:%S) [readiness] $sig"; last="$sig"
     fi
@@ -582,7 +592,10 @@ for _ in $(seq 1 360); do
     fi
     sleep 10
 done
-echo "FAIL: volumemgr did not reach Initialized:true within 40m" >&2
+echo "FAIL: volumemgr did not reach Initialized:true within ${BUDGET_MIN}m" >&2
+# A reported UnmetCondition distinguishes cluster storage that never converged
+# from a device that published nothing at all.
+echo "FAIL: last reported unmet condition: ${unmet:-<none reported>}" >&2
 probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>&1' >&2
 exit 1
 

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_volmig.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_volmig.txt
@@ -675,8 +675,11 @@ test:
 # that follows can be short, and a failure here clearly says "longhorn", not "app".
 set -uo pipefail
 EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+began=$(date +%s)
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [longhorn-sc] waiting for the StorageClass"
 for _ in $(seq 1 90); do   # ~45m at 30s
     if "$EDEN" eve ssh -- 'eve exec kube kubectl get sc 2>/dev/null' 2>/dev/null | grep -qE '^longhorn'; then
+        echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [longhorn-sc] ready after $(( $(date +%s) - began ))s"
         echo "OK: longhorn StorageClass ready"; exit 0
     fi
     sleep 30

--- a/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_volmig.txt
+++ b/tests/update_eve_image/testdata/update_eve_image_kvm_to_k_volmig.txt
@@ -1,0 +1,707 @@
+# Test: EVE-kvm -> EVE-k app-volume migration. An app instance and its disk
+# volume must SURVIVE the cross-flavor upgrade WITHOUT recreate (app-written data
+# preserved), on ext4 /persist with a TPM (swtpm). The boot disk starts at the
+# LARGE EVE-k geometry, so the conversion takes the no-shrink "proceed" path and
+# the cross-flavor gate allows the upgrade with volumes present. The code under
+# test: upgradeconverter relocates the carried-over kvm volume to
+# /persist/vault/volumes-kvm, and volumemgr (csihandler) rolls that file into the
+# Longhorn PVC so the app's data survives instead of being regenerated.
+#
+# Image sequence (exact):
+#   1. start : EVE up on <VOLMIG_EVE_VER>-kvm (large geometry, ext4, tpm).
+#   2. k     : BaseOs-update kvm->k to <VOLMIG_EVE_VER>-k; the app is KEPT across it.
+#
+# What it asserts:
+#   - the running vault is TPM-backed (UnlockMethod != no-tpm);
+#   - BOTH apps reach RUNNING on EVE-k: a VM app (Ubuntu qcow2 disk) AND a
+#     container app (eclient with a --mount data volume at /data);
+#   - a data marker written into EACH app's volume BEFORE the conversion is still
+#     present AFTER it (both the VM disk volume and the container data volume
+#     survived without recreate);
+#   - the image was not re-downloaded across the conversion (RecvByteCount ~0).
+#
+# Parameters (env):
+#   VOLMIG_EVE_VER  (required) version base of the local volmig images, without
+#                   the -<hv>-<arch> suffix, e.g. "0.0.0-kvm-to-k-volmig-<sha8>".
+#   VOLMIG_EVE_REG  (default lfedge/eve) image registry/repo namespace.
+# Bringup is manual (see README_kvm_to_k.md): EVE must already be up on the -kvm image.
+
+{{$arch := EdenConfig "eve.arch"}}
+{{$ver_env := EdenGetEnv "VOLMIG_EVE_VER"}}
+{{$ver := "REPLACE-WITH-VOLMIG-VERSION"}}
+{{if $ver_env}}{{$ver = $ver_env}}{{end}}
+{{$reg_env := EdenGetEnv "VOLMIG_EVE_REG"}}
+{{$reg := "lfedge/eve"}}
+{{if $reg_env}}{{$reg = $reg_env}}{{end}}
+{{$kvm_short := printf "%s-kvm-%s" $ver $arch}}
+{{$k_short   := printf "%s-k-%s" $ver $arch}}
+{{$appimg := "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"}}
+{{define "eclient_image"}}docker://{{EdenConfig "eden.eclient.image"}}:{{EdenConfig "eden.eclient.tag"}}{{end}}
+
+# Step 0: pre-flight — params, clean state, on the expected -kvm image, TPM live.
+message 'pre-flight: parameters, clean state, TPM-backed vault'
+exec -t 1m bash require-ver.sh
+exec -t 1m bash assert-no-volumes.sh
+exec -t 3m bash assert-running-version.sh {{ $kvm_short }}
+exec -t 2m bash tpm-guard.sh
+stdout 'TPM-backed'
+eden controller edge-node update --config timer.test.baseimage.update=30
+
+# Step 1: deploy a VM app with a disk volume, then write a data marker into the
+# guest disk so we can later prove the SAME bytes survived the conversion.
+message 'deploying Ubuntu VM app with a disk volume on EVE-kvm'
+eden -t 1m network create 10.11.12.0/24 -n xhv-app-net
+# Inject the eclient SSH pubkey into the guest via cloud-init user-data so the
+# marker uses key auth (no sshpass / no password). cloud-init runs once on first
+# boot and writes authorized_keys onto the guest disk = the volume that migrates,
+# so key auth keeps working post-conversion on EVE-k. (Ubuntu cloud image: it
+# honors cloud-config ssh_authorized_keys; Cirros does NOT — see gen-metadata.sh.)
+exec -t 1m bash gen-metadata.sh
+eden -t 15m pod deploy --format=qcow2 --memory=1024MB -n xhv-vmapp -p 2223:22 {{ $appimg }} --networks=xhv-app-net --metadata=/tmp/xhv-volmig-userdata.yaml
+# Pre-conversion the device is EVE-kvm (no longhorn/kube), so wait only for the
+# app itself here; the longhorn-StorageClass wait belongs to the post-conversion
+# (EVE-k) app-wait in Step 4.
+exec -t 20m bash wait-for-app-running.sh
+message 'writing a data marker into the guest disk volume'
+exec -t 20m bash marker.sh write
+stdout 'MARKER_WRITTEN'
+
+# Step 1b: ALSO deploy a CONTAINER app (eclient) with its own persistent data
+# volume, and write a marker into that volume — so the migration is exercised for
+# BOTH a VM app's disk volume AND a container app's data volume. eclient declares
+# no image VOLUME and EVE does not mkfs empty volumes, so the data volume is a
+# PRE-FORMATTED (ext4) empty qcow2 built host-side (gen-data-volume.sh) and
+# attached via --mount at /data. The marker lives on that migrating volume (not the
+# recreated container rootfs). NOTE: EVE-k does not auto-mount the volume at /data
+# (lf-edge/eve#6145), so ctr-marker.sh verify reads it via the block device.
+message 'deploying eclient CONTAINER app with a pre-formatted ext4 data volume on EVE-kvm'
+exec -t 2m bash gen-data-volume.sh
+stdout 'DATA_VOLUME_READY'
+eden -t 15m pod deploy {{template "eclient_image"}} --memory=512MB -n xhv-ctrapp -p 2224:22 --networks=xhv-app-net --mount=src=file://{{EdenConfig "eden.root"}}/xhv-data.qcow2,dst=/data
+exec -t 20m bash wait-for-app-running.sh xhv-ctrapp
+message 'writing a data marker into the container app data volume'
+exec -t 20m bash ctr-marker.sh write
+stdout 'CTR_MARKER_WRITTEN'
+
+# Step 2: BaseOs-update kvm->k while KEEPING the app+volume. The cross-flavor gate
+# allows this because the large geometry means no shrink.
+message 'downloading volmig k rootfs'
+eden -t 10m utils download eve-rootfs --eve-tag={{$ver}} --eve-hv=k --eve-registry={{$reg}} --downloader-dist={{EdenConfigPath "eve.dist"}} -v debug
+stdout '{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs'
+message 'pushing kvm->k BaseOs update (app + volume kept)'
+eden -t 10m controller edge-node eveimage-update file://{{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs --os-version={{ $k_short }} -m adam://
+! stderr .
+
+# Step 3: drive and watch the conversion to EVE-k.
+message 'watching the kvm->k conversion to completion'
+exec -t 45m bash watch-conversion.sh {{ $k_short }}
+message 'ASSERT: converted device carries the reserved ESP-B (#7, …30056) — proceed-path large layout'
+exec -t 2m bash assert-espb-present.sh
+stdout 'OK: ESP-B present'
+
+# Step 4: on EVE-k, wait for the cluster + app, then the load-bearing assertion:
+# the data marker survived (the volume was migrated, not recreated).
+message 'waiting for EVE-k content store (volumemgr) ready'
+exec -t 65m bash wait-for-volumemgr-ready.sh
+message 'snapshot downloader RecvByteCount baseline on EVE-k'
+exec -t 1m bash snapshot-rcv-bytes.sh pre
+message 'waiting for EVE-k longhorn StorageClass ready (cluster storage up)'
+exec -t 50m bash wait-for-longhorn-sc.sh
+stdout 'OK: longhorn StorageClass ready'
+message 'waiting for the app to reach RUNNING on EVE-k'
+exec -t 45m bash wait-for-app-running.sh
+message 'ASSERT: the disk volume survived the conversion without recreate'
+exec -t 10m bash marker.sh verify
+stdout 'VOLUME SURVIVED'
+message 'waiting for the CONTAINER app to reach RUNNING on EVE-k'
+exec -t 45m bash wait-for-app-running.sh xhv-ctrapp
+message 'ASSERT: the container app data volume survived the conversion without recreate'
+exec -t 10m bash ctr-marker.sh verify
+stdout 'CONTAINER VOLUME SURVIVED'
+message 'asserting the image was not re-downloaded across the conversion'
+exec -t 1m bash snapshot-rcv-bytes.sh post-and-assert
+
+# Cleanup.
+eden -t 1m pod delete xhv-vmapp
+eden -t 1m pod delete xhv-ctrapp
+eden -t 1m network delete xhv-app-net
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs
+exec rm -f {{EdenConfigPath "eve.dist"}}/rootfs-{{ $k_short }}.squashfs.ver
+exec sleep 5
+eden eve reset
+
+-- require-ver.sh --
+#!/bin/bash
+# Fail fast if VOLMIG_EVE_VER was not supplied.
+set -uo pipefail
+VER='{{ $ver }}'
+if [ -z "$VER" ] || [ "$VER" = "REPLACE-WITH-VOLMIG-VERSION" ]; then
+    echo "FAIL: VOLMIG_EVE_VER not set." >&2
+    echo "      Export it to the version base of your local volmig build," >&2
+    echo "      e.g. VOLMIG_EVE_VER=0.0.0-kvm-to-k-volmig-1a2b3c4d" >&2
+    echo "      (the part before -kvm-amd64 / -k-amd64 in the docker tag)." >&2
+    exit 1
+fi
+echo "OK: VOLMIG_EVE_VER=$VER"
+
+-- tpm-guard.sh --
+#!/bin/bash
+# Confirm the test is really running with a TPM (swtpm), not a no-tpm vault — an
+# app volume in /persist/vault is only meaningful when the vault is TPM-backed.
+# swtpm and the EVE QEMU both run on this host (the eden VM), so check them here.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+pgrep -x swtpm >/dev/null && echo "swtpm: running" || { echo "FAIL: swtpm not running" >&2; exit 1; }
+ps -eo args | grep "[d]efault-eve.log" | grep -q "tpm-tis" && echo "qemu: tpm-tis present" || { echo "FAIL: qemu has no tpm-tis device" >&2; exit 1; }
+um=$(timeout 15 "$EDEN" eve ssh -- 'eve exec pillar sh -c "cat /run/vaultmgr/VaultStatus/*.json 2>/dev/null"' 2>/dev/null | grep -v 'level=fatal' | grep -oE '"UnlockMethod":[0-9]+' | head -1 | cut -d: -f2)
+echo "VaultStatus.UnlockMethod=${um:-<none>} (1=tpm-local-sealed 2=controller-key 3=no-tpm)"
+case "${um:-x}" in
+    1|2) echo "OK: TPM-backed vault confirmed" ;;
+    3)   echo "FAIL: vault is no-tpm — swtpm is not in use" >&2; exit 1 ;;
+    *)   echo "OK: TPM-backed (swtpm + tpm-tis present; UnlockMethod not yet published)" ;;
+esac
+
+-- marker.sh --
+#!/bin/bash
+# write : ssh into the Ubuntu guest and write a unique data marker into its disk
+#         volume; remember it.
+# verify: after the conversion, re-read the marker; PASS only if it matches the
+#         one written pre-conversion (proves the volume's bytes survived without
+#         recreate). Auth is KEY-BASED: gen-metadata.sh injected the eclient
+#         pubkey via cloud-init, so we log in as ubuntu with the eclient id_rsa
+#         (no password, no sshpass) over hostfwd 127.0.0.1:2223 -> EVE -> app:22.
+set -uo pipefail
+MODE=${1:?write|verify}
+PORT=2223
+MF=/tmp/xhv-volmig-marker.txt
+# ssh refuses group-readable keys, so copy the eclient id_rsa to a 0600 temp file.
+# testscript sets HOME=/no-home, so resolve the real home from the running UID;
+# dist/tests is only populated by a full `make eden`, so fall back to the
+# master/main reference clones (same list gen-metadata.sh uses for the pubkey).
+EDEN_TESTS="{{EdenConfig "eden.tests"}}"
+USER_HOME=$(getent passwd "$(id -u)" | cut -d: -f6)
+SRC=""
+for c in "$EDEN_TESTS/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/master/eden/tests/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/main/eden/tests/eclient/image/cert/id_rsa"; do
+    if [ -f "$c" ]; then SRC="$c"; break; fi
+done
+[ -n "$SRC" ] || { echo "FAIL: could not locate eclient id_rsa cert (EDEN_TESTS=$EDEN_TESTS, USER_HOME=$USER_HOME)" >&2; exit 1; }
+KEY=$(mktemp); install -m 600 "$SRC" "$KEY"; trap 'rm -f "$KEY"' EXIT
+SSHP=(-o ConnectTimeout=10 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -o PreferredAuthentications=publickey -i "$KEY")
+guest() { ssh "${SSHP[@]}" ubuntu@127.0.0.1 -p "$PORT" "$@" 2>/dev/null; }
+
+case "$MODE" in
+    write)
+        m="VOLMIG-SURVIVES-$(date +%s)"
+        ok=0
+        for _ in $(seq 1 90); do guest true && { ok=1; break; }; sleep 10; done
+        [ "$ok" = 1 ] || { echo "FAIL: ubuntu guest ssh not reachable pre-conversion" >&2; exit 1; }
+        guest "echo $m > /home/ubuntu/volmig-marker && sync && cat /home/ubuntu/volmig-marker"
+        echo "$m" > "$MF"
+        echo "MARKER_WRITTEN=$m"
+        ;;
+    verify)
+        want=$(cat "$MF" 2>/dev/null)
+        for _ in $(seq 1 48); do
+            got=$(guest 'cat /home/ubuntu/volmig-marker 2>/dev/null' | tr -d '\r')
+            if [ -n "$got" ]; then
+                echo "guest marker='$got' expected='$want'"
+                if [ "$got" = "$want" ]; then
+                    echo "PASS: VOLUME SURVIVED kvm->k WITHOUT RECREATE (data marker intact)"
+                    exit 0
+                fi
+                echo "FAIL: marker mismatch — the volume was recreated/replaced" >&2
+                exit 1
+            fi
+            sleep 15
+        done
+        echo "FAIL: marker not readable on EVE-k (app not ssh-reachable or volume lost)" >&2
+        exit 1
+        ;;
+    *) echo "usage: marker.sh write|verify" >&2; exit 1 ;;
+esac
+
+-- ctr-marker.sh --
+#!/bin/bash
+# Container-app sibling of marker.sh. Proves the eclient CONTAINER app's DATA
+# VOLUME survived kvm->k without recreate. eclient runs sshd with ROOT key auth via
+# the eclient id_rsa over hostfwd 127.0.0.1:2224 -> EVE -> app:22.
+#   write : EVE-kvm auto-mounts the data volume at /data (runx shim), so write the
+#           marker to /data (a mounted-volume check guards a failed mount).
+#   verify: EVE-k (kubevirt) does NOT auto-mount container data volumes at their
+#           MountDir (lf-edge/eve#6145) — the volume is presented as a raw block
+#           device. So mount the migrated volume by its block device and read the
+#           marker there. This tests the migration invariant (the volume's data
+#           survived, no recreate) independent of the #6145 auto-mount gap; tighten
+#           back to reading /data once #6145 is fixed.
+set -uo pipefail
+MODE=${1:?write|verify}
+PORT=2224
+MF=/tmp/xhv-volmig-ctr-marker.txt
+MPATH=/data/ctr-marker
+EDEN_TESTS="{{EdenConfig "eden.tests"}}"
+USER_HOME=$(getent passwd "$(id -u)" | cut -d: -f6)
+SRC=""
+for c in "$EDEN_TESTS/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/master/eden/tests/eclient/image/cert/id_rsa" \
+         "$USER_HOME/lf-edge/main/eden/tests/eclient/image/cert/id_rsa"; do
+    if [ -f "$c" ]; then SRC="$c"; break; fi
+done
+[ -n "$SRC" ] || { echo "FAIL: could not locate eclient id_rsa cert (EDEN_TESTS=$EDEN_TESTS, USER_HOME=$USER_HOME)" >&2; exit 1; }
+KEY=$(mktemp); install -m 600 "$SRC" "$KEY"; trap 'rm -f "$KEY"' EXIT
+SSHP=(-o ConnectTimeout=10 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -o PreferredAuthentications=publickey -i "$KEY")
+guest() { ssh "${SSHP[@]}" root@127.0.0.1 -p "$PORT" "$@" 2>/dev/null; }
+
+case "$MODE" in
+    write)
+        m="VOLMIG-CTR-SURVIVES-$(date +%s)"
+        ok=0
+        for _ in $(seq 1 90); do guest true && { ok=1; break; }; sleep 10; done
+        [ "$ok" = 1 ] || { echo "FAIL: eclient container ssh not reachable pre-conversion" >&2; exit 1; }
+        # Confirm /data is the MOUNTED data volume (not just a rootfs dir) so a
+        # failed volume mount is caught here (pre-conversion), not after convert.
+        guest "grep -q ' /data ' /proc/mounts" || { echo "FAIL: /data is not a mounted volume (data-volume mount failed)"; guest "cat /proc/mounts" >&2; exit 1; }
+        guest "echo $m > $MPATH && sync && cat $MPATH"
+        echo "$m" > "$MF"
+        echo "CTR_MARKER_WRITTEN=$m"
+        ;;
+    verify)
+        want=$(cat "$MF" 2>/dev/null)
+        # Mount the migrated data volume by its block device (EVE-k does not
+        # auto-mount it at /data — #6145). Find it by fs LABEL (XHVDATA); busybox
+        # blkid lacks -L, so scan `blkid` output, falling back to /dev/vdb (the sole
+        # extra virtio disk on this app).
+        for _ in $(seq 1 48); do
+            got=$(guest "
+                umount /mnt/xhvdata 2>/dev/null; mkdir -p /mnt/xhvdata
+                dev=\$(blkid 2>/dev/null | grep -i XHVDATA | head -1 | cut -d: -f1)
+                [ -n \"\$dev\" ] || dev=/dev/vdb
+                mount \"\$dev\" /mnt/xhvdata 2>/dev/null && cat /mnt/xhvdata/ctr-marker 2>/dev/null
+            " | tr -d '\r' | tail -1)
+            if [ -n "$got" ]; then
+                echo "container marker='$got' expected='$want'"
+                if [ "$got" = "$want" ]; then
+                    echo "PASS: CONTAINER VOLUME SURVIVED kvm->k WITHOUT RECREATE (data marker intact, read from the migrated block device)"
+                    exit 0
+                fi
+                echo "FAIL: container marker mismatch — the volume was recreated/replaced" >&2
+                exit 1
+            fi
+            sleep 15
+        done
+        echo "FAIL: container marker not readable from the migrated data volume (app not ssh-reachable or volume lost)" >&2
+        exit 1
+        ;;
+    *) echo "usage: ctr-marker.sh write|verify" >&2; exit 1 ;;
+esac
+
+-- gen-data-volume.sh --
+#!/bin/bash
+# Build a PRE-FORMATTED empty data volume for the container app: a whole-device
+# ext4 qcow2 (no partition), so /data is a mountable writable filesystem regardless
+# of whether EVE formats empty volumes (it does not — no mkfs in the pillar volume
+# path). Sudo-free (mkfs.ext4 on a sparse raw, then convert to qcow2). Placed at
+# eden.root so the escript can reference it as a file:// URL under that dir.
+set -uo pipefail
+OUT="{{EdenConfig "eden.root"}}/xhv-data.qcow2"
+RAW="$OUT.raw.tmp"
+rm -f "$RAW" "$OUT"
+truncate -s 512M "$RAW"
+mkfs.ext4 -F -q -L XHVDATA "$RAW"
+qemu-img convert -f raw -O qcow2 "$RAW" "$OUT"
+rm -f "$RAW"
+echo "DATA_VOLUME_READY=$OUT ($(qemu-img info "$OUT" | sed -ne 's/^virtual size: //p'))"
+
+-- gen-metadata.sh --
+#!/bin/bash
+# Write the cloud-init user-data that `eden pod deploy --metadata=` reads, so the
+# Ubuntu guest authorizes the eclient SSH pubkey for its default (ubuntu) user,
+# so marker.sh logs in with a key and needs no sshpass/password. (Cirros does NOT
+# honor cloud-config ssh_authorized_keys, verified 2026-07-01 — hence Ubuntu.) Same cert
+# search list as marker.sh (dist/tests, then the master/main reference clones).
+set -uo pipefail
+EDEN_TESTS="{{EdenConfig "eden.tests"}}"
+USER_HOME=$(getent passwd "$(id -u)" | cut -d: -f6)
+PUB=""
+for c in "$EDEN_TESTS/eclient/image/cert/id_rsa.pub" \
+         "$USER_HOME/lf-edge/master/eden/tests/eclient/image/cert/id_rsa.pub" \
+         "$USER_HOME/lf-edge/main/eden/tests/eclient/image/cert/id_rsa.pub"; do
+    if [ -f "$c" ]; then PUB="$c"; break; fi
+done
+[ -n "$PUB" ] || { echo "FAIL: could not locate eclient id_rsa.pub (EDEN_TESTS=$EDEN_TESTS, USER_HOME=$USER_HOME)" >&2; exit 1; }
+UD=/tmp/xhv-volmig-userdata.yaml
+{
+    echo "#cloud-config"
+    echo "ssh_authorized_keys:"
+    echo " - $(cat "$PUB")"
+} > "$UD"
+echo "OK: wrote cloud-init userdata (eclient pubkey) to $UD"
+
+-- assert-running-version.sh --
+#!/bin/bash
+# Sanity-check that EVE is running the expected SMALL bringup release before the
+# conversion starts. This escript does not install the base image — bringup
+# happens manually before the test (see README_kvm_to_k.md). This guards
+# against running the test against the wrong base image or an already-upgraded
+# device.
+#
+# Matches the expected version as a substring of /run/eve-release (which is the
+# full "<ver>-<hv>-<arch>" form, e.g. "12.1.0-kvm-amd64"), so passing "12.1.0"
+# accepts the kvm bringup image without pinning the hv/arch suffix.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+EXPECT="${1:?expected bringup version substring}"
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+for _ in $(seq 1 18); do   # ~3m at 10s; tolerate ssh not up yet
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -n "$running" ]; then
+        case "$running" in
+            *"$EXPECT"*)
+                echo "OK: running the expected bringup release ('$running' contains '$EXPECT')"
+                exit 0 ;;
+            *)
+                echo "FAIL: running version '$running' does not match expected bringup '$EXPECT'." >&2
+                echo "      Bring eve up on the small '$EXPECT' image before this test, or set" >&2
+                echo "      BRINGUP_EVE_VER to the release you brought up on." >&2
+                echo "      See README_kvm_to_k.md." >&2
+                exit 1 ;;
+        esac
+    fi
+    sleep 10
+done
+echo "FAIL: could not read /run/eve-release (ssh down / device not up?)" >&2
+exit 1
+
+-- assert-no-volumes.sh --
+#!/bin/bash
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 12); do
+    out=$("$EDEN" volume ls 2>/dev/null)
+    live=$(echo "$out" | awk 'NR>1 && ($(NF-1) == "IN_CONFIG" || $NF == "DELIVERED")')
+    if [ -z "$live" ]; then echo "OK: no live volumes"; exit 0; fi
+    sleep 5
+done
+echo "FAIL: live volume(s) present" >&2; "$EDEN" volume ls >&2; exit 1
+
+-- wait-for-app-running.sh --
+#!/bin/bash
+# Poll `eden pod ps` until xhv-vmapp reaches LAST_STATE(EVE)=RUNNING. 25m budget
+# covers both the fast pre-conversion kvm case and the slow post-conversion
+# eve-k redeploy (longhorn install + VMI start).
+set -uo pipefail
+APP="${1:-xhv-vmapp}"   # app name to wait for (default keeps the VM-app callers working)
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 240); do   # 40m at 10s (deploy-on-boot: app RUNNING is gated on the full post-longhorn volume create + CDI upload + guest boot, ~27m observed)
+    line=$("$EDEN" pod ps 2>/dev/null | grep -E "^${APP}\s")
+    if echo "$line" | grep -q 'RUNNING'; then
+        echo "OK: $APP RUNNING"; echo "$line"; exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: $APP did not reach RUNNING in 40m" >&2
+"$EDEN" pod ps >&2
+exit 1
+
+-- watch-conversion.sh --
+#!/bin/bash
+# Drive AND watch the kvm->k conversion (shrink+grow, or grow) to completion,
+# state/sub-state TRANSITION. The post-grow vault seal check is done POST-HOC
+# from /persist/newlog (assert-seal-from-newlog.sh): the live post-grow EVE-kvm
+# window is only ~1-2 min and an ssh poll loop misses it.
+#
+# The repartition runs OFFLINE in storage-init (the boot disk's GPT can't be re-read
+# live while its rootfs is mounted): baseosmgr arms the shrink/grow flag and
+# reboots, storage-init grows ESP/IMGA/IMGB (possibly with a busy-disk
+# reboot-to-apply), the device re-checks (proceed) and does the cross-flavor A/B
+# install, then reboots into EVE-k.
+#
+# Logs, only when it changes, the tuple of: running version, IMGA/IMGB active
+# partition+version, controller-reported device state + sub-state (from adam),
+# and on-device Converting + ConvertSubState. Completion is slot-agnostic (the
+# grow can relocate the active slot).
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+K_VERSION="${1:?expected -k version}"
+SERIAL_LOG='{{EdenConfig "eve.log"}}'
+DEADLINE=$(( $(date +%s) + 2700 ))   # 45m
+
+probe() { timeout 15 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+
+substate_name() {
+    case "$1" in
+        1) echo preflight ;;
+        2) echo rebooting-to-resize ;;
+        3) echo making-space ;;
+        4) echo creating-partitions ;;
+        5) echo renaming-partitions ;;
+        6) echo installing ;;
+        7) echo rebooting-to-target ;;
+        *) echo "sub_$1" ;;
+    esac
+}
+
+# Controller's view from adam: the latest ZiDevice report's state + sub_state.
+# (eden info -o/--format json panics on this build, so grep the text-proto.)
+ctrl_state() {
+    local c st sub
+    c=$(timeout 20 "$EDEN" info --tail 8 2>/dev/null | grep -a '^content: ztype:ZiDevice' | tail -1)
+    st=$(echo "$c" | grep -oE 'state:ZDEVICE_STATE_[A-Z_]+' | head -1 | cut -d: -f2)
+    sub=$(echo "$c" | grep -oE 'sub_state:ZDEVICE_SUBSTATE_[A-Z_]+' | head -1 | cut -d: -f2)
+    echo "${st:-?}/${sub:-NONE}"
+}
+
+# Which partition (IMGA/IMGB) is active, and the version on it.
+active_part() {
+    probe 'eve exec pillar sh -c "cat /run/baseosmgr/ZbootStatus/IMGA.json /run/baseosmgr/ZbootStatus/IMGB.json 2>/dev/null"' | python3 -c '
+import sys, json, re
+act = "?"; ver = "?"
+_d = sys.stdin.read()
+_dec = json.JSONDecoder(); _p = 0
+while _p < len(_d):
+    _s = _d[_p:].lstrip()
+    if not _s: break
+    _p = len(_d) - len(_s)
+    try:
+        o, _p = _dec.raw_decode(_d, _p)
+    except Exception:
+        break
+    if o.get("PartitionState") == "active":
+        act = o.get("PartitionLabel", "?"); ver = o.get("ShortVersion", "?")
+print("%s:%s" % (act, ver))' 2>/dev/null || echo "?:?"
+}
+
+serial_off=0
+report_serial() {
+    [ -f "$SERIAL_LOG" ] || return 0
+    local size new
+    size=$(stat -c%s "$SERIAL_LOG" 2>/dev/null || echo 0)
+    if [ "$size" -gt "$serial_off" ]; then
+        new=$(tail -c +$(( serial_off + 1 )) "$SERIAL_LOG" 2>/dev/null)
+        serial_off=$size
+        echo "$new" | grep -aE 'storage-resizer:|repartition|grow|reboot to apply|convert' | while IFS= read -r l; do
+            echo "  serial> $l"
+        done
+    fi
+}
+
+last_sig=""
+reboots=0
+unreachable_run=0
+seen_converting=0
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    report_serial
+    running=$(probe 'cat /run/eve-release' | tr -d '\r' | grep -E '^[A-Za-z0-9._+-]+$' | tail -1)
+    if [ -z "$running" ]; then
+        unreachable_run=$(( unreachable_run + 1 ))
+        if [ "$last_sig" != "UNREACHABLE" ]; then
+            echo "$(date +%H:%M:%S) [transition] EVE unreachable (rebooting?)"
+            last_sig="UNREACHABLE"
+        fi
+        sleep 15
+        continue
+    fi
+    if [ "$unreachable_run" -ge 2 ]; then
+        reboots=$(( reboots + 1 ))
+        echo "$(date +%H:%M:%S) observed a reboot (count=$reboots)"
+    fi
+    unreachable_run=0
+
+    actver=$(active_part)
+    bos=$(probe 'eve exec pillar sh -c "cat /run/baseosmgr/BaseOsStatus/*.json 2>/dev/null"')
+    conv=$(echo "$bos" | grep -o '"Converting":[a-z]*' | head -1 | cut -d: -f2); [ -z "$conv" ] && conv=false
+    csub=$(echo "$bos" | grep -o '"ConvertSubState":[0-9]*' | head -1 | cut -d: -f2); [ -z "$csub" ] && csub=0
+    [ "$conv" = "true" ] && seen_converting=1
+    dev=$(ctrl_state)
+
+    sig="run=$running active=$actver dev=$dev converting=$conv csub=$csub($(substate_name "$csub"))"
+    if [ "$sig" != "$last_sig" ]; then
+        echo "$(date +%H:%M:%S) [transition] $sig"
+        last_sig="$sig"
+    fi
+
+    # Done: the device has BOOTED the -k version. We deliberately do NOT wait for
+    # the A/B commit to 'active' or for the cluster to be online here — readiness
+    # is verified in the split steps that follow. PartitionState is typically still
+    # 'updating'/'inprogress' now.
+    if [ "$running" = "$K_VERSION" ]; then
+        report_serial
+        echo "OK: EVE-k booted (running=$running, active=$actver, converting=$conv)"
+        echo "    observed: CONVERTING=$seen_converting reboots=$reboots"
+        exit 0
+    fi
+    sleep 15
+done
+echo "FAIL: 45m timeout. running='${running:-?}' active='${actver:-?}' dev='${dev:-?}'" >&2
+echo "      observed: CONVERTING=$seen_converting reboots=$reboots" >&2
+exit 1
+
+-- wait-for-volumemgr-ready.sh --
+#!/bin/bash
+# Gate before the post-conversion redeploy. On EVE-k, volumemgr must finish its
+# "wait for kubernetes" / longhorn-ready init and RE-ESTABLISH the retained
+# ContentTree blobs in the EVE-k content store before a redeploy can REUSE them.
+# Deploying earlier causes the image to be re-downloaded (verified: ~44 MiB vs 0
+# with this gate). Wait for /run/volumemgr/VolumeMgrStatus/volumemgr.json
+# "Initialized":true (set after kubeapi.WaitForKubernetes returns).
+#
+# Instrumented: logs a timeline of (volumemgr Initialized, number of
+# ContentTreeStatus objects volumemgr currently tracks) so we can see WHEN the
+# store becomes ready and whether the retained ContentTree is recognized before
+# full Initialized — i.e. whether a narrower "blobs recognized" signal would let
+# the deploy fire sooner than waiting for the whole longhorn bring-up.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+probe() { timeout 8 "$EDEN" eve ssh -- "$1" 2>/dev/null | grep -v 'level=fatal'; }
+ct_count() {
+    probe 'eve exec pillar sh -c "ls /run/volumemgr/ContentTreeStatus/*.json 2>/dev/null | wc -l"' \
+        | tr -d '\r' | grep -E '^[0-9]+$' | tail -1
+}
+last=""
+# 60m at 10s. This MUST exceed volumemgr's own pre-publish block, which is up to
+# 20m in WaitForKubernetes (node + kubevirt + longhorn) plus up to 20m more in
+# storageWait before VolumeMgrStatus is published at all. This loop also begins
+# timing before volumemgr begins its own, so a 40m budget could not observe the
+# publish even on a device that converges -- it expired at the very moment volumemgr
+# was released. Initialized is set unconditionally once both waits end
+# (handlediskmetrics.go generateAndPublishVolumeMgrStatus), so reaching it under a
+# longer budget means "the device recovered", not "cluster storage is healthy" --
+# the longhorn and app steps that follow are what establish that.
+for _ in $(seq 1 360); do
+    init=$(probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>/dev/null' \
+            | tr -d '\r' | grep -oE '"Initialized":[a-z]+')
+    ct=$(ct_count); [ -z "$ct" ] && ct='?'
+    sig="init=${init:-<none>} contenttrees=$ct"
+    if [ "$sig" != "$last" ]; then
+        echo "$(date +%H:%M:%S) [readiness] $sig"; last="$sig"
+    fi
+    if [ "$init" = '"Initialized":true' ]; then
+        echo "OK: volumemgr Initialized:true (contenttrees=$ct)"; exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: volumemgr did not reach Initialized:true within 40m" >&2
+probe 'eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json 2>&1' >&2
+exit 1
+
+-- snapshot-rcv-bytes.sh --
+#!/bin/bash
+# Snapshot cumulative RecvByteCount from /run/downloader/MetricsMap on EVE.
+# "pre" saves the baseline; "post-and-assert" recomputes the delta and asserts
+# it is below MAX_DELTA_BYTES (default 1 MiB). /run is tmpfs (reset on reboot),
+# so pre/post must bracket a single phase with no intervening reboot.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+MODE=${1:-pre}
+MAX_DELTA_BYTES=${2:-1048576}
+
+capture_recv_bytes() {
+    timeout 15 "$EDEN" eve ssh -- 'eve exec pillar cat /run/downloader/MetricsMap/global.json 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print(0); sys.exit(0)
+total = 0
+for iface, conn in d.items():
+    for url, m in (conn.get('URLCounters') or {}).items():
+        total += m.get('RecvByteCount', 0)
+print(total)
+"
+}
+
+case "$MODE" in
+    pre)
+        bytes=$(capture_recv_bytes)
+        echo "$bytes" > /tmp/xhv-rcv-pre.txt
+        echo "Pre-snapshot: RecvByteCount total = $bytes bytes"
+        ;;
+    post-and-assert)
+        post=$(capture_recv_bytes)
+        pre=$(cat /tmp/xhv-rcv-pre.txt 2>/dev/null || echo 0)
+        delta=$(( post - pre ))
+        echo "Post-snapshot: RecvByteCount total = $post bytes (pre was $pre, delta = $delta)"
+        if [ "$delta" -lt 0 ]; then
+            echo "FAIL: post < pre — counter went backwards (unexpected reboot?)" >&2; exit 1
+        fi
+        if [ "$delta" -lt "$MAX_DELTA_BYTES" ]; then
+            echo "OK: only $delta bytes received (< ${MAX_DELTA_BYTES}) — no image re-download"; exit 0
+        fi
+        info=$(cat /tmp/xhv-persist-recreate.info 2>/dev/null || echo clean)
+        if [ "${info%%|*}" = "recreated" ]; then
+            rts=$(printf '%s' "$info" | cut -d'|' -f2); rstep=$(printf '%s' "$info" | cut -d'|' -f3)
+            echo "FAIL[recreate-induced]: $delta bytes re-downloaded, BUT /persist was recreated during the resize -- storage-init mount-fsck found P3 corrupt at $rts, after the watchdog interrupted: $rstep. The re-download is the expected consequence; the conversion otherwise completed (this is the ONLY failure)." >&2
+            exit 1
+        fi
+        echo "FAIL[blob-reuse]: $delta bytes re-downloaded with NO /persist recreate -- real blob-reuse regression (image not reused across the conversion)." >&2
+        exit 1
+        ;;
+    *) echo "Usage: $0 pre | post-and-assert [max-delta-bytes]" >&2; exit 1 ;;
+esac
+
+-- eden-config.yml --
+test:
+    controller: adam://{{EdenConfig "adam.ip"}}:{{EdenConfig "adam.port"}}
+    eve:
+      {{EdenConfig "eve.name"}}:
+        onboard-cert: {{EdenConfigPath "eve.cert"}}
+        serial: "{{EdenConfig "eve.serial"}}"
+        model: {{EdenConfig "eve.devmodel"}}
+
+
+-- wait-for-longhorn-sc.sh --
+#!/bin/bash
+# Wait until the EVE-k `longhorn` StorageClass exists (longhorn deployed + its CSI
+# provisioner up). On a freshly-converted EVE-k node longhorn can take tens of
+# minutes to deploy -- well after the device reports ONLINE -- so wait for it
+# EXPLICITLY here, before deploying/waiting for an app whose volume needs longhorn.
+# This separates cluster-bringup time from app-bringup time: the wait-for-app-running
+# that follows can be short, and a failure here clearly says "longhorn", not "app".
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+for _ in $(seq 1 90); do   # ~45m at 30s
+    if "$EDEN" eve ssh -- 'eve exec kube kubectl get sc 2>/dev/null' 2>/dev/null | grep -qE '^longhorn'; then
+        echo "OK: longhorn StorageClass ready"; exit 0
+    fi
+    sleep 30
+done
+echo "FAIL: longhorn StorageClass not ready within budget" >&2; exit 1
+
+-- assert-espb-present.sh --
+#!/bin/bash
+# Assert the boot disk carries the reserved ESP-B (GPT #7, fresh-install GUID
+# …30056) at ~2 GiB — the full 2+2+10+10 EVE-k layout. This test runs on an
+# already-LARGE device (no repartition here), so it does NOT create ESP-B; it
+# DEPENDS on the image already shipping it (eve#6158 runme.sh do_live). Asserting
+# it makes that silent precondition explicit. Reads via lsblk PARTUUID, keyed on
+# the …30056 GUID, exactly like capture-partitions.sh.
+set -uo pipefail
+EDEN="{{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}"
+GiB=$(( 1024 * 1024 * 1024 )); MiB=$(( 1024 * 1024 ))
+read_espb() {
+    timeout 20 "$EDEN" eve ssh -- \
+        'eve exec pillar lsblk -b -P -o NAME,PARTLABEL,PARTUUID,SIZE /dev/sda 2>/dev/null' \
+        2>/dev/null | grep -v 'level=fatal' | python3 -c '
+import sys, re
+for line in sys.stdin:
+    m = dict(re.findall(r"(\w+)=\"([^\"]*)\"", line))
+    if m.get("PARTLABEL") == "EFI System" and m.get("PARTUUID", "").lower().endswith("30056"):
+        print("%s %s" % (m.get("NAME", ""), m.get("SIZE", "0"))); break
+'
+}
+for _ in $(seq 1 6); do   # ~1m; tolerate ssh/pillar not up yet
+    read -r name size <<<"$(read_espb)"
+    if [ -n "${size:-}" ] && [ "${size:-0}" != "0" ]; then
+        echo "ESP-B: name=${name:-?} size=$size ($(( size / MiB )) MiB)"
+        [ "$size" -ge "$GiB" ] 2>/dev/null || { echo "FAIL: ESP-B < 1 GiB floor (target 2 GiB): $size" >&2; exit 1; }
+        [ "${name:-}" = "sda7" ] || { echo "FAIL: ESP-B at ${name:-<none>}, expected sda7 (partition #7)" >&2; exit 1; }
+        echo "OK: ESP-B present (#7 …30056 at $(( size / MiB )) MiB)"; exit 0
+    fi
+    sleep 10
+done
+echo "FAIL: no ESP-B (#7 GUID …30056) on /dev/sda — the live image lacks the reserved ESP-B (eve#6158)?" >&2
+timeout 20 "$EDEN" eve ssh -- 'eve exec pillar lsblk -o NAME,PARTLABEL,PARTUUID,SIZE /dev/sda' >&2 2>/dev/null
+exit 1


### PR DESCRIPTION
End-to-end eden tests for the EVE-kvm → EVE-k cross-flavor BaseOs upgrade
and the in-field boot-disk repartition (small → large GPT geometry). They
verify that OCI blobs are reused across the flavor switch (no re-download),
that a deployed app and its volume survive the conversion and a
controller-initiated reboot, that resize variants actually grow the
partitions, and that the TPM-sealed vault stays locally unlocked across the
geometry change.

All scenarios live under `tests/update_eve_image/testdata/`, each a
self-contained escript with helper scripts and READMEs:

- `update_eve_image_cross_hv.txt` — base cross-HV upgrade; IMGB reaches
  `active` on the alternate flavor.
- `update_eve_image_cross_hv_with_contenttree.txt` — pre-stages a
  ContentTree, asserts zero bytes re-downloaded after the switch.
- `update_eve_image_cross_hv_with_app_recreate.txt` — app + volume survive
  the switch and a reboot with no re-download.
- `update_eve_image_kvm_to_k{,_grow,_resize,_refused,_volmig}.txt` —
  repartition variants asserting SMALL→LARGE partition growth,
  `BaseOsStatus.Converting` device state, blob reuse, local vault unlock
  (`VaultStatus.UnlockMethod`), and (volmig) live app-volume migration to a
  Longhorn PVC. The volmig leg covers both a VM app's disk volume and a
  container app's data volume; verify reads the container marker from the
  migrated block device, because EVE-k (kubevirt) does not auto-mount a
  container's data volume at its `MountDir` — tracked as lf-edge/eve#6145.
- `update_eve_image_kvm_to_k_geom.txt` — geometry-only matrix, parameterized
  by starting release, asserting the boot disk ends at the full EVE-k target
  2+2+10+10 (ESP-A 2G, reserved ESP-B 2G at GPT #7, IMGA/IMGB 10G).
- `update_eve_image_kvm_to_k_persist_wipe_restore.txt` — persist-wipe restore:
  offline identity + WiFi-cred decrypt after a `/persist` loss.
- `update_eve_image_kvm_to_k_backup_corrupt_restore.txt` — backup-corruption
  restore: per-type validity gate + `.bak` fallback.

Disk-topology setup for the repartition / two-disk / ZFS cases is
`prep-kvm-to-k-topology.sh` (`ext4-shrink`, `ext4-grow`, `twodisk-zfs`,
`twodisk-ext4`, `ext4-toofull`, `zfs-grow`/`zfs-notail`).

The whole matrix can be driven in one command with `run-kvm-to-k-tests.sh`: it
reclaims the single-tenant eden slot before each leg, brings the topology up via
`prep-kvm-to-k-topology.sh`, runs the matching escript, and prints a PASS/FAIL
summary. `RESIZE_EVE_VER=<tag>` selects the image under test (required),
`BRINGUP_EVE_VER` the small-layout start release (default 12.1.0), and
`ONLY=`/`SKIP=` narrow to a subset — e.g. `ONLY=twodisk-zfs,zfs-grow`.

Supersedes #1196 and #1203, folding both into one branch. References
lf-edge/eve#6145.


