### PR TITLE
Bump eclient test image and CI action to Go 1.25

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -27,7 +27,7 @@ runs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.24'
+        go-version: '1.25'
     - name: Check
       run: |
         for addr in $(ip addr list|sed -En -e 's/.*inet ([0-9.]+).*/\1/p')

--- a/tests/eclient/image/Dockerfile
+++ b/tests/eclient/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS build
+FROM golang:1.25-alpine AS build
 
 WORKDIR /go/src/local_manager
 COPY pkg .

--- a/tests/eclient/image/pkg/go.mod
+++ b/tests/eclient/image/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/lf-edge/eden/tests/eclient/image/pgk
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/lf-edge/eve-api/go v0.0.0-20250922144401-abfd2fa2b728


### PR DESCRIPTION
PR #1204 moved eden's main modules, build images, and workflows to Go 1.25 but left two spots pinned to 1.24. This brings them in line so nothing in the tree still builds against the older toolchain:

- `tests/eclient/image/pkg/go.mod` — `go` directive `1.24.0` → `1.25.0`
- `tests/eclient/image/Dockerfile` — build image `golang:1.24-alpine` → `golang:1.25-alpine`
- `.github/actions/setup-environment/action.yml` — `setup-go` version `1.24` → `1.25`

The `io_performance` test image stays on `golang:1.16-alpine`; that's a separate long-standing pin unrelated to this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)