### PR TITLE
tests: wait for the reboot, not just for ssh

### DIFF
--- a/tests/eclient/testdata/radio_silence_persistence.txt
+++ b/tests/eclient/testdata/radio_silence_persistence.txt
@@ -93,14 +93,17 @@ stdout 'radio-silence=true'
 
 # STEP 3: snapshot the EVE-side ZedAgentStatus.RadioSilence.Imposed
 # before reboot so the post-reboot read is comparing apples to apples.
-exec -t 3m bash check-eve-radio-imposed.sh true
+exec -t 5m bash check-eve-radio-imposed.sh true
 stdout 'imposed=true'
 
-# STEP 4: reboot EVE and wait for ssh to come back.
-eden controller edge-node reboot
-exec sleep 60
-exec -t 5m bash wait-eve-ssh.sh
-stdout 'eve ssh ok'
+# STEP 4: reboot EVE and wait for the controller to observe the reboot.
+# No `!` here, unlike the watchdog above: that one is a background
+# detector that exits non-zero only because kill_watchdog.sh kills it.
+# This one drives the reboot in the foreground and exits 0 once the
+# controller reports a new LastRebootTime; it exits non-zero only on
+# timeout or an abnormal reboot reason, both of which should fail us.
+test eden.reboot.test -test.v -timewait 10m -reboot=1 -count=1
+stdout 'Number of reboots: 1'
 
 # Give zedagent a moment to read lastradioconfig and republish.
 exec sleep 20
@@ -109,7 +112,7 @@ exec sleep 20
 # RadioSilence.Imposed is still true. We do this BEFORE re-checking the
 # local-manager app — the app may not have reconnected to LPS yet, and
 # this test is about EVE's own persistence, not LPS reachability.
-exec -t 3m bash check-eve-radio-imposed.sh true
+exec -t 5m bash check-eve-radio-imposed.sh true
 stdout 'imposed=true'
 
 # STEP 6: tear down. The test's substantive claim has already been
@@ -144,28 +147,6 @@ do
     $EDEN sdn fwd eth0 $p -- {{template "ssh"}} grep -q Ubuntu /etc/issue && break
   done
 done
-
--- wait-eve-ssh.sh --
-#!/bin/bash
-# Wait for stable ssh to the EVE host (3 consecutive successful echos).
-EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
-for i in $(seq 1 90); do
-    ok=0
-    for j in 1 2 3; do
-        if $EDEN eve ssh 'echo ok' 2>/dev/null | grep -q ok; then
-            ok=$((ok+1))
-        else
-            ok=0
-        fi
-        sleep 2
-    done
-    if [ $ok -ge 3 ]; then
-        echo "eve ssh ok"
-        exit 0
-    fi
-done
-echo "eve ssh still unavailable"
-exit 1
 
 -- local-manager-start.sh --
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
@@ -256,9 +237,11 @@ exit 1
 # last value seen and exits before the caller's `exec -t` deadline can
 # fire — otherwise a stuck value surfaces only as an opaque
 # "context deadline exceeded" with no clue whether it read false or hung.
+# The budget has to exceed the tail of a boot: at 90s a post-reboot read
+# gave up 5s before the device had finished booting.
 EDEN={{EdenConfig "eden.root"}}/{{EdenConfig "eden.bin-dist"}}/{{EdenConfig "eden.eden-bin"}}
 WANT="$1"
-deadline=$(( $(date +%s) + 90 ))
+deadline=$(( $(date +%s) + 240 ))
 last=""
 while [ "$(date +%s)" -lt "$deadline" ]; do
     raw=$(timeout 20 $EDEN eve ssh 'eve exec pillar jq -r ".RadioSilence.Imposed" /run/zedagent/ZedAgentStatus/zedagent.json 2>/dev/null' 2>/dev/null)


### PR DESCRIPTION
`radio_silence_persistence` asserts `RadioSilence.Imposed` after a controller
reboot, but STEP 4 only waited for `eve ssh` to answer. A controller reboot can
take over a minute to land, so ssh may still be served by the **pre-reboot**
boot.

Observed in CI: the wait reported `eve ssh ok` 67s after the reboot request
while the device was still logging; the reboot landed while STEP 5 was already
polling; every ssh in that window failed with exit 255, and the assertion gave
up 5s before the device had finished booting.

This is not specific to one EVE change — the same failure at
`radio_silence_persistence.txt:112` appears on unrelated PRs, with the other
five LPS/LOC scripts passing each time:

| EVE PR | LPS/LOC |
| --- | --- |
| lf-edge/eve#5922 | [fail](https://github.com/lf-edge/eve/actions/runs/30443456912/job/90548011974) |
| lf-edge/eve#5915 | [fail](https://github.com/lf-edge/eve/actions/runs/30441984894/job/90543234923) |
| lf-edge/eve#6234 | [fail](https://github.com/lf-edge/eve/actions/runs/30384478453/job/90360258131) |
| lf-edge/eve#6209 | [fail](https://github.com/lf-edge/eve/actions/runs/30134421001/job/89628062703) |
| lf-edge/eve#6231 | [fail, 4 attempts](https://github.com/lf-edge/eve/actions/runs/30351195118/job/90537553935) |
| lf-edge/eve#5914 | [pass](https://github.com/lf-edge/eve/actions/runs/30441839150/job/90542782269) |
| lf-edge/eve#6100 | [pass](https://github.com/lf-edge/eve/actions/runs/30145205987/job/89748177550) |

Failing and passing on near-adjacent PRs is what you'd expect from a timing
race rather than a product regression.

## Change

- STEP 4 uses `eden.reboot.test -reboot=1 -count=1`: it snapshots
  `LastRebootTime`, issues the reboot itself, and returns once the controller
  observes the timestamp change, so it cannot mistake one boot for the other
  regardless of how long the reboot takes. `wait-eve-ssh.sh` has no callers
  left and is removed.
- `check-eve-radio-imposed.sh` budget 90s → 240s, and its two call sites 3m →
  5m, so the post-reboot read covers the tail of a boot and still reports the
  last value seen before the caller's deadline fires.

Net `8 insertions, 30 deletions` in one file.

## Note for reviewers

`eden.reboot.test` exits non-zero once the reboot count is reached — hence the
`!` prefix, matching the watchdog invocation earlier in the same file. A
timeout would also exit non-zero, so the reboot is asserted with
`stdout 'Number of reboots: 1'`; the timeout path prints
`Number of reboots: 0`. I could not confirm those exit-code semantics without a
live device, so that assertion is the one line worth watching on the first CI
run — if it is inverted it fails loudly rather than passing silently.
