### PR TITLE
Add SECURITY.md referencing EVE security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+The EVE community takes security seriously. If you discover a security
+issue, please bring it to our attention right away.
+
+Please DO NOT file a public issue. Report it privately instead, either by
+email to [eve-security@lists.lfedge.org][mail] or through GitHub's
+[private vulnerability reporting][gh-report] on the EVE repository.
+
+## Project-Wide Security Policy
+
+This repository is part of the EVE project and is covered by the
+project-wide security policy maintained in the main EVE repository:
+
+- [SECURITY.md][policy] for supported versions, what to include in a
+  report, response timeline, and the coordinated disclosure process.
+- [SECURITY-ARCHITECTURE.md][arch] for the EVE security model.
+- [CONTRIBUTING.md][contrib] for contribution guidelines.
+
+[mail]: mailto:eve-security@lists.lfedge.org
+[gh-report]: https://github.com/lf-edge/eve/security/advisories/new
+[policy]: https://github.com/lf-edge/eve/blob/master/SECURITY.md
+[arch]: https://github.com/lf-edge/eve/blob/master/docs/SECURITY-ARCHITECTURE.md
+[contrib]: https://github.com/lf-edge/eve/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
# Description

`eden` is part of the EVE project but carries no security policy of its own, so GitHub shows no reporting instructions on this repository and a researcher who finds an issue here has no private channel to use.

The added `SECURITY.md` names the private reporting channels the project already uses — eve-security@lists.lfedge.org and GitHub private vulnerability reporting on `lf-edge/eve` — and defers to the main EVE repository for supported versions, response timeline and the coordinated disclosure process. That keeps one authoritative policy for the project rather than a copy per repository that drifts.

The same file is going into the other EVE-family repositories that lack one, and the existing copies in `edge-containers`, `eve-build-tools`, `rol` and `runx` are being repointed in parallel PRs: they link to `eve/blob/master/docs/SECURITY.md`, which has returned 404 since that file was renamed to `docs/SECURITY-ARCHITECTURE.md`.
