### PR TITLE
tests/zedagent: add EVE version to combined check

### DIFF
--- a/tests/zedagent/testdata/device_info_completeness.txt
+++ b/tests/zedagent/testdata/device_info_completeness.txt
@@ -14,10 +14,9 @@
 # Trigger a fresh info publish by bumping the controller epoch.
 eden eve epoch &
 
-# --- system adapters + machine arch + vault status in one ZInfoDevice message ---
-# All three fields must be present together.  The test PASSES only if they all
-# match in the same message; stdout confirms we got the machineArch value back.
-{{$info}} -timewait 5m -out InfoContent.dinfo.machineArch 'InfoContent.dinfo.systemAdapter.status.ports.ifname:.+' 'InfoContent.dinfo.machineArch:.+' 'InfoContent.dinfo.dataSecAtRestInfo.status:.+'
+# --- system adapters + machine arch + vault status + EVE version in one message ---
+# All fields must be present together in a single ZInfoDevice message.
+{{$info}} -timewait 10m -out InfoContent.dinfo.machineArch -out InfoContent.dinfo.swList.shortVersion 'InfoContent.dinfo.systemAdapter.status.ports.ifname:.+' 'InfoContent.dinfo.machineArch:.+' 'InfoContent.dinfo.dataSecAtRestInfo.status:.+' 'InfoContent.dinfo.swList.shortVersion:.+'
 stdout 'x86_64'
 
 # --- EVE version ---


### PR DESCRIPTION
The device-info completeness test asserts that system adapters, machine
arch, and vault status all arrive together in a single ZInfoDevice
message. This extends that combined assertion to also require the EVE
version (`swList.shortVersion`) in the same message — proving all four
fields publish atomically rather than across separate messages — and
raises the wait to 10m to tolerate slower publishing.