### PR TITLE
Reap leftover EVE VM before running eden tests

### DIFF
--- a/.github/actions/run-eden-test/action.yml
+++ b/.github/actions/run-eden-test/action.yml
@@ -33,6 +33,13 @@ runs:
       with:
         proc_trace_sys_enable: true
         comment_on_pr: false
+    - name: Clean up before test
+      # Make sure there are no leftovers from a previous job on this runner.
+      run: |
+        fuser -k 17777/tcp || true
+        make clean || true
+      shell: bash
+      working-directory: "./eden"
     - name: Setup Environment
       uses: ./eden/.github/actions/setup-environment
       with:


### PR DESCRIPTION
## Problem

Self-hosted runners were getting wedged: several `kratos-runner-eden-*` runners had a leftover `qemu-system-x86_64` (an EVE VM) holding the console port **17777**, so every subsequent eden test job on that runner failed at `eden start` with the port already in use.

Tracing it back, the orphaned VMs all came from the **Smoke** suite's `eve_restart` test in jobs that were **cancelled mid-test** (e.g. a newer PR-Gate run superseding an in-flight one).

## Why the existing cleanup doesn't handle it

The `Clean up after test` step in this composite action (`./eden stop` etc.) is guarded by `if: always()`:

- `always()` runs on success and failure, but a **composite action's remaining steps are not executed when the job is cancelled** — the whole action is torn down mid-run. So on cancellation the VM is never stopped.
- It also can't be reaped after the fact: eden tracks the VM through a context stored under the **ephemeral HOME of the cancelled test run**, which is gone. A later job's `eden stop` / `make clean` finds no context and skips stopping the process. Verified on the stuck runners — running both `eden stop` and `make clean` were no-ops and the qemu kept running; only freeing the port directly reaped it.

## Fix

Add a pre-test step that frees port 17777 and cleans the workspace before `Setup Environment`, so a leftover from a previous job can't block the next one. Killing by the well-known EVE console port is surgical — it only targets an orphaned EVE VM, not any unrelated qemu.

```yaml
- name: Clean up before test
  run: |
    fuser -k 17777/tcp || true
    make clean || true
```