### PR TITLE
Give eden devices a real DeviceName

### DIFF
--- a/cmd/edenStart.go
+++ b/cmd/edenStart.go
@@ -59,6 +59,7 @@ func newStartCmd(configName, verbosity *string) *cobra.Command {
 	startCmd.Flags().StringVarP(&cfg.Eve.QemuOS, "eve-os", "", runtime.GOOS, "os to run on")
 	startCmd.Flags().BoolVarP(&cfg.Eve.Accel, "eve-accel", "", cfg.Eve.Accel, "use acceleration")
 	startCmd.Flags().StringVarP(&cfg.Eve.Serial, "eve-serial", "", defaults.DefaultEVESerial, "SMBIOS serial")
+	startCmd.Flags().StringVarP(&cfg.Eve.DeviceName, "eve-device-name", "", "", "device name reported to the controller (random virtualdevice<N> if empty)")
 	startCmd.Flags().StringVarP(&cfg.Eve.QemuConfigPath, "qemu-config", "", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultQemuFileToSave), "config file to use")
 	startCmd.Flags().IntVarP(&cfg.Eve.QemuConfig.MonitorPort, "qemu-monitor-port", "", defaults.DefaultQemuMonitorPort, "Port for access to QEMU monitor")
 	startCmd.Flags().StringVarP(&cfg.Eve.Pid, "eve-pid", "", filepath.Join(currentPath, defaults.DefaultDist, "eve.pid"), "file for save EVE pid")

--- a/cmd/eve.go
+++ b/cmd/eve.go
@@ -79,6 +79,7 @@ func newStartEveCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 	startEveCmd.Flags().StringVarP(&cfg.Eve.QemuOS, "eve-os", "", runtime.GOOS, "os to run on")
 	startEveCmd.Flags().BoolVarP(&cfg.Eve.Accel, "eve-accel", "", cfg.Eve.Accel, "use acceleration")
 	startEveCmd.Flags().StringVarP(&cfg.Eve.Serial, "eve-serial", "", cfg.Eve.Serial, "SMBIOS serial")
+	startEveCmd.Flags().StringVarP(&cfg.Eve.DeviceName, "eve-device-name", "", cfg.Eve.DeviceName, "device name reported to the controller (random virtualdevice<N> if empty)")
 	startEveCmd.Flags().StringVarP(&cfg.Eve.QemuConfigPath, "qemu-config", "", filepath.Join(currentPath, defaults.DefaultDist, "qemu.conf"), "config file to use")
 	startEveCmd.Flags().StringVarP(&cfg.Eve.Pid, "eve-pid", "", filepath.Join(currentPath, defaults.DefaultDist, "eve.pid"), "file for save EVE pid")
 	startEveCmd.Flags().StringVarP(&cfg.Eve.Log, "eve-log", "", filepath.Join(currentPath, defaults.DefaultDist, "eve.log"), "file for save EVE log")

--- a/pkg/controller/device.go
+++ b/pkg/controller/device.go
@@ -90,6 +90,9 @@ func (cloud *CloudCtx) ConfigParse(config *config.EdgeDevConfig) (*device.Ctx, e
 	version, _ := strconv.Atoi(config.Id.Version)
 	dev.SetConfigVersion(version)
 	dev.SetDevModel(config.ProductName)
+	if config.DeviceName != "" {
+		dev.SetDevName(config.DeviceName)
+	}
 	for _, el := range config.ConfigItems {
 		dev.SetConfigItem(el.GetKey(), el.GetValue())
 	}
@@ -679,7 +682,7 @@ standaloneContentTreeLoop:
 			Uuid:    dev.GetID().String(),
 			Version: strconv.Itoa(dev.GetConfigVersion()),
 		},
-		DeviceName:         dev.GetID().String(),
+		DeviceName:         dev.GetDevName(),
 		Volumes:            volumes,
 		ContentInfo:        contentTrees,
 		Apps:               applicationInstances,

--- a/pkg/controller/functions.go
+++ b/pkg/controller/functions.go
@@ -60,6 +60,9 @@ func (cloud *CloudCtx) ResetDev(node *device.Ctx) error {
 	node.SetSerial(vars.EveSerial)
 	node.SetOnboardKey(vars.EveCert)
 	node.SetDevModel(vars.DevModel)
+	if vars.EveDeviceName != "" {
+		node.SetDevName(vars.EveDeviceName)
+	}
 	node.SetGlobalProfile("")
 	node.SetLocalProfileServer("")
 	return cloud.OnBoardDev(node)

--- a/pkg/defaults/templates.go
+++ b/pkg/defaults/templates.go
@@ -93,6 +93,9 @@ eve:
     #serial number in SMBIOS
     serial: '{{parse "eve.serial"}}'
 
+    #device name reported to the controller (random virtualdevice<N> if empty)
+    device-name: '{{parse "eve.device-name"}}'
+
     #onboarding certificate of EVE to put into adam
     cert: '{{parse "eve.cert"}}'
 

--- a/pkg/device/device.go
+++ b/pkg/device/device.go
@@ -3,6 +3,7 @@ package device
 import (
 	"fmt"
 	"log"
+	"math/rand"
 
 	"github.com/lf-edge/eve-api/go/config"
 	"github.com/lf-edge/eve-api/go/evecommon"
@@ -23,6 +24,7 @@ var (
 type Ctx struct {
 	onboardKey                 string
 	serial                     string
+	devName                    string
 	state                      EdgeNodeState
 	project                    string
 	hash                       [32]byte
@@ -65,6 +67,7 @@ func CreateEdgeNode() *Ctx {
 	id, _ := uuid.NewV4()
 	return &Ctx{
 		id:            id,
+		devName:       fmt.Sprintf("virtualdevice%d", rand.Intn(1<<16)),
 		rebootCounter: 1000,
 		rebootState:   false,
 		configVersion: 4,
@@ -347,6 +350,16 @@ func (cfg *Ctx) GetSerial() string {
 // SetSerial setter
 func (cfg *Ctx) SetSerial(serial string) {
 	cfg.serial = serial
+}
+
+// GetDevName getter
+func (cfg *Ctx) GetDevName() string {
+	return cfg.devName
+}
+
+// SetDevName setter
+func (cfg *Ctx) SetDevName(devName string) {
+	cfg.devName = devName
 }
 
 // GetOnboardKey getter

--- a/pkg/openevec/config.go
+++ b/pkg/openevec/config.go
@@ -129,6 +129,7 @@ type EveConfig struct {
 	Password       string            `mapstructure:"password" cobraflag:"password"`
 	Serial         string            `mapstructure:"serial" cobraflag:"eve-serial"`
 	DevSerial      bool              `mapstructure:"dev-serial" cobraflag:"eve-serial-pci"`
+	DeviceName     string            `mapstructure:"device-name" cobraflag:"eve-device-name"`
 	Accel          bool              `mapstructure:"accel" cobraflag:"eve-accel"`
 
 	Pid            string `mapstructure:"pid" cobraflag:"eve-pid" resolvepath:""`

--- a/pkg/openevec/onboard.go
+++ b/pkg/openevec/onboard.go
@@ -35,6 +35,9 @@ func (openEVEC *OpenEVEC) OnboardEve(eveUUID string) error {
 		dev.SetSerial(vars.EveSerial)
 		dev.SetOnboardKey(vars.EveCert)
 		dev.SetDevModel(vars.DevModel)
+		if vars.EveDeviceName != "" {
+			dev.SetDevName(vars.EveDeviceName)
+		}
 		err = ctrl.OnBoardDev(dev)
 		if err != nil {
 			return fmt.Errorf("error onboarding %w", err)

--- a/pkg/openevec/test.go
+++ b/pkg/openevec/test.go
@@ -69,6 +69,7 @@ func InitVarsFromConfig(cfg *EdenSetupArgs) (*utils.ConfigVars, error) {
 	cv.EveCert = utils.ResolveAbsPathWithRoot(cfg.Eden.Root, cfg.Eve.Cert)
 	cv.EveDeviceCert = utils.ResolveAbsPathWithRoot(cfg.Eden.Root, cfg.Eve.DeviceCert)
 	cv.EveSerial = cfg.Eve.Serial
+	cv.EveDeviceName = cfg.Eve.DeviceName
 	cv.EveDist = cfg.Eve.Dist
 	cv.EveQemuConfig = cfg.Eve.QemuFileToSave
 	cv.ZArch = cfg.Eve.Arch

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -68,6 +68,7 @@ type ConfigVars struct {
 	EveDeviceCert     string
 	EveSerial         string
 	EveDevSerial      bool
+	EveDeviceName     string
 	ZArch             string
 	DevModel          string
 	DevModelFIle      string
@@ -124,6 +125,7 @@ func InitVars() (*ConfigVars, error) {
 			EveDeviceCert:     ResolveAbsPath(viper.GetString("eve.device-cert")),
 			EveSerial:         viper.GetString("eve.serial"),
 			EveDevSerial:      viper.GetBool("eve.dev-serial"),
+			EveDeviceName:     viper.GetString("eve.device-name"),
 			EveDist:           viper.GetString("eve.dist"),
 			EveQemuConfig:     viper.GetString("eve.qemu-config"),
 			ZArch:             viper.GetString("eve.arch"),
@@ -404,6 +406,8 @@ func generateConfigFileFromTemplate(filePath string, templateString string, cont
 			return defaults.DefaultEVEHV
 		case "eve.serial":
 			return eveSerial
+		case "eve.device-name":
+			return ""
 		case "eve.cert":
 			return filepath.Join(certsDist, "onboard.cert.pem")
 		case "eve.device-cert":


### PR DESCRIPTION
Eden set `EdgeDevConfig.DeviceName` to the device UUID, so the name EVE
echoes back in `EdgeNodeInfo` / `ZInfoDevice.device_name` was just the
UUID string. A real controller lets the user pick a hostname-like name;
eden had no such concept.

Each new edge node now defaults to a name of the form `virtualdevice<N>`
(N is a random 16-bit number). The name can be overridden via the new
`eve.device-name` config setting or the `--eve-device-name` flag, and is
preserved when an existing config is re-parsed so it stays stable across
runs.
